### PR TITLE
[NATIVECPU] Handle oneAPI Construction Kit integration in runtime

### DIFF
--- a/source/adapters/native_cpu/enqueue.cpp
+++ b/source/adapters/native_cpu/enqueue.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
 #include <array>
 #include <cstdint>
 
@@ -76,6 +75,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   for (unsigned g2 = 0; g2 < numWG2; g2++) {
     for (unsigned g1 = 0; g1 < numWG1; g1++) {
       for (unsigned g0 = 0; g0 < numWG0; g0++) {
+#ifdef NATIVECPU_USE_OCK
+        state.update(g0, g1, g2);
+        hKernel->_subhandler(hKernel->_args.data(), &state);
+#else
         for (unsigned local2 = 0; local2 < ndr.LocalSize[2]; local2++) {
           for (unsigned local1 = 0; local1 < ndr.LocalSize[1]; local1++) {
             for (unsigned local0 = 0; local0 < ndr.LocalSize[0]; local0++) {
@@ -84,6 +87,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
             }
           }
         }
+#endif
       }
     }
   }

--- a/source/adapters/native_cpu/nativecpu_state.hpp
+++ b/source/adapters/native_cpu/nativecpu_state.hpp
@@ -53,6 +53,13 @@ struct state {
     MGlobal_id[2] =
         MWorkGroup_size[2] * MWorkGroup_id[2] + MLocal_id[2] + MGlobalOffset[2];
   }
+
+  void update(size_t group0, size_t group1, size_t group2) {
+    MWorkGroup_id[0] = group0;
+    MWorkGroup_id[1] = group1;
+    MWorkGroup_id[2] = group2;
+  }
+
 };
 
 } // namespace native_cpu

--- a/source/adapters/native_cpu/nativecpu_state.hpp
+++ b/source/adapters/native_cpu/nativecpu_state.hpp
@@ -59,7 +59,6 @@ struct state {
     MWorkGroup_id[1] = group1;
     MWorkGroup_id[2] = group2;
   }
-
 };
 
 } // namespace native_cpu


### PR DESCRIPTION
intel/llvm PR: https://github.com/intel/llvm/pull/11614

With https://github.com/intel/llvm/pull/11614 we start integrating the [oneAPI Construction Kit](https://github.com/codeplaysoftware/oneapi-construction-kit). If the OCK is enabled, it creates the work item loops in the compiler, so it is not necessary to execute the loops in the adapter.