### PR TITLE
Fix tracing param in disjoint_pool_parser

### DIFF
--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -49,14 +49,6 @@ ur_result_t umf2urResult(umf_result_t umfResult) {
 }
 
 usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig() {
-  const char *PoolUrConfigVal = std::getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR");
-  const char *PoolPiConfigVal = std::getenv("UR_L0_USM_ALLOCATOR");
-  const char *PoolConfigVal =
-      PoolUrConfigVal ? PoolUrConfigVal : PoolPiConfigVal;
-  if (PoolConfigVal == nullptr) {
-    return usm::DisjointPoolAllConfigs();
-  }
-
   const char *PoolUrTraceVal = std::getenv("UR_L0_USM_ALLOCATOR_TRACE");
   const char *PoolPiTraceVal =
       std::getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR_TRACE");
@@ -67,6 +59,14 @@ usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig() {
   int PoolTrace = 0;
   if (PoolTraceVal != nullptr) {
     PoolTrace = std::atoi(PoolTraceVal);
+  }
+
+  const char *PoolUrConfigVal = std::getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR");
+  const char *PoolPiConfigVal = std::getenv("UR_L0_USM_ALLOCATOR");
+  const char *PoolConfigVal =
+      PoolUrConfigVal ? PoolUrConfigVal : PoolPiConfigVal;
+  if (PoolConfigVal == nullptr) {
+    return usm::DisjointPoolAllConfigs(PoolTrace);
   }
 
   return usm::parseDisjointPoolConfig(PoolConfigVal, PoolTrace);

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -64,7 +64,7 @@ usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig() {
                                  ? PoolUrTraceVal
                                  : (PoolPiTraceVal ? PoolPiTraceVal : nullptr);
 
-  bool PoolTrace = false;
+  int PoolTrace = 0;
   if (PoolTraceVal != nullptr) {
     PoolTrace = std::atoi(PoolTraceVal);
   }

--- a/source/common/umf_pools/disjoint_pool_config_parser.cpp
+++ b/source/common/umf_pools/disjoint_pool_config_parser.cpp
@@ -24,7 +24,7 @@ constexpr auto operator""_GB(unsigned long long x) -> size_t {
     return x * 1024 * 1024 * 1024;
 }
 
-DisjointPoolAllConfigs::DisjointPoolAllConfigs() {
+DisjointPoolAllConfigs::DisjointPoolAllConfigs(int trace) {
     Configs[DisjointPoolMemType::Host].name = "Host";
     Configs[DisjointPoolMemType::Device].name = "Device";
     Configs[DisjointPoolMemType::Shared].name = "Shared";
@@ -58,6 +58,10 @@ DisjointPoolAllConfigs::DisjointPoolAllConfigs() {
     Configs[DisjointPoolMemType::SharedReadOnly].MaxPoolableSize = 4_MB;
     Configs[DisjointPoolMemType::SharedReadOnly].Capacity = 4;
     Configs[DisjointPoolMemType::SharedReadOnly].SlabMinSize = 2_MB;
+
+    for (auto &Config : Configs) {
+        Config.PoolTrace = trace;
+    }
 }
 
 DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,

--- a/source/common/umf_pools/disjoint_pool_config_parser.cpp
+++ b/source/common/umf_pools/disjoint_pool_config_parser.cpp
@@ -61,7 +61,7 @@ DisjointPoolAllConfigs::DisjointPoolAllConfigs() {
 }
 
 DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,
-                                               bool trace) {
+                                               int trace) {
     DisjointPoolAllConfigs AllConfigs;
 
     // TODO: replace with UR ENV var parser and avoid creating a copy of 'config'

--- a/source/common/umf_pools/disjoint_pool_config_parser.hpp
+++ b/source/common/umf_pools/disjoint_pool_config_parser.hpp
@@ -23,7 +23,7 @@ class DisjointPoolAllConfigs {
     size_t EnableBuffers = 1;
     DisjointPoolConfig Configs[DisjointPoolMemType::All];
 
-    DisjointPoolAllConfigs();
+    DisjointPoolAllConfigs(int trace = 0);
 };
 
 // Parse optional config parameters of this form:

--- a/source/common/umf_pools/disjoint_pool_config_parser.hpp
+++ b/source/common/umf_pools/disjoint_pool_config_parser.hpp
@@ -51,7 +51,7 @@ class DisjointPoolAllConfigs {
 // Example of usage:
 // "1;32M;host:1M,4,64K;device:1M,4,64K;shared:0,0,2M"
 DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,
-                                               bool trace = 1);
+                                               int trace = 1);
 } // namespace usm
 
 #endif


### PR DESCRIPTION
The disjoint_pool implementation distinguishes between a few different levels of logging (0-3). The argument should be an int, not bool.