### PR TITLE
Update and extend dockers

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -8,10 +8,10 @@ development environment.
 
 # How to build docker image
 
-To build docker image on local machine execute:
+To build docker image on local machine, enter the root dir of the repository and execute:
 
 ```sh
-docker build -t ur:ubuntu-22.04 -f ./ubuntu-22.04.Dockerfile .
+docker build -t ur:ubuntu-22.04 -f .github/docker/ubuntu-22.04.Dockerfile .
 ```
 
 To set any build time variable (e.g., an optional ARG from docker recipe), add to the command (after `build`), e.g.:

--- a/.github/docker/fedora-40.Dockerfile
+++ b/.github/docker/fedora-40.Dockerfile
@@ -4,18 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
+# Dockerfile - a 'recipe' for Docker to build an image of fedora-based
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("40")
+FROM registry.hub.docker.com/library/fedora@sha256:5ce8497aeea599bf6b54ab3979133923d82aaa4f6ca5ced1812611b197c79eb0
 
 # Set environment variables
-ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS fedora
+ENV OS_VER 40
 ENV NOTTY 1
-ENV DEBIAN_FRONTEND noninteractive
 
 # Additional parameters to build docker without building components.
 # These ARGs can be set in docker building phase and are used
@@ -25,9 +24,9 @@ ARG SKIP_LIBBACKTRACE_BUILD
 
 # Base development packages
 ARG BASE_DEPS="\
-	build-essential \
 	cmake \
-	git"
+	git \
+	make"
 
 # Unified Runtime's dependencies
 ARG UR_DEPS="\
@@ -38,26 +37,27 @@ ARG UR_DEPS="\
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
-	libncurses5 \
+	ncurses-libs-6.4 \
+	passwd \
 	sudo \
-	wget \
-	whois"
+	wget"
 
 # Update and install required packages
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN dnf update -y \
+ && dnf install -y \
 	${BASE_DEPS} \
 	${UR_DEPS} \
 	${MISC_DEPS} \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean all
+ && dnf clean all
 
 # Prepare a dir (accessible by anyone)
 RUN mkdir --mode 777 /opt/ur/
 
 # Additional dev. dependencies (installed via pip)
+#
+# It's actively used and tested only on selected distros. Be aware
+# they may not work, because pip packages list differ from OS to OS.
 COPY third_party/requirements.txt /opt/ur/requirements.txt
-RUN pip3 install --no-cache-dir -r /opt/ur/requirements.txt
 
 # Install DPC++
 COPY .github/docker/install_dpcpp.sh /opt/ur/install_dpcpp.sh
@@ -68,8 +68,15 @@ RUN /opt/ur/install_dpcpp.sh
 COPY .github/docker/install_libbacktrace.sh /opt/ur/install_libbacktrace.sh
 RUN /opt/ur/install_libbacktrace.sh
 
-# Add a new (non-root) 'test_user' and switch to it
+# Add a new (non-root) 'test_user'
 ENV USER test_user
 ENV USERPASS pass
-RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+# Change shell to bash with safe pipe usage
+SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
+RUN useradd -m ${USER} \
+ && echo "${USER}:${USERPASS}" | chpasswd \
+ && gpasswd wheel -a ${USER}
+
+# Change shell back to default and switch to 'test_user'
+SHELL ["/bin/sh", "-c"]
 USER test_user

--- a/.github/docker/install_dpcpp.sh
+++ b/.github/docker/install_dpcpp.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2023-2024 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -15,9 +15,6 @@ if [ "${SKIP_DPCPP_BUILD}" ]; then
 	exit
 fi
 
-apt-get install -y --no-install-recommends \
-	libncurses5
-
-mkdir -p ${DPCPP_PATH}
-wget -O ${DPCPP_PATH}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/sycl-nightly%2F20230626/dpcpp-compiler.tar.gz
-tar -xvf ${DPCPP_PATH}/dpcpp_compiler.tar.gz -C ${DPCPP_PATH}/
+mkdir -p ${DPCPP_PATH}/dpcpp_compiler
+wget -O ${DPCPP_PATH}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/nightly-2024-01-29/sycl_linux.tar.gz
+tar -xvf ${DPCPP_PATH}/dpcpp_compiler.tar.gz -C ${DPCPP_PATH}/dpcpp_compiler

--- a/.github/docker/opensuse-leap-15.Dockerfile
+++ b/.github/docker/opensuse-leap-15.Dockerfile
@@ -4,18 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
+# Dockerfile - a 'recipe' for Docker to build an image of opensuse-leap-based
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("15")
+FROM registry.hub.docker.com/opensuse/leap@sha256:1cf79e78bb69f39fb2f78a7c2c7ebc4b64cf8d82eb1df76cd36767a595ada7a8
 
 # Set environment variables
-ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS opensuse-leap
+ENV OS_VER 15
 ENV NOTTY 1
-ENV DEBIAN_FRONTEND noninteractive
 
 # Additional parameters to build docker without building components.
 # These ARGs can be set in docker building phase and are used
@@ -25,39 +24,49 @@ ARG SKIP_LIBBACKTRACE_BUILD
 
 # Base development packages
 ARG BASE_DEPS="\
-	build-essential \
 	cmake \
-	git"
+	gcc \
+	gcc-c++ \
+	git \
+	glibc-devel \
+	libstdc++-devel \
+	make"
 
 # Unified Runtime's dependencies
 ARG UR_DEPS="\
 	doxygen \
 	python3 \
+	python3-devel \
 	python3-pip"
 
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
+	gzip \
 	libncurses5 \
 	sudo \
-	wget \
-	whois"
+	tar \
+	wget"
+
+# add openSUSE Leap 15.5 Oss repo
+RUN zypper ar -f https://download.opensuse.org/distribution/leap/15.5/repo/oss/ oss
 
 # Update and install required packages
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN zypper update -y \
+ && zypper install -y \
 	${BASE_DEPS} \
 	${UR_DEPS} \
 	${MISC_DEPS} \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean all
+ && zypper clean all
 
 # Prepare a dir (accessible by anyone)
 RUN mkdir --mode 777 /opt/ur/
 
 # Additional dev. dependencies (installed via pip)
+#
+# It's actively used and tested only on selected distros. Be aware
+# they may not work, because pip packages list differ from OS to OS.
 COPY third_party/requirements.txt /opt/ur/requirements.txt
-RUN pip3 install --no-cache-dir -r /opt/ur/requirements.txt
 
 # Install DPC++
 COPY .github/docker/install_dpcpp.sh /opt/ur/install_dpcpp.sh
@@ -71,5 +80,13 @@ RUN /opt/ur/install_libbacktrace.sh
 # Add a new (non-root) 'test_user' and switch to it
 ENV USER test_user
 ENV USERPASS pass
-RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+ENV PFILE ./password
+RUN useradd -m ${USER} \
+ && echo ${USERPASS} > ${PFILE} \
+ && echo ${USERPASS} >> ${PFILE} \
+ && passwd ${USER} < ${PFILE} \
+ && rm -f ${PFILE} \
+ && sed -i 's/# %wheel/%wheel/g' /etc/sudoers \
+ && groupadd wheel \
+ && gpasswd wheel -a ${USER}
 USER test_user

--- a/.github/docker/rockylinux-8.Dockerfile
+++ b/.github/docker/rockylinux-8.Dockerfile
@@ -4,18 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
+# Dockerfile - a 'recipe' for Docker to build an image of rockylinux-based
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("8.9")
+FROM registry.hub.docker.com/library/rockylinux@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
 
 # Set environment variables
-ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS rockylinux
+ENV OS_VER 8
 ENV NOTTY 1
-ENV DEBIAN_FRONTEND noninteractive
 
 # Additional parameters to build docker without building components.
 # These ARGs can be set in docker building phase and are used
@@ -25,9 +24,11 @@ ARG SKIP_LIBBACKTRACE_BUILD
 
 # Base development packages
 ARG BASE_DEPS="\
-	build-essential \
 	cmake \
-	git"
+	git \
+	glibc-devel \
+	libstdc++-devel \
+	make"
 
 # Unified Runtime's dependencies
 ARG UR_DEPS="\
@@ -35,29 +36,38 @@ ARG UR_DEPS="\
 	python3 \
 	python3-pip"
 
+# Packages required by requirements.txt
+ARG PRE_PYTHON_DEPS="\
+	libjpeg-turbo-devel \
+	python3-devel \
+	python3-wheel \
+	zlib-devel"
+
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
-	libncurses5 \
+	ncurses-libs-6.1 \
+	passwd \
 	sudo \
-	wget \
-	whois"
+	wget"
 
 # Update and install required packages
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN dnf update -y \
+ && dnf --enablerepo devel install -y \
 	${BASE_DEPS} \
 	${UR_DEPS} \
+	${PRE_PYTHON_DEPS} \
 	${MISC_DEPS} \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean all
+ && dnf clean all
 
 # Prepare a dir (accessible by anyone)
 RUN mkdir --mode 777 /opt/ur/
 
 # Additional dev. dependencies (installed via pip)
+#
+# It's actively used and tested only on selected distros. Be aware
+# they may not work, because pip packages list differ from OS to OS.
 COPY third_party/requirements.txt /opt/ur/requirements.txt
-RUN pip3 install --no-cache-dir -r /opt/ur/requirements.txt
 
 # Install DPC++
 COPY .github/docker/install_dpcpp.sh /opt/ur/install_dpcpp.sh
@@ -68,8 +78,16 @@ RUN /opt/ur/install_dpcpp.sh
 COPY .github/docker/install_libbacktrace.sh /opt/ur/install_libbacktrace.sh
 RUN /opt/ur/install_libbacktrace.sh
 
-# Add a new (non-root) 'test_user' and switch to it
+# Add a new (non-root) 'test_user'
 ENV USER test_user
 ENV USERPASS pass
-RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+# Change shell to bash with safe pipe usage
+SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
+RUN useradd -m $USER \
+ && echo "${USERPASS}" | passwd "${USER}" --stdin \
+ && gpasswd wheel -a "${USER}" \
+ && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Change shell back to default and switch to 'test_user'
+SHELL ["/bin/sh", "-c"]
 USER test_user

--- a/.github/docker/rockylinux-9.Dockerfile
+++ b/.github/docker/rockylinux-9.Dockerfile
@@ -4,18 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
+# Dockerfile - a 'recipe' for Docker to build an image of rockylinux-based
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("9.3")
+FROM registry.hub.docker.com/library/rockylinux@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6
 
 # Set environment variables
-ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS rockylinux
+ENV OS_VER 9
 ENV NOTTY 1
-ENV DEBIAN_FRONTEND noninteractive
 
 # Additional parameters to build docker without building components.
 # These ARGs can be set in docker building phase and are used
@@ -25,9 +24,11 @@ ARG SKIP_LIBBACKTRACE_BUILD
 
 # Base development packages
 ARG BASE_DEPS="\
-	build-essential \
 	cmake \
-	git"
+	git \
+	glibc-devel \
+	libstdc++-devel \
+	make"
 
 # Unified Runtime's dependencies
 ARG UR_DEPS="\
@@ -38,26 +39,27 @@ ARG UR_DEPS="\
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
-	libncurses5 \
+	ncurses-libs-6.2 \
+	passwd \
 	sudo \
-	wget \
-	whois"
+	wget"
 
 # Update and install required packages
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
+RUN dnf update -y \
+ && dnf --enablerepo devel install -y \
 	${BASE_DEPS} \
 	${UR_DEPS} \
 	${MISC_DEPS} \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean all
+ && dnf clean all
 
 # Prepare a dir (accessible by anyone)
 RUN mkdir --mode 777 /opt/ur/
 
 # Additional dev. dependencies (installed via pip)
+#
+# It's actively used and tested only on selected distros. Be aware
+# they may not work, because pip packages list differ from OS to OS.
 COPY third_party/requirements.txt /opt/ur/requirements.txt
-RUN pip3 install --no-cache-dir -r /opt/ur/requirements.txt
 
 # Install DPC++
 COPY .github/docker/install_dpcpp.sh /opt/ur/install_dpcpp.sh
@@ -68,8 +70,16 @@ RUN /opt/ur/install_dpcpp.sh
 COPY .github/docker/install_libbacktrace.sh /opt/ur/install_libbacktrace.sh
 RUN /opt/ur/install_libbacktrace.sh
 
-# Add a new (non-root) 'test_user' and switch to it
+# Add a new (non-root) 'test_user'
 ENV USER test_user
 ENV USERPASS pass
-RUN useradd -m "${USER}" -g sudo -p "$(mkpasswd ${USERPASS})"
+# Change shell to bash with safe pipe usage
+SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
+RUN useradd -m $USER \
+ && echo "${USERPASS}" | passwd "${USER}" --stdin \
+ && gpasswd wheel -a "${USER}" \
+ && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Change shell back to default and switch to 'test_user'
+SHELL ["/bin/sh", "-c"]
 USER test_user

--- a/.github/docker/ubuntu-20.04.Dockerfile
+++ b/.github/docker/ubuntu-20.04.Dockerfile
@@ -8,12 +8,12 @@
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("20.04")
+FROM registry.hub.docker.com/library/ubuntu@sha256:d86db849e59626d94f768c679aba441163c996caf7a3426f44924d0239ffe03f
 
 # Set environment variables
 ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS_VER 20.04
 ENV NOTTY 1
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -26,7 +26,6 @@ ARG SKIP_LIBBACKTRACE_BUILD
 # Base development packages
 ARG BASE_DEPS="\
 	build-essential \
-	cmake \
 	git"
 
 # Unified Runtime's dependencies
@@ -38,6 +37,7 @@ ARG UR_DEPS="\
 # Miscellaneous for our builds/CI (optional)
 ARG MISC_DEPS="\
 	clang \
+	g++-7 \
 	libncurses5 \
 	sudo \
 	wget \
@@ -52,17 +52,17 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get clean all
 
+# Install CMake from source (the version in apt it's too old)
+RUN wget https://cmake.org/files/v3.20/cmake-3.20.0-linux-x86_64.sh -O cmake.sh \
+ && chmod +x cmake.sh \
+ && ./cmake.sh --skip-license --prefix=/usr/local
+
 # Prepare a dir (accessible by anyone)
 RUN mkdir --mode 777 /opt/ur/
 
 # Additional dev. dependencies (installed via pip)
 COPY third_party/requirements.txt /opt/ur/requirements.txt
 RUN pip3 install --no-cache-dir -r /opt/ur/requirements.txt
-
-# Install DPC++
-COPY .github/docker/install_dpcpp.sh /opt/ur/install_dpcpp.sh
-ENV DPCPP_PATH=/opt/dpcpp
-RUN /opt/ur/install_dpcpp.sh
 
 # Install libbacktrace
 COPY .github/docker/install_libbacktrace.sh /opt/ur/install_libbacktrace.sh

--- a/.github/docker/ubuntu-24.04.Dockerfile
+++ b/.github/docker/ubuntu-24.04.Dockerfile
@@ -8,12 +8,12 @@
 #              environment for building the Unified Runtime project.
 #
 
-# Pull base image ("22.04")
-FROM registry.hub.docker.com/library/ubuntu@sha256:0eb0f877e1c869a300c442c41120e778db7161419244ee5cbc6fa5f134e74736
+# Pull base image ("24.04")
+FROM registry.hub.docker.com/library/ubuntu@sha256:340d9b015b194dc6e2a13938944e0d016e57b9679963fdeb9ce021daac430221
 
 # Set environment variables
 ENV OS ubuntu
-ENV OS_VER 22.04
+ENV OS_VER 24.04
 ENV NOTTY 1
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Add new docker images and update the existing ones with proper dependencies. I've added pip requirements into the docker, hence updated README with proper usage.

These images should be ready to use in CI.

// I've tested these dockers on a sep. branch (`test-dockers`) on my fork, results are all green (except for clang build in Ubuntu 20.04 - but this will be fixed separately):
https://github.com/lukaszstolarczuk/unified-runtime/actions/runs/10073401444
\+ Fedora build: https://github.com/lukaszstolarczuk/unified-runtime/actions/runs/10073471475