### PR TITLE
[GHA] Separate HW concurrency groups per apdater

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,10 +2,6 @@ name: Build and test
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   ubuntu-build:
     name: Build - Ubuntu
@@ -32,6 +28,10 @@ jobs:
           - os: 'ubuntu-20.04'
             build_type: Release
             compiler: {c: gcc-7, cxx: g++-7}
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     runs-on: ${{matrix.os}}
 
@@ -118,6 +118,10 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         compiler: [{c: clang, cxx: clang++}]
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     runs-on: 'ubuntu-22.04'
 
@@ -241,6 +245,10 @@ jobs:
         build_type: [Debug, Release]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     runs-on: ${{matrix.adapter.name}}
 
     steps:
@@ -307,6 +315,11 @@ jobs:
         include:
           - compiler: {c: clang-cl, cxx: clang-cl}
             toolset: "-T ClangCL"
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     runs-on: ${{matrix.os}}
 
     steps:
@@ -359,6 +372,10 @@ jobs:
         matrix:
           os: ['macos-12', 'macos-13']
     runs-on: ${{matrix.os}}
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -171,6 +171,10 @@ jobs:
         build_type: [Debug, Release]
         compiler: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{matrix.adapter.name}}
+      cancel-in-progress: true
+
     runs-on: ${{matrix.adapter.name}}
 
     steps:


### PR DESCRIPTION
Currently when any adapter fails testing on hardware all the jobs for all the adapters are cancelled. This can mean issues on adapters which didn't fail first are hidden and require multiple round-trips of bug fixes and GHA runs. This patch changes the HR runner concurrency groupings to be specific to each adapter rather than global.
