### PR TITLE
[UR] add dependent-load flag to exclude CWD from default search path …

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -133,6 +133,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES
 )
 
 if (WIN32)
+ # 0x800: Search for the DLL only in the System32 folder
  target_link_options(ur_adapter_level_zero PUBLIC /DEPENDENTLOADFLAG:0x800)
 endif()
 

--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -132,6 +132,10 @@ set_target_properties(${TARGET_NAME} PROPERTIES
     SOVERSION "${PROJECT_VERSION_MAJOR}"
 )
 
+if (WIN32)
+ target_link_options(ur_adapter_level_zero PUBLIC /DEPENDENTLOADFLAG:0x800)
+endif()
+
 target_link_libraries(${TARGET_NAME} PRIVATE
     ${PROJECT_NAME}::headers
     ${PROJECT_NAME}::common


### PR DESCRIPTION
…for DLLs

intel//llvm:https://github.com/intel/llvm/pull/12222/files