### PR TITLE
Replace PROGRAM_INFO_SOURCE with PROGRAM_INFO_IL.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4491,7 +4491,8 @@ typedef enum ur_program_info_t {
                                          ///< This is either the list of devices associated with the context or a
                                          ///< subset of those devices when the program is created using ::urProgramCreateWithBinary.
     UR_PROGRAM_INFO_IL = 4,              ///< [char[]] Return program IL if the program was created with
-                                         ///< ::urProgramCreateWithIL
+                                         ///< ::urProgramCreateWithIL, otherwise return size will be set to 0 and
+                                         ///< nothing will be returned.
     UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< [size_t[]] Return program binary sizes for each device.
     UR_PROGRAM_INFO_BINARIES = 6,        ///< [unsigned char[]] Return program binaries for all devices for this
                                          ///< Program.

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4490,7 +4490,8 @@ typedef enum ur_program_info_t {
     UR_PROGRAM_INFO_DEVICES = 3,         ///< [::ur_device_handle_t[]] Return list of devices associated with a program.
                                          ///< This is either the list of devices associated with the context or a
                                          ///< subset of those devices when the program is created using ::urProgramCreateWithBinary.
-    UR_PROGRAM_INFO_SOURCE = 4,          ///< [char[]] Return program source associated with Program.
+    UR_PROGRAM_INFO_IL = 4,              ///< [char[]] Return program IL if the program was created with
+                                         ///< ::urProgramCreateWithIL
     UR_PROGRAM_INFO_BINARY_SIZES = 5,    ///< [size_t[]] Return program binary sizes for each device.
     UR_PROGRAM_INFO_BINARIES = 6,        ///< [unsigned char[]] Return program binaries for all devices for this
                                          ///< Program.

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -7501,8 +7501,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_program_info_t value) 
     case UR_PROGRAM_INFO_DEVICES:
         os << "UR_PROGRAM_INFO_DEVICES";
         break;
-    case UR_PROGRAM_INFO_SOURCE:
-        os << "UR_PROGRAM_INFO_SOURCE";
+    case UR_PROGRAM_INFO_IL:
+        os << "UR_PROGRAM_INFO_IL";
         break;
     case UR_PROGRAM_INFO_BINARY_SIZES:
         os << "UR_PROGRAM_INFO_BINARY_SIZES";
@@ -7584,7 +7584,7 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_program_inf
         }
         os << "}";
     } break;
-    case UR_PROGRAM_INFO_SOURCE: {
+    case UR_PROGRAM_INFO_IL: {
 
         const char *tptr = (const char *)ptr;
         printPtr(os, tptr);

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -377,7 +377,7 @@ etors:
           [$x_device_handle_t[]] Return list of devices associated with a program.
           This is either the list of devices associated with the context or a subset of those devices when the program is created using $xProgramCreateWithBinary.
     - name: IL
-      desc: "[char[]] Return program IL if the program was created with $xProgramCreateWithIL"
+      desc: "[char[]] Return program IL if the program was created with $xProgramCreateWithIL, otherwise return size will be set to 0 and nothing will be returned."
     - name: BINARY_SIZES
       desc: "[size_t[]] Return program binary sizes for each device."
     - name: BINARIES

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -376,8 +376,8 @@ etors:
       desc: |
           [$x_device_handle_t[]] Return list of devices associated with a program.
           This is either the list of devices associated with the context or a subset of those devices when the program is created using $xProgramCreateWithBinary.
-    - name: SOURCE
-      desc: "[char[]] Return program source associated with Program."
+    - name: IL
+      desc: "[char[]] Return program IL if the program was created with $xProgramCreateWithIL"
     - name: BINARY_SIZES
       desc: "[size_t[]] Return program binary sizes for each device."
     - name: BINARIES

--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -399,8 +399,6 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     return ReturnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
     return ReturnValue(&hProgram->Device, 1);
-  case UR_PROGRAM_INFO_SOURCE:
-    return ReturnValue(hProgram->Binary);
   case UR_PROGRAM_INFO_BINARY_SIZES:
     return ReturnValue(&hProgram->BinarySizeInBytes, 1);
   case UR_PROGRAM_INFO_BINARIES:
@@ -410,6 +408,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     UR_ASSERT(getKernelNames(hProgram), UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_PROGRAM_INFO_NUM_KERNELS:
+  case UR_PROGRAM_INFO_IL:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     break;

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -403,14 +403,14 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     return ReturnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
     return ReturnValue(&hProgram->getContext()->getDevices()[0], 1);
-  case UR_PROGRAM_INFO_SOURCE:
-    return ReturnValue(hProgram->Binary);
   case UR_PROGRAM_INFO_BINARY_SIZES:
     return ReturnValue(&hProgram->BinarySizeInBytes, 1);
   case UR_PROGRAM_INFO_BINARIES:
     return ReturnValue(&hProgram->Binary, 1);
   case UR_PROGRAM_INFO_KERNEL_NAMES:
     return getKernelNames(hProgram);
+  case UR_PROGRAM_INFO_IL:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     break;
   }

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -816,7 +816,7 @@ ur_result_t urProgramGetInfo(
     } catch (...) {
       return UR_RESULT_ERROR_UNKNOWN;
     }
-  case UR_PROGRAM_INFO_SOURCE:
+  case UR_PROGRAM_INFO_IL:
     return ReturnValue(Program->Code.get());
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -223,8 +223,6 @@ ur_result_t urProgramBuildExp(
     hProgram->ZeBuildLogMap.insert(std::make_pair(ZeDevice, ZeBuildLog));
   }
 
-  // We no longer need the IL / native code.
-  hProgram->Code.reset();
   if (!hProgram->ZeModuleMap.empty())
     hProgram->ZeModule = hProgram->ZeModuleMap.begin()->second;
   if (!hProgram->ZeBuildLogMap.empty())
@@ -817,7 +815,7 @@ ur_result_t urProgramGetInfo(
       return UR_RESULT_ERROR_UNKNOWN;
     }
   case UR_PROGRAM_INFO_IL:
-    return ReturnValue(Program->Code.get());
+    return ReturnValue(Program->Code.get(), Program->CodeLength);
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -204,8 +204,6 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     return returnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
     return returnValue(hProgram->_ctx->_device);
-  case UR_PROGRAM_INFO_SOURCE:
-    return returnValue(nullptr);
   case UR_PROGRAM_INFO_BINARY_SIZES:
     return returnValue("foo");
   case UR_PROGRAM_INFO_BINARIES:
@@ -213,6 +211,8 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   case UR_PROGRAM_INFO_KERNEL_NAMES: {
     return returnValue("foo");
   }
+  case UR_PROGRAM_INFO_IL:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     break;
   }

--- a/source/adapters/opencl/program.cpp
+++ b/source/adapters/opencl/program.cpp
@@ -159,8 +159,8 @@ static cl_int mapURProgramInfoToCL(ur_program_info_t URPropName) {
     return CL_PROGRAM_NUM_DEVICES;
   case UR_PROGRAM_INFO_DEVICES:
     return CL_PROGRAM_DEVICES;
-  case UR_PROGRAM_INFO_SOURCE:
-    return CL_PROGRAM_SOURCE;
+  case UR_PROGRAM_INFO_IL:
+    return CL_PROGRAM_IL;
   case UR_PROGRAM_INFO_BINARY_SIZES:
     return CL_PROGRAM_BINARY_SIZES;
   case UR_PROGRAM_INFO_BINARIES:

--- a/test/conformance/program/program_adapter_cuda.match
+++ b/test/conformance/program/program_adapter_cuda.match
@@ -4,9 +4,6 @@ urProgramBuildTest.BuildFailure/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urProgramCreateWithILTest.BuildInvalidProgram/NVIDIA_CUDA_BACKEND___{{.*}}
 # This test flakily fails
 {{OPT}}urProgramGetBuildInfoSingleTest.LogIsNullTerminated/NVIDIA_CUDA_BACKEND___{{.*}}
-# CUDA doesn't expose kernel numbers or names
-urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_KERNELS
-urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES
 {{OPT}}urProgramSetSpecializationConstantsTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramSetSpecializationConstantsTest.UseDefaultValue/NVIDIA_CUDA_BACKEND___{{.*}}
 urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/NVIDIA_CUDA_BACKEND___{{.*}}

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -57,7 +57,7 @@
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -66,7 +66,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS
@@ -75,7 +75,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS
@@ -84,7 +84,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidSizeZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS
@@ -93,7 +93,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidSizeSmall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS
@@ -102,7 +102,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS
@@ -111,7 +111,7 @@
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_DEVICES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_DEVICES
-{{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_SOURCE
+{{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_IL
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARY_SIZES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidNullPointerPropValueRet/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_PROGRAM_INFO_NUM_KERNELS

--- a/test/conformance/program/program_adapter_opencl.match
+++ b/test/conformance/program/program_adapter_opencl.match
@@ -1,2 +1,3 @@
 urProgramCreateWithILTest.BuildInvalidProgram/Intel_R__OpenCL___{{.*}}_
-urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_SOURCE
+urProgramGetFunctionPointerTest.InvalidFunctionName/Intel_R__OpenCL___{{.*}}_
+urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_BINARIES

--- a/test/conformance/program/program_adapter_opencl.match
+++ b/test/conformance/program/program_adapter_opencl.match
@@ -1,3 +1,1 @@
 urProgramCreateWithILTest.BuildInvalidProgram/Intel_R__OpenCL___{{.*}}_
-urProgramGetFunctionPointerTest.InvalidFunctionName/Intel_R__OpenCL___{{.*}}_
-urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_BINARIES

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -103,6 +103,10 @@ TEST_P(urProgramGetInfoTest, Success) {
         ASSERT_STRNE(returned_kernel_names, "");
         break;
     }
+    case UR_PROGRAM_INFO_IL: {
+        ASSERT_EQ(property_value, *il_binary.get());
+        break;
+    }
     default:
         break;
     }

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -18,7 +18,7 @@ UUR_TEST_SUITE_P(
     urProgramGetInfoTest,
     ::testing::Values(UR_PROGRAM_INFO_REFERENCE_COUNT, UR_PROGRAM_INFO_CONTEXT,
                       UR_PROGRAM_INFO_NUM_DEVICES, UR_PROGRAM_INFO_DEVICES,
-                      UR_PROGRAM_INFO_SOURCE, UR_PROGRAM_INFO_BINARY_SIZES,
+                      UR_PROGRAM_INFO_IL, UR_PROGRAM_INFO_BINARY_SIZES,
                       UR_PROGRAM_INFO_BINARIES, UR_PROGRAM_INFO_NUM_KERNELS,
                       UR_PROGRAM_INFO_KERNEL_NAMES),
     uur::deviceTestWithParamPrinter<ur_program_info_t>);

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -52,8 +52,12 @@ TEST_P(urProgramGetInfoTest, Success) {
                                         sizeof(binaries[0]), binaries,
                                         nullptr));
     } else {
-        ASSERT_SUCCESS(urProgramGetInfo(program, property_name, 0, nullptr,
-                                        &property_size));
+        auto result = urProgramGetInfo(program, property_name, 0, nullptr,
+                                       &property_size);
+        if (result != UR_RESULT_SUCCESS) {
+            ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
+            return;
+        }
         property_value.resize(property_size);
         ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
                                         property_value.data(), nullptr));


### PR DESCRIPTION
Also make returns for this consistent across adapter implementations (i.e. actual IL if that's supported, otherwise return UNSUPPORTED_ENUMERATION).

resolves #1138

LLVM testing https://github.com/intel/llvm/pull/12265