### PR TITLE
[NATIVECPU] Empty implementation for command buffer fill

### DIFF
--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -133,3 +133,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
                   "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+    ur_exp_command_buffer_handle_t, ur_mem_handle_t,
+    const void *, size_t, size_t, size_t,
+    uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *) {
+  detail::ur::die("Experimental Command-buffer feature is not "
+                  "implemented for the NativeCPU adapter.");
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+     ur_exp_command_buffer_handle_t,
+     void *,  const void *,
+     size_t,  size_t,
+     uint32_t,
+     const ur_exp_command_buffer_sync_point_t *,
+     ur_exp_command_buffer_sync_point_t *) {
+  detail::ur::die("Experimental Command-buffer feature is not "
+                  "implemented for the NativeCPU adapter.");
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -147,3 +147,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_sync_point_t *) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+    ur_exp_command_buffer_handle_t, const void *, size_t,
+    ur_usm_migration_flags_t, uint32_t,
+    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+    ur_exp_command_buffer_handle_t, const void *, size_t, ur_usm_advice_flags_t,
+    uint32_t, const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -138,8 +138,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t, ur_mem_handle_t, const void *, size_t,
     size_t, size_t, uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -147,7 +145,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t, void *, const void *, size_t, size_t,
     uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
-  detail::ur::die("Experimental Command-buffer feature is not "
-                  "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }

--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -135,10 +135,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
-    ur_exp_command_buffer_handle_t, ur_mem_handle_t,
-    const void *, size_t, size_t, size_t,
-    uint32_t,
-    const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_handle_t, ur_mem_handle_t, const void *, size_t,
+    size_t, size_t, uint32_t, const ur_exp_command_buffer_sync_point_t *,
     ur_exp_command_buffer_sync_point_t *) {
   detail::ur::die("Experimental Command-buffer feature is not "
                   "implemented for the NativeCPU adapter.");
@@ -146,12 +144,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
-     ur_exp_command_buffer_handle_t,
-     void *,  const void *,
-     size_t,  size_t,
-     uint32_t,
-     const ur_exp_command_buffer_sync_point_t *,
-     ur_exp_command_buffer_sync_point_t *) {
+    ur_exp_command_buffer_handle_t, void *, const void *, size_t, size_t,
+    uint32_t, const ur_exp_command_buffer_sync_point_t *,
+    ur_exp_command_buffer_sync_point_t *) {
   detail::ur::die("Experimental Command-buffer feature is not "
                   "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;


### PR DESCRIPTION
Adds empty implementations for `urCommandBufferAppendMemBufferFillExp` and `urCommandBufferAppendUSMFillExp` on Native CPU.
intel/llvm PR: https://github.com/intel/llvm/pull/12379