### PR TITLE
[NATIVECPU] Use static_cast in switch for ur_device_info_t

### DIFF
--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -60,7 +60,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
-  switch (propName) {
+  switch (static_cast<uint32_t>(propName)) {
   case UR_DEVICE_INFO_TYPE:
     return ReturnValue(UR_DEVICE_TYPE_CPU);
   case UR_DEVICE_INFO_PARENT_DEVICE:


### PR DESCRIPTION
This should fix https://github.com/oneapi-src/unified-runtime/issues/1164 by using `static_cast` to silence warnings about values that are not yet part of the `ur_device_info_t` enum, similarly to what is done by the other adapters.