### PR TITLE
[CTS][OPENCL] Add segmentation fault to match file

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -33,3 +33,4 @@
 {{OPT}}urEnqueueUSMMemcpy2DNegativeTest.InvalidSize/Intel_R__OpenCL___{{.*}}_
 {{OPT}}urEnqueueUSMMemcpy2DNegativeTest.InvalidEventWaitList/Intel_R__OpenCL___{{.*}}_
 {{OPT}}urEnqueueUSMPrefetchTest.InvalidSizeTooLarge/Intel_R__OpenCL___{{.*}}_
+{{OPT}}Segmentation Fault


### PR DESCRIPTION
Filters segmentation fault in urEnqueueMemBufferWriteRectTest from CI output. Can be removed once this PR is merged: https://github.com/oneapi-src/unified-runtime/pull/1093