### PR TITLE
Remove ur_base_desc_t, use ur_base_properties_t instead.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -494,17 +494,9 @@ typedef enum ur_result_t {
 /// @brief Base for all properties types
 typedef struct ur_base_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
-
-} ur_base_properties_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Base for all descriptor types
-typedef struct ur_base_desc_t {
-    ur_structure_type_t stype; ///< [in] type of this structure
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
-} ur_base_desc_t;
+} ur_base_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief 3D offset argument passed to buffer rect operations
@@ -1149,7 +1141,7 @@ urPlatformGetNativeHandle(
 typedef struct ur_platform_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
                                ///< interoperability operation in the application that asked to not
                                ///< transfer the ownership to the unified-runtime.
@@ -1742,7 +1734,7 @@ typedef struct ur_device_partition_property_t {
 typedef struct ur_device_partition_properties_t {
     ur_structure_type_t stype;                         ///< [in] type of this structure, must be
                                                        ///< ::UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES
-    void *pNext;                                       ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;                                 ///< [in][optional] pointer to extension-specific structure
     const ur_device_partition_property_t *pProperties; ///< [in] Pointer to the beginning of the properties array.
     size_t PropCount;                                  ///< [in] The length of properties pointed to by `pProperties`.
 
@@ -1917,7 +1909,7 @@ urDeviceGetNativeHandle(
 typedef struct ur_device_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
                                ///< interoperability operation in the application that asked to not
                                ///< transfer the ownership to the unified-runtime.
@@ -2055,7 +2047,7 @@ typedef enum ur_context_flag_t {
 typedef struct ur_context_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_context_flags_t flags;  ///< [in] context creation flags.
 
 } ur_context_properties_t;
@@ -2258,7 +2250,7 @@ urContextGetNativeHandle(
 typedef struct ur_context_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an interoperability
                                ///< operation in the application that asked to not transfer the ownership to
                                ///< the unified-runtime.
@@ -2517,7 +2509,7 @@ urMemImageCreate(
 typedef struct ur_buffer_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_BUFFER_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     void *pHost;               ///< [in][optional] pointer to the buffer data
 
 } ur_buffer_properties_t;
@@ -2535,7 +2527,7 @@ typedef struct ur_buffer_properties_t {
 typedef struct ur_buffer_channel_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     uint32_t channel;          ///< [in] Identifies the channel/region to which the buffer should be mapped.
 
 } ur_buffer_channel_properties_t;
@@ -2553,7 +2545,7 @@ typedef struct ur_buffer_channel_properties_t {
 typedef struct ur_buffer_alloc_location_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     uint32_t location;         ///< [in] Identifies the ID of global memory partition to which the memory
                                ///< should be allocated.
 
@@ -2738,7 +2730,7 @@ urMemGetNativeHandle(
 typedef struct ur_mem_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
                                ///< interoperability operation in the application that asked to not
                                ///< transfer the ownership to the unified-runtime.
@@ -3104,7 +3096,7 @@ urSamplerGetNativeHandle(
 typedef struct ur_sampler_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
                                ///< interoperability operation in the application that asked to not
                                ///< transfer the ownership to the unified-runtime.
@@ -3876,7 +3868,7 @@ typedef enum ur_physical_mem_flag_t {
 typedef struct ur_physical_mem_properties_t {
     ur_structure_type_t stype;     ///< [in] type of this structure, must be
                                    ///< ::UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES
-    void *pNext;                   ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;             ///< [in][optional] pointer to extension-specific structure
     ur_physical_mem_flags_t flags; ///< [in] physical memory creation flags
 
 } ur_physical_mem_properties_t;
@@ -3988,7 +3980,7 @@ typedef struct ur_program_metadata_t {
 typedef struct ur_program_properties_t {
     ur_structure_type_t stype;               ///< [in] type of this structure, must be
                                              ///< ::UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES
-    void *pNext;                             ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;                       ///< [in][optional] pointer to extension-specific structure
     uint32_t count;                          ///< [in] the number of entries in pMetadatas, if count is greater than
                                              ///< zero then pMetadatas must not be null.
     const ur_program_metadata_t *pMetadatas; ///< [in][optional][range(0,count)] pointer to array of metadata entries.
@@ -4473,7 +4465,7 @@ urProgramGetNativeHandle(
 typedef struct ur_program_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an
                                ///< interoperability operation in the application that asked to not
                                ///< transfer the ownership to the unified-runtime.
@@ -4546,7 +4538,7 @@ urKernelCreate(
 typedef struct ur_kernel_arg_value_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_ARG_VALUE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_kernel_arg_value_properties_t;
 
@@ -4583,7 +4575,7 @@ urKernelSetArgValue(
 typedef struct ur_kernel_arg_local_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_ARG_LOCAL_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_kernel_arg_local_properties_t;
 
@@ -4838,7 +4830,7 @@ urKernelRelease(
 typedef struct ur_kernel_arg_pointer_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_ARG_POINTER_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_kernel_arg_pointer_properties_t;
 
@@ -4877,7 +4869,7 @@ urKernelSetArgPointer(
 typedef struct ur_kernel_exec_info_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_EXEC_INFO_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_kernel_exec_info_properties_t;
 
@@ -4919,7 +4911,7 @@ urKernelSetExecInfo(
 typedef struct ur_kernel_arg_sampler_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_ARG_SAMPLER_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
 } ur_kernel_arg_sampler_properties_t;
 
@@ -4953,7 +4945,7 @@ urKernelSetArgSampler(
 typedef struct ur_kernel_arg_mem_obj_properties_t {
     ur_structure_type_t stype;   ///< [in] type of this structure, must be
                                  ///< ::UR_STRUCTURE_TYPE_KERNEL_ARG_MEM_OBJ_PROPERTIES
-    void *pNext;                 ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;           ///< [in][optional] pointer to extension-specific structure
     ur_mem_flags_t memoryAccess; ///< [in] Memory access flag. Allowed values are: ::UR_MEM_FLAG_READ_WRITE,
                                  ///< ::UR_MEM_FLAG_WRITE_ONLY, ::UR_MEM_FLAG_READ_ONLY.
 
@@ -5056,7 +5048,7 @@ urKernelGetNativeHandle(
 typedef struct ur_kernel_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an interoperability
                                ///< operation in the application that asked to not transfer the ownership to
                                ///< the unified-runtime.
@@ -5191,7 +5183,7 @@ urQueueGetInfo(
 typedef struct ur_queue_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_QUEUE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     ur_queue_flags_t flags;    ///< [in] Bitfield of queue creation flags
 
 } ur_queue_properties_t;
@@ -5205,7 +5197,7 @@ typedef struct ur_queue_properties_t {
 typedef struct ur_queue_index_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     uint32_t computeIndex;     ///< [in] Specifies the compute index as described in the
                                ///< sycl_ext_intel_queue_index extension.
 
@@ -5355,7 +5347,7 @@ urQueueGetNativeHandle(
 typedef struct ur_queue_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an interoperability
                                ///< operation in the application that asked to not transfer the ownership to
                                ///< the unified-runtime.
@@ -5722,7 +5714,7 @@ urEventGetNativeHandle(
 typedef struct ur_event_native_properties_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
                                ///< ::UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES
-    void *pNext;               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;         ///< [in][optional] pointer to extension-specific structure
     bool isNativeHandleOwned;  ///< [in] Indicates UR owns the native handle or if it came from an interoperability
                                ///< operation in the application that asked to not transfer the ownership to
                                ///< the unified-runtime.
@@ -7111,7 +7103,7 @@ typedef struct ur_exp_win32_handle_t {
 typedef struct ur_exp_sampler_mip_properties_t {
     ur_structure_type_t stype;              ///< [in] type of this structure, must be
                                             ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES
-    void *pNext;                            ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;                      ///< [in][optional] pointer to extension-specific structure
     float minMipmapLevelClamp;              ///< [in] minimum mipmap level from which we can sample, minimum value
                                             ///< being 0
     float maxMipmapLevelClamp;              ///< [in] maximum mipmap level from which we can sample, maximum value
@@ -7131,7 +7123,7 @@ typedef struct ur_exp_sampler_mip_properties_t {
 typedef struct ur_exp_sampler_addr_modes_t {
     ur_structure_type_t stype;                 ///< [in] type of this structure, must be
                                                ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
-    void *pNext;                               ///< [in,out][optional] pointer to extension-specific structure
+    const void *pNext;                         ///< [in][optional] pointer to extension-specific structure
     ur_sampler_addressing_mode_t addrModes[3]; ///< [in] Specify the address mode of the sampler per dimension
 
 } ur_exp_sampler_addr_modes_t;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -59,16 +59,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintResult(enum ur_result_t value, char *
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseProperties(const struct ur_base_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_base_desc_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         - `NULL == buffer`
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintBaseDesc(const struct ur_base_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_rect_offset_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -208,7 +208,6 @@ inline std::ostream &operator<<(std::ostream &os, ur_function_t value);
 inline std::ostream &operator<<(std::ostream &os, ur_structure_type_t value);
 inline std::ostream &operator<<(std::ostream &os, ur_result_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_base_properties_t params);
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_base_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_rect_offset_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_rect_region_t params);
 inline std::ostream &operator<<(std::ostream &os, ur_device_init_flag_t value);
@@ -1487,26 +1486,6 @@ inline std::ostream &operator<<(std::ostream &os, ur_result_t value) {
 ///     std::ostream &
 inline std::ostream &operator<<(std::ostream &os, const struct ur_base_properties_t params) {
     os << "(struct ur_base_properties_t){";
-
-    os << ".stype = ";
-
-    os << (params.stype);
-
-    os << ", ";
-    os << ".pNext = ";
-
-    ur::details::printStruct(os,
-                             (params.pNext));
-
-    os << "}";
-    return os;
-}
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_base_desc_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, const struct ur_base_desc_t params) {
-    os << "(struct ur_base_desc_t){";
 
     os << ".stype = ";
 

--- a/scripts/core/CONTRIB.rst
+++ b/scripts/core/CONTRIB.rst
@@ -365,8 +365,7 @@ The following naming conventions must be followed:
 
 The following coding conventions must be followed:
 
-*   All descriptor structures must be derived from ${x}_base_desc_t
-*   All property structures must be derived from ${x}_base_properties_t
+*   All descriptor or property structures must be derived from ${x}_base_properties_t
 *   All function input parameters must precede output parameters
 *   All functions must return ${x}_result_t
 

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -285,18 +285,6 @@ members:
     - type: $x_structure_type_t
       name: stype
       desc: "[in] type of this structure"
-    - type: "void*"
-      name: pNext
-      desc: "[in,out][optional] pointer to extension-specific structure"
-      init: nullptr
---- #--------------------------------------------------------------------------
-type: struct
-desc: "Base for all descriptor types"
-name: $x_base_desc_t
-members:
-    - type: $x_structure_type_t
-      name: stype
-      desc: "[in] type of this structure"
     - type: "const void*"
       name: pNext
       desc: "[in][optional] pointer to extension-specific structure"

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -69,7 +69,7 @@ value: "\"native_cpu\""
 type: struct
 desc: "Device Binary Type"
 name: $x_device_binary_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: const char*
       name: pDeviceTargetSpec

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -138,7 +138,7 @@ etors:
 type: struct
 desc: "File descriptor"
 name: $x_exp_file_descriptor_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: int
       name: fd
@@ -147,7 +147,7 @@ members:
 type: struct
 desc: "Windows specific file handle"
 name: $x_exp_win32_handle_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: void*
       name: handle
@@ -192,14 +192,14 @@ type: struct
 desc: "Describes an interop memory resource descriptor"
 class: $xBindlessImages
 name: $x_exp_interop_mem_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members: []
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Describes an interop semaphore resource descriptor"
 class: $xBindlessImages
 name: $x_exp_interop_semaphore_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members: []
 --- #--------------------------------------------------------------------------
 type: function

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -53,7 +53,7 @@ value: "\"$x_exp_command_buffer\""
 type: struct
 desc: "Command-Buffer Descriptor Type"
 name: $x_exp_command_buffer_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members: []
 --- #--------------------------------------------------------------------------
 type: typedef

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -176,7 +176,7 @@ type: struct
 desc: "Image descriptor type."
 class: $xMem
 name: $x_image_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: $x_mem_type_t
       name: type
@@ -366,7 +366,7 @@ type: struct
 desc: "Buffer region type, used to describe a sub buffer"
 class: $xMem
 name: $x_buffer_region_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: size_t
       name: origin

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -214,7 +214,7 @@ details:
       as part of a `pNext` chain.
 class: $xQueue
 name: $x_queue_native_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: "void*"
       name: pNativeData

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -67,7 +67,7 @@ type: struct
 desc: "Sampler description."
 class: $xSampler
 name: $x_sampler_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: bool
       name: normalizedCoords

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -136,7 +136,7 @@ type: struct
 desc: "USM allocation descriptor type."
 class: $xUSM
 name: $x_usm_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: $x_usm_advice_flags_t
       name: hints
@@ -155,7 +155,7 @@ details:
     as part of a `pNext` chain.
 class: $xUSM
 name: $x_usm_host_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: $x_usm_host_mem_flags_t
       name: flags
@@ -168,7 +168,7 @@ details:
     as part of a `pNext` chain.
 class: $xUSM
 name: $x_usm_device_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: $x_usm_device_mem_flags_t
       name: flags
@@ -183,7 +183,7 @@ analogue:
     - "cl_intel_mem_alloc_buffer_location"
 class: $xUSM
 name: $x_usm_alloc_location_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: uint32_t
       name: location
@@ -195,7 +195,7 @@ type: struct
 desc: "USM pool descriptor type"
 class: $xUSM
 name: $x_usm_pool_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: $x_usm_pool_flags_t
       name:  flags
@@ -208,7 +208,7 @@ details:
     as part of a `pNext` chain.
 class: $xUSM
 name: $x_usm_pool_limits_desc_t
-base: $x_base_desc_t
+base: $x_base_properties_t
 members:
     - type: "size_t"
       name:  maxPoolableSize

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -254,15 +254,12 @@ def _validate_doc(f, d, tags, line_num):
     def __validate_base(d):
         namespace = re.sub(r"(\$[a-z])\w+", r"\1", d['name'])
         valid_names = [
-            "%s_base_desc_t"%namespace,
             "%s_base_properties_t"%namespace,
             "%s_driver_extension_properties_t"%namespace
             ]
         if d['name'] not in valid_names:
-            if type_traits.is_descriptor(d['name']) and not d.get('base', "").endswith("base_desc_t"):
-                raise Exception("'base' must be '%s_base_desc_t': %s"%(namespace, d['name']))
-
-            elif type_traits.is_properties(d['name']) and not d.get('base', "").endswith("base_properties_t"):
+            needs_base = type_traits.is_descriptor(d['name']) or type_traits.is_properties(d['name'])
+            if needs_base and not d.get('base', "").endswith("base_properties_t"):
                 raise Exception("'base' must be '%s_base_properties_t': %s"%(namespace, d['name']))
 
     def __validate_members(d, tags):

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -850,8 +850,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
 
     void *pNext = const_cast<void *>(pInteropMemDesc->pNext);
     while (pNext != nullptr) {
-      const ur_base_desc_t *BaseDesc =
-          reinterpret_cast<const ur_base_desc_t *>(pNext);
+      const auto *BaseDesc =
+          reinterpret_cast<const ur_base_properties_t *>(pNext);
       if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
         const ur_exp_file_descriptor_t *FileDescriptor =
             reinterpret_cast<const ur_exp_file_descriptor_t *>(pNext);
@@ -956,8 +956,8 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
 
     void *pNext = const_cast<void *>(pInteropSemaphoreDesc->pNext);
     while (pNext != nullptr) {
-      const ur_base_desc_t *BaseDesc =
-          reinterpret_cast<const ur_base_desc_t *>(pNext);
+      const auto *BaseDesc =
+          reinterpret_cast<const ur_base_properties_t *>(pNext);
       if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
         const ur_exp_file_descriptor_t *FileDescriptor =
             reinterpret_cast<const ur_exp_file_descriptor_t *>(pNext);

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -29,8 +29,8 @@ urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
 
   void *pNext = const_cast<void *>(pDesc->pNext);
   while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc =
-        reinterpret_cast<const ur_base_desc_t *>(pNext);
+    const auto *BaseDesc =
+        reinterpret_cast<const ur_base_properties_t *>(pNext);
     if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES) {
       const ur_exp_sampler_mip_properties_t *SamplerMipProperties =
           reinterpret_cast<const ur_exp_sampler_mip_properties_t *>(pNext);

--- a/source/adapters/cuda/usm.cpp
+++ b/source/adapters/cuda/usm.cpp
@@ -378,7 +378,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
     : Context(Context) {
   const void *pNext = PoolDesc->pNext;
   while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
+    const auto *BaseDesc = static_cast<const ur_base_properties_t *>(pNext);
     switch (BaseDesc->stype) {
     case UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC: {
       const ur_usm_pool_limits_desc_t *Limits =

--- a/source/adapters/hip/usm.cpp
+++ b/source/adapters/hip/usm.cpp
@@ -321,7 +321,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
     : Context(Context) {
   const void *pNext = PoolDesc->pNext;
   while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
+    const auto *BaseDesc = static_cast<const ur_base_properties_t *>(pNext);
     switch (BaseDesc->stype) {
     case UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC: {
       const ur_usm_pool_limits_desc_t *Limits =

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -544,7 +544,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
   if (NativeProperties) {
     OwnNativeHandle = NativeProperties->isNativeHandleOwned;
-    void *pNext = NativeProperties->pNext;
+    const void *pNext = NativeProperties->pNext;
     while (pNext) {
       const ur_base_properties_t *extendedProperties =
           reinterpret_cast<const ur_base_properties_t *>(pNext);

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -465,8 +465,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
 
   void *pNext = USMDesc ? const_cast<void *>(USMDesc->pNext) : nullptr;
   while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc =
-        reinterpret_cast<const ur_base_desc_t *>(pNext);
+    const auto *BaseDesc =
+        reinterpret_cast<const ur_base_properties_t *>(pNext);
     if (BaseDesc->stype == UR_STRUCTURE_TYPE_USM_DEVICE_DESC) {
       const ur_usm_device_desc_t *UsmDeviceDesc =
           reinterpret_cast<const ur_usm_device_desc_t *>(pNext);
@@ -809,8 +809,8 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
 
   void *pNext = const_cast<void *>(PoolDesc->pNext);
   while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc =
-        reinterpret_cast<const ur_base_desc_t *>(pNext);
+    const auto *BaseDesc =
+        reinterpret_cast<const ur_base_properties_t *>(pNext);
     switch (BaseDesc->stype) {
     case UR_STRUCTURE_TYPE_USM_POOL_LIMITS_DESC: {
       const ur_usm_pool_limits_desc_t *Limits =

--- a/source/adapters/opencl/memory.cpp
+++ b/source/adapters/opencl/memory.cpp
@@ -239,25 +239,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
             cl_ext::CreateBufferWithPropertiesName, &FuncPtr);
     if (FuncPtr) {
       std::vector<cl_mem_properties_intel> PropertiesIntel;
-      auto Prop = static_cast<ur_base_properties_t *>(pProperties->pNext);
+      const auto *Prop =
+          static_cast<const ur_base_properties_t *>(pProperties->pNext);
       while (Prop) {
         switch (Prop->stype) {
         case UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES: {
           auto BufferChannelProperty =
-              reinterpret_cast<ur_buffer_channel_properties_t *>(Prop);
+              reinterpret_cast<const ur_buffer_channel_properties_t *>(Prop);
           PropertiesIntel.push_back(CL_MEM_CHANNEL_INTEL);
           PropertiesIntel.push_back(BufferChannelProperty->channel);
         } break;
         case UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES: {
           auto BufferLocationProperty =
-              reinterpret_cast<ur_buffer_alloc_location_properties_t *>(Prop);
+              reinterpret_cast<const ur_buffer_alloc_location_properties_t *>(
+                  Prop);
           PropertiesIntel.push_back(CL_MEM_ALLOC_FLAGS_INTEL);
           PropertiesIntel.push_back(BufferLocationProperty->location);
         } break;
         default:
           break;
         }
-        Prop = static_cast<ur_base_properties_t *>(Prop->pNext);
+        Prop = static_cast<const ur_base_properties_t *>(Prop->pNext);
       }
       PropertiesIntel.push_back(0);
 

--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -32,7 +32,7 @@ deviceDescToClFlags(const ur_usm_device_desc_t &desc) {
 }
 
 ur_result_t
-usmDescToCLMemProperties(const ur_base_desc_t *Desc,
+usmDescToCLMemProperties(const ur_base_properties_t *Desc,
                          std::vector<cl_mem_properties_intel> &Properties) {
   cl_mem_alloc_flags_intel AllocFlags = 0;
   const auto *Next = Desc;
@@ -66,7 +66,7 @@ usmDescToCLMemProperties(const ur_base_desc_t *Desc,
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
 
-    Next = Next->pNext ? static_cast<const ur_base_desc_t *>(Next->pNext)
+    Next = Next->pNext ? static_cast<const ur_base_properties_t *>(Next->pNext)
                        : nullptr;
   } while (Next);
 
@@ -89,7 +89,8 @@ urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {
     UR_RETURN_ON_FAILURE(usmDescToCLMemProperties(
-        static_cast<const ur_base_desc_t *>(pUSMDesc->pNext), AllocProperties));
+        static_cast<const ur_base_properties_t *>(pUSMDesc->pNext),
+        AllocProperties));
   }
 
   // First we need to look up the function pointer
@@ -132,7 +133,8 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {
     UR_RETURN_ON_FAILURE(usmDescToCLMemProperties(
-        static_cast<const ur_base_desc_t *>(pUSMDesc->pNext), AllocProperties));
+        static_cast<const ur_base_properties_t *>(pUSMDesc->pNext),
+        AllocProperties));
   }
 
   // First we need to look up the function pointer
@@ -175,7 +177,8 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {
     UR_RETURN_ON_FAILURE(usmDescToCLMemProperties(
-        static_cast<const ur_base_desc_t *>(pUSMDesc->pNext), AllocProperties));
+        static_cast<const ur_base_properties_t *>(pUSMDesc->pNext),
+        AllocProperties));
   }
 
   // First we need to look up the function pointer

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -67,13 +67,6 @@ ur_result_t urPrintBaseProperties(const struct ur_base_properties_t params,
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintBaseDesc(const struct ur_base_desc_t params, char *buffer,
-                            const size_t buff_size, size_t *out_size) {
-    std::stringstream ss;
-    ss << params;
-    return str_copy(&ss, buffer, buff_size, out_size);
-}
-
 ur_result_t urPrintRectOffset(const struct ur_rect_offset_t params,
                               char *buffer, const size_t buff_size,
                               size_t *out_size) {


### PR DESCRIPTION
The definitions of these two base structs are slightly different which potentially has weird consequences if a given pNext chain contains extension structs derived from both. Unifying these structs removes the possibility of their definitions drifting further apart and prevents the mixed pNext chain scenario.