### PR TITLE
[UR][HIP] Fix include for AMD COMGR

### DIFF
--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -108,8 +108,8 @@ if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
             INTERFACE_INCLUDE_DIRECTORIES        "${HIP_HEADERS}"
             INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${HIP_HEADERS}"
         )
-        target_link_libraries(pi_hip PUBLIC amd_comgr)
-        target_compile_definitions(pi_hip PRIVATE SYCL_ENABLE_KERNEL_FUSION)
+        target_link_libraries(${TARGET_NAME} PUBLIC amd_comgr)
+        target_compile_definitions(${TARGET_NAME} PRIVATE SYCL_ENABLE_KERNEL_FUSION)
     endif(UR_ENABLE_COMGR)
 
     target_link_libraries(${TARGET_NAME} PRIVATE

--- a/source/adapters/hip/CMakeLists.txt
+++ b/source/adapters/hip/CMakeLists.txt
@@ -101,6 +101,21 @@ if("${UR_HIP_PLATFORM}" STREQUAL "AMD")
     )
 
     if(UR_ENABLE_COMGR)
+        set(UR_COMGR_VERSION5_HEADER "${UR_HIP_INCLUDE_DIR}/amd_comgr/amd_comgr.h")
+        set(UR_COMGR_VERSION4_HEADER "${UR_HIP_INCLUDE_DIR}/amd_comgr.h")
+        # The COMGR header changed location between ROCm versions 4 and 5.
+        # Check for existence in the version 5 location or fallback to version 4
+        if(NOT EXISTS "${UR_COMGR_VERSION5_HEADER}")
+            if(NOT EXISTS "${UR_COMGR_VERSION4_HEADER}")
+                message(FATAL_ERROR "Could not find AMD COMGR header at "
+                                    "${UR_COMGR_VERSION5_HEADER} or"
+                                    "${UR_COMGR_VERSION4_HEADER}, "
+                                    "check ROCm installation")
+            else()
+                target_compile_definitions(${TARGET_NAME} PRIVATE UR_COMGR_VERSION4_INCLUDE)
+            endif()
+        endif()
+
         add_library(amd_comgr SHARED IMPORTED GLOBAL)
         set_target_properties(
         amd_comgr PROPERTIES

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -10,11 +10,10 @@
 #pragma once
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
-#include <rocm/rocm_version.h>
-#if (ROCM_VERSION_MAJOR >= 5)
-#include <amd_comgr/amd_comgr.h>
-#else
+#ifdef UR_COMGR_VERSION4_INCLUDE
 #include <amd_comgr.h>
+#else
+#include <amd_comgr/amd_comgr.h>
 #endif
 #endif
 #include <hip/hip_runtime.h>

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -10,7 +10,11 @@
 #pragma once
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
+#if (ROCM_VERSION_MAJOR >= 5)
 #include <amd_comgr/amd_comgr.h>
+#else
+#include <amd_comgr.h>
+#endif
 #endif
 #include <hip/hip_runtime.h>
 #include <ur/ur.hpp>

--- a/source/adapters/hip/common.hpp
+++ b/source/adapters/hip/common.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
+#include <rocm/rocm_version.h>
 #if (ROCM_VERSION_MAJOR >= 5)
 #include <amd_comgr/amd_comgr.h>
 #else

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -11,6 +11,7 @@
 #include "program.hpp"
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
+#include <rocm/rocm_version.h>
 #if (ROCM_VERSION_MAJOR >= 5)
 #include <amd_comgr/amd_comgr.h>
 #else

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -11,11 +11,10 @@
 #include "program.hpp"
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
-#include <rocm/rocm_version.h>
-#if (ROCM_VERSION_MAJOR >= 5)
-#include <amd_comgr/amd_comgr.h>
-#else
+#ifdef UR_COMGR_VERSION4_INCLUDE
 #include <amd_comgr.h>
+#else
+#include <amd_comgr/amd_comgr.h>
 #endif
 namespace {
 template <typename ReleaseType, ReleaseType Release, typename T>

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -11,7 +11,11 @@
 #include "program.hpp"
 
 #ifdef SYCL_ENABLE_KERNEL_FUSION
+#if (ROCM_VERSION_MAJOR >= 5)
 #include <amd_comgr/amd_comgr.h>
+#else
+#include <amd_comgr.h>
+#endif
 namespace {
 template <typename ReleaseType, ReleaseType Release, typename T>
 struct COMgrObjCleanUp {


### PR DESCRIPTION
The code object finalization for kernel fusion uses the AMD COMGR. The location of the corresponding header changed between ROCm version 4 and 5.

This PR fixes the include for ROCm version 4.