### PR TITLE
[UR][L0] Make urPlatformGetBackendOption return -ze-opt-level=2 for -O1 and -O2

### DIFF
--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -433,8 +433,8 @@ ur_result_t ur_platform_handle_t_::populateDeviceCacheIfNeeded() {
 // Returns plugin specific backend option.
 // Current support is only for optimization options.
 // Return '-ze-opt-disable' for frontend_option = -O0.
-// Return '-ze-opt-level=1' for frontend_option = -O1 or -O2.
-// Return '-ze-opt-level=2' for frontend_option = -O3.
+// Return '-ze-opt-level=1' for frontend_option = -O1.
+// Return '-ze-opt-level=2' for frontend_option = -O2 or -O3.
 // Return '-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'' for
 // frontend_option=-ftarget-compile-fast.
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
@@ -457,11 +457,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
     *PlatformOption = "-ze-opt-disable";
     return UR_RESULT_SUCCESS;
   }
-  if (FrontendOption == "-O1"sv || FrontendOption == "-O2"sv) {
+  if (FrontendOption == "-O1"sv) {
     *PlatformOption = "-ze-opt-level=1";
     return UR_RESULT_SUCCESS;
   }
-  if (FrontendOption == "-O3"sv) {
+  if (FrontendOption == "-O2"sv || FrontendOption == "-O3"sv) {
     *PlatformOption = "-ze-opt-level=2";
     return UR_RESULT_SUCCESS;
   }

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -433,8 +433,7 @@ ur_result_t ur_platform_handle_t_::populateDeviceCacheIfNeeded() {
 // Returns plugin specific backend option.
 // Current support is only for optimization options.
 // Return '-ze-opt-disable' for frontend_option = -O0.
-// Return '-ze-opt-level=1' for frontend_option = -O1.
-// Return '-ze-opt-level=2' for frontend_option = -O2 or -O3.
+// Return '-ze-opt-level=2' for frontend_option = -O1, -O2 or -O3.
 // Return '-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'' for
 // frontend_option=-ftarget-compile-fast.
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
@@ -457,11 +456,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
     *PlatformOption = "-ze-opt-disable";
     return UR_RESULT_SUCCESS;
   }
-  if (FrontendOption == "-O1"sv) {
-    *PlatformOption = "-ze-opt-level=1";
-    return UR_RESULT_SUCCESS;
-  }
-  if (FrontendOption == "-O2"sv || FrontendOption == "-O3"sv) {
+  if (FrontendOption == "-O1"sv || FrontendOption == "-O2"sv ||
+      FrontendOption == "-O3"sv) {
     *PlatformOption = "-ze-opt-level=2";
     return UR_RESULT_SUCCESS;
   }


### PR DESCRIPTION
IGC only accepts three values for -ze-opt-level, 0, 1 and 2, however dpcpp has at least four options, O0, O1, O2 and O3.

Right now we decided to map O1 and O2 to -ze-opt-level=1, but we have determined that this is not the best for user experience and may defy user expectation, and actually produces worse code than specifying nothing because IGC uses ze-opt-level=2 if nothing is specified.

https://github.com/intel/llvm/pull/12023