### PR TITLE
[CTS] Add more USM testing

### DIFF
--- a/test/conformance/device_code/CMakeLists.txt
+++ b/test/conformance/device_code/CMakeLists.txt
@@ -93,6 +93,7 @@ add_device_binary(${CMAKE_CURRENT_SOURCE_DIR}/foo.cpp)
 add_device_binary(${CMAKE_CURRENT_SOURCE_DIR}/image_copy.cpp)
 add_device_binary(${CMAKE_CURRENT_SOURCE_DIR}/mean.cpp)
 add_device_binary(${CMAKE_CURRENT_SOURCE_DIR}/spec_constant.cpp)
+add_device_binary(${CMAKE_CURRENT_SOURCE_DIR}/usm_ll.cpp)
 
 set(KERNEL_HEADER ${UR_CONFORMANCE_DEVICE_BINARIES_DIR}/kernel_entry_points.h)
 add_custom_command(OUTPUT ${KERNEL_HEADER}

--- a/test/conformance/device_code/usm_ll.cpp
+++ b/test/conformance/device_code/usm_ll.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int numNodes = 4;
+
+struct Node {
+    Node() : pNext(nullptr), Num(0xDEADBEEF) {}
+
+    Node *pNext;
+    uint32_t Num;
+};
+
+int main() {
+    queue q;
+    auto dev = q.get_device();
+    auto ctxt = q.get_context();
+
+    if (!dev.get_info<info::device::usm_shared_allocations>()) {
+        return 0;
+    }
+
+    Node *s_head =
+        (Node *)aligned_alloc_shared(alignof(Node), sizeof(Node), dev, ctxt);
+    if (s_head == nullptr) {
+        return -1;
+    }
+    Node *s_cur = s_head;
+
+    for (int i = 0; i < numNodes; i++) {
+        s_cur->Num = i * 2;
+
+        if (i != (numNodes - 1)) {
+            s_cur->pNext = (Node *)aligned_alloc_shared(
+                alignof(Node), sizeof(Node), dev, ctxt);
+        } else {
+            s_cur->pNext = nullptr;
+        }
+
+        s_cur = s_cur->pNext;
+    }
+
+    auto e1 = q.submit([=](handler &cgh) {
+        cgh.single_task<class linkedlist>([=]() {
+            Node *pHead = s_head;
+            while (pHead) {
+                pHead->Num = pHead->Num * 2 + 1;
+                pHead = pHead->pNext;
+            }
+        });
+    });
+
+    e1.wait();
+
+    s_cur = s_head;
+    for (int i = 0; i < numNodes; i++) {
+        Node *old = s_cur;
+        s_cur = s_cur->pNext;
+        free(old, ctxt);
+    }
+
+    return 0;
+}

--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -33,3 +33,4 @@
 {{OPT}}urEnqueueUSMMemcpy2DNegativeTest.InvalidSize/Intel_R__OpenCL___{{.*}}
 {{OPT}}urEnqueueUSMMemcpy2DNegativeTest.InvalidEventWaitList/Intel_R__OpenCL___{{.*}}
 {{OPT}}urEnqueueUSMPrefetchTest.InvalidSizeTooLarge/Intel_R__OpenCL___{{.*}}
+{{OPT}}urEnqueueKernelLaunchUSMLinkedList.Success/Intel_R__OpenCL___{{.*}}_UsePoolEnabled

--- a/test/conformance/enqueue/helpers.h
+++ b/test/conformance/enqueue/helpers.h
@@ -66,6 +66,18 @@ struct TestParameters2D {
     size_t height;
 };
 
+inline std::string USMKindToString(USMKind kind) {
+    switch (kind) {
+    case USMKind::Device:
+        return "Device";
+    case USMKind::Host:
+        return "Host";
+    case USMKind::Shared:
+    default:
+        return "Shared";
+    }
+}
+
 template <typename T>
 inline std::string
 print2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
@@ -73,10 +85,14 @@ print2DTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
     const auto platform_device_name =
         uur::GetPlatformAndDeviceName(device_handle);
     std::stringstream test_name;
+    auto src_kind = std::get<1>(std::get<1>(info.param));
+    auto dst_kind = std::get<2>(std::get<1>(info.param));
     test_name << platform_device_name << "__pitch__"
-              << std::get<1>(info.param).pitch << "__width__"
-              << std::get<1>(info.param).width << "__height__"
-              << std::get<1>(info.param).height;
+              << std::get<0>(std::get<1>(info.param)).pitch << "__width__"
+              << std::get<0>(std::get<1>(info.param)).width << "__height__"
+              << std::get<0>(std::get<1>(info.param)).height << "__src__"
+              << USMKindToString(src_kind) << "__dst__"
+              << USMKindToString(dst_kind);
     return test_name.str();
 }
 

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1071,7 +1071,8 @@ struct urProgramTest : urQueueTest {
 template <class T> struct urProgramTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
-        uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary);
+        uur::KernelsEnvironment::instance->LoadSource(program_name, 0,
+                                                      il_binary);
         ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
             this->platform, this->context, this->device, *il_binary, &program));
     }

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -378,6 +378,18 @@ ur_device_partition_property_t makePartitionEquallyDesc(uint32_t cu_per_device);
 ur_device_partition_property_t
 makePartitionByAffinityDomain(ur_device_affinity_domain_flags_t aff_domain);
 
+enum class USMKind {
+    Device,
+    Host,
+    Shared,
+};
+
+ur_result_t MakeUSMAllocationByType(USMKind kind, ur_context_handle_t hContext,
+                                    ur_device_handle_t hDevice,
+                                    const ur_usm_desc_t *pUSMDesc,
+                                    ur_usm_pool_handle_t hPool, size_t size,
+                                    void **ppMem);
+
 } // namespace uur
 
 #endif // UR_CONFORMANCE_INCLUDE_UTILS_H_INCLUDED

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -658,4 +658,22 @@ makePartitionByAffinityDomain(ur_device_affinity_domain_flags_t aff_domain) {
     return desc;
 }
 
+ur_result_t MakeUSMAllocationByType(USMKind kind, ur_context_handle_t hContext,
+                                    ur_device_handle_t hDevice,
+                                    const ur_usm_desc_t *pUSMDesc,
+                                    ur_usm_pool_handle_t hPool, size_t size,
+                                    void **ppMem) {
+    switch (kind) {
+    case USMKind::Device:
+        return urUSMDeviceAlloc(hContext, hDevice, pUSMDesc, hPool, size,
+                                ppMem);
+    case USMKind::Host:
+        return urUSMHostAlloc(hContext, pUSMDesc, hPool, size, ppMem);
+    default:
+    case USMKind::Shared:
+        return urUSMSharedAlloc(hContext, hDevice, pUSMDesc, hPool, size,
+                                ppMem);
+    }
+}
+
 } // namespace uur


### PR DESCRIPTION
* Expand USMMemcpy2D testing to test all USM allocation types
* Add USM linked list kernel execution test

The linked list test is based on USM/smemll.cpp from the SYCL-E2E tests and checks that USM allocations are actually usable from a kernel.