### PR TITLE
[urinfo] Fix printing of device UUID

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1546,7 +1546,7 @@ typedef enum ur_device_info_t {
                                                                     ///< shared memory access
     UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,                  ///< [::ur_device_usm_access_capability_flags_t] support USM system wide
                                                                     ///< shared memory access
-    UR_DEVICE_INFO_UUID = 88,                                       ///< [char[]] return device UUID
+    UR_DEVICE_INFO_UUID = 88,                                       ///< [uint8_t[]] return device UUID
     UR_DEVICE_INFO_PCI_ADDRESS = 89,                                ///< [char[]] return device PCI address
     UR_DEVICE_INFO_GPU_EU_COUNT = 90,                               ///< [uint32_t] return Intel GPU EU count
     UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                          ///< [uint32_t] return Intel GPU EU SIMD width

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -3596,8 +3596,17 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
     } break;
     case UR_DEVICE_INFO_UUID: {
 
-        const char *tptr = (const char *)ptr;
-        printPtr(os, tptr);
+        const uint8_t *tptr = (const uint8_t *)ptr;
+        os << "{";
+        size_t nelems = size / sizeof(uint8_t);
+        for (size_t i = 0; i < nelems; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+
+            os << tptr[i];
+        }
+        os << "}";
     } break;
     case UR_DEVICE_INFO_PCI_ADDRESS: {
 

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -377,7 +377,7 @@ etors:
     - name: USM_SYSTEM_SHARED_SUPPORT
       desc: "[$x_device_usm_access_capability_flags_t] support USM system wide shared memory access"
     - name: UUID
-      desc: "[char[]] return device UUID"
+      desc: "[uint8_t[]] return device UUID"
     - name: PCI_ADDRESS
       desc: "[char[]] return device PCI address"
     - name: GPU_EU_COUNT

--- a/scripts/templates/tools-info.hpp.mako
+++ b/scripts/templates/tools-info.hpp.mako
@@ -62,7 +62,11 @@ inline void printPlatformInfos(${x}_platform_handle_t hPlatform, std::string_vie
 inline void printDeviceInfos(${x}_device_handle_t hDevice, std::string_view prefix = "      ") {
 %for etor in obj['etors']:
     std::cout << prefix;
+%if etor['name'] == '$X_DEVICE_INFO_UUID':
+    printDeviceUUID(hDevice, ${etor['name'].replace('$X', X)});
+%else:
     printDeviceInfo<${etor['desc'][1:etor['desc'].find(' ')-1].replace('$x', x)}>(hDevice, ${etor['name'].replace('$X', X)});
+%endif
 %endfor
 }
 %endif

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -10,6 +10,7 @@
 #include "common.hpp"
 #include "platform.hpp"
 
+#include <array>
 #include <cassert>
 
 ur_result_t cl_adapter::getDeviceVersion(cl_device_id Dev,
@@ -941,6 +942,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     }
     return ReturnValue(SupportedExtensions.c_str());
   }
+
+  case UR_DEVICE_INFO_UUID: {
+    // Use the cl_khr_device_uuid extension, if available.
+    bool isKhrDeviceUuidSupported = false;
+    if (cl_adapter::checkDeviceExtensions(
+            cl_adapter::cast<cl_device_id>(hDevice), {"cl_khr_device_uuid"},
+            isKhrDeviceUuidSupported) != UR_RESULT_SUCCESS ||
+        !isKhrDeviceUuidSupported) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+    static_assert(CL_UUID_SIZE_KHR == 16);
+    std::array<uint8_t, CL_UUID_SIZE_KHR> UUID{};
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_UUID_KHR, UUID.size(), UUID.data(), nullptr));
+    return ReturnValue(UUID);
+  }
+
   case UR_DEVICE_INFO_COMPONENT_DEVICES:
   case UR_DEVICE_INFO_COMPOSITE_DEVICE:
     // These two are exclusive of L0.
@@ -957,10 +976,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE:
   case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
   case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH:
-  /* TODO: Check if device UUID extension is enabled in OpenCL. For details
-   * about Intel UUID extension, see
-   * sycl/doc/extensions/supported/sycl_ext_intel_device_info.md */
-  case UR_DEVICE_INFO_UUID:
   /* This enums have no equivalent in OpenCL */
   case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP:
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE:

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -258,7 +258,7 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
     printDeviceInfo<ur_device_usm_access_capability_flags_t>(
         hDevice, UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT);
     std::cout << prefix;
-    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_UUID);
+    printDeviceUUID(hDevice, UR_DEVICE_INFO_UUID);
     std::cout << prefix;
     printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_PCI_ADDRESS);
     std::cout << prefix;

--- a/tools/urinfo/utils.hpp
+++ b/tools/urinfo/utils.hpp
@@ -244,4 +244,19 @@ inline void printDeviceInfo<char[]>(ur_device_handle_t device,
     str.pop_back(); // std::string does not need a terminating NULL, remove it here
     std::cout << str << "\n";
 }
+
+inline void printDeviceUUID(ur_device_handle_t device, ur_device_info_t info) {
+    std::cout << getDeviceInfoName(info) << ": ";
+    size_t size;
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, 0, nullptr, &size));
+    std::vector<uint8_t> values(size / sizeof(uint8_t));
+    UR_CHECK_WEAK(urDeviceGetInfo(device, info, size, values.data(), nullptr));
+    for (size_t i = 0; i < values.size(); i++) {
+        if (i == 4 || i == 6 || i == 8 || i == 10) {
+            std::printf("-");
+        }
+        std::printf("%.2x", (uint32_t)values[i]);
+    }
+    std::printf("\n");
+}
 } // namespace urinfo


### PR DESCRIPTION
* Change the type returned by the `UR_DEVICE_INFO_UUID` query to `uint8_t` to match the type returned from Level Zero, CUDA, & HIP.
* Modify template to emit call to `printDeviceUUID()` instead of generic info printer to special case output formatting.
* Add `printDeviceUUID()` to print the device UUID in a human friendly format.
