### PR TITLE
[OpenCL] Add ur_usm_alloc_location_desc struct and handle it in the CL adapter.

### DIFF
--- a/include/ur.py
+++ b/include/ur.py
@@ -249,6 +249,7 @@ class ur_structure_type_v(IntEnum):
     KERNEL_EXEC_INFO_PROPERTIES = 31                ## ::ur_kernel_exec_info_properties_t
     KERNEL_ARG_VALUE_PROPERTIES = 32                ## ::ur_kernel_arg_value_properties_t
     KERNEL_ARG_LOCAL_PROPERTIES = 33                ## ::ur_kernel_arg_local_properties_t
+    USM_ALLOC_LOCATION_DESC = 35                    ## ::ur_usm_alloc_location_desc_t
     EXP_COMMAND_BUFFER_DESC = 0x1000                ## ::ur_exp_command_buffer_desc_t
     EXP_SAMPLER_MIP_PROPERTIES = 0x2000             ## ::ur_exp_sampler_mip_properties_t
     EXP_INTEROP_MEM_DESC = 0x2001                   ## ::ur_exp_interop_mem_desc_t
@@ -1556,6 +1557,25 @@ class ur_usm_device_desc_t(Structure):
                                                                         ## ::UR_STRUCTURE_TYPE_USM_DEVICE_DESC
         ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
         ("flags", ur_usm_device_mem_flags_t)                            ## [in] device memory allocation flags.
+    ]
+
+###############################################################################
+## @brief USM allocation location desc
+## 
+## @details
+##     - Specify these properties in ::urUSMHostAlloc, ::urUSMDeviceAlloc and
+##       ::urUSMSharedAlloc via ::ur_usm_desc_t as part of a `pNext` chain.
+## 
+## @remarks
+##   _Analogues_
+##     - cl_intel_mem_alloc_buffer_location
+class ur_usm_alloc_location_desc_t(Structure):
+    _fields_ = [
+        ("stype", ur_structure_type_t),                                 ## [in] type of this structure, must be
+                                                                        ## ::UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC
+        ("pNext", c_void_p),                                            ## [in][optional] pointer to extension-specific structure
+        ("location", c_ulong)                                           ## [in] Identifies the ID of global memory partition to which the memory
+                                                                        ## should be allocated.
     ]
 
 ###############################################################################

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -258,6 +258,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_KERNEL_EXEC_INFO_PROPERTIES = 31,      ///< ::ur_kernel_exec_info_properties_t
     UR_STRUCTURE_TYPE_KERNEL_ARG_VALUE_PROPERTIES = 32,      ///< ::ur_kernel_arg_value_properties_t
     UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES = 33,      ///< ::ur_kernel_arg_local_properties_t
+    UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC = 35,          ///< ::ur_usm_alloc_location_desc_t
     UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC = 0x1000,      ///< ::ur_exp_command_buffer_desc_t
     UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 0x2000,   ///< ::ur_exp_sampler_mip_properties_t
     UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC = 0x2001,         ///< ::ur_exp_interop_mem_desc_t
@@ -3288,6 +3289,25 @@ typedef struct ur_usm_device_desc_t {
 } ur_usm_device_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief USM allocation location desc
+///
+/// @details
+///     - Specify these properties in ::urUSMHostAlloc, ::urUSMDeviceAlloc and
+///       ::urUSMSharedAlloc via ::ur_usm_desc_t as part of a `pNext` chain.
+///
+/// @remarks
+///   _Analogues_
+///     - cl_intel_mem_alloc_buffer_location
+typedef struct ur_usm_alloc_location_desc_t {
+    ur_structure_type_t stype; ///< [in] type of this structure, must be
+                               ///< ::UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
+    uint32_t location;         ///< [in] Identifies the ID of global memory partition to which the memory
+                               ///< should be allocated.
+
+} ur_usm_alloc_location_desc_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief USM pool descriptor type
 typedef struct ur_usm_pool_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_POOL_DESC
@@ -3324,6 +3344,7 @@ typedef struct ur_usm_pool_limits_desc_t {
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -3369,6 +3390,7 @@ urUSMHostAlloc(
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -3417,6 +3439,7 @@ urUSMDeviceAlloc(
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -267,6 +267,7 @@ inline std::ostream &operator<<(std::ostream &os, ur_usm_advice_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_host_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_device_desc_t params);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_alloc_location_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_pool_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_usm_pool_limits_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, ur_usm_pool_info_t value);
@@ -993,6 +994,9 @@ inline std::ostream &operator<<(std::ostream &os, ur_structure_type_t value) {
     case UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES";
         break;
+    case UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC:
+        os << "UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC";
+        break;
     case UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC:
         os << "UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC";
         break;
@@ -1201,6 +1205,11 @@ inline ur_result_t printStruct(std::ostream &os, const void *ptr) {
 
     case UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES: {
         const ur_kernel_arg_local_properties_t *pstruct = (const ur_kernel_arg_local_properties_t *)ptr;
+        printPtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC: {
+        const ur_usm_alloc_location_desc_t *pstruct = (const ur_usm_alloc_location_desc_t *)ptr;
         printPtr(os, pstruct);
     } break;
 
@@ -6532,6 +6541,31 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_usm_device_des
 
     ur::details::printFlag<ur_usm_device_mem_flag_t>(os,
                                                      (params.flags));
+
+    os << "}";
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_usm_alloc_location_desc_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, const struct ur_usm_alloc_location_desc_t params) {
+    os << "(struct ur_usm_alloc_location_desc_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur::details::printStruct(os,
+                             (params.pNext));
+
+    os << ", ";
+    os << ".location = ";
+
+    os << (params.location);
 
     os << "}";
     return os;

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -666,3 +666,6 @@ etors:
 - name: KERNEL_ARG_LOCAL_PROPERTIES
   desc: $x_kernel_arg_local_properties_t
   value: '33'
+- name: USM_ALLOC_LOCATION_DESC
+  desc: $x_usm_alloc_location_desc_t
+  value: '35'

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -175,6 +175,23 @@ members:
       desc: "[in] device memory allocation flags."
 --- #--------------------------------------------------------------------------
 type: struct
+desc: "USM allocation location desc"
+details:
+    - Specify these properties in $xUSMHostAlloc, $xUSMDeviceAlloc and
+      $xUSMSharedAlloc via $x_usm_desc_t as part of a `pNext` chain.
+analogue:
+    - "cl_intel_mem_alloc_buffer_location"
+class: $xUSM
+name: $x_usm_alloc_location_desc_t
+base: $x_base_desc_t
+members:
+    - type: uint32_t
+      name: location
+      desc: >
+          [in] Identifies the ID of global memory partition to which the memory
+          should be allocated.
+--- #--------------------------------------------------------------------------
+type: struct
 desc: "USM pool descriptor type"
 class: $xUSM
 name: $x_usm_pool_desc_t
@@ -212,6 +229,7 @@ details:
   - "Allocations served from different memory pools must be isolated and must not reside on the same page."
   - "Any flags/hints passed through pUSMDesc only affect the single allocation."
   - "See also $x_usm_host_desc_t."
+  - "See also $x_usm_alloc_location_desc_t."
 params:
     - type: $x_context_handle_t
       name: hContext
@@ -253,6 +271,7 @@ details:
   - "Allocations served from different memory pools must be isolated and must not reside on the same page."
   - "Any flags/hints passed through pUSMDesc only affect the single allocation."
   - "See also $x_usm_device_desc_t."
+  - "See also $x_usm_alloc_location_desc_t."
 params:
     - type: $x_context_handle_t
       name: hContext
@@ -298,6 +317,7 @@ details:
   - "Any flags/hints passed through pUSMDesc only affect the single allocation."
   - "See also $x_usm_host_desc_t."
   - "See also $x_usm_device_desc_t."
+  - "See also $x_usm_alloc_location_desc_t."
 params:
     - type: $x_context_handle_t
       name: hContext

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2121,6 +2121,7 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -2177,6 +2178,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -2236,6 +2238,7 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1811,6 +1811,7 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1861,6 +1862,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
 ///     - Any flags/hints passed through pUSMDesc only affect the single
 ///       allocation.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1914,6 +1916,7 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
 ///       allocation.
 ///     - See also ::ur_usm_host_desc_t.
 ///     - See also ::ur_usm_device_desc_t.
+///     - See also ::ur_usm_alloc_location_desc_t.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/test/conformance/usm/usm_adapter_opencl.match
+++ b/test/conformance/usm/usm_adapter_opencl.match
@@ -1,6 +1,5 @@
 urUSMDeviceAllocTest.Success/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.SuccessWithDescriptors/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
-urUSMDeviceAllocTest.SuccessWithDescriptors/Intel_R__OpenCL___{{.*}}___UsePoolDisabled
 urUSMDeviceAllocTest.InvalidNullHandleContext/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.InvalidNullHandleDevice/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.InvalidNullPtrResult/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
@@ -9,7 +8,6 @@ urUSMDeviceAllocTest.InvalidValueAlignPowerOfTwo/Intel_R__OpenCL___{{.*}}___UseP
 urUSMAllocInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_USM_ALLOC_INFO_POOL
 urUSMHostAllocTest.Success/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMHostAllocTest.SuccessWithDescriptors/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
-urUSMHostAllocTest.SuccessWithDescriptors/Intel_R__OpenCL___{{.*}}___UsePoolDisabled
 urUSMHostAllocTest.InvalidNullHandleContext/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMHostAllocTest.InvalidNullPtrMem/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMHostAllocTest.InvalidUSMSize/Intel_R__OpenCL___{{.*}}___UsePoolEnabled


### PR DESCRIPTION
This is the equivalent ur_buffer_alloc_location_properties_t, it turns out the CL extension flag is applicable to both buffer creation and USM allocations.

Tested in https://github.com/intel/llvm/pull/12005