### PR TITLE
[draft] Add new experimental entry point for get native mem on device

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -215,6 +215,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 213,                    ///< Enumerator for ::urCommandBufferAppendUSMAdviseExp
     UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP = 214,                   ///< Enumerator for ::urEnqueueCooperativeKernelLaunchExp
     UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 215,          ///< Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
+    UR_FUNCTION_MEM_GET_NATIVE_HANDLE_EXP = 216,                               ///< Enumerator for ::urMemGetNativeHandleExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -2730,6 +2731,37 @@ urMemBufferPartition(
 UR_APIEXPORT ur_result_t UR_APICALL
 urMemGetNativeHandle(
     ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native mem handle.
+///
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeMem`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no underlying equivalent handle.
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem,           ///< [in] handle of the mem.
+    ur_device_handle_t hDevice,     ///< [in] handle of the device that native handle will be resident on.
     ur_native_handle_t *phNativeMem ///< [out] a pointer to the native handle of the mem.
 );
 
@@ -9487,6 +9519,16 @@ typedef struct ur_mem_get_native_handle_params_t {
     ur_mem_handle_t *phMem;
     ur_native_handle_t **pphNativeMem;
 } ur_mem_get_native_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urMemGetNativeHandleExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_mem_get_native_handle_exp_params_t {
+    ur_mem_handle_t *phMem;
+    ur_device_handle_t *phDevice;
+    ur_native_handle_t **pphNativeMem;
+} ur_mem_get_native_handle_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urMemBufferCreateWithNativeHandle

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -773,6 +773,13 @@ typedef ur_result_t(UR_APICALL *ur_pfnMemGetNativeHandle_t)(
     ur_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemGetNativeHandleExp
+typedef ur_result_t(UR_APICALL *ur_pfnMemGetNativeHandleExp_t)(
+    ur_mem_handle_t,
+    ur_device_handle_t,
+    ur_native_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urMemBufferCreateWithNativeHandle
 typedef ur_result_t(UR_APICALL *ur_pfnMemBufferCreateWithNativeHandle_t)(
     ur_native_handle_t,
@@ -817,6 +824,7 @@ typedef struct ur_mem_dditable_t {
     ur_pfnMemRelease_t pfnRelease;
     ur_pfnMemBufferPartition_t pfnBufferPartition;
     ur_pfnMemGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnMemGetNativeHandleExp_t pfnGetNativeHandleExp;
     ur_pfnMemBufferCreateWithNativeHandle_t pfnBufferCreateWithNativeHandle;
     ur_pfnMemImageCreateWithNativeHandle_t pfnImageCreateWithNativeHandle;
     ur_pfnMemGetInfo_t pfnGetInfo;
@@ -843,6 +851,40 @@ urGetMemProcAddrTable(
 typedef ur_result_t(UR_APICALL *ur_pfnGetMemProcAddrTable_t)(
     ur_api_version_t,
     ur_mem_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urMemGetNativeHandleExp
+typedef ur_result_t(UR_APICALL *ur_pfnMemGetNativeHandleExp_t)(
+    ur_mem_handle_t,
+    ur_device_handle_t,
+    ur_native_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of MemExp functions pointers
+typedef struct ur_mem_exp_dditable_t {
+    ur_pfnMemGetNativeHandleExp_t pfnGetNativeHandleExp;
+} ur_mem_exp_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MemExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemExpProcAddrTable(
+    ur_api_version_t version,        ///< [in] API version requested
+    ur_mem_exp_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetMemExpProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetMemExpProcAddrTable_t)(
+    ur_api_version_t,
+    ur_mem_exp_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPhysicalMemCreate
@@ -2311,6 +2353,7 @@ typedef struct ur_dditable_t {
     ur_kernel_exp_dditable_t KernelExp;
     ur_sampler_dditable_t Sampler;
     ur_mem_dditable_t Mem;
+    ur_mem_exp_dditable_t MemExp;
     ur_physical_mem_dditable_t PhysicalMem;
     ur_global_dditable_t Global;
     ur_enqueue_dditable_t Enqueue;

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -879,6 +879,9 @@ inline std::ostream &operator<<(std::ostream &os, ur_function_t value) {
     case UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP:
         os << "UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP";
         break;
+    case UR_FUNCTION_MEM_GET_NATIVE_HANDLE_EXP:
+        os << "UR_FUNCTION_MEM_GET_NATIVE_HANDLE_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -11184,6 +11187,32 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_mem_get_native_handle_exp_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_mem_get_native_handle_exp_params_t *params) {
+
+    os << ".hMem = ";
+
+    ur::details::printPtr(os,
+                          *(params->phMem));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur::details::printPtr(os,
+                          *(params->phDevice));
+
+    os << ", ";
+    os << ".phNativeMem = ";
+
+    ur::details::printPtr(os,
+                          *(params->pphNativeMem));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_mem_buffer_create_with_native_handle_params_t type
 /// @returns
 ///     std::ostream &
@@ -16090,6 +16119,9 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     } break;
     case UR_FUNCTION_MEM_GET_NATIVE_HANDLE: {
         os << (const struct ur_mem_get_native_handle_params_t *)params;
+    } break;
+    case UR_FUNCTION_MEM_GET_NATIVE_HANDLE_EXP: {
+        os << (const struct ur_mem_get_native_handle_exp_params_t *)params;
     } break;
     case UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE: {
         os << (const struct ur_mem_buffer_create_with_native_handle_params_t *)params;

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -440,6 +440,34 @@ returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."
 --- #--------------------------------------------------------------------------
+type: function
+desc: "Return platform native mem handle."
+class: $xMem
+name: GetNativeHandleExp
+decl: static
+ordinal: "0"
+details:
+    - "Retrieved native handle can be used for direct interaction with the native platform driver."
+    - "Use interoperability platform extensions to convert native handle to native type."
+    - "The application may call this function from simultaneous threads for the same context."
+    - "The implementation of this function should be thread-safe."
+params:
+    - type: $x_mem_handle_t
+      name: hMem
+      desc: |
+            [in] handle of the mem.
+    - type: $x_device_handle_t
+      name: hDevice
+      desc: |
+            [in] handle of the device that native handle will be resident on.
+    - type: $x_native_handle_t*
+      name: phNativeMem
+      desc: |
+            [out] a pointer to the native handle of the mem.
+returns:
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+        - "If the adapter has no underlying equivalent handle."
+--- #--------------------------------------------------------------------------
 type: struct
 desc: "Native memory object creation properties"
 class: $xMem

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -559,6 +559,9 @@ etors:
 - name: KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP
   desc: Enumerator for $xKernelSuggestMaxCooperativeGroupCountExp
   value: '215'
+- name: MEM_GET_NATIVE_HANDLE_EXP
+  desc: Enumerator for $xMemGetNativeHandleExp
+  value: '216'
 ---
 type: enum
 desc: Defines structure types

--- a/source/adapters/adapter.def.in
+++ b/source/adapters/adapter.def.in
@@ -10,6 +10,7 @@ EXPORTS
 	urGetKernelProcAddrTable
 	urGetKernelExpProcAddrTable
 	urGetMemProcAddrTable
+	urGetMemExpProcAddrTable
 	urGetPhysicalMemProcAddrTable
 	urGetPlatformProcAddrTable
 	urGetProgramProcAddrTable

--- a/source/adapters/adapter.map.in
+++ b/source/adapters/adapter.map.in
@@ -10,6 +10,7 @@
 		urGetKernelProcAddrTable;
 		urGetKernelExpProcAddrTable;
 		urGetMemProcAddrTable;
+		urGetMemExpProcAddrTable;
 		urGetPhysicalMemProcAddrTable;
 		urGetPlatformProcAddrTable;
 		urGetProgramProcAddrTable;

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -168,6 +168,20 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_native_handle_t *phNativeMem) {
   return UR_RESULT_SUCCESS;
 }
 
+/// Gets the native CUDA handle of a UR mem object
+/// This is the same as urMemGetNativeHandle but it will be changed when multi
+/// device context is supported
+///
+/// \param[in] hMem The UR mem to get the native CUDA object of.
+/// \param[in] hDevice The UR mem to get the native CUDA object of.
+/// \param[out] phNativeMem Set to the native handle of the UR mem object.
+///
+/// \return UR_RESULT_SUCCESS
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ur_device_handle_t, ur_native_handle_t *phNativeMem) {
+  return urMemGetNativeHandle(hMem, phNativeMem);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
                                                  ur_mem_info_t MemInfoType,
                                                  size_t propSize,

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -162,6 +162,16 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ur_mem_exp_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetNativeHandleExp = urMemGetNativeHandleExp;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t version, ur_enqueue_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -162,6 +162,16 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ur_mem_exp_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetNativeHandleExp = urMemGetNativeHandleExp;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t version, ur_enqueue_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -1867,6 +1867,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
+// Experimental entry point
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ur_device_handle_t, ur_native_handle_t *phNativeMem) {
+  return urMemGetNativeHandle(hMem, phNativeMem);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t NativeMem, ///< [in] the native handle to the memory.
     ur_context_handle_t Context,  ///< [in] handle of the context object.

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -178,6 +178,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
   return retVal;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ur_mem_exp_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetNativeHandleExp = urMemGetNativeHandleExp;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_platform_dditable_t

--- a/source/adapters/native_cpu/memory.cpp
+++ b/source/adapters/native_cpu/memory.cpp
@@ -118,6 +118,12 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_native_handle_t *phNativeMem) {
   DIE_NO_IMPLEMENTATION
 }
 
+// Experimental entry point
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ur_device_handle_t, ur_native_handle_t *phNativeMem) {
+  return urMemGetNativeHandle(hMem, phNativeMem);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
     const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -160,6 +160,16 @@ urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ur_mem_exp_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetNativeHandleExp = urMemGetNativeHandleExp;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t version, ur_enqueue_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);

--- a/source/adapters/opencl/memory.cpp
+++ b/source/adapters/opencl/memory.cpp
@@ -336,6 +336,12 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_native_handle_t *phNativeMem) {
   return getNativeHandle(hMem, phNativeMem);
 }
 
+// Experimental entry point
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ur_device_handle_t, ur_native_handle_t *phNativeMem) {
+  return urMemGetNativeHandle(hMem, phNativeMem);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t hNativeMem,
     [[maybe_unused]] ur_context_handle_t hContext,

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -161,6 +161,16 @@ urGetMemProcAddrTable(ur_api_version_t Version, ur_mem_dditable_t *pDdiTable) {
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ur_mem_exp_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetNativeHandleExp = urMemGetNativeHandleExp;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t Version, ur_enqueue_dditable_t *pDdiTable) {
   auto Result = validateProcInputs(Version, pDdiTable);

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1213,6 +1213,41 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urMemGetNativeHandleExp
+__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device that native handle will be resident on.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+) {
+    auto pfnGetNativeHandleExp =
+        context.urDdiTable.MemExp.pfnGetNativeHandleExp;
+
+    if (nullptr == pfnGetNativeHandleExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hDevice) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phNativeMem) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    ur_result_t result = pfnGetNativeHandleExp(hMem, hDevice, phNativeMem);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreateWithNativeHandle
 __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t
@@ -8706,6 +8741,41 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetMemProcAddrTable(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's MemExp table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetMemExpProcAddrTable(
+    ur_api_version_t version, ///< [in] API version requested
+    ur_mem_exp_dditable_t
+        *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+) {
+    auto &dditable = ur_validation_layer::context.urDdiTable.MemExp;
+
+    if (nullptr == pDdiTable) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+    }
+
+    if (UR_MAJOR_VERSION(ur_validation_layer::context.version) !=
+            UR_MAJOR_VERSION(version) ||
+        UR_MINOR_VERSION(ur_validation_layer::context.version) >
+            UR_MINOR_VERSION(version)) {
+        return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+    }
+
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    dditable.pfnGetNativeHandleExp = pDdiTable->pfnGetNativeHandleExp;
+    pDdiTable->pfnGetNativeHandleExp =
+        ur_validation_layer::urMemGetNativeHandleExp;
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's PhysicalMem table
 ///        with current process' addresses
 ///
@@ -9344,6 +9414,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
     if (UR_RESULT_SUCCESS == result) {
         result = ur_validation_layer::urGetMemProcAddrTable(
             UR_API_VERSION_CURRENT, &dditable->Mem);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
+        result = ur_validation_layer::urGetMemExpProcAddrTable(
+            UR_API_VERSION_CURRENT, &dditable->MemExp);
     }
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1675,6 +1675,48 @@ ur_result_t UR_APICALL urMemGetNativeHandle(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native mem handle.
+///
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeMem`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no underlying equivalent handle.
+ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device that native handle will be resident on.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+    ) try {
+    auto pfnGetNativeHandleExp =
+        ur_lib::context->urDdiTable.MemExp.pfnGetNativeHandleExp;
+    if (nullptr == pfnGetNativeHandleExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnGetNativeHandleExp(hMem, hDevice, phNativeMem);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime buffer memory object from native memory handle.
 ///
 /// @details

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -70,6 +70,11 @@ __urdlllocal ur_result_t context_t::urLoaderInit() {
     }
 
     if (UR_RESULT_SUCCESS == result) {
+        result = urGetMemExpProcAddrTable(UR_API_VERSION_CURRENT,
+                                          &urDdiTable.MemExp);
+    }
+
+    if (UR_RESULT_SUCCESS == result) {
         result = urGetPhysicalMemProcAddrTable(UR_API_VERSION_CURRENT,
                                                &urDdiTable.PhysicalMem);
     }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1433,6 +1433,41 @@ ur_result_t UR_APICALL urMemGetNativeHandle(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Return platform native mem handle.
+///
+/// @details
+///     - Retrieved native handle can be used for direct interaction with the
+///       native platform driver.
+///     - Use interoperability platform extensions to convert native handle to
+///       native type.
+///     - The application may call this function from simultaneous threads for
+///       the same context.
+///     - The implementation of this function should be thread-safe.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hMem`
+///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phNativeMem`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If the adapter has no underlying equivalent handle.
+ur_result_t UR_APICALL urMemGetNativeHandleExp(
+    ur_mem_handle_t hMem, ///< [in] handle of the mem.
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device that native handle will be resident on.
+    ur_native_handle_t
+        *phNativeMem ///< [out] a pointer to the native handle of the mem.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Create runtime buffer memory object from native memory handle.
 ///
 /// @details


### PR DESCRIPTION
Accessor interop requires `urMemGetNativeHandle` to return a valid mem handle. Multi dev ctx breaks this because a UR mem can be on many different devices now, so we need a new entry point that also takes a device or a queue param. 

Will wait until @kbenzie is back to discuss the best approach