### PR TITLE
[NATIVECPU] Remove event.hpp inclusion

### DIFF
--- a/source/adapters/native_cpu/physical_mem.cpp
+++ b/source/adapters/native_cpu/physical_mem.cpp
@@ -11,7 +11,6 @@
 #include "physical_mem.hpp"
 #include "common.hpp"
 #include "context.hpp"
-#include "event.hpp"
 
 UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
     ur_context_handle_t, ur_device_handle_t, size_t,

--- a/source/adapters/native_cpu/virtual_mem.cpp
+++ b/source/adapters/native_cpu/virtual_mem.cpp
@@ -10,7 +10,6 @@
 
 #include "common.hpp"
 #include "context.hpp"
-#include "event.hpp"
 #include "physical_mem.hpp"
 
 UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(


### PR DESCRIPTION
The header does not exists for the Native CPU adapter.