### PR TITLE
[CTS] Don't use urProgramCreateWithIL on HIP adapter

### DIFF
--- a/test/conformance/program/urProgramCreateWithIL.cpp
+++ b/test/conformance/program/urProgramCreateWithIL.cpp
@@ -8,6 +8,15 @@
 struct urProgramCreateWithILTest : uur::urContextTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
+        // TODO: This should use a query for urProgramCreateWithIL support or
+        // rely on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.
+        ur_platform_backend_t backend;
+        ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
+                                         sizeof(ur_platform_backend_t),
+                                         &backend, nullptr));
+        if (backend == UR_PLATFORM_BACKEND_HIP) {
+            GTEST_SKIP();
+        }
         uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary);
     }
 

--- a/test/conformance/program/urProgramLink.cpp
+++ b/test/conformance/program/urProgramLink.cpp
@@ -8,6 +8,15 @@
 struct urProgramLinkTest : uur::urProgramTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
+        // TODO: This should use a query for urProgramCreateWithIL support or
+        // rely on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.
+        ur_platform_backend_t backend;
+        ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
+                                         sizeof(ur_platform_backend_t),
+                                         &backend, nullptr));
+        if (backend == UR_PLATFORM_BACKEND_HIP) {
+            GTEST_SKIP();
+        }
         ASSERT_SUCCESS(urProgramCompile(context, program, nullptr));
         programs.push_back(program);
 

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -477,6 +477,35 @@ void KernelsEnvironment::LoadSource(
     binary_out = binary_ptr;
 }
 
+ur_result_t KernelsEnvironment::CreateProgram(ur_platform_handle_t hPlatform,
+                                              ur_context_handle_t hContext,
+                                              ur_device_handle_t hDevice,
+                                              const std::vector<char> &binary,
+                                              ur_program_handle_t *phProgram) {
+    ur_platform_backend_t backend;
+    if (auto error = urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_BACKEND,
+                                       sizeof(ur_platform_backend_t), &backend,
+                                       nullptr)) {
+        return error;
+    }
+    if (backend == UR_PLATFORM_BACKEND_HIP) {
+        // The HIP adapter does not support urProgramCreateWithIL so we need to
+        // use urProgramCreateWithBinary instead.
+        if (auto error = urProgramCreateWithBinary(
+                hContext, hDevice, binary.size(),
+                reinterpret_cast<const uint8_t *>(binary.data()), nullptr,
+                phProgram)) {
+            return error;
+        }
+    } else {
+        if (auto error = urProgramCreateWithIL(
+                hContext, binary.data(), binary.size(), nullptr, phProgram)) {
+            return error;
+        }
+    }
+    return UR_RESULT_SUCCESS;
+}
+
 std::vector<std::string> KernelsEnvironment::GetEntryPointNames(
     [[maybe_unused]] std::string program_name) {
     std::vector<std::string> entry_points;

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -75,6 +75,12 @@ struct KernelsEnvironment : DevicesEnvironment {
     void LoadSource(const std::string &kernel_name, uint32_t device_index,
                     std::shared_ptr<std::vector<char>> &binary_out);
 
+    ur_result_t CreateProgram(ur_platform_handle_t hPlatform,
+                              ur_context_handle_t hContext,
+                              ur_device_handle_t hDevice,
+                              const std::vector<char> &binary,
+                              ur_program_handle_t *phProgram);
+
     std::vector<std::string> GetEntryPointNames(std::string program);
 
     static KernelsEnvironment *instance;

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -324,8 +324,8 @@ struct urHostPipeTest : urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary);
-        ASSERT_SUCCESS(urProgramCreateWithIL(
-            context, il_binary->data(), il_binary->size(), nullptr, &program));
+        ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
+            platform, context, device, *il_binary, &program));
 
         size_t size = 0;
         ASSERT_SUCCESS(urDeviceGetInfo(
@@ -1052,8 +1052,8 @@ struct urProgramTest : urQueueTest {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         uur::KernelsEnvironment::instance->LoadSource(program_name, 0,
                                                       il_binary);
-        ASSERT_SUCCESS(urProgramCreateWithIL(
-            context, il_binary->data(), il_binary->size(), nullptr, &program));
+        ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
+            platform, context, device, *il_binary, &program));
     }
 
     void TearDown() override {
@@ -1072,9 +1072,8 @@ template <class T> struct urProgramTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
         uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary);
-        ASSERT_SUCCESS(urProgramCreateWithIL(this->context, il_binary->data(),
-                                             il_binary->size(), nullptr,
-                                             &program));
+        ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
+            this->platform, this->context, this->device, *il_binary, &program));
     }
 
     void TearDown() override {


### PR DESCRIPTION
Since 5dc6e464c83fa41045d4f352a300db9b16400d1d CTS tests which execute
kernels have been failing to create programs. This has been hidden due
to the match files containing expected failures in combination with an
bug in the match file script found while debugging #1029 check failures.

This patch adds `uur::KernelsEnvironment::CreateProgram()` which
automatically handles the differences between the HIP adapter and
others. On the hip path `urProgramCreateWithIL` is not longer called
because it is not supported by the adatper and
`urProgramCreateWithBinary` is used instead. The non-HIP path continues
to use `urProgramCreateWithIL`.
