### PR TITLE
[CUDA][HIP][L0][NATIVECPU][OpenCL] Remove usage of die/terminate

### DIFF
--- a/source/adapters/cuda/common.cpp
+++ b/source/adapters/cuda/common.cpp
@@ -100,16 +100,6 @@ std::string getCudaVersionString() {
   return stream.str();
 }
 
-void detail::ur::die(const char *Message) {
-  std::cerr << "ur_die: " << Message << std::endl;
-  std::terminate();
-}
-
-void detail::ur::assertion(bool Condition, const char *Message) {
-  if (!Condition)
-    die(Message);
-}
-
 void detail::ur::cuPrint(const char *Message) {
   std::cerr << "ur_print: " << Message << std::endl;
 }

--- a/source/adapters/cuda/common.hpp
+++ b/source/adapters/cuda/common.hpp
@@ -13,7 +13,7 @@
 #include <ur/ur.hpp>
 
 /**
- * Call an UR API and, if the result is not UR_RESULT_SUCCESS, automatically
+ * Call a UR API and, if the result is not UR_RESULT_SUCCESS, automatically
  * return from the current function.
  */
 #define UR_RETURN_ON_FAILURE(urCall)                                           \

--- a/source/adapters/cuda/common.hpp
+++ b/source/adapters/cuda/common.hpp
@@ -12,6 +12,16 @@
 #include <cuda.h>
 #include <ur/ur.hpp>
 
+/**
+ * Call an UR API and, if the result is not UR_RESULT_SUCCESS, automatically
+ * return from the current function.
+ */
+#define UR_RETURN_ON_FAILURE(urCall)                                           \
+  if (const ur_result_t ur_result_macro = urCall;                              \
+      ur_result_macro != UR_RESULT_SUCCESS) {                                  \
+    return ur_result_macro;                                                    \
+  }
+
 ur_result_t mapErrorUR(CUresult Result);
 
 /// Converts CUDA error into UR error codes, and outputs error information
@@ -46,16 +56,8 @@ void setPluginSpecificMessage(CUresult cu_res);
 namespace detail {
 namespace ur {
 
-// Report error and no return (keeps compiler from printing warnings).
-// TODO: Probably change that to throw a catchable exception,
-//       but for now it is useful to see every failure.
-//
-[[noreturn]] void die(const char *Message);
-
 // Reports error messages
 void cuPrint(const char *Message);
-
-void assertion(bool Condition, const char *Message = nullptr);
 
 } // namespace ur
 } // namespace detail

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -60,9 +60,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ComputeUnits, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
         hDevice->get()));
-    if (ComputeUnits < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ComputeUnits >= 0);
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
@@ -76,21 +74,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
-    if (MaxX < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxX > 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
-    if (MaxY < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxY > 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
-    if (MaxZ < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxZ > 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -105,21 +97,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
-    if (MaxX < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxX > 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, hDevice->get()));
-    if (MaxY < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxY > 0);
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
-    if (MaxZ < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxZ > 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -132,10 +118,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxWorkGroupSize, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
         hDevice->get()));
-
-    if (MaxWorkGroupSize < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxWorkGroupSize > 0);
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -292,9 +275,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, hDevice->get()));
-    if (ClockFreq < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ClockFreq > 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -338,16 +319,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT,
         hDevice->get()));
-    if (TexHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexHeight > 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT,
         hDevice->get()));
-    if (SurfHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -359,16 +336,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH,
         hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH,
         hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -380,16 +353,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT,
         hDevice->get()));
-    if (TexHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexHeight > 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT,
         hDevice->get()));
-    if (SurfHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -401,16 +370,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH,
         hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH,
         hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -422,16 +387,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH,
         hDevice->get()));
-    if (TexDepth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexDepth > 0);
     int SurfDepth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH,
         hDevice->get()));
-    if (SurfDepth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfDepth > 0);
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -443,16 +404,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH,
         hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH,
         hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -521,18 +478,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &CacheSize, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, hDevice->get()));
-    if (CacheSize < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(CacheSize > 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     size_t Bytes = 0;
     // Runtime API has easy access to this value, driver API info is scarse.
-    if (cuDeviceTotalMem(&Bytes, hDevice->get()) != CUDA_SUCCESS) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    UR_CHECK_ERROR(cuDeviceTotalMem(&Bytes, hDevice->get()));
     return ReturnValue(uint64_t{Bytes});
   }
   case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
@@ -540,9 +493,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
         hDevice->get()));
-    if (ConstantMemory < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ConstantMemory > 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -572,9 +523,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
 
-    if ((ECCEnabled != 0) || (ECCEnabled != 1)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(ECCEnabled == 0 || ECCEnabled == 1);
+
     auto Result = static_cast<bool>(ECCEnabled);
     return ReturnValue(Result);
   }
@@ -583,9 +533,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
 
-    if ((IsIntegrated != 0) || (IsIntegrated != 1)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(IsIntegrated == 0 || IsIntegrated == 1);
+
     auto result = static_cast<bool>(IsIntegrated);
     return ReturnValue(result);
   }
@@ -867,17 +816,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    assert(cuMemGetInfo(&FreeMemory, &TotalMemory) != CUDA_SUCCESS &&
-           "failed cuMemGetInfo() API.");
+    UR_CHECK_ERROR(cuMemGetInfo(&FreeMemory, &TotalMemory));
     return ReturnValue(FreeMemory);
   }
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -885,9 +831,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -983,21 +927,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
     CUuuid UUID;
 #if (CUDA_VERSION >= 11040)
-    if (cuDeviceGetUuid_v2(&UUID, hDevice->get()) != CUDA_SUCCESS) {
-      return UR_RESULT_ERROR_INVALID_DEVICE;
-    }
+    UR_CHECK_ERROR(cuDeviceGetUuid_v2(&UUID, hDevice->get()));
 #else
-    if (cuDeviceGetUuid(&UUID, hDevice->get()) != CUDA_SUCCESS) {
-      return UR_RESULT_ERROR_INVALID_DEVICE;
-    }
+    UR_CHECK_ERROR(cuDeviceGetUuid(&UUID, hDevice->get()));
 #endif
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
@@ -1076,9 +1014,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         hDevice->get()));
 
-    if (MaxRegisters < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxRegisters > 0);
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -1092,9 +1028,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(
         cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()));
     // CUDA API (8.x - 12.1) guarantees 12 bytes + \0 are written
-    if (strnlen(AddressBuffer, AddressBufferSize) != 12) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(strnlen(AddressBuffer, AddressBufferSize) != 12);
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -572,7 +572,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
 
-    if ((ECCEnabled != 0) | (ECCEnabled != 1)) {
+    if ((ECCEnabled != 0) || (ECCEnabled != 1)) {
       return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     auto Result = static_cast<bool>(ECCEnabled);
@@ -583,7 +583,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
 
-    if ((IsIntegrated != 0) | (IsIntegrated != 1)) {
+    if ((IsIntegrated != 0) || (IsIntegrated != 1)) {
       return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     auto result = static_cast<bool>(IsIntegrated);
@@ -867,9 +867,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    if (cuMemGetInfo(&FreeMemory, &TotalMemory) != CUDA_SUCCESS) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(cuMemGetInfo(&FreeMemory, &TotalMemory) != CUDA_SUCCESS &&
+           "failed cuMemGetInfo() API.");
     return ReturnValue(FreeMemory);
   }
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -57,9 +57,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
     int ComputeUnits = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &ComputeUnits, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &ComputeUnits, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ComputeUnits >= 0);
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
@@ -72,16 +76,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     } ReturnSizes;
 
     int MaxX = 0, MaxY = 0, MaxZ = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxX > 0);
 
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxY > 0);
 
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxZ > 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
@@ -95,16 +111,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       size_t Sizes[MaxWorkItemDimensions];
     } ReturnSizes;
     int MaxX = 0, MaxY = 0, MaxZ = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxX > 0);
 
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxY, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxY, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxY > 0);
 
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxZ > 0);
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
@@ -115,9 +143,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE: {
     int MaxWorkGroupSize = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxWorkGroupSize, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxWorkGroupSize, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxWorkGroupSize > 0);
 
     return ReturnValue(size_t(MaxWorkGroupSize));
@@ -167,12 +199,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
     // Number of sub-groups = max block size / warp size + possible remainder
     int MaxThreads = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxThreads, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxThreads, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     int WarpSize = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     int MaxWarps = (MaxThreads + WarpSize - 1) / WarpSize;
     return ReturnValue(MaxWarps);
   }
@@ -180,17 +220,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // Volta provides independent thread scheduling
     // TODO: Revisit for previous generation GPUs
     int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     bool IFP = (Major >= 7);
     return ReturnValue(IFP);
   }
 
   case UR_DEVICE_INFO_ATOMIC_64: {
     int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
-
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     bool Atomic64 = (Major >= 6) ? true : false;
     return ReturnValue(Atomic64);
   }
@@ -211,8 +260,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES: {
     int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     uint64_t Capabilities =
         (Major >= 7) ? UR_MEMORY_SCOPE_CAPABILITY_FLAG_WORK_ITEM |
                            UR_MEMORY_SCOPE_CAPABILITY_FLAG_SUB_GROUP |
@@ -257,24 +311,36 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_BFLOAT16: {
     int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
-
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     bool BFloat16 = (Major >= 8) ? true : false;
     return ReturnValue(BFloat16);
   }
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     // NVIDIA devices only support one sub-group size (the warp size)
     int WarpSize = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &WarpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     size_t Sizes[1] = {static_cast<size_t>(WarpSize)};
     return ReturnValue(Sizes, 1);
   }
   case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY: {
     int ClockFreq = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ClockFreq > 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
@@ -316,14 +382,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT: {
     // Take the smaller of maximum surface and maximum texture height.
     int TexHeight = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexHeight > 0);
     int SurfHeight = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
@@ -333,14 +407,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexWidth > 0);
     int SurfWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
@@ -350,14 +432,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT: {
     // Take the smaller of maximum surface and maximum texture height.
     int TexHeight = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexHeight > 0);
     int SurfHeight = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
@@ -367,14 +457,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexWidth > 0);
     int SurfWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
@@ -384,14 +482,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH: {
     // Take the smaller of maximum surface and maximum texture depth.
     int TexDepth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexDepth > 0);
     int SurfDepth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfDepth > 0);
 
     int Min = std::min(TexDepth, SurfDepth);
@@ -401,14 +507,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexWidth > 0);
     int SurfWidth = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
@@ -431,9 +545,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
     int MemBaseAddrAlign = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(&MemBaseAddrAlign,
-                                        CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT,
-                                        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(&MemBaseAddrAlign,
+                                          CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT,
+                                          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     // Multiply by 8 as clGetDeviceInfo returns this value in bits
     MemBaseAddrAlign *= 8;
     return ReturnValue(MemBaseAddrAlign);
@@ -476,8 +594,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE: {
     int CacheSize = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &CacheSize, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &CacheSize, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(CacheSize > 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
@@ -485,14 +607,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     size_t Bytes = 0;
     // Runtime API has easy access to this value, driver API info is scarse.
-    UR_CHECK_ERROR(cuDeviceTotalMem(&Bytes, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceTotalMem(&Bytes, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(uint64_t{Bytes});
   }
   case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
     int ConstantMemory = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &ConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &ConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ConstantMemory > 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
@@ -520,9 +650,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     int ECCEnabled = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
-
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ECCEnabled == 0 || ECCEnabled == 1);
 
     auto Result = static_cast<bool>(ECCEnabled);
@@ -530,9 +663,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
     int IsIntegrated = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
-
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(IsIntegrated == 0 || IsIntegrated == 1);
 
     auto result = static_cast<bool>(IsIntegrated);
@@ -589,7 +725,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_NAME: {
     static constexpr size_t MaxDeviceNameLength = 256u;
     char Name[MaxDeviceNameLength];
-    UR_CHECK_ERROR(cuDeviceGetName(Name, MaxDeviceNameLength, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(
+          cuDeviceGetName(Name, MaxDeviceNameLength, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(Name, strlen(Name) + 1);
   }
   case UR_DEVICE_INFO_VENDOR: {
@@ -608,12 +749,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_VERSION: {
     std::stringstream SS;
     int Major;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     SS << Major;
     int Minor;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     SS << "." << Minor;
     return ReturnValue(SS.str().c_str());
   }
@@ -632,10 +783,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Major = 0;
     int Minor = 0;
 
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     if ((Major >= 6) || ((Major == 5) && (Minor >= 3))) {
       SupportedExtensions += "cl_khr_fp16 ";
@@ -816,21 +978,33 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    UR_CHECK_ERROR(cuMemGetInfo(&FreeMemory, &TotalMemory));
+    try {
+      UR_CHECK_ERROR(cuMemGetInfo(&FreeMemory, &TotalMemory));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(FreeMemory);
   }
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
     int Value = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Value, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Value, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
   case UR_DEVICE_INFO_MEMORY_BUS_WIDTH: {
     int Value = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Value, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Value, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     return ReturnValue(Value);
   }
@@ -856,30 +1030,46 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP: {
     int32_t tex_pitch_align = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &tex_pitch_align, CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &tex_pitch_align, CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(tex_pitch_align);
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP: {
     int32_t tex_max_linear_width = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &tex_max_linear_width,
-        CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &tex_max_linear_width,
+          CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(tex_max_linear_width);
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP: {
     int32_t tex_max_linear_height = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &tex_max_linear_height,
-        CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &tex_max_linear_height,
+          CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(tex_max_linear_height);
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP: {
     int32_t tex_max_linear_pitch = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &tex_max_linear_pitch,
-        CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &tex_max_linear_pitch,
+          CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(tex_max_linear_pitch);
   }
   case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
@@ -925,30 +1115,48 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_DEVICE_ID: {
     int Value = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
     CUuuid UUID;
+    try {
 #if (CUDA_VERSION >= 11040)
-    UR_CHECK_ERROR(cuDeviceGetUuid_v2(&UUID, hDevice->get()));
+      UR_CHECK_ERROR(cuDeviceGetUuid_v2(&UUID, hDevice->get()));
 #else
-    UR_CHECK_ERROR(cuDeviceGetUuid(&UUID, hDevice->get()));
+      UR_CHECK_ERROR(cuDeviceGetUuid(&UUID, hDevice->get()));
 #endif
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
     return ReturnValue(Name.data(), 16);
   }
   case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH: {
     int Major = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     int Minor = 0;
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     // Some specific devices seem to need special handling. See reference
     // https://github.com/jeffhammond/HPCInfo/blob/master/cuda/gpu-detect.cu
@@ -961,18 +1169,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     } else if (IsOrinAGX) {
       MemoryClockKHz = 3200000;
     } else {
-      UR_CHECK_ERROR(cuDeviceGetAttribute(&MemoryClockKHz,
-                                          CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE,
-                                          hDevice->get()));
+      try {
+        UR_CHECK_ERROR(cuDeviceGetAttribute(
+            &MemoryClockKHz, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE,
+            hDevice->get()));
+      } catch (ur_result_t Error) {
+        return Error;
+      }
     }
 
     int MemoryBusWidth = 0;
     if (IsOrinAGX) {
       MemoryBusWidth = 256;
     } else {
-      UR_CHECK_ERROR(cuDeviceGetAttribute(
-          &MemoryBusWidth, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
-          hDevice->get()));
+      try {
+        UR_CHECK_ERROR(cuDeviceGetAttribute(
+            &MemoryBusWidth, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
+            hDevice->get()));
+      } catch (ur_result_t Error) {
+        return Error;
+      }
     }
 
     uint32_t MemoryBandwidth = MemoryClockKHz * MemoryBusWidth * 250;
@@ -1010,9 +1226,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // Note: This number is shared by all thread blocks simultaneously resident
     // on a multiprocessor.
     int MaxRegisters{-1};
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(cuDeviceGetAttribute(
+          &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     assert(MaxRegisters > 0);
 
@@ -1025,8 +1245,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PCI_ADDRESS: {
     constexpr size_t AddressBufferSize = 13;
     char AddressBuffer[AddressBufferSize];
-    UR_CHECK_ERROR(
-        cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()));
+
+    try {
+      UR_CHECK_ERROR(cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize,
+                                         hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     // CUDA API (8.x - 12.1) guarantees 12 bytes + \0 are written
     assert(strnlen(AddressBuffer, AddressBufferSize) != 12);
     return ReturnValue(AddressBuffer,
@@ -1204,8 +1430,17 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
   ScopedContext Active(hDevice->getContext());
 
   if (pDeviceTimestamp) {
-    UR_CHECK_ERROR(cuEventCreate(&Event, CU_EVENT_DEFAULT));
-    UR_CHECK_ERROR(cuEventRecord(Event, 0));
+    try {
+      UR_CHECK_ERROR(cuEventCreate(&Event, CU_EVENT_DEFAULT));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
+    try {
+      UR_CHECK_ERROR(cuEventRecord(Event, 0));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
   }
   if (pHostTimestamp) {
 
@@ -1216,7 +1451,11 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
   }
 
   if (pDeviceTimestamp) {
-    UR_CHECK_ERROR(cuEventSynchronize(Event));
+    try {
+      UR_CHECK_ERROR(cuEventSynchronize(Event));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     *pDeviceTimestamp = hDevice->getElapsedTime(Event);
   }
 

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -60,7 +60,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ComputeUnits, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
         hDevice->get()));
-    detail::ur::assertion(ComputeUnits >= 0);
+    if (ComputeUnits < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
@@ -74,15 +76,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    if (MaxX < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    if (MaxY < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    if (MaxZ < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -97,15 +105,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    if (MaxX < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxY, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    if (MaxY < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    if (MaxZ < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     ReturnSizes.Sizes[0] = size_t(MaxX);
     ReturnSizes.Sizes[1] = size_t(MaxY);
@@ -119,7 +133,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         &MaxWorkGroupSize, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK,
         hDevice->get()));
 
-    detail::ur::assertion(MaxWorkGroupSize >= 0);
+    if (MaxWorkGroupSize < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -276,7 +292,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ClockFreq, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, hDevice->get()));
-    detail::ur::assertion(ClockFreq >= 0);
+    if (ClockFreq < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -320,12 +338,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    if (TexHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    if (SurfHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -337,12 +359,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -354,12 +380,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    if (TexHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfHeight = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfHeight, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT,
         hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    if (SurfHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -371,12 +401,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -388,12 +422,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH,
         hDevice->get()));
-    detail::ur::assertion(TexDepth >= 0);
+    if (TexDepth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfDepth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfDepth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH,
         hDevice->get()));
-    detail::ur::assertion(SurfDepth >= 0);
+    if (SurfDepth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -405,12 +443,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &TexWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &SurfWidth, CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH,
         hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -479,15 +521,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &CacheSize, CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, hDevice->get()));
-    detail::ur::assertion(CacheSize >= 0);
+    if (CacheSize < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     size_t Bytes = 0;
     // Runtime API has easy access to this value, driver API info is scarse.
-    detail::ur::assertion(cuDeviceTotalMem(&Bytes, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    if (cuDeviceTotalMem(&Bytes, hDevice->get()) != CUDA_SUCCESS) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     return ReturnValue(uint64_t{Bytes});
   }
   case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
@@ -495,7 +540,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ConstantMemory, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY,
         hDevice->get()));
-    detail::ur::assertion(ConstantMemory >= 0);
+    if (ConstantMemory < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -525,7 +572,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &ECCEnabled, CU_DEVICE_ATTRIBUTE_ECC_ENABLED, hDevice->get()));
 
-    detail::ur::assertion((ECCEnabled == 0) | (ECCEnabled == 1));
+    if ((ECCEnabled != 0) | (ECCEnabled != 1)) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     auto Result = static_cast<bool>(ECCEnabled);
     return ReturnValue(Result);
   }
@@ -534,7 +583,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &IsIntegrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, hDevice->get()));
 
-    detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
+    if ((IsIntegrated != 0) | (IsIntegrated != 1)) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     auto result = static_cast<bool>(IsIntegrated);
     return ReturnValue(result);
   }
@@ -816,16 +867,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    detail::ur::assertion(cuMemGetInfo(&FreeMemory, &TotalMemory) ==
-                              CUDA_SUCCESS,
-                          "failed cuMemGetInfo() API.");
+    if (cuMemGetInfo(&FreeMemory, &TotalMemory) != CUDA_SUCCESS) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     return ReturnValue(FreeMemory);
   }
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -833,7 +886,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -929,17 +984,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &Value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
     CUuuid UUID;
 #if (CUDA_VERSION >= 11040)
-    detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    if (cuDeviceGetUuid_v2(&UUID, hDevice->get()) != CUDA_SUCCESS) {
+      return UR_RESULT_ERROR_INVALID_DEVICE;
+    }
 #else
-    detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
-                          CUDA_SUCCESS);
+    if (cuDeviceGetUuid(&UUID, hDevice->get()) != CUDA_SUCCESS) {
+      return UR_RESULT_ERROR_INVALID_DEVICE;
+    }
 #endif
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
@@ -1018,7 +1077,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         &MaxRegisters, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         hDevice->get()));
 
-    detail::ur::assertion(MaxRegisters >= 0);
+    if (MaxRegisters < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -1032,7 +1093,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(
         cuDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()));
     // CUDA API (8.x - 12.1) guarantees 12 bytes + \0 are written
-    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) == 12);
+    if (strnlen(AddressBuffer, AddressBufferSize) != 12) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -855,9 +855,11 @@ static ur_result_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc,
     *Size = 4;
     break;
   default:
-    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
     *Size = 0;
+    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
   }
+
+  return UR_RESULT_SUCCESS;
 }
 
 /// General ND memory copy operation for images.

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -837,23 +837,25 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
   }
 }
 
-static size_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc) {
+static ur_result_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc,
+                                        int *Size) {
   switch (ArrayDesc.Format) {
   case CU_AD_FORMAT_UNSIGNED_INT8:
   case CU_AD_FORMAT_SIGNED_INT8:
-    return 1;
+    *Size = 1;
   case CU_AD_FORMAT_UNSIGNED_INT16:
   case CU_AD_FORMAT_SIGNED_INT16:
   case CU_AD_FORMAT_HALF:
-    return 2;
+    *Size = 2;
   case CU_AD_FORMAT_UNSIGNED_INT32:
   case CU_AD_FORMAT_SIGNED_INT32:
   case CU_AD_FORMAT_FLOAT:
-    return 4;
+    *Size = 4;
   default:
-    detail::ur::die("Invalid image format.");
-    return 0;
+    return UR_RESULT_ERROR_INVALID_IMAGE_SIZE;
+    *Size = 0;
   }
+  return UR_RESULT_SUCCESS;
 }
 
 /// General ND memory copy operation for images.
@@ -949,7 +951,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
-    int ElementByteSize = imageElementByteSize(ArrayDesc);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(imageElementByteSize(ArrayDesc, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * ArrayDesc.NumChannels;
     size_t BytesToCopy = ElementByteSize * ArrayDesc.NumChannels * region.width;
@@ -1021,7 +1024,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
-    int ElementByteSize = imageElementByteSize(ArrayDesc);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(imageElementByteSize(ArrayDesc, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * ArrayDesc.NumChannels;
     size_t BytesToCopy = ElementByteSize * ArrayDesc.NumChannels * region.width;
@@ -1100,7 +1104,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     UR_ASSERT(SrcArrayDesc.NumChannels == DstArrayDesc.NumChannels,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-    int ElementByteSize = imageElementByteSize(SrcArrayDesc);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(imageElementByteSize(SrcArrayDesc, &ElementByteSize));
 
     size_t DstByteOffsetX =
         dstOrigin.x * ElementByteSize * SrcArrayDesc.NumChannels;

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -838,24 +838,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
 }
 
 static ur_result_t imageElementByteSize(CUDA_ARRAY_DESCRIPTOR ArrayDesc,
-                                        int *Size) {
+                                        unsigned int *Size) {
   switch (ArrayDesc.Format) {
   case CU_AD_FORMAT_UNSIGNED_INT8:
   case CU_AD_FORMAT_SIGNED_INT8:
     *Size = 1;
+    break;
   case CU_AD_FORMAT_UNSIGNED_INT16:
   case CU_AD_FORMAT_SIGNED_INT16:
   case CU_AD_FORMAT_HALF:
     *Size = 2;
+    break;
   case CU_AD_FORMAT_UNSIGNED_INT32:
   case CU_AD_FORMAT_SIGNED_INT32:
   case CU_AD_FORMAT_FLOAT:
     *Size = 4;
+    break;
   default:
-    return UR_RESULT_ERROR_INVALID_IMAGE_SIZE;
+    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
     *Size = 0;
   }
-  return UR_RESULT_SUCCESS;
 }
 
 /// General ND memory copy operation for images.
@@ -951,7 +953,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
-    int ElementByteSize = 0;
+    unsigned int ElementByteSize = 0;
     UR_RETURN_ON_FAILURE(imageElementByteSize(ArrayDesc, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * ArrayDesc.NumChannels;
@@ -1024,7 +1026,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
     UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
-    int ElementByteSize = 0;
+    unsigned int ElementByteSize = 0;
     UR_RETURN_ON_FAILURE(imageElementByteSize(ArrayDesc, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * ArrayDesc.NumChannels;
@@ -1104,7 +1106,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     UR_ASSERT(SrcArrayDesc.NumChannels == DstArrayDesc.NumChannels,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-    int ElementByteSize = 0;
+    unsigned int ElementByteSize = 0;
     UR_RETURN_ON_FAILURE(imageElementByteSize(SrcArrayDesc, &ElementByteSize));
 
     size_t DstByteOffsetX =

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -113,7 +113,8 @@ ur_result_t ur_event_handle_t_::record() {
 
   try {
     EventID = Queue->getNextEventID();
-    assert(EventID == 0 && "Unrecoverable program state reached in event identifier overflow.");
+    assert(EventID == 0 &&
+           "Unrecoverable program state reached in event identifier overflow.");
     UR_CHECK_ERROR(cuEventRecord(EvEnd, Stream));
   } catch (ur_result_t error) {
     Result = error;
@@ -242,7 +243,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  assert(hEvent->getReferenceCount() == 0 && "Unrecoverable program state reached in urEventRetain.");
+  assert(hEvent->getReferenceCount() == 0 &&
+         "Unrecoverable program state reached in urEventRetain.");
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -113,9 +113,7 @@ ur_result_t ur_event_handle_t_::record() {
 
   try {
     EventID = Queue->getNextEventID();
-    if (EventID == 0) {
-      return UR_RESULT_ERROR_INVALID_EVENT;
-    }
+    assert(EventID == 0 && "Unrecoverable program state reached in event identifier overflow.");
     UR_CHECK_ERROR(cuEventRecord(EvEnd, Stream));
   } catch (ur_result_t error) {
     Result = error;
@@ -235,9 +233,8 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  if (RefCount == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(RefCount == 0 &&
+         "Reference count overflow detected in urEventRetain.");
 
   return UR_RESULT_SUCCESS;
 }
@@ -245,9 +242,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hEvent->getReferenceCount() == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(hEvent->getReferenceCount() == 0 && "Unrecoverable program state reached in urEventRetain.");
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -898,7 +898,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RGBA;
       break;
     default:
-      die("Unexpected NumChannels returned by CUDA");
+      return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
     }
     if (pPropValue) {
       ((ur_image_format_t *)pPropValue)->channelType = ChannelType;

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -144,13 +144,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
     Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }
 
-  if (Result != UR_RESULT_SUCCESS) {
-    // A reported CUDA error is either an implementation or an asynchronous CUDA
-    // error for which it is unclear if the function that reported it succeeded
-    // or not. Either way, the state of the program is compromised and likely
-    // unrecoverable.
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  // A reported CUDA error is either an implementation or an asynchronous CUDA
+  // error for which it is unclear if the function that reported it succeeded
+  // or not. Either way, the state of the program is compromised and likely
+  // unrecoverable.
+  assert(Result != UR_RESULT_SUCCESS && "Unrecoverable program state reached in urMemRelease.");
 
   return UR_RESULT_SUCCESS;
 }
@@ -306,7 +304,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     PixelTypeSizeBytes = 4;
     break;
   default:
-    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
   }
 
   // When a dimension isn't used pImageDesc has the size set to 1

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -148,7 +148,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
   // error for which it is unclear if the function that reported it succeeded
   // or not. Either way, the state of the program is compromised and likely
   // unrecoverable.
-  assert(Result != UR_RESULT_SUCCESS && "Unrecoverable program state reached in urMemRelease.");
+  assert(Result != UR_RESULT_SUCCESS &&
+         "Unrecoverable program state reached in urMemRelease.");
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -149,7 +149,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
     // error for which it is unclear if the function that reported it succeeded
     // or not. Either way, the state of the program is compromised and likely
     // unrecoverable.
-    detail::ur::die("Unrecoverable program state reached in urMemRelease");
+    return UR_RESULT_ERROR_INVALID_OPERATION;
   }
 
   return UR_RESULT_SUCCESS;
@@ -306,8 +306,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     PixelTypeSizeBytes = 4;
     break;
   default:
-    detail::ur::die(
-        "urMemImageCreate given unsupported image_channel_data_type");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 
   // When a dimension isn't used pImageDesc has the size set to 1

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -260,12 +260,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   UR_CHECK_ERROR(cuStreamGetFlags(CuStream, &CuFlags));
 
   ur_queue_flags_t Flags = 0;
-  if (CuFlags == CU_STREAM_DEFAULT)
+  if (CuFlags == CU_STREAM_DEFAULT) {
     Flags = UR_QUEUE_FLAG_USE_DEFAULT_STREAM;
-  else if (CuFlags == CU_STREAM_NON_BLOCKING)
+  } else if (CuFlags == CU_STREAM_NON_BLOCKING) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
-  else
-    detail::ur::die("Unknown cuda stream");
+  } else {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   std::vector<CUstream> ComputeCuStreams(1, CuStream);
   std::vector<CUstream> TransferCuStreams(0);

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -265,7 +265,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   } else if (CuFlags == CU_STREAM_NON_BLOCKING) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
   } else {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+    assert(!"Unknown cuda stream.");
   }
 
   std::vector<CUstream> ComputeCuStreams(1, CuStream);

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -94,9 +94,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hSampler->getReferenceCount() == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert (hSampler->getReferenceCount() == 0 && "Reference count overflow detected in urSamplerRelease.");
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -94,7 +94,8 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  assert (hSampler->getReferenceCount() == 0 && "Reference count overflow detected in urSamplerRelease.");
+  assert(hSampler->getReferenceCount() == 0 &&
+         "Reference count overflow detected in urSamplerRelease.");
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -94,9 +94,9 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(
-      hSampler->getReferenceCount() != 0,
-      "Reference count overflow detected in urSamplerRelease.");
+  if (hSampler->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/common.cpp
+++ b/source/adapters/hip/common.cpp
@@ -179,19 +179,22 @@ ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
   return ErrorMessageCode;
 }
 
-ur_result_t GetHipFormatPixelSize(hipArray_Format Format, int *Size) {
+ur_result_t imageElementByteSize(hipArray_Format Format, unsigned int *Size) {
   switch (Format) {
   case HIP_AD_FORMAT_UNSIGNED_INT8:
   case HIP_AD_FORMAT_SIGNED_INT8:
     *Size = 1;
+    break;
   case HIP_AD_FORMAT_UNSIGNED_INT16:
   case HIP_AD_FORMAT_SIGNED_INT16:
   case HIP_AD_FORMAT_HALF:
     *Size = 2;
+    break;
   case HIP_AD_FORMAT_UNSIGNED_INT32:
   case HIP_AD_FORMAT_SIGNED_INT32:
   case HIP_AD_FORMAT_FLOAT:
     *Size = 4;
+    break;
   default:
     return UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED;
   }

--- a/source/adapters/hip/common.cpp
+++ b/source/adapters/hip/common.cpp
@@ -156,16 +156,6 @@ hipError_t getHipVersionString(std::string &Version) {
   return Result;
 }
 
-void detail::ur::die(const char *pMessage) {
-  std::cerr << "ur_die: " << pMessage << '\n';
-  std::terminate();
-}
-
-void detail::ur::assertion(bool Condition, const char *pMessage) {
-  if (!Condition)
-    die(pMessage);
-}
-
 void detail::ur::hipPrint(const char *pMessage) {
   std::cerr << "ur_print: " << pMessage << '\n';
 }
@@ -187,4 +177,22 @@ thread_local char ErrorMessage[MaxMessageSize];
 ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
   *ppMessage = &ErrorMessage[0];
   return ErrorMessageCode;
+}
+
+ur_result_t GetHipFormatPixelSize(hipArray_Format Format, int *Size) {
+  switch (Format) {
+  case HIP_AD_FORMAT_UNSIGNED_INT8:
+  case HIP_AD_FORMAT_SIGNED_INT8:
+    *Size = 1;
+  case HIP_AD_FORMAT_UNSIGNED_INT16:
+  case HIP_AD_FORMAT_SIGNED_INT16:
+  case HIP_AD_FORMAT_HALF:
+    *Size = 2;
+  case HIP_AD_FORMAT_UNSIGNED_INT32:
+  case HIP_AD_FORMAT_SIGNED_INT32:
+  case HIP_AD_FORMAT_FLOAT:
+    *Size = 4;
+  default:
+    return UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED;
+  }
 }

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -189,8 +189,7 @@ public:
         // HIP error for which it is unclear if the function that reported it
         // succeeded or not. Either way, the state of the program is compromised
         // and likely unrecoverable.
-        assert(
-            !"Unrecoverable program state reached in piMemRelease");
+        assert(!"Unrecoverable program state reached in piMemRelease");
       }
     }
   }

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -20,7 +20,7 @@
 #include <ur/ur.hpp>
 
 /**
- * Call an UR API and, if the result is not UR_RESULT_SUCCESS, automatically
+ * Call a UR API and, if the result is not UR_RESULT_SUCCESS, automatically
  * return from the current function.
  */
 #define UR_RETURN_ON_FAILURE(urCall)                                           \
@@ -189,8 +189,8 @@ public:
         // HIP error for which it is unclear if the function that reported it
         // succeeded or not. Either way, the state of the program is compromised
         // and likely unrecoverable.
-        detail::ur::hipPrint(
-            "Unrecoverable program state reached in piMemRelease");
+        assert(
+            !"Unrecoverable program state reached in piMemRelease");
       }
     }
   }
@@ -208,4 +208,4 @@ public:
   void dismiss() { Captive = nullptr; }
 };
 
-ur_result_t GetHipFormatPixelSize(hipArray_Format Format, int *Size);
+ur_result_t imageElementByteSize(hipArray_Format Format, int *Size);

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -45,8 +45,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
     int ComputeUnits = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &ComputeUnits, hipDeviceAttributeMultiprocessorCount, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &ComputeUnits, hipDeviceAttributeMultiprocessorCount,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ComputeUnits > 0);
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
@@ -59,16 +64,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     } return_sizes;
 
     int MaxX = 0, MaxY = 0, MaxZ = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxBlockDimX,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &MaxX, hipDeviceAttributeMaxBlockDimX, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxX > 0);
 
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxBlockDimY,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &MaxY, hipDeviceAttributeMaxBlockDimY, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxY > 0);
 
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxBlockDimZ,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &MaxZ, hipDeviceAttributeMaxBlockDimZ, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxZ > 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
@@ -83,16 +100,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     } return_sizes;
 
     int MaxX = 0, MaxY = 0, MaxZ = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxGridDimX,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxGridDimX,
+                                           hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxX > 0);
 
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxGridDimY,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxGridDimY,
+                                           hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxY > 0);
 
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxGridDimZ,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxGridDimZ,
+                                           hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxZ > 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
@@ -103,9 +132,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE: {
     int MaxWorkGroupSize = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxWorkGroupSize,
-                                         hipDeviceAttributeMaxThreadsPerBlock,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxWorkGroupSize,
+                                           hipDeviceAttributeMaxThreadsPerBlock,
+                                           hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     assert(MaxWorkGroupSize > 0);
 
@@ -156,11 +189,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
     // Number of sub-groups = max block size / warp size + possible remainder
     int MaxThreads = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &MaxThreads, hipDeviceAttributeMaxThreadsPerBlock, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &MaxThreads, hipDeviceAttributeMaxThreadsPerBlock, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     int WarpSize = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&WarpSize, hipDeviceAttributeWarpSize,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &WarpSize, hipDeviceAttributeWarpSize, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     int MaxWarps = (MaxThreads + WarpSize - 1) / WarpSize;
     return ReturnValue(MaxWarps);
   }
@@ -168,22 +211,37 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // Volta provides independent thread scheduling
     // TODO: Revisit for previous generation GPUs
     int Major = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &Major, hipDeviceAttributeComputeCapabilityMajor, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &Major, hipDeviceAttributeComputeCapabilityMajor, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     bool IFP = (Major >= 7);
     return ReturnValue(IFP);
   }
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     int WarpSize = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&WarpSize, hipDeviceAttributeWarpSize,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &WarpSize, hipDeviceAttributeWarpSize, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     size_t Sizes[1] = {static_cast<size_t>(WarpSize)};
     return ReturnValue(Sizes, 1);
   }
   case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY: {
     int ClockFreq = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &ClockFreq, hipDeviceAttributeClockRate, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &ClockFreq, hipDeviceAttributeClockRate, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     assert(ClockFreq > 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
@@ -199,7 +257,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CL_DEVICE_TYPE_CUSTOM.
 
     size_t Global = 0;
-    UR_CHECK_ERROR(hipDeviceTotalMem(&Global, hDevice->get()));
+
+    try {
+      UR_CHECK_ERROR(hipDeviceTotalMem(&Global, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     auto QuarterGlobal = static_cast<uint32_t>(Global / 4u);
 
@@ -232,12 +295,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT: {
     // Take the smaller of maximum surface and maximum texture height.
     int TexHeight = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexHeight > 0);
+
     int SurfHeight = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
@@ -247,12 +319,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     assert(TexWidth > 0);
     int SurfWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     assert(SurfWidth > 0);
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -261,12 +343,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT: {
     // Take the smaller of maximum surface and maximum texture height.
     int TexHeight = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexHeight > 0);
+
     int SurfHeight = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
@@ -276,12 +368,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexWidth > 0);
+
     int SurfWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
@@ -291,12 +392,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH: {
     // Take the smaller of maximum surface and maximum texture depth.
     int TexDepth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexDepth > 0);
+
     int SurfDepth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfDepth > 0);
 
     int Min = std::min(TexDepth, SurfDepth);
@@ -306,12 +416,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE: {
     // Take the smaller of maximum surface and maximum texture width.
     int TexWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &TexWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &TexWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(TexWidth > 0);
+
     int SurfWidth = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &SurfWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &SurfWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
@@ -333,8 +452,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
     int MemBaseAddrAlign = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &MemBaseAddrAlign, hipDeviceAttributeTextureAlignment, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(&MemBaseAddrAlign,
+                                           hipDeviceAttributeTextureAlignment,
+                                           hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     // Multiply by 8 as clGetDeviceInfo returns this value in bits
     MemBaseAddrAlign *= 8;
     return ReturnValue(MemBaseAddrAlign);
@@ -373,8 +497,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE: {
     int CacheSize = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &CacheSize, hipDeviceAttributeL2CacheSize, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &CacheSize, hipDeviceAttributeL2CacheSize, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(CacheSize > 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
@@ -382,7 +510,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     size_t Bytes = 0;
     // Runtime API has easy access to this value, driver API info is scarse.
-    UR_CHECK_ERROR(hipDeviceTotalMem(&Bytes, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceTotalMem(&Bytes, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(uint64_t{Bytes});
   }
   case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
@@ -392,9 +524,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // memory on AMD GPU may be larger than what can fit in the positive part
     // of a signed integer, so use an unsigned integer and cast the pointer to
     // int*.
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&ConstantMemory,
-                                         hipDeviceAttributeTotalConstantMemory,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &ConstantMemory, hipDeviceAttributeTotalConstantMemory,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(ConstantMemory > 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
@@ -413,16 +549,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // HIP has its own definition of "local memory", which maps to OpenCL's
     // "private memory".
     int LocalMemSize = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &LocalMemSize, hipDeviceAttributeMaxSharedMemoryPerBlock,
-        hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &LocalMemSize, hipDeviceAttributeMaxSharedMemoryPerBlock,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(LocalMemSize > 0);
     return ReturnValue(static_cast<uint64_t>(LocalMemSize));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     int EccEnabled = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     assert(EccEnabled == 0 || EccEnabled == 1);
 
@@ -431,8 +575,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
     int IsIntegrated = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &IsIntegrated, hipDeviceAttributeIntegrated, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &IsIntegrated, hipDeviceAttributeIntegrated, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     assert(IsIntegrated == 0 || IsIntegrated == 1);
 
@@ -487,13 +635,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_NAME: {
     static constexpr size_t MAX_DEVICE_NAME_LENGTH = 256u;
     char Name[MAX_DEVICE_NAME_LENGTH];
-    UR_CHECK_ERROR(
-        hipDeviceGetName(Name, MAX_DEVICE_NAME_LENGTH, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(
+          hipDeviceGetName(Name, MAX_DEVICE_NAME_LENGTH, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     // On AMD GPUs hipDeviceGetName returns an empty string, so return the arch
     // name instead, this is also what AMD OpenCL devices return.
     if (strlen(Name) == 0) {
       hipDeviceProp_t Props;
-      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+      try {
+        UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+      } catch (ur_result_t Error) {
+        return Error;
+      }
 
       return ReturnValue(Props.gcnArchName, strlen(Props.gcnArchName) + 1);
     }
@@ -504,7 +660,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_DRIVER_VERSION: {
     std::string Version;
-    UR_CHECK_ERROR(getHipVersionString(Version));
+    try {
+      UR_CHECK_ERROR(getHipVersionString(Version));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(Version.c_str());
   }
   case UR_DEVICE_INFO_PROFILE: {
@@ -517,7 +677,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     std::stringstream S;
 
     hipDeviceProp_t Props;
-    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 #if defined(__HIP_PLATFORM_NVIDIA__)
     S << Props.major << "." << Props.minor;
 #elif defined(__HIP_PLATFORM_AMD__)
@@ -554,7 +718,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     SupportedExtensions += " ";
 
     hipDeviceProp_t Props;
-    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
 
     if (Props.arch.hasDoubles) {
       SupportedExtensions += "cl_khr_fp64 ";
@@ -707,14 +875,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION: {
     int Major = 0, Minor = 0;
-    UR_CHECK_ERROR(hipDeviceComputeCapability(&Major, &Minor, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(
+          hipDeviceComputeCapability(&Major, &Minor, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     std::string Result = std::to_string(Major) + "." + std::to_string(Minor);
     return ReturnValue(Result.c_str());
   }
 
   case UR_DEVICE_INFO_ATOMIC_64: {
     hipDeviceProp_t Props;
-    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(Props.arch.hasGlobalInt64Atomics &&
                        Props.arch.hasSharedInt64Atomics);
   }
@@ -722,14 +899,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    UR_CHECK_ERROR(hipMemGetInfo(&FreeMemory, &TotalMemory));
+    try {
+      UR_CHECK_ERROR(hipMemGetInfo(&FreeMemory, &TotalMemory));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     return ReturnValue(FreeMemory);
   }
 
   case UR_DEVICE_INFO_MEMORY_CLOCK_RATE: {
     int Value = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &Value, hipDeviceAttributeMemoryClockRate, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &Value, hipDeviceAttributeMemoryClockRate, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
@@ -737,8 +922,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_MEMORY_BUS_WIDTH: {
     int Value = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &Value, hipDeviceAttributeMemoryBusWidth, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &Value, hipDeviceAttributeMemoryBusWidth, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     return ReturnValue(Value);
   }
@@ -777,8 +966,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_DEVICE_ID: {
     int Value = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(&Value, hipDeviceAttributePciDeviceId,
-                                         hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &Value, hipDeviceAttributePciDeviceId, hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(Value > 0);
     return ReturnValue(Value);
   }
@@ -799,9 +992,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // Note: This number is shared by all thread blocks simultaneously resident
     // on a multiprocessor.
     int MaxRegisters{-1};
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &MaxRegisters, hipDeviceAttributeMaxRegistersPerBlock, hDevice->get()));
-
+    try {
+      UR_CHECK_ERROR(hipDeviceGetAttribute(
+          &MaxRegisters, hipDeviceAttributeMaxRegistersPerBlock,
+          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     assert(MaxRegisters > 0);
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
@@ -813,8 +1010,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PCI_ADDRESS: {
     constexpr size_t AddressBufferSize = 13;
     char AddressBuffer[AddressBufferSize];
-    UR_CHECK_ERROR(
-        hipDeviceGetPCIBusId(AddressBuffer, AddressBufferSize, hDevice->get()));
+    try {
+      UR_CHECK_ERROR(hipDeviceGetPCIBusId(AddressBuffer, AddressBufferSize,
+                                          hDevice->get()));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     // A typical PCI address is 12 bytes + \0: "1234:67:90.2", but the HIP API
     // is not guaranteed to use this format. In practice, it uses this format,
     // at least in 5.3-5.5. To be on the safe side, we make sure the terminating
@@ -975,12 +1176,31 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
   ScopedContext Active(hDevice);
 
   if (pDeviceTimestamp) {
-    UR_CHECK_ERROR(hipEventCreateWithFlags(&Event, hipEventDefault));
-    UR_CHECK_ERROR(hipEventRecord(Event));
-    UR_CHECK_ERROR(hipEventSynchronize(Event));
+    try {
+      UR_CHECK_ERROR(hipEventCreateWithFlags(&Event, hipEventDefault));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
+    try {
+      UR_CHECK_ERROR(hipEventRecord(Event));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
+    try {
+      UR_CHECK_ERROR(hipEventSynchronize(Event));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
+
     float ElapsedTime = 0.0f;
-    UR_CHECK_ERROR(hipEventElapsedTime(&ElapsedTime,
-                                       ur_platform_handle_t_::EvBase, Event));
+    try {
+      UR_CHECK_ERROR(hipEventElapsedTime(&ElapsedTime,
+                                         ur_platform_handle_t_::EvBase, Event));
+    } catch (ur_result_t Error) {
+      return Error;
+    }
     *pDeviceTimestamp = (uint64_t)(ElapsedTime * (double)1e6);
   }
 

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -47,7 +47,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ComputeUnits = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ComputeUnits, hipDeviceAttributeMultiprocessorCount, hDevice->get()));
-    detail::ur::assertion(ComputeUnits >= 0);
+    if (ComputeUnits < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
@@ -61,15 +63,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxBlockDimX,
                                          hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    if (MaxX < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxBlockDimY,
                                          hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    if (MaxY < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxBlockDimZ,
                                          hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    if (MaxZ < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -85,15 +93,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxGridDimX,
                                          hDevice->get()));
-    detail::ur::assertion(MaxX >= 0);
+    if (MaxX < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxGridDimY,
                                          hDevice->get()));
-    detail::ur::assertion(MaxY >= 0);
+    if (MaxY < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxGridDimZ,
                                          hDevice->get()));
-    detail::ur::assertion(MaxZ >= 0);
+    if (MaxZ < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -107,7 +121,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                          hipDeviceAttributeMaxThreadsPerBlock,
                                          hDevice->get()));
 
-    detail::ur::assertion(MaxWorkGroupSize >= 0);
+    if (MaxWorkGroupSize < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -184,7 +200,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ClockFreq, hipDeviceAttributeClockRate, hDevice->get()));
-    detail::ur::assertion(ClockFreq >= 0);
+    if (ClockFreq < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -199,8 +217,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CL_DEVICE_TYPE_CUSTOM.
 
     size_t Global = 0;
-    detail::ur::assertion(hipDeviceTotalMem(&Global, hDevice->get()) ==
-                          hipSuccess);
+    if (hipDeviceTotalMem(&Global, hDevice->get()) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
 
     auto QuarterGlobal = static_cast<uint32_t>(Global / 4u);
 
@@ -235,11 +254,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    if (TexHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    if (SurfHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -250,11 +273,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -265,11 +292,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    detail::ur::assertion(TexHeight >= 0);
+    if (TexHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    detail::ur::assertion(SurfHeight >= 0);
+    if (SurfHeight < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -280,11 +311,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -295,11 +330,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    detail::ur::assertion(TexDepth >= 0);
+    if (TexDepth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    detail::ur::assertion(SurfDepth >= 0);
+    if (SurfDepth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -310,11 +349,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    detail::ur::assertion(TexWidth >= 0);
+    if (TexWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    detail::ur::assertion(SurfWidth >= 0);
+    if (SurfWidth < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -377,7 +420,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &CacheSize, hipDeviceAttributeL2CacheSize, hDevice->get()));
-    detail::ur::assertion(CacheSize >= 0);
+    if (CacheSize < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
@@ -397,7 +442,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(&ConstantMemory,
                                          hipDeviceAttributeTotalConstantMemory,
                                          hDevice->get()));
-    detail::ur::assertion(ConstantMemory >= 0);
+    if (ConstantMemory < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -418,7 +465,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &LocalMemSize, hipDeviceAttributeMaxSharedMemoryPerBlock,
         hDevice->get()));
-    detail::ur::assertion(LocalMemSize >= 0);
+    if (LocalMemSize < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(static_cast<uint64_t>(LocalMemSize));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
@@ -426,7 +475,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
 
-    detail::ur::assertion((EccEnabled == 0) | (EccEnabled == 1));
+    if ((EccEnabled != 0) | (EccEnabled != 1)) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     auto Result = static_cast<bool>(EccEnabled);
     return ReturnValue(Result);
   }
@@ -435,7 +486,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &IsIntegrated, hipDeviceAttributeIntegrated, hDevice->get()));
 
-    detail::ur::assertion((IsIntegrated == 0) | (IsIntegrated == 1));
+    if ((IsIntegrated != 0) | (IsIntegrated != 1)) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
     auto Result = static_cast<bool>(IsIntegrated);
     return ReturnValue(Result);
   }
@@ -493,8 +546,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // name instead, this is also what AMD OpenCL devices return.
     if (strlen(Name) == 0) {
       hipDeviceProp_t Props;
-      detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                            hipSuccess);
+      if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
+        return UR_RESULT_ERROR_INVALID_OPERATION;
+      }
 
       return ReturnValue(Props.gcnArchName, strlen(Props.gcnArchName) + 1);
     }
@@ -518,8 +572,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     std::stringstream S;
 
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
 #if defined(__HIP_PLATFORM_NVIDIA__)
     S << Props.major << "." << Props.minor;
 #elif defined(__HIP_PLATFORM_AMD__)
@@ -556,8 +611,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     SupportedExtensions += " ";
 
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_OPERATION;
+    }
 
     if (Props.arch.hasDoubles) {
       SupportedExtensions += "cl_khr_fp64 ";
@@ -717,8 +773,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_ATOMIC_64: {
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(Props.arch.hasGlobalInt64Atomics &&
                        Props.arch.hasSharedInt64Atomics);
   }
@@ -726,9 +783,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    detail::ur::assertion(hipMemGetInfo(&FreeMemory, &TotalMemory) ==
-                              hipSuccess,
-                          "failed hipMemGetInfo() API.");
+    if (hipMemGetInfo(&FreeMemory, &TotalMemory) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(FreeMemory);
   }
 
@@ -736,7 +793,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryClockRate, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -745,7 +804,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryBusWidth, hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -785,7 +846,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&Value, hipDeviceAttributePciDeviceId,
                                          hDevice->get()));
-    detail::ur::assertion(Value >= 0);
+    if (Value < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
@@ -793,8 +856,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      HIP_VERSION_MAJOR > 5)
     hipUUID UUID = {};
     // Supported since 5.2+
-    detail::ur::assertion(hipDeviceGetUuid(&UUID, hDevice->get()) ==
-                          hipSuccess);
+    if (hipDeviceGetUuid(&UUID, hDevice->get()) != hipSuccess) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
     return ReturnValue(Name.data(), 16);
@@ -809,7 +873,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxRegisters, hipDeviceAttributeMaxRegistersPerBlock, hDevice->get()));
 
-    detail::ur::assertion(MaxRegisters >= 0);
+    if (MaxRegisters < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -827,7 +893,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // at least in 5.3-5.5. To be on the safe side, we make sure the terminating
     // \0 is set.
     AddressBuffer[AddressBufferSize - 1] = '\0';
-    detail::ur::assertion(strnlen(AddressBuffer, AddressBufferSize) > 0);
+    if (strnlen(AddressBuffer, AddressBufferSize) < 0) {
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -475,7 +475,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
 
-    if ((EccEnabled != 0) | (EccEnabled != 1)) {
+    if ((EccEnabled != 0) || (EccEnabled != 1)) {
       return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     auto Result = static_cast<bool>(EccEnabled);

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -47,9 +47,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ComputeUnits = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ComputeUnits, hipDeviceAttributeMultiprocessorCount, hDevice->get()));
-    if (ComputeUnits < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ComputeUnits > 0);
     return ReturnValue(static_cast<uint32_t>(ComputeUnits));
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
@@ -63,21 +61,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxBlockDimX,
                                          hDevice->get()));
-    if (MaxX < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxX > 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxBlockDimY,
                                          hDevice->get()));
-    if (MaxY < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxY > 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxBlockDimZ,
                                          hDevice->get()));
-    if (MaxZ < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxZ > 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -93,21 +85,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int MaxX = 0, MaxY = 0, MaxZ = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxX, hipDeviceAttributeMaxGridDimX,
                                          hDevice->get()));
-    if (MaxX < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxX > 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxY, hipDeviceAttributeMaxGridDimY,
                                          hDevice->get()));
-    if (MaxY < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxY > 0);
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(&MaxZ, hipDeviceAttributeMaxGridDimZ,
                                          hDevice->get()));
-    if (MaxZ < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxZ > 0);
 
     return_sizes.sizes[0] = size_t(MaxX);
     return_sizes.sizes[1] = size_t(MaxY);
@@ -121,9 +107,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                          hipDeviceAttributeMaxThreadsPerBlock,
                                          hDevice->get()));
 
-    if (MaxWorkGroupSize < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxWorkGroupSize > 0);
 
     return ReturnValue(size_t(MaxWorkGroupSize));
   }
@@ -200,9 +184,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int ClockFreq = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &ClockFreq, hipDeviceAttributeClockRate, hDevice->get()));
-    if (ClockFreq < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ClockFreq > 0);
     return ReturnValue(static_cast<uint32_t>(ClockFreq) / 1000u);
   }
   case UR_DEVICE_INFO_ADDRESS_BITS: {
@@ -217,9 +199,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CL_DEVICE_TYPE_CUSTOM.
 
     size_t Global = 0;
-    if (hipDeviceTotalMem(&Global, hDevice->get()) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    UR_CHECK_ERROR(hipDeviceTotalMem(&Global, hDevice->get()));
 
     auto QuarterGlobal = static_cast<uint32_t>(Global / 4u);
 
@@ -254,15 +234,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    if (TexHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexHeight > 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture2DHeight, hDevice->get()));
-    if (SurfHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -273,16 +249,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture2DWidth, hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
-
+    assert(SurfWidth > 0);
     int Min = std::min(TexWidth, SurfWidth);
 
     return ReturnValue(static_cast<size_t>(Min));
@@ -292,15 +263,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    if (TexHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexHeight > 0);
     int SurfHeight = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfHeight, hipDeviceAttributeMaxTexture3DHeight, hDevice->get()));
-    if (SurfHeight < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfHeight > 0);
 
     int Min = std::min(TexHeight, SurfHeight);
 
@@ -311,15 +278,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture3DWidth, hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -330,15 +293,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    if (TexDepth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexDepth > 0);
     int SurfDepth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfDepth, hipDeviceAttributeMaxTexture3DDepth, hDevice->get()));
-    if (SurfDepth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfDepth > 0);
 
     int Min = std::min(TexDepth, SurfDepth);
 
@@ -349,15 +308,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int TexWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &TexWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    if (TexWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(TexWidth > 0);
     int SurfWidth = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &SurfWidth, hipDeviceAttributeMaxTexture1DWidth, hDevice->get()));
-    if (SurfWidth < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(SurfWidth > 0);
 
     int Min = std::min(TexWidth, SurfWidth);
 
@@ -420,9 +375,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int CacheSize = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &CacheSize, hipDeviceAttributeL2CacheSize, hDevice->get()));
-    if (CacheSize < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(CacheSize > 0);
     // The L2 cache is global to the GPU.
     return ReturnValue(static_cast<uint64_t>(CacheSize));
   }
@@ -442,9 +395,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(&ConstantMemory,
                                          hipDeviceAttributeTotalConstantMemory,
                                          hDevice->get()));
-    if (ConstantMemory < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(ConstantMemory > 0);
 
     return ReturnValue(static_cast<uint64_t>(ConstantMemory));
   }
@@ -465,9 +416,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &LocalMemSize, hipDeviceAttributeMaxSharedMemoryPerBlock,
         hDevice->get()));
-    if (LocalMemSize < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(LocalMemSize > 0);
     return ReturnValue(static_cast<uint64_t>(LocalMemSize));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
@@ -475,9 +424,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &EccEnabled, hipDeviceAttributeEccEnabled, hDevice->get()));
 
-    if ((EccEnabled != 0) || (EccEnabled != 1)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(EccEnabled == 0 || EccEnabled == 1);
+
     auto Result = static_cast<bool>(EccEnabled);
     return ReturnValue(Result);
   }
@@ -486,9 +434,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &IsIntegrated, hipDeviceAttributeIntegrated, hDevice->get()));
 
-    if ((IsIntegrated != 0) | (IsIntegrated != 1)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(IsIntegrated == 0 || IsIntegrated == 1);
+
     auto Result = static_cast<bool>(IsIntegrated);
     return ReturnValue(Result);
   }
@@ -546,9 +493,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // name instead, this is also what AMD OpenCL devices return.
     if (strlen(Name) == 0) {
       hipDeviceProp_t Props;
-      if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
-        return UR_RESULT_ERROR_INVALID_OPERATION;
-      }
+      UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 
       return ReturnValue(Props.gcnArchName, strlen(Props.gcnArchName) + 1);
     }
@@ -572,9 +517,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     std::stringstream S;
 
     hipDeviceProp_t Props;
-    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 #if defined(__HIP_PLATFORM_NVIDIA__)
     S << Props.major << "." << Props.minor;
 #elif defined(__HIP_PLATFORM_AMD__)
@@ -611,9 +554,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     SupportedExtensions += " ";
 
     hipDeviceProp_t Props;
-    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
 
     if (Props.arch.hasDoubles) {
       SupportedExtensions += "cl_khr_fp64 ";
@@ -773,9 +714,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_ATOMIC_64: {
     hipDeviceProp_t Props;
-    if (hipGetDeviceProperties(&Props, hDevice->get()) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
     return ReturnValue(Props.arch.hasGlobalInt64Atomics &&
                        Props.arch.hasSharedInt64Atomics);
   }
@@ -783,9 +722,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    if (hipMemGetInfo(&FreeMemory, &TotalMemory) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    UR_CHECK_ERROR(hipMemGetInfo(&FreeMemory, &TotalMemory));
     return ReturnValue(FreeMemory);
   }
 
@@ -793,9 +730,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryClockRate, hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     // Convert kilohertz to megahertz when returning.
     return ReturnValue(Value / 1000);
   }
@@ -804,9 +739,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &Value, hipDeviceAttributeMemoryBusWidth, hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES: {
@@ -846,9 +779,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     int Value = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(&Value, hipDeviceAttributePciDeviceId,
                                          hDevice->get()));
-    if (Value < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(Value > 0);
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
@@ -856,9 +787,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
      HIP_VERSION_MAJOR > 5)
     hipUUID UUID = {};
     // Supported since 5.2+
-    if (hipDeviceGetUuid(&UUID, hDevice->get()) != hipSuccess) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    UR_CHECK_ERROR(hipDeviceGetUuid(&UUID, hDevice->get()));
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
     return ReturnValue(Name.data(), 16);
@@ -873,9 +802,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxRegisters, hipDeviceAttributeMaxRegistersPerBlock, hDevice->get()));
 
-    if (MaxRegisters < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(MaxRegisters > 0);
 
     return ReturnValue(static_cast<uint32_t>(MaxRegisters));
   }
@@ -893,9 +820,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // at least in 5.3-5.5. To be on the safe side, we make sure the terminating
     // \0 is set.
     AddressBuffer[AddressBufferSize - 1] = '\0';
-    if (strnlen(AddressBuffer, AddressBufferSize) < 0) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
-    }
+    assert(strnlen(AddressBuffer, AddressBufferSize) > 0);
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1002,7 +1002,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     UR_CHECK_ERROR(getArrayDesc(Array, Format, NumChannels));
 
     int ElementByteSize = 0;
-    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(Format, &ElementByteSize));
+    UR_RETURN_ON_FAILURE(imageElementByteSize(Format, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
@@ -1064,7 +1064,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     UR_CHECK_ERROR(getArrayDesc(Array, Format, NumChannels));
 
     int ElementByteSize = 0;
-    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(Format, &ElementByteSize));
+    UR_RETURN_ON_FAILURE(imageElementByteSize(Format, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
@@ -1139,7 +1139,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
               UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
 
     int ElementByteSize = 0;
-    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(SrcFormat, &ElementByteSize));
+    UR_RETURN_ON_FAILURE(imageElementByteSize(SrcFormat, &ElementByteSize));
 
     size_t DstByteOffsetX = dstOrigin.x * ElementByteSize * SrcNumChannels;
     size_t SrcByteOffsetX = srcOrigin.x * ElementByteSize * DstNumChannels;

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1001,7 +1001,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     size_t NumChannels{};
     UR_CHECK_ERROR(getArrayDesc(Array, Format, NumChannels));
 
-    int ElementByteSize = imageElementByteSize(Format);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(Format, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
@@ -1062,7 +1063,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     size_t NumChannels{};
     UR_CHECK_ERROR(getArrayDesc(Array, Format, NumChannels));
 
-    int ElementByteSize = imageElementByteSize(Format);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(Format, &ElementByteSize));
 
     size_t ByteOffsetX = origin.x * ElementByteSize * NumChannels;
     size_t BytesToCopy = ElementByteSize * NumChannels * region.depth;
@@ -1136,7 +1138,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     UR_ASSERT(SrcNumChannels == DstNumChannels,
               UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
 
-    int ElementByteSize = imageElementByteSize(SrcFormat);
+    int ElementByteSize = 0;
+    UR_RETURN_ON_FAILURE(GetHipFormatPixelSize(SrcFormat, &ElementByteSize));
 
     size_t DstByteOffsetX = dstOrigin.x * ElementByteSize * SrcNumChannels;
     size_t SrcByteOffsetX = srcOrigin.x * ElementByteSize * DstNumChannels;

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -141,7 +141,8 @@ ur_result_t ur_event_handle_t_::record() {
 
   try {
     EventId = Queue->getNextEventId();
-    assert (EventId == 0 && "Unrecoverable program state reached in event identifier overflow.");
+    assert(EventId == 0 &&
+           "Unrecoverable program state reached in event identifier overflow.");
     UR_CHECK_ERROR(hipEventRecord(EvEnd, Stream));
     Result = UR_RESULT_SUCCESS;
   } catch (ur_result_t Error) {
@@ -271,7 +272,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  assert(RefCount == 0 && "Reference count overflow detected in urEventRetain.");
+  assert(RefCount == 0 &&
+         "Reference count overflow detected in urEventRetain.");
 
   return UR_RESULT_SUCCESS;
 }
@@ -279,7 +281,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  assert(hEvent->getReferenceCount() == 0 && "Reference count overflow detected in urEventRelease.");
+  assert(hEvent->getReferenceCount() == 0 &&
+         "Reference count overflow detected in urEventRelease.");
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -142,8 +142,7 @@ ur_result_t ur_event_handle_t_::record() {
   try {
     EventId = Queue->getNextEventId();
     if (EventId == 0) {
-      detail::ur::die(
-          "Unrecoverable program state reached in event identifier overflow");
+      return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     UR_CHECK_ERROR(hipEventRecord(EvEnd, Stream));
     Result = UR_RESULT_SUCCESS;
@@ -274,8 +273,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  detail::ur::assertion(RefCount != 0,
-                        "Reference count overflow detected in urEventRetain.");
+  if (RefCount == 0) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -283,8 +283,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(hEvent->getReferenceCount() != 0,
-                        "Reference count overflow detected in urEventRelease.");
+  if (hEvent->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -141,9 +141,7 @@ ur_result_t ur_event_handle_t_::record() {
 
   try {
     EventId = Queue->getNextEventId();
-    if (EventId == 0) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert (EventId == 0 && "Unrecoverable program state reached in event identifier overflow.");
     UR_CHECK_ERROR(hipEventRecord(EvEnd, Stream));
     Result = UR_RESULT_SUCCESS;
   } catch (ur_result_t Error) {
@@ -273,9 +271,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 
-  if (RefCount == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(RefCount == 0 && "Reference count overflow detected in urEventRetain.");
 
   return UR_RESULT_SUCCESS;
 }
@@ -283,9 +279,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hEvent->getReferenceCount() == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(hEvent->getReferenceCount() == 0 && "Reference count overflow detected in urEventRelease.");
 
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -296,9 +296,7 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
       if (Format != HIP_AD_FORMAT_UNSIGNED_INT32 &&
           Format != HIP_AD_FORMAT_SIGNED_INT32 &&
           Format != HIP_AD_FORMAT_HALF && Format != HIP_AD_FORMAT_FLOAT) {
-        detail::ur::die(
-            "UR HIP kernels only support images with channel types int32, "
-            "uint32, float, and half.");
+        return UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
       }
       hipSurfaceObject_t hipSurf =
           std::get<SurfaceMem>(hArgValue->Mem).getSurface(Device);

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -245,7 +245,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
           throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 #else
           HIP_ARRAY3D_DESCRIPTOR ArrayDescriptor;
-          UR_CHECK_ERROR(hipArray3DGetDescriptor(&ArrayDescriptor, Mem.Array));
+          UR_CHECK_ERROR(
+              hipArray3DGetDescriptor(&ArrayDescriptor, Mem.getArray(Device)));
           int PixelSize = 0;
           UR_RETURN_ON_FAILURE(
               imageElementByteSize(ArrayDescriptor.Format, &PixelSize));

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -71,7 +71,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
     // error for which it is unclear if the function that reported it succeeded
     // or not. Either way, the state of the program is compromised and likely
     // unrecoverable.
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+    assert(!"Unrecoverable program state reached in urMemRelease");
   }
 
   return UR_RESULT_SUCCESS;
@@ -245,11 +245,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
           throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 #else
           HIP_ARRAY3D_DESCRIPTOR ArrayDescriptor;
-          UR_CHECK_ERROR(
-              hipArray3DGetDescriptor(&ArrayDescriptor, Mem.getArray(Device)));
-          const auto PixelSizeBytes =
-              imageElementByteSize(ArrayDescriptor.Format) *
-              ArrayDescriptor.NumChannels;
+          UR_CHECK_ERROR(hipArray3DGetDescriptor(&ArrayDescriptor, Mem.Array));
+          int PixelSize = 0;
+          UR_RETURN_ON_FAILURE(
+              imageElementByteSize(ArrayDescriptor.Format, &PixelSize));
+          const auto PixelSizeBytes = PixelSize * ArrayDescriptor.NumChannels;
           const auto ImageSizeBytes =
               PixelSizeBytes *
               (ArrayDescriptor.Width ? ArrayDescriptor.Width : 1) *

--- a/source/adapters/hip/memory.hpp
+++ b/source/adapters/hip/memory.hpp
@@ -242,7 +242,7 @@ public:
       break;
     default:
       // urMemImageCreate given unsupported image_channel_data_type
-      detail::ur::die("Bad image format given to ur_image_ constructor");
+      assert(!"Bad image format given to ur_image_ constructor");
     }
   }
 

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -261,8 +261,8 @@ ur_result_t getKernelNames(ur_program_handle_t) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramCreateWithIL(ur_context_handle_t, const void *, size_t,
                       const ur_program_properties_t *, ur_program_handle_t *) {
-  detail::ur::die("urProgramCreateWithIL not implemented for HIP adapter"
-                  " please use urProgramCreateWithBinary instead");
+  assert(!"urProgramCreateWithIL not implemented for HIP adapter"
+          " please use urProgramCreateWithBinary instead");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -149,8 +149,10 @@ ur_result_t ur_program_handle_t_::finalizeRelocatable() {
 
   std::string ISA = "amdgcn-amd-amdhsa--";
   hipDeviceProp_t Props;
-  detail::ur::assertion(hipGetDeviceProperties(&Props, getDevice()->get()) ==
-                        hipSuccess);
+  if (hipGetDeviceProperties(&Props, Context->getDevice()->get()) !=
+      hipSuccess) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
   ISA += Props.gcnArchName;
   UR_CHECK_ERROR(amd_comgr_action_info_set_isa_name(Action, ISA.data()));
 

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -287,12 +287,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   UR_CHECK_ERROR(hipStreamGetFlags(HIPStream, &HIPFlags));
 
   ur_queue_flags_t Flags = 0;
-  if (HIPFlags == hipStreamDefault)
+  if (HIPFlags == hipStreamDefault) {
     Flags = UR_QUEUE_FLAG_USE_DEFAULT_STREAM;
-  else if (HIPFlags == hipStreamNonBlocking)
+  } else if (HIPFlags == hipStreamNonBlocking) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
-  else
-    detail::ur::die("Unknown hip stream");
+  } else {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   std::vector<hipStream_t> ComputeHIPStreams(1, HIPStream);
   std::vector<hipStream_t> TransferHIPStreams(0);

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -292,7 +292,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   } else if (HIPFlags == hipStreamNonBlocking) {
     Flags = UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM;
   } else {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+    assert(!"Unknown hip stream.");
   }
 
   std::vector<hipStream_t> ComputeHIPStreams(1, HIPStream);

--- a/source/adapters/hip/sampler.cpp
+++ b/source/adapters/hip/sampler.cpp
@@ -68,9 +68,9 @@ ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  detail::ur::assertion(
-      hSampler->getReferenceCount() != 0,
-      "Reference count overflow detected in urSamplerRelease.");
+  if (hSampler->getReferenceCount() == 0) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/sampler.cpp
+++ b/source/adapters/hip/sampler.cpp
@@ -68,9 +68,7 @@ ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  if (hSampler->getReferenceCount() == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(hSampler->getReferenceCount() == 0 && "Reference count overflow detected in urSamplerRelease.");
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/hip/sampler.cpp
+++ b/source/adapters/hip/sampler.cpp
@@ -68,7 +68,8 @@ ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
   // double delete or someone is messing with the ref count.
   // either way, cannot safely proceed.
-  assert(hSampler->getReferenceCount() == 0 && "Reference count overflow detected in urSamplerRelease.");
+  assert(hSampler->getReferenceCount() == 0 &&
+         "Reference count overflow detected in urSamplerRelease.");
 
   // decrement ref count. If it is 0, delete the sampler.
   if (hSampler->decrementReferenceCount() == 0) {

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -125,7 +125,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(
 
   default:
     // TODO: implement other parameters
-    die("urGetContextInfo: unsuppported ParamName.");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 
   return UR_RESULT_SUCCESS;
@@ -584,8 +584,9 @@ ur_context_handle_t_::decrementUnreleasedEventsInPool(ur_event_handle_t Event) {
       Event->isHostVisible(), Event->isProfilingEnabled(), ZeDevice);
 
   // Put the empty pool to the cache of the pools.
-  if (NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0)
-    die("Invalid event release: event pool doesn't have unreleased events");
+  if (NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0) {
+    return UR_RESULT_ERROR_INVALID_OPERATION;
+  }
   if (--NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0) {
     if (ZePoolCache->front() != Event->ZeEventPool) {
       ZePoolCache->push_back(Event->ZeEventPool);

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -584,7 +584,8 @@ ur_context_handle_t_::decrementUnreleasedEventsInPool(ur_event_handle_t Event) {
       Event->isHostVisible(), Event->isProfilingEnabled(), ZeDevice);
 
   // Put the empty pool to the cache of the pools.
-  assert(NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0 && "Invalid event release: event pool doesn't have unreleased events");
+  assert(NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0 &&
+         "Invalid event release: event pool doesn't have unreleased events");
   if (--NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0) {
     if (ZePoolCache->front() != Event->ZeEventPool) {
       ZePoolCache->push_back(Event->ZeEventPool);

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -584,9 +584,7 @@ ur_context_handle_t_::decrementUnreleasedEventsInPool(ur_event_handle_t Event) {
       Event->isHostVisible(), Event->isProfilingEnabled(), ZeDevice);
 
   // Put the empty pool to the cache of the pools.
-  if (NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0) {
-    return UR_RESULT_ERROR_INVALID_OPERATION;
-  }
+  assert(NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0 && "Invalid event release: event pool doesn't have unreleased events");
   if (--NumEventsUnreleasedInEventPool[Event->ZeEventPool] == 0) {
     if (ZePoolCache->front() != Event->ZeEventPool) {
       ZePoolCache->push_back(Event->ZeEventPool);

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -662,7 +662,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT:
       return ReturnValue(MapCaps(Props->sharedSystemAllocCapabilities));
     default:
-      die("urDeviceGetInfo: unexpected ParamName.");
+      return UR_RESULT_ERROR_INVALID_ENUMERATION;
     }
   }
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -594,7 +594,8 @@ ur_result_t ur_event_handle_t_::getOrCreateHostVisibleEvent(
                                                           this->Mutex);
 
   if (!HostVisibleEvent) {
-    assert(UrQueue->ZeEventsScope != OnDemandHostVisibleProxy && "getOrCreateHostVisibleEvent: missing host-visible event");
+    assert(UrQueue->ZeEventsScope != OnDemandHostVisibleProxy &&
+           "getOrCreateHostVisibleEvent: missing host-visible event");
 
     // Submit the command(s) signalling the proxy event to the queue.
     // We have to first submit a wait for the device-only event for which this
@@ -642,7 +643,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
       //
       ur_event_handle_t_ *Event =
           ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
-      assert(!Event->hasExternalRefs() && "urEventsWait must not be called for an internal event");
+      assert(!Event->hasExternalRefs() &&
+             "urEventsWait must not be called for an internal event");
 
       ze_event_handle_t ZeHostVisibleEvent;
       if (auto Res = Event->getOrCreateHostVisibleEvent(ZeHostVisibleEvent))
@@ -667,7 +669,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
           ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
       {
         std::shared_lock<ur_shared_mutex> EventLock(Event->Mutex);
-        assert(!Event->hasExternalRefs() && "urEventWait must not be called for an internal event");
+        assert(!Event->hasExternalRefs() &&
+               "urEventWait must not be called for an internal event");
 
         if (!Event->Completed) {
           auto HostVisibleEvent = Event->HostVisibleEvent;

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -594,9 +594,7 @@ ur_result_t ur_event_handle_t_::getOrCreateHostVisibleEvent(
                                                           this->Mutex);
 
   if (!HostVisibleEvent) {
-    if (UrQueue->ZeEventsScope != OnDemandHostVisibleProxy) {
-      return UR_RESULT_ERROR_INVALID_EVENT;
-    }
+    assert(UrQueue->ZeEventsScope != OnDemandHostVisibleProxy && "getOrCreateHostVisibleEvent: missing host-visible event");
 
     // Submit the command(s) signalling the proxy event to the queue.
     // We have to first submit a wait for the device-only event for which this
@@ -644,9 +642,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
       //
       ur_event_handle_t_ *Event =
           ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
-      if (!Event->hasExternalRefs()) {
-        return UR_RESULT_ERROR_INVALID_OPERATION;
-      }
+      assert(!Event->hasExternalRefs() && "urEventsWait must not be called for an internal event");
 
       ze_event_handle_t ZeHostVisibleEvent;
       if (auto Res = Event->getOrCreateHostVisibleEvent(ZeHostVisibleEvent))
@@ -671,15 +667,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
           ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
       {
         std::shared_lock<ur_shared_mutex> EventLock(Event->Mutex);
-        if (!Event->hasExternalRefs()) {
-          return UR_RESULT_ERROR_INVALID_OPERATION;
-        }
+        assert(!Event->hasExternalRefs() && "urEventWait must not be called for an internal event");
 
         if (!Event->Completed) {
           auto HostVisibleEvent = Event->HostVisibleEvent;
-          if (!HostVisibleEvent) {
-            return UR_RESULT_ERROR_INVALID_EVENT;
-          }
+          assert(!HostVisibleEvent && "The host-visible proxy event missing");
 
           ze_event_handle_t ZeEvent = HostVisibleEvent->ZeEvent;
           urPrint("ZeEvent = %#llx\n", ur_cast<std::uintptr_t>(ZeEvent));

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -316,8 +316,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
   }
   default:
     urPrint("format channel order = %d\n", ImageFormat->channelOrder);
-    die("ur2zeImageDesc: unsupported image channel order\n");
-    break;
+    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
   }
 
   ze_image_format_t ZeFormatDesc = {
@@ -345,7 +344,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
     break;
   default:
     urPrint("ur2zeImageDesc: unsupported image type\n");
-    return UR_RESULT_ERROR_INVALID_VALUE;
+    return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
   }
 
   ZeImageDesc.stype = ZE_STRUCTURE_TYPE_IMAGE_DESC;

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -629,8 +629,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSubGroupInfo(
   } else if (PropName == UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL) {
     ReturnValue(uint32_t{Kernel->ZeKernelProperties->requiredSubgroupSize});
   } else {
-    die("urKernelGetSubGroupInfo: parameter not implemented");
-    return {};
+    return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -1443,7 +1443,7 @@ static ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
   }
   default:
     urPrint("format layout = %d\n", ImageFormat->channelOrder);
-    die("urMemImageCreate: unsupported image format layout\n");
+    return UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
     break;
   }
 
@@ -1498,8 +1498,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
 ) {
   // TODO: implement read-only, write-only
   if ((Flags & UR_MEM_FLAG_READ_WRITE) == 0) {
-    die("urMemImageCreate: Level-Zero implements only read-write buffer,"
-        "no read-only or write-only yet.");
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   std::shared_lock<ur_shared_mutex> Lock(Context->Mutex);
@@ -1655,7 +1654,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     } else if (Flags == 0 || (Flags == UR_MEM_FLAG_READ_WRITE)) {
       // Nothing more to do.
     } else
-      die("urMemBufferCreate: not implemented");
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 
   *RetBuffer = reinterpret_cast<ur_mem_handle_t>(Buffer);
@@ -1713,8 +1712,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   std::shared_lock<ur_shared_mutex> Guard(Buffer->Mutex);
 
   if (Flags != UR_MEM_FLAG_READ_WRITE) {
-    die("urMemBufferPartition: Level-Zero implements only read-write buffer,"
-        "no read-only or write-only yet.");
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   try {
@@ -1780,7 +1778,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     // Memory allocation is unrelated to the context
     return UR_RESULT_ERROR_INVALID_CONTEXT;
   default:
-    die("Unexpected memory type");
+    return UR_RESULT_ERROR_MEM_OBJECT_ALLOCATION_FAILURE;
   }
 
   ur_device_handle_t Device{};
@@ -1877,7 +1875,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(
     return ReturnValue(size_t{Buffer->Size});
   }
   default: {
-    die("urMemGetInfo: Parameter is not implemented");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
   }
 
@@ -2061,7 +2059,7 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
   if (!Allocation.Valid) {
     // LastDeviceWithValidAllocation should always have valid allocation.
     if (Device == LastDeviceWithValidAllocation)
-      die("getZeHandle: last used allocation is not valid");
+      return UR_RESULT_ERROR_INVALID_OPERATION;
 
     // For write-only access the allocation contents is not going to be used.
     // So don't do anything to make it "valid".
@@ -2195,7 +2193,7 @@ ur_result_t _ur_buffer::free() {
       ZeUSMImport.doZeUSMRelease(UrContext->getPlatform()->ZeDriver, ZeHandle);
       break;
     default:
-      die("_ur_buffer::free(): Unhandled release action");
+      return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     ZeHandle = nullptr; // don't leave hanging pointers
   }

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -2058,7 +2058,8 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
   // If some prior access invalidated this allocation then make it valid again.
   if (!Allocation.Valid) {
     // LastDeviceWithValidAllocation should always have valid allocation.
-    assert(Device == LastDeviceWithValidAllocation && "getZeHandle: last used allocation is not valid.");
+    assert(Device == LastDeviceWithValidAllocation &&
+           "getZeHandle: last used allocation is not valid.");
 
     // For write-only access the allocation contents is not going to be used.
     // So don't do anything to make it "valid".

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -2058,8 +2058,7 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
   // If some prior access invalidated this allocation then make it valid again.
   if (!Allocation.Valid) {
     // LastDeviceWithValidAllocation should always have valid allocation.
-    if (Device == LastDeviceWithValidAllocation)
-      return UR_RESULT_ERROR_INVALID_OPERATION;
+    assert(Device == LastDeviceWithValidAllocation && "getZeHandle: last used allocation is not valid.");
 
     // For write-only access the allocation contents is not going to be used.
     // So don't do anything to make it "valid".
@@ -2193,7 +2192,7 @@ ur_result_t _ur_buffer::free() {
       ZeUSMImport.doZeUSMRelease(UrContext->getPlatform()->ZeDriver, ZeHandle);
       break;
     default:
-      return UR_RESULT_ERROR_INVALID_OPERATION;
+      assert(!"_ur_buffer::free(): Unhandled release action");
     }
     ZeHandle = nullptr; // don't leave hanging pointers
   }

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -718,7 +718,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetInfo(
       return UR_RESULT_ERROR_UNKNOWN;
     }
   default:
-    die("urProgramGetInfo: not implemented");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 
   return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -162,13 +162,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(
   case UR_QUEUE_INFO_REFERENCE_COUNT:
     return ReturnValue(uint32_t{Queue->RefCount.load()});
   case UR_QUEUE_INFO_FLAGS:
-    die("UR_QUEUE_INFO_FLAGS in urQueueGetInfo not implemented\n");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     break;
   case UR_QUEUE_INFO_SIZE:
-    die("UR_QUEUE_INFO_SIZE in urQueueGetInfo not implemented\n");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     break;
   case UR_QUEUE_INFO_DEVICE_DEFAULT:
-    die("UR_QUEUE_INFO_DEVICE_DEFAULT in urQueueGetInfo not implemented\n");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     break;
   case UR_QUEUE_INFO_EMPTY: {
     // We can exit early if we have in-order queue.
@@ -792,7 +792,7 @@ static const zeCommandListBatchConfig ZeCommandListBatchConfig(bool IsCopy) {
           Config.NumTimesClosedFullThreshold = Val;
           break;
         default:
-          die("Unexpected batch config");
+          urPrint("Unexpected batch config");
         }
         if (IsCopy)
           urPrint("UR_L0_COPY_BATCH_SIZE: dynamic batch param "
@@ -910,7 +910,7 @@ ur_queue_handle_t_::ur_queue_handle_t_(
       ComputeQueueGroup.UpperIndex = FilterUpperIndex;
       ComputeQueueGroup.NextIndex = ComputeQueueGroup.LowerIndex;
     } else {
-      die("No compute queue available/allowed.");
+      urPrint("No compute queue available/allowed.");
     }
   }
   if (UsingImmCmdLists) {
@@ -1067,8 +1067,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
 
       if (hasOpenCommandList(UseCopyEngine) &&
           CommandBatch.OpenCommandList != CommandList)
-        die("executeCommandList: OpenCommandList should be equal to"
-            "null or CommandList");
+        return UR_RESULT_ERROR_INVALID_ARGUMENT;
 
       if (CommandList->second.size() < CommandBatch.QueueBatchSize) {
         CommandBatch.OpenCommandList = CommandList;
@@ -1830,7 +1829,7 @@ ur_queue_handle_t_::ur_queue_group_t::getZeQueue(uint32_t *QueueGroupOrdinal) {
       zeCommandQueueCreate, (Queue->Context->ZeContext, Queue->Device->ZeDevice,
                              &ZeCommandQueueDesc, &ZeQueue));
   if (ZeResult) {
-    die("[L0] getZeQueue: failed to create queue");
+    urPrint("[L0] getZeQueue: failed to create queue");
   }
 
   return ZeQueue;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -792,7 +792,7 @@ static const zeCommandListBatchConfig ZeCommandListBatchConfig(bool IsCopy) {
           Config.NumTimesClosedFullThreshold = Val;
           break;
         default:
-          urPrint("Unexpected batch config");
+          assert(!"Unexpected batch config");
         }
         if (IsCopy)
           urPrint("UR_L0_COPY_BATCH_SIZE: dynamic batch param "
@@ -910,7 +910,7 @@ ur_queue_handle_t_::ur_queue_handle_t_(
       ComputeQueueGroup.UpperIndex = FilterUpperIndex;
       ComputeQueueGroup.NextIndex = ComputeQueueGroup.LowerIndex;
     } else {
-      urPrint("No compute queue available/allowed.");
+      assert(!"No compute queue available/allowed.");
     }
   }
   if (UsingImmCmdLists) {
@@ -1065,9 +1065,9 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
     if (OKToBatchCommand && this->isBatchingAllowed(UseCopyEngine) &&
         (!ZeCommandListBatchConfig.dynamic() || !CurrentlyEmpty)) {
 
-      if (hasOpenCommandList(UseCopyEngine) &&
-          CommandBatch.OpenCommandList != CommandList)
-        return UR_RESULT_ERROR_INVALID_ARGUMENT;
+      assert((hasOpenCommandList(UseCopyEngine) &&
+          CommandBatch.OpenCommandList != CommandList) && "executeCommandList: OpenCommandList should be equal to"
+            "null or CommandList");
 
       if (CommandList->second.size() < CommandBatch.QueueBatchSize) {
         CommandBatch.OpenCommandList = CommandList;
@@ -1829,7 +1829,7 @@ ur_queue_handle_t_::ur_queue_group_t::getZeQueue(uint32_t *QueueGroupOrdinal) {
       zeCommandQueueCreate, (Queue->Context->ZeContext, Queue->Device->ZeDevice,
                              &ZeCommandQueueDesc, &ZeQueue));
   if (ZeResult) {
-    urPrint("[L0] getZeQueue: failed to create queue");
+    assert(!"[L0] getZeQueue: failed to create queue");
   }
 
   return ZeQueue;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1066,8 +1066,9 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
         (!ZeCommandListBatchConfig.dynamic() || !CurrentlyEmpty)) {
 
       assert((hasOpenCommandList(UseCopyEngine) &&
-          CommandBatch.OpenCommandList != CommandList) && "executeCommandList: OpenCommandList should be equal to"
-            "null or CommandList");
+              CommandBatch.OpenCommandList != CommandList) &&
+             "executeCommandList: OpenCommandList should be equal to"
+             "null or CommandList");
 
       if (CommandList->second.size() < CommandBatch.QueueBatchSize) {
         CommandBatch.OpenCommandList = CommandList;

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -949,7 +949,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
     ContextsLock.lock();
     auto It = Context->MemAllocs.find(Ptr);
     if (It == std::end(Context->MemAllocs)) {
-      die("All memory allocations must be tracked!");
+      return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
@@ -996,7 +996,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
   if (IndirectAccessTrackingEnabled) {
     auto It = Context->MemAllocs.find(Ptr);
     if (It == std::end(Context->MemAllocs)) {
-      die("All memory allocations must be tracked!");
+      return UR_RESULT_ERROR_INVALID_OPERATION;
     }
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -948,7 +948,8 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
   if (IndirectAccessTrackingEnabled) {
     ContextsLock.lock();
     auto It = Context->MemAllocs.find(Ptr);
-    assert(It == std::end(Context->MemAllocs) && "All memory allocations must be tracked!");
+    assert(It == std::end(Context->MemAllocs) &&
+           "All memory allocations must be tracked!");
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
@@ -993,7 +994,8 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
 
   if (IndirectAccessTrackingEnabled) {
     auto It = Context->MemAllocs.find(Ptr);
-    assert(It == std::end(Context->MemAllocs) && "All memory allocations must be tracked!");
+    assert(It == std::end(Context->MemAllocs) &&
+           "All memory allocations must be tracked!");
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -948,9 +948,7 @@ ur_result_t ZeMemFreeHelper(ur_context_handle_t Context, void *Ptr) {
   if (IndirectAccessTrackingEnabled) {
     ContextsLock.lock();
     auto It = Context->MemAllocs.find(Ptr);
-    if (It == std::end(Context->MemAllocs)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(It == std::end(Context->MemAllocs) && "All memory allocations must be tracked!");
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;
@@ -995,9 +993,7 @@ ur_result_t USMFreeHelper(ur_context_handle_t Context, void *Ptr,
 
   if (IndirectAccessTrackingEnabled) {
     auto It = Context->MemAllocs.find(Ptr);
-    if (It == std::end(Context->MemAllocs)) {
-      return UR_RESULT_ERROR_INVALID_OPERATION;
-    }
+    assert(It == std::end(Context->MemAllocs) && "All memory allocations must be tracked!");
     if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return UR_RESULT_SUCCESS;

--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -20,29 +20,21 @@
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t, ur_device_handle_t,
     const ur_exp_command_buffer_desc_t *, ur_exp_command_buffer_handle_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferRetainExp(ur_exp_command_buffer_handle_t) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -50,10 +42,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t, ur_kernel_handle_t, uint32_t,
     const size_t *, const size_t *, const size_t *, uint32_t,
     const ur_exp_command_buffer_sync_point_t *,
-    ur_exp_command_buffer_sync_point_t *,
-    ur_exp_command_buffer_command_handle_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
+    ur_exp_command_buffer_sync_point_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -61,8 +50,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t, void *, const void *, size_t, uint32_t,
     const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -70,8 +57,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t, ur_mem_handle_t, ur_mem_handle_t, size_t,
     size_t, size_t, uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -80,8 +65,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur_rect_offset_t, ur_rect_offset_t, ur_rect_region_t, size_t, size_t,
     size_t, size_t, uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -90,8 +73,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t, ur_mem_handle_t, size_t, size_t,
     const void *, uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -100,8 +81,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t, ur_mem_handle_t, size_t, size_t, void *,
     uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -111,8 +90,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur_rect_offset_t, ur_rect_region_t, size_t, size_t, size_t, size_t, void *,
     uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -122,16 +99,12 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur_rect_offset_t, ur_rect_region_t, size_t, size_t, size_t, size_t, void *,
     uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t, ur_queue_handle_t, uint32_t,
     const ur_event_handle_t *, ur_event_handle_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/native_cpu/common.cpp
+++ b/source/adapters/native_cpu/common.cpp
@@ -27,8 +27,3 @@ ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
   *ppMessage = &ErrorMessage[0];
   return ErrorMessageCode;
 }
-
-void detail::ur::die(const char *pMessage) {
-  std::cerr << "ur_die: " << pMessage << '\n';
-  std::terminate();
-}

--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -17,45 +17,6 @@ constexpr size_t MaxMessageSize = 256;
 extern thread_local ur_result_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
 
-#define DIE_NO_IMPLEMENTATION                                                  \
-  if (PrintTrace) {                                                            \
-    std::cerr << "Not Implemented : " << __FUNCTION__                          \
-              << " - File : " << __FILE__;                                     \
-    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
-  }                                                                            \
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-
-#define CONTINUE_NO_IMPLEMENTATION                                             \
-  if (PrintTrace) {                                                            \
-    std::cerr << "Warning : Not Implemented : " << __FUNCTION__                \
-              << " - File : " << __FILE__;                                     \
-    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
-  }                                                                            \
-  return UR_RESULT_SUCCESS;
-
-#define CASE_UR_UNSUPPORTED(not_supported)                                     \
-  case not_supported:                                                          \
-    if (PrintTrace) {                                                          \
-      std::cerr << std::endl                                                   \
-                << "Unsupported UR case : " << #not_supported << " in "        \
-                << __FUNCTION__ << ":" << __LINE__ << "(" << __FILE__ << ")"   \
-                << std::endl;                                                  \
-    }                                                                          \
-    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-
-/// ------ Error handling, matching OpenCL plugin semantics.
-/// Taken from other adapter
-namespace detail {
-namespace ur {
-
-// Report error and no return (keeps compiler from printing warnings).
-// TODO: Probably change that to throw a catchable exception,
-//       but for now it is useful to see every failure.
-//
-[[noreturn]] void die(const char *pMessage);
-} // namespace ur
-} // namespace detail
-
 // Base class to store common data
 struct _ur_object {
   ur_shared_mutex Mutex;

--- a/source/adapters/native_cpu/context.cpp
+++ b/source/adapters/native_cpu/context.cpp
@@ -75,7 +75,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ur_native_handle_t *phNativeContext) {
   std::ignore = hContext;
   std::ignore = phNativeContext;
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
@@ -89,7 +89,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phContext;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
@@ -99,5 +99,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
   std::ignore = pfnDeleter;
   std::ignore = pUserData;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -300,12 +300,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_ESIMD_SUPPORT:
     return ReturnValue(false);
-  case UR_DEVICE_INFO_COMPONENT_DEVICES:
-  case UR_DEVICE_INFO_COMPOSITE_DEVICE:
-    // These two are exclusive of L0.
-    return ReturnValue(0);
-
-    CASE_UR_UNSUPPORTED(UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
     return ReturnValue(false);
 
@@ -314,9 +308,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(false);
 
   default:
-    DIE_NO_IMPLEMENTATION;
+    return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
-  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
@@ -342,7 +335,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
   std::ignore = phSubDevices;
   std::ignore = pNumDevicesRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
@@ -350,7 +343,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
   std::ignore = hDevice;
   std::ignore = phNativeDevice;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
@@ -362,7 +355,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phDevice;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(

--- a/source/adapters/native_cpu/enqueue.cpp
+++ b/source/adapters/native_cpu/enqueue.cpp
@@ -56,7 +56,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   UR_ASSERT(workDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
   if (*pGlobalWorkSize == 0) {
-    DIE_NO_IMPLEMENTATION;
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   // TODO: add proper error checking
@@ -107,7 +107,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
@@ -118,7 +118,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 template <bool IsRead>
@@ -286,7 +286,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
@@ -306,7 +306,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
@@ -325,7 +325,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
@@ -410,7 +410,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -422,7 +422,7 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
   std::ignore = advice;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
@@ -441,7 +441,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
@@ -461,7 +461,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
@@ -480,7 +480,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
@@ -499,7 +499,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
@@ -517,7 +517,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
@@ -535,5 +535,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/event.cpp
+++ b/source/adapters/native_cpu/event.cpp
@@ -23,7 +23,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
@@ -35,7 +35,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -49,12 +49,12 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   std::ignore = hEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   std::ignore = hEvent;
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
@@ -62,7 +62,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
   std::ignore = hEvent;
   std::ignore = phNativeEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
@@ -74,7 +74,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phEvent;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -85,5 +85,5 @@ urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
   std::ignore = pfnNotify;
   std::ignore = pUserData;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/kernel.cpp
+++ b/source/adapters/native_cpu/kernel.cpp
@@ -98,6 +98,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
   default:
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -176,7 +177,7 @@ urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
     ur::unreachable();
   }
   }
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
@@ -231,7 +232,7 @@ urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
   std::ignore = pProperties;
   std::ignore = hArgValue;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -262,7 +263,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
   std::ignore = count;
   std::ignore = pSpecConstants;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
@@ -270,7 +271,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
   std::ignore = hKernel;
   std::ignore = phNativeKernel;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
@@ -284,5 +285,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phKernel;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/memory.cpp
+++ b/source/adapters/native_cpu/memory.cpp
@@ -23,7 +23,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
   std::ignore = pHost;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
@@ -65,7 +65,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
   std::ignore = hMem;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
@@ -93,8 +93,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   std::shared_lock<ur_shared_mutex> Guard(hBuffer->Mutex);
 
   if (flags != UR_MEM_FLAG_READ_WRITE) {
-    die("urMemBufferPartition: NativeCPU implements only read-write buffer,"
-        "no read-only or write-only yet.");
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   try {
@@ -117,7 +116,7 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_device_handle_t hDevice,
   std::ignore = hDevice;
   std::ignore = phNativeMem;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
@@ -128,7 +127,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
@@ -142,7 +141,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phMem;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
@@ -156,7 +155,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
@@ -170,5 +169,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/platform.cpp
+++ b/source/adapters/native_cpu/platform.cpp
@@ -81,7 +81,7 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
     // https://github.com/oneapi-src/unified-runtime
     return ReturnValue(UR_PLATFORM_BACKEND_NATIVE_CPU);
   default:
-    DIE_NO_IMPLEMENTATION;
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
   return UR_RESULT_SUCCESS;
@@ -94,7 +94,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
   std::ignore = pFrontendOption;
   std::ignore = ppPlatformOption;
 
-  CONTINUE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
@@ -105,7 +105,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phPlatform;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
@@ -113,5 +113,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
   std::ignore = hPlatform;
   std::ignore = phNativePlatform;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -139,7 +139,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
   std::ignore = pGlobalVariableSizeRet;
   std::ignore = ppGlobalVariablePointerRet;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -23,7 +23,7 @@ urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
   std::ignore = pProperties;
   std::ignore = phProgram;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
@@ -71,7 +71,7 @@ urProgramCompile(ur_context_handle_t hContext, ur_program_handle_t hProgram,
   std::ignore = hProgram;
   std::ignore = pOptions;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -84,7 +84,7 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
   std::ignore = pOptions;
   std::ignore = phProgram;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCompileExp(ur_program_handle_t,
@@ -127,7 +127,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   std::ignore = pFunctionName;
   std::ignore = ppFunctionPointer;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
@@ -185,7 +185,7 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  CONTINUE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
@@ -195,7 +195,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
   std::ignore = count;
   std::ignore = pSpecConstants;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
@@ -203,7 +203,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
   std::ignore = hProgram;
   std::ignore = phNativeProgram;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
@@ -215,5 +215,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phProgram;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/queue.cpp
+++ b/source/adapters/native_cpu/queue.cpp
@@ -25,7 +25,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
@@ -38,7 +38,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   auto Queue = new ur_queue_handle_t_();
   *phQueue = Queue;
 
-  CONTINUE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
@@ -61,7 +61,7 @@ urQueueGetNativeHandle(ur_queue_handle_t hQueue, ur_queue_native_desc_t *pDesc,
   std::ignore = pDesc;
   std::ignore = phNativeQueue;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
@@ -74,7 +74,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phQueue;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
@@ -86,5 +86,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
 UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
   std::ignore = hQueue;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/sampler.cpp
+++ b/source/adapters/native_cpu/sampler.cpp
@@ -19,21 +19,21 @@ urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
   std::ignore = pDesc;
   std::ignore = phSampler;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRetain(ur_sampler_handle_t hSampler) {
   std::ignore = hSampler;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerRelease(ur_sampler_handle_t hSampler) {
   std::ignore = hSampler;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -45,7 +45,7 @@ urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
@@ -53,7 +53,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
   std::ignore = hSampler;
   std::ignore = phNativeSampler;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
@@ -65,5 +65,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
   std::ignore = pProperties;
   std::ignore = phSampler;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/usm.cpp
+++ b/source/adapters/native_cpu/usm.cpp
@@ -86,7 +86,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -96,21 +96,21 @@ urUSMPoolCreate(ur_context_handle_t hContext, ur_usm_pool_desc_t *pPoolDesc,
   std::ignore = pPoolDesc;
   std::ignore = ppPool;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMPoolRetain(ur_usm_pool_handle_t pPool) {
   std::ignore = pPool;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMPoolRelease(ur_usm_pool_handle_t pPool) {
   std::ignore = pPool;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -122,7 +122,7 @@ urUSMPoolGetInfo(ur_usm_pool_handle_t hPool, ur_usm_pool_info_t propName,
   std::ignore = pPropValue;
   std::ignore = pPropSizeRet;
 
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t Context,
@@ -130,12 +130,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMImportExp(ur_context_handle_t Context,
   std::ignore = Context;
   std::ignore = HostPtr;
   std::ignore = Size;
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMReleaseExp(ur_context_handle_t Context,
                                                     void *HostPtr) {
   std::ignore = Context;
   std::ignore = HostPtr;
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/usm_p2p.cpp
+++ b/source/adapters/native_cpu/usm_p2p.cpp
@@ -12,16 +12,16 @@
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUsmP2PEnablePeerAccessExp(ur_device_handle_t, ur_device_handle_t) {
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUsmP2PDisablePeerAccessExp(ur_device_handle_t, ur_device_handle_t) {
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUsmP2PPeerAccessGetInfoExp(ur_device_handle_t, ur_device_handle_t,
                              ur_exp_peer_info_t, size_t, void *, size_t *) {
-  DIE_NO_IMPLEMENTATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/opencl/command_buffer.cpp
+++ b/source/adapters/opencl/command_buffer.cpp
@@ -202,9 +202,6 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     [[maybe_unused]] const ur_exp_command_buffer_sync_point_t
         *pSyncPointWaitList,
     [[maybe_unused]] ur_exp_command_buffer_sync_point_t *pSyncPoint) {
-
-  cl_adapter::die("Experimental Command-buffer feature is not "
-                  "implemented for OpenCL adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/opencl/common.cpp
+++ b/source/adapters/opencl/common.cpp
@@ -90,11 +90,6 @@ ur_result_t mapCLErrorToUR(cl_int Result) {
   }
 }
 
-void cl_adapter::die(const char *Message) {
-  logger::always("ur_die: {}", Message);
-  std::terminate();
-}
-
 /// Common API for getting the native handle of a UR object
 ///
 /// \param URObj is the UR object to get the native handle of

--- a/source/adapters/opencl/common.hpp
+++ b/source/adapters/opencl/common.hpp
@@ -157,8 +157,6 @@ extern thread_local char ErrorMessage[MaxMessageSize];
 [[maybe_unused]] void setErrorMessage(const char *Message,
                                       ur_result_t ErrorCode);
 
-[[noreturn]] void die(const char *Message);
-
 template <class To, class From> To cast(From Value) {
 
   if constexpr (std::is_pointer_v<From>) {

--- a/source/adapters/opencl/common.hpp
+++ b/source/adapters/opencl/common.hpp
@@ -24,7 +24,7 @@
   }
 
 /**
- * Call an UR API and, if the result is not UR_RESULT_SUCCESS, automatically
+ * Call a UR API and, if the result is not UR_RESULT_SUCCESS, automatically
  * return from the current function.
  */
 #define UR_RETURN_ON_FAILURE(urCall)                                           \

--- a/source/adapters/opencl/sampler.cpp
+++ b/source/adapters/opencl/sampler.cpp
@@ -12,11 +12,13 @@
 
 namespace {
 
-cl_sampler_info ur2CLSamplerInfo(ur_sampler_info_t URInfo) {
+ur_result_t ur2CLSamplerInfo(ur_sampler_info_t URInfo,
+                             cl_sampler_info *CLInfo) {
   switch (URInfo) {
 #define CASE(UR_INFO, CL_INFO)                                                 \
   case UR_INFO:                                                                \
-    return CL_INFO;
+    *CLInfo = CL_INFO;                                                         \
+    return UR_RESULT_SUCCESS;
 
     CASE(UR_SAMPLER_INFO_REFERENCE_COUNT, CL_SAMPLER_REFERENCE_COUNT)
     CASE(UR_SAMPLER_INFO_CONTEXT, CL_SAMPLER_CONTEXT)
@@ -27,16 +29,17 @@ cl_sampler_info ur2CLSamplerInfo(ur_sampler_info_t URInfo) {
 #undef CASE
 
   default:
-    cl_adapter::die("Unhandled: ur_sampler_info_t");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 }
 
-cl_addressing_mode ur2CLAddressingMode(ur_sampler_addressing_mode_t Mode) {
+ur_result_t ur2CLAddressingMode(ur_sampler_addressing_mode_t Mode,
+                                cl_addressing_mode *CLMode) {
   switch (Mode) {
-
 #define CASE(UR_MODE, CL_MODE)                                                 \
   case UR_MODE:                                                                \
-    return CL_MODE;
+    *CLMode = CL_MODE;                                                         \
+    return UR_RESULT_SUCCESS;
 
     CASE(UR_SAMPLER_ADDRESSING_MODE_NONE, CL_ADDRESS_NONE);
     CASE(UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE, CL_ADDRESS_CLAMP_TO_EDGE);
@@ -48,16 +51,17 @@ cl_addressing_mode ur2CLAddressingMode(ur_sampler_addressing_mode_t Mode) {
 #undef CASE
 
   default:
-    cl_adapter::die("Unhandled: ur_sampler_addressing_mode_t");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 }
 
-cl_filter_mode ur2CLFilterMode(ur_sampler_filter_mode_t Mode) {
+ur_result_t ur2CLFilterMode(ur_sampler_filter_mode_t Mode,
+                            cl_filter_mode *CLMode) {
   switch (Mode) {
-
 #define CASE(UR_MODE, CL_MODE)                                                 \
   case UR_MODE:                                                                \
-    return CL_MODE;
+    *CLMode = CL_MODE;                                                         \
+    return UR_RESULT_SUCCESS;
 
     CASE(UR_SAMPLER_FILTER_MODE_NEAREST, CL_FILTER_NEAREST)
     CASE(UR_SAMPLER_FILTER_MODE_LINEAR, CL_FILTER_LINEAR)
@@ -65,16 +69,17 @@ cl_filter_mode ur2CLFilterMode(ur_sampler_filter_mode_t Mode) {
 #undef CASE
 
   default:
-    cl_adapter::die("Unhandled: ur_sampler_filter_mode_t");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 }
 
-ur_sampler_addressing_mode_t cl2URAddressingMode(cl_addressing_mode Mode) {
+ur_result_t cl2URAddressingMode(cl_addressing_mode Mode,
+                                ur_sampler_addressing_mode_t *URMode) {
   switch (Mode) {
-
 #define CASE(CL_MODE, UR_MODE)                                                 \
   case CL_MODE:                                                                \
-    return UR_MODE;
+    *URMode = UR_MODE;                                                         \
+    return UR_RESULT_SUCCESS;
 
     CASE(CL_ADDRESS_NONE, UR_SAMPLER_ADDRESSING_MODE_NONE);
     CASE(CL_ADDRESS_CLAMP_TO_EDGE, UR_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE);
@@ -86,15 +91,17 @@ ur_sampler_addressing_mode_t cl2URAddressingMode(cl_addressing_mode Mode) {
 #undef CASE
 
   default:
-    cl_adapter::die("Unhandled: cl_addressing_mode");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 }
 
-ur_sampler_filter_mode_t cl2URFilterMode(cl_filter_mode Mode) {
+ur_result_t cl2URFilterMode(cl_filter_mode Mode,
+                            ur_sampler_filter_mode_t *URMode) {
   switch (Mode) {
 #define CASE(CL_MODE, UR_MODE)                                                 \
   case CL_MODE:                                                                \
-    return UR_MODE;
+    *URMode = UR_MODE;                                                         \
+    return UR_RESULT_SUCCESS;
 
     CASE(CL_FILTER_NEAREST, UR_SAMPLER_FILTER_MODE_NEAREST)
     CASE(CL_FILTER_LINEAR, UR_SAMPLER_FILTER_MODE_LINEAR);
@@ -102,7 +109,7 @@ ur_sampler_filter_mode_t cl2URFilterMode(cl_filter_mode Mode) {
 #undef CASE
 
   default:
-    cl_adapter::die("Unhandled: cl_filter_mode");
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 }
 
@@ -114,14 +121,17 @@ void cl2URSamplerInfoValue(cl_sampler_info Info, void *InfoValue) {
   case CL_SAMPLER_ADDRESSING_MODE: {
     cl_addressing_mode CLValue =
         *reinterpret_cast<cl_addressing_mode *>(InfoValue);
+    ur_sampler_addressing_mode_t AddressingMode;
+    cl2URAddressingMode(CLValue, &AddressingMode);
     *reinterpret_cast<ur_sampler_addressing_mode_t *>(InfoValue) =
-        cl2URAddressingMode(CLValue);
+        AddressingMode;
     break;
   }
   case CL_SAMPLER_FILTER_MODE: {
     cl_filter_mode CLMode = *reinterpret_cast<cl_filter_mode *>(InfoValue);
-    *reinterpret_cast<ur_sampler_filter_mode_t *>(InfoValue) =
-        cl2URFilterMode(CLMode);
+    ur_sampler_filter_mode_t FilterMode;
+    cl2URFilterMode(CLMode, &FilterMode);
+    *reinterpret_cast<ur_sampler_filter_mode_t *>(InfoValue) = FilterMode;
     break;
   }
 
@@ -138,9 +148,11 @@ ur_result_t urSamplerCreate(ur_context_handle_t hContext,
 
   // Initialize properties according to OpenCL 2.1 spec.
   ur_result_t ErrorCode;
-  cl_addressing_mode AddressingMode =
-      ur2CLAddressingMode(pDesc->addressingMode);
-  cl_filter_mode FilterMode = ur2CLFilterMode(pDesc->filterMode);
+  cl_addressing_mode AddressingMode;
+  UR_RETURN_ON_FAILURE(
+      ur2CLAddressingMode(pDesc->addressingMode, &AddressingMode));
+  cl_filter_mode FilterMode;
+  UR_RETURN_ON_FAILURE(ur2CLFilterMode(pDesc->filterMode, &FilterMode));
 
   // Always call OpenCL 1.0 API
   *phSampler = cl_adapter::cast<ur_sampler_handle_t>(clCreateSampler(
@@ -154,7 +166,8 @@ ur_result_t urSamplerCreate(ur_context_handle_t hContext,
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
                  size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
-  cl_sampler_info SamplerInfo = ur2CLSamplerInfo(propName);
+  cl_sampler_info SamplerInfo;
+  UR_RETURN_ON_FAILURE(ur2CLSamplerInfo(propName, &SamplerInfo));
   static_assert(sizeof(cl_addressing_mode) ==
                 sizeof(ur_sampler_addressing_mode_t));
 

--- a/source/adapters/opencl/usm_p2p.cpp
+++ b/source/adapters/opencl/usm_p2p.cpp
@@ -13,18 +13,12 @@
 UR_APIEXPORT ur_result_t UR_APICALL
 urUsmP2PEnablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
                             [[maybe_unused]] ur_device_handle_t peerDevice) {
-
-  cl_adapter::die(
-      "Experimental P2P feature is not implemented for OpenCL adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urUsmP2PDisablePeerAccessExp([[maybe_unused]] ur_device_handle_t commandDevice,
                              [[maybe_unused]] ur_device_handle_t peerDevice) {
-
-  cl_adapter::die(
-      "Experimental P2P feature is not implemented for OpenCL adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -34,8 +28,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     [[maybe_unused]] ur_exp_peer_info_t propName,
     [[maybe_unused]] size_t propSize, [[maybe_unused]] void *pPropValue,
     [[maybe_unused]] size_t *pPropSizeRet) {
-
-  cl_adapter::die(
-      "Experimental P2P feature is not implemented for OpenCL adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -12,6 +12,7 @@
 
 #include "asan_interceptor.hpp"
 #include "ur_sanitizer_layer.hpp"
+#include <cassert>
 
 namespace ur_sanitizer_layer {
 
@@ -541,11 +542,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
     if (context.enabledType == SanitizerType::AddressSanitizer) {
         if (!(dditable->VirtualMem.pfnReserve && dditable->VirtualMem.pfnMap &&
               dditable->VirtualMem.pfnGranularityGetInfo)) {
-            die("Some VirtualMem APIs are needed to enable UR_LAYER_ASAN");
+            assert(!"Some VirtualMem APIs are needed to enable UR_LAYER_ASAN");
         }
 
         if (!dditable->PhysicalMem.pfnCreate) {
-            die("Some PhysicalMem APIs are needed to enable UR_LAYER_ASAN");
+            assert(!"Some PhysicalMem APIs are needed to enable UR_LAYER_ASAN");
         }
     }
 

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -54,12 +54,6 @@ const ur_command_t UR_EXT_COMMAND_TYPE_USER =
 #define __SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING "@global_id_mapping"
 #define __SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION "Requires finalization"
 
-// Terminates the process with a catastrophic error message.
-[[noreturn]] inline void die(const char *Message) {
-  std::cerr << "die: " << Message << std::endl;
-  std::terminate();
-}
-
 // A single-threaded app has an opportunity to enable this mode to avoid
 // overhead from mutex locking. Default value is 0 which means that single
 // thread mode is disabled.


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/1078. 

This PR attempts to replace all die/terminate calls with simply returning an appropriate error code. There may be a better code, or some kind of assert/abort may be more appropriate in some cases so any suggestions are appreciated.

intel-llvm run https://github.com/intel/llvm/pull/12076
