### PR TITLE
[CTS][CUDA] Ignore adapter warnings in conformance tests

### DIFF
--- a/source/adapters/cuda/adapter.cpp
+++ b/source/adapters/cuda/adapter.cpp
@@ -57,7 +57,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
-  std::ignore = pError;
+  *pError = ErrorMessageCode;
   *ppMessage = ErrorMessage;
   return ErrorMessageCode;
 }

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1366,46 +1366,55 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   UR_ASSERT(size <= PointerRangeSize, UR_RESULT_ERROR_INVALID_SIZE);
   ur_device_handle_t Device = hQueue->getContext()->getDevice();
 
-  // Certain cuda devices and Windows do not have support for some Unified
-  // Memory features. cuMemPrefetchAsync requires concurrent memory access
-  // for managed memory. Therefore, ignore prefetch hint if concurrent managed
-  // memory access is not available.
-  if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
-    setErrorMessage("Prefetch hint ignored as device does not support "
-                    "concurrent managed access",
-                    UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-  }
-
-  unsigned int IsManaged;
-  UR_CHECK_ERROR(cuPointerGetAttribute(
-      &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
-  if (!IsManaged) {
-    setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
-                    UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-  }
-
   ur_result_t Result = UR_RESULT_SUCCESS;
-  std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
-
   try {
+
     ScopedContext Active(hQueue->getContext());
     CUstream CuStream = hQueue->getNextTransferStream();
-    Result = enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
-                               phEventWaitList);
+    std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
+
     if (phEvent) {
       EventPtr =
           std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
               UR_COMMAND_MEM_BUFFER_COPY, hQueue, CuStream));
       UR_CHECK_ERROR(EventPtr->start());
     }
+
+    auto releaseEvent = [&EventPtr, &phEvent]() {
+      if (phEvent) {
+        UR_CHECK_ERROR(EventPtr->record());
+        *phEvent = EventPtr.release();
+      }
+    };
+
+    // Certain cuda devices and Windows do not have support for some Unified
+    // Memory features. cuMemPrefetchAsync requires concurrent memory access
+    // for managed memory. Therefore, ignore prefetch hint if concurrent managed
+    // memory access is not available.
+    if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
+      setErrorMessage("Prefetch hint ignored as device does not support "
+                      "concurrent managed access",
+                      UR_RESULT_SUCCESS);
+      releaseEvent();
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    }
+
+    unsigned int IsManaged;
+    UR_CHECK_ERROR(cuPointerGetAttribute(
+        &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
+    if (!IsManaged) {
+      setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
+                      UR_RESULT_SUCCESS);
+      releaseEvent();
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    }
+
+    Result = enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
+                               phEventWaitList);
+
     UR_CHECK_ERROR(
         cuMemPrefetchAsync((CUdeviceptr)pMem, size, Device->get(), CuStream));
-    if (phEvent) {
-      UR_CHECK_ERROR(EventPtr->record());
-      *phEvent = EventPtr.release();
-    }
+    releaseEvent();
   } catch (ur_result_t Err) {
     Result = Err;
   }
@@ -1421,50 +1430,61 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
       &PointerRangeSize, CU_POINTER_ATTRIBUTE_RANGE_SIZE, (CUdeviceptr)pMem));
   UR_ASSERT(size <= PointerRangeSize, UR_RESULT_ERROR_INVALID_SIZE);
 
-  // Certain cuda devices and Windows do not have support for some Unified
-  // Memory features. Passing CU_MEM_ADVISE_SET/CLEAR_PREFERRED_LOCATION and
-  // to cuMemAdvise on a GPU device requires the GPU device to report a non-zero
-  // value for CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS. Therfore, ignore
-  // memory advise if concurrent managed memory access is not available.
-  if ((advice & UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION) ||
-      (advice & UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION) ||
-      (advice & UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE) ||
-      (advice & UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE) ||
-      (advice & UR_USM_ADVICE_FLAG_DEFAULT)) {
-    ur_device_handle_t Device = hQueue->getContext()->getDevice();
-    if (!getAttribute(Device, CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
-      setErrorMessage("Mem advise ignored as device does not support "
-                      "concurrent managed access",
-                      UR_RESULT_SUCCESS);
-      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-    }
-
-    // TODO: If ptr points to valid system-allocated pageable memory we should
-    // check that the device also has the
-    // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS property.
-  }
-
-  unsigned int IsManaged;
-  UR_CHECK_ERROR(cuPointerGetAttribute(
-      &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
-  if (!IsManaged) {
-    setErrorMessage(
-        "Memory advice ignored as memory advices only works with USM",
-        UR_RESULT_SUCCESS);
-    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-  }
-
   ur_result_t Result = UR_RESULT_SUCCESS;
-  std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
-
   try {
+
     ScopedContext Active(hQueue->getContext());
+    std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
     if (phEvent) {
       EventPtr =
           std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
               UR_COMMAND_USM_ADVISE, hQueue, hQueue->getNextTransferStream()));
       UR_CHECK_ERROR(EventPtr->start());
+    }
+
+    auto releaseEvent = [&EventPtr, &phEvent]() {
+      if (phEvent) {
+        UR_CHECK_ERROR(EventPtr->record());
+        *phEvent = EventPtr.release();
+      }
+    };
+
+    // Certain cuda devices and Windows do not have support for some Unified
+    // Memory features. Passing CU_MEM_ADVISE_SET/CLEAR_PREFERRED_LOCATION and
+    // to cuMemAdvise on a GPU device requires the GPU device to report a
+    // non-zero value for CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS.
+    // Therfore, ignore memory advise if concurrent managed memory access is not
+    // available.
+    if ((advice & UR_USM_ADVICE_FLAG_SET_PREFERRED_LOCATION) ||
+        (advice & UR_USM_ADVICE_FLAG_CLEAR_PREFERRED_LOCATION) ||
+        (advice & UR_USM_ADVICE_FLAG_SET_ACCESSED_BY_DEVICE) ||
+        (advice & UR_USM_ADVICE_FLAG_CLEAR_ACCESSED_BY_DEVICE) ||
+        (advice & UR_USM_ADVICE_FLAG_DEFAULT)) {
+      ur_device_handle_t Device = hQueue->getContext()->getDevice();
+      if (!getAttribute(Device,
+                        CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS)) {
+        setErrorMessage("Mem advise ignored as device does not support "
+                        "concurrent managed access",
+                        UR_RESULT_SUCCESS);
+        releaseEvent();
+        return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+      }
+
+      // TODO: If ptr points to valid system-allocated pageable memory we should
+      // check that the device also has the
+      // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS property.
+    }
+
+    unsigned int IsManaged;
+    UR_CHECK_ERROR(cuPointerGetAttribute(
+        &IsManaged, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)pMem));
+    if (!IsManaged) {
+      setErrorMessage(
+          "Memory advice ignored as memory advices only works with USM",
+          UR_RESULT_SUCCESS);
+      releaseEvent();
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
 
     if (advice & UR_USM_ADVICE_FLAG_DEFAULT) {
@@ -1482,10 +1502,8 @@ urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
                               hQueue->getContext()->getDevice()->get());
     }
 
-    if (phEvent) {
-      UR_CHECK_ERROR(EventPtr->record());
-      *phEvent = EventPtr.release();
-    }
+    releaseEvent();
+
   } catch (ur_result_t err) {
     Result = err;
   } catch (...) {

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
 inline int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
 #else

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -9,3 +9,9 @@ this solution will no longer be necessary.
 When you fix any test, the match file must be updated
 Empty match files indicate that there are no failing tests
 in a particular group for the corresponding adapter.
+
+## Adapter Warnings
+
+By default, conformance tests ignore all warning messages returned by 
+UR adapters. The environment variable `UR_CTS_PRINT_ADAPTER_WARNINGS`
+can be set to print all warnings to stderr when running the tests.

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -28,7 +28,7 @@ struct PlatformEnvironment : ::testing::Environment {
     PlatformOptions parsePlatformOptions(int argc, char **argv);
 
     PlatformOptions platform_options;
-    std::vector<ur_adapter_handle_t> adapters{};
+    ur_adapter_handle_t adapter = nullptr;
     ur_platform_handle_t platform = nullptr;
     std::string error;
     static PlatformEnvironment *instance;


### PR DESCRIPTION
Adapter warnings are supported in the UR spec for every
entrypoint. This commit updates the CTS to not fail
when a warning is returned. An environment variable was
added to optionally print the warnings to stderr.

A few fixes to the CUDA adapter were also added as part of this
commit:

- Always return a valid event for urEnqueueUSMPrefetch and
urEnqueueUSMAdvise.
- urAdapterGetLastError no longer ignores the error parameter.

E2E run: https://github.com/intel/llvm/pull/12051
