### PR TITLE
Directly query environment platform in KernelSetArgSampler backend check.

### DIFF
--- a/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -9,8 +9,9 @@ struct urKernelSetArgSamplerTest : uur::urKernelTest {
     void SetUp() {
         // Images and samplers are not available on AMD
         ur_platform_backend_t backend;
-        ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                         sizeof(backend), &backend, nullptr));
+        ASSERT_SUCCESS(urPlatformGetInfo(
+            uur::PlatformEnvironment::instance->platform,
+            UR_PLATFORM_INFO_BACKEND, sizeof(backend), &backend, nullptr));
         if (backend == UR_PLATFORM_BACKEND_HIP) {
             GTEST_SKIP() << "Sampler are not supported on hip.";
         }


### PR DESCRIPTION
The fixture's platform is initialized to point at the environment one in the platform test SetUp(), but that's too late for this query. This is a little hacky but it lets us skip the test without building the kernel (which will potentially cause a fail if images aren't supported).