### PR TITLE
[common] remove the use of std::getenv from common code

### DIFF
--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -22,6 +22,8 @@
 #include <vector>
 
 #ifdef _WIN32
+#define NOMINMAX
+
 #include <windows.h>
 inline int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
 #else
@@ -59,7 +61,6 @@ inline int ur_getpid(void) { return static_cast<int>(getpid()); }
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(_WIN32)
-#include <Windows.h>
 #define MAKE_LIBRARY_NAME(NAME, VERSION) NAME ".dll"
 #else
 #define HMODULE void *

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -23,6 +23,8 @@
 
 #include <ur_api.h>
 
+#include "ur_util.hpp"
+
 template <class To, class From> To ur_cast(From Value) {
   // TODO: see if more sanity checks are possible.
   assert(sizeof(From) == sizeof(To));
@@ -61,9 +63,10 @@ const ur_command_t UR_EXT_COMMAND_TYPE_USER =
 // overhead from mutex locking. Default value is 0 which means that single
 // thread mode is disabled.
 static const bool SingleThreadMode = [] {
-  const char *UrRet = std::getenv("UR_L0_SINGLE_THREAD_MODE");
-  const char *PiRet = std::getenv("SYCL_PI_LEVEL_ZERO_SINGLE_THREAD_MODE");
-  const bool RetVal = UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0);
+  auto UrRet = ur_getenv("UR_L0_SINGLE_THREAD_MODE");
+  auto PiRet = ur_getenv("SYCL_PI_LEVEL_ZERO_SINGLE_THREAD_MODE");
+  const bool RetVal =
+      UrRet ? std::stoi(*UrRet) : (PiRet ? std::stoi(*PiRet) : 0);
   return RetVal;
 }();
 


### PR DESCRIPTION
MSVC complains about it being insecure.