### PR TITLE
[HIP] Explicitly specify copy direction for USM 2D async memory copies

### DIFF
--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1666,6 +1666,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     // There is an issue with hipMemcpy2D* when hipMemcpyDefault is used, which
     // makes the HIP runtime not correctly derive the copy kind (direction) for
     // the copies since ROCm 5.6.0+. See: https://github.com/ROCm/clr/issues/40
+    // TODO: Add maximum HIP_VERSION when bug has been fixed.
 #if HIP_VERSION >= 50600000
     hipPointerAttribute_t srcAttribs{};
     hipPointerAttribute_t dstAttribs{};

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1687,8 +1687,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     if (hipRes == hipErrorInvalidValue && pDst)
       dstIsSystemAlloc = true;
 
-    const unsigned int srcMemType{srcAttribs.memoryType};
-    const unsigned int dstMemType{dstAttribs.memoryType};
+    const unsigned int srcMemType{srcAttribs.type};
+    const unsigned int dstMemType{dstAttribs.type};
 
     const bool srcIsHost{(srcMemType == hipMemoryTypeHost) || srcIsSystemAlloc};
     const bool srcIsDevice{srcMemType == hipMemoryTypeDevice};


### PR DESCRIPTION
There is an issue with `hipMemcpy2D*` when `hipMemcpyDefault` is used, which makes the HIP runtime not correctly derive the copy kind (direction) for the copies introduced since **ROCm 5.6.0**. See: https://github.com/ROCm/clr/issues/40.

This PR aims to provide a work-around in the meantime even though having to introduce the overhead of `hipPointerGetAttributes` in the memcpy2D. It patches it to work for the all possible copy kind directions (host / device / os-allocated host pageable memory) explicitly. Ideally, ROCm will fix the API when using just `hipMemcpyDefault` going forward.

**Testing:** [intel/llvm/pull/12200](https://github.com/intel/llvm/pull/12200)