### PR TITLE
[HIP] Allow custom location of ROCm components

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ List of options provided by CMake:
 | UR_SYCL_LIBRARY_DIR | Path of the SYCL runtime library directory to build CTS device binaries | Directory path | `""` |
 | UR_HIP_ROCM_DIR | Path of the default ROCm HIP installation | Directory path | `/opt/rocm` |
 | UR_HIP_INCLUDE_DIR | Path of the ROCm HIP include directory | Directory path | `${UR_HIP_ROCM_DIR}/include` |
-| UR_HIP_HSA_INCLUDE_DIR | Path of the ROCm HSA include directory | Directory path | `${UR_HIP_ROCM_DIR}/hsa/include""` |
-| UR_HIP_LIB_DIR | Path of the ROCm HIP library directory | Directory path | `${UR_HIP_ROCM_DIR}/lib""` |
+| UR_HIP_HSA_INCLUDE_DIRS | Path of the ROCm HSA include directory | Directory path | `${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include` |
+| UR_HIP_LIB_DIR | Path of the ROCm HIP library directory | Directory path | `${UR_HIP_ROCM_DIR}/lib` |
 
 ### Additional make targets
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ List of options provided by CMake:
 | UR_ENABLE_COMGR         | Enable comgr lib usage           | AMD/NVIDIA | AMD     |
 | UR_DPCXX | Path of the DPC++ compiler executable to build CTS device binaries | File path | `""` |
 | UR_SYCL_LIBRARY_DIR | Path of the SYCL runtime library directory to build CTS device binaries | Directory path | `""` |
+| UR_HIP_ROCM_DIR | Path of the default ROCm HIP installation | Directory path | `/opt/rocm` |
+| UR_HIP_INCLUDE_DIR | Path of the ROCm HIP include directory | Directory path | `${UR_HIP_ROCM_DIR}/include` |
+| UR_HIP_HSA_INCLUDE_DIR | Path of the ROCm HSA include directory | Directory path | `${UR_HIP_ROCM_DIR}/hsa/include""` |
+| UR_HIP_LIB_DIR | Path of the ROCm HIP library directory | Directory path | `${UR_HIP_ROCM_DIR}/lib""` |
 
 ### Additional make targets
 

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -31,7 +31,8 @@ if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
                         " please check ROCm installation.")
     endif()
 
-    # Check if HSA include path exists
+    # Check if HSA include path exists. In rocm-6.0.0 the layout of HSA
+    # directory has changed, check for the new location as well.
     foreach(D IN LISTS UR_HIP_HSA_INCLUDE_DIRS)
         if(EXISTS "${D}")
             set(UR_HIP_HSA_INCLUDE_DIR "${D}")

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -17,7 +17,7 @@ set(UR_HIP_HSA_INCLUDE_DIRS
   "${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
   "Custom ROCm HSA include dir")
 set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib" CACHE FILEPATH
-  "Custom ROCm HIP library dir" FORCE)
+  "Custom ROCm HIP library dir")
 
 # Check if HIP library path exists (AMD platform only)
 if("${UR_HIP_PLATFORM}" STREQUAL "AMD")

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -17,7 +17,7 @@ set(UR_HIP_HSA_INCLUDE_DIRS
   "${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
   "Custom ROCm HSA include dir")
 set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib" CACHE FILEPATH
-  "Custom ROCm HIP library dir")
+  "Custom ROCm HIP library dir" FORCE)
 
 # Check if HIP library path exists (AMD platform only)
 if("${UR_HIP_PLATFORM}" STREQUAL "AMD")

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -10,14 +10,14 @@ set(UR_HIP_PLATFORM "AMD" CACHE STRING "UR HIP platform, AMD or NVIDIA")
 
 # Set default ROCm installation directory
 set(UR_HIP_ROCM_DIR "/opt/rocm" CACHE STRING "ROCm installation dir")
-
-set(UR_HIP_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/include")
-
+# Allow custom location of HIP/HSA include and HIP library directories
+set(UR_HIP_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
+  "Custom ROCm HIP include dir")
 set(UR_HIP_HSA_INCLUDE_DIRS
-    "${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include")
-
-# Set HIP lib dir
-set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib")
+  "${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
+  "Custom ROCm HSA include dir")
+set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib" CACHE FILEPATH
+  "Custom ROCm HIP library dir")
 
 # Check if HIP library path exists (AMD platform only)
 if("${UR_HIP_PLATFORM}" STREQUAL "AMD")

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -11,12 +11,12 @@ set(UR_HIP_PLATFORM "AMD" CACHE STRING "UR HIP platform, AMD or NVIDIA")
 # Set default ROCm installation directory
 set(UR_HIP_ROCM_DIR "/opt/rocm" CACHE STRING "ROCm installation dir")
 # Allow custom location of HIP/HSA include and HIP library directories
-set(UR_HIP_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
+set(UR_HIP_INCLUDE_DIR "${UR_HIP_ROCM_DIR}/include" CACHE PATH
   "Custom ROCm HIP include dir")
 set(UR_HIP_HSA_INCLUDE_DIRS
   "${UR_HIP_ROCM_DIR}/hsa/include;${UR_HIP_ROCM_DIR}/include" CACHE FILEPATH
   "Custom ROCm HSA include dir")
-set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib" CACHE FILEPATH
+set(UR_HIP_LIB_DIR "${UR_HIP_ROCM_DIR}/lib" CACHE PATH
   "Custom ROCm HIP library dir")
 
 # Check if HIP library path exists (AMD platform only)


### PR DESCRIPTION
Allow custom location of HIP/HSA include and HIP library directories using the following CMake variables:
* `UR_HIP_INCLUDE_DIR`,
* `UR_HIP_HSA_INCLUDE_DIR`,
* `UR_HIP_LIB_DIR`.