### PR TITLE
[L0] move platform cache into the adapter structure

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -213,15 +213,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -L "adapter-specific" --timeout 180
 
-    # Temporarily disabling platform test for L0, because of hang
-    # See issue: #824
-    - name: Test L0 adapter
-      if: matrix.adapter.name == 'L0'
-      working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "conformance" -E "platform-adapter_level_zero" --timeout 180
-
     - name: Test adapters
-      if: matrix.adapter.name != 'L0'
       working-directory: ${{github.workspace}}/build
       run: env UR_CTS_ADAPTER_PLATFORM="${{matrix.adapter.platform}}" ctest -C ${{matrix.build_type}} --output-on-failure -L "conformance" --timeout 180
 

--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -10,10 +10,18 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
+#include <ur/ur.hpp>
+#include <ze_api.h>
+
+using PlatformVec = std::vector<std::unique_ptr<ur_platform_handle_t_>>;
 
 struct ur_adapter_handle_t_ {
   std::atomic<uint32_t> RefCount = 0;
   std::mutex Mutex;
+
+  std::optional<ze_result_t> ZeResult;
+  ZeCache<Result<PlatformVec>> PlatformCache;
 };
 
 extern ur_adapter_handle_t_ Adapter;

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -27,101 +27,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
     uint32_t *NumPlatforms ///< [out][optional] returns the total number of
                            ///< platforms available.
 ) {
-  static std::once_flag ZeCallCountInitialized;
-  try {
-    std::call_once(ZeCallCountInitialized, []() {
-      if (UrL0LeaksDebug) {
-        ZeCallCount = new std::map<std::string, int>;
-      }
-    });
-  } catch (const std::bad_alloc &) {
-    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-  } catch (...) {
-    return UR_RESULT_ERROR_UNKNOWN;
-  }
-
-  // Setting these environment variables before running zeInit will enable the
-  // validation layer in the Level Zero loader.
-  if (UrL0Debug & UR_L0_DEBUG_VALIDATION) {
-    setEnvVar("ZE_ENABLE_VALIDATION_LAYER", "1");
-    setEnvVar("ZE_ENABLE_PARAMETER_VALIDATION", "1");
-  }
-
-  if (getenv("SYCL_ENABLE_PCI") != nullptr) {
-    urPrint("WARNING: SYCL_ENABLE_PCI is deprecated and no longer needed.\n");
-  }
-
-  // TODO: We can still safely recover if something goes wrong during the init.
-  // Implement handling segfault using sigaction.
-
-  // We must only initialize the driver once, even if urPlatformGet() is called
-  // multiple times.  Declaring the return value as "static" ensures it's only
-  // called once.
-  static ze_result_t ZeResult =
-      ZE_CALL_NOCHECK(zeInit, (ZE_INIT_FLAG_GPU_ONLY));
-
-  // Absorb the ZE_RESULT_ERROR_UNINITIALIZED and just return 0 Platforms.
-  if (ZeResult == ZE_RESULT_ERROR_UNINITIALIZED) {
-    UR_ASSERT(NumEntries == 0, UR_RESULT_ERROR_INVALID_VALUE);
-    if (NumPlatforms)
-      *NumPlatforms = 0;
-    return UR_RESULT_SUCCESS;
-  }
-
-  if (ZeResult != ZE_RESULT_SUCCESS) {
-    urPrint("zeInit: Level Zero initialization failure\n");
-    return ze2urResult(ZeResult);
-  }
-
-  // Cache ur_platform_handle_t for reuse in the future
-  // It solves two problems;
-  // 1. sycl::platform equality issue; we always return the same
-  // ur_platform_handle_t
-  // 2. performance; we can save time by immediately return from cache.
-  //
-
-  const std::lock_guard<SpinLock> Lock{*URPlatformsCacheMutex};
-  if (!URPlatformCachePopulated) {
-    try {
-      // Level Zero does not have concept of Platforms, but Level Zero driver is
-      // the closest match.
-      uint32_t ZeDriverCount = 0;
-      ZE2UR_CALL(zeDriverGet, (&ZeDriverCount, nullptr));
-      if (ZeDriverCount == 0) {
-        URPlatformCachePopulated = true;
-      } else {
-        std::vector<ze_driver_handle_t> ZeDrivers;
-        ZeDrivers.resize(ZeDriverCount);
-
-        ZE2UR_CALL(zeDriverGet, (&ZeDriverCount, ZeDrivers.data()));
-        for (uint32_t I = 0; I < ZeDriverCount; ++I) {
-          auto Platform = new ur_platform_handle_t_(ZeDrivers[I]);
-          // Save a copy in the cache for future uses.
-          URPlatformsCache->push_back(Platform);
-
-          UR_CALL(Platform->initialize());
-        }
-        URPlatformCachePopulated = true;
-      }
-    } catch (const std::bad_alloc &) {
-      return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    } catch (...) {
-      return UR_RESULT_ERROR_UNKNOWN;
+  // Platform handles are cached for reuse. This is to ensure consistent
+  // handle pointers across invocations and to improve retrieval performance.
+  if (const auto *cached_platforms = Adapter.PlatformCache->get_value()) {
+    uint32_t nplatforms = (uint32_t)cached_platforms->size();
+    if (NumPlatforms) {
+      *NumPlatforms = nplatforms;
     }
-  }
-
-  // Populate returned platforms from the cache.
-  if (Platforms) {
-    UR_ASSERT(NumEntries <= URPlatformsCache->size(),
-              UR_RESULT_ERROR_INVALID_PLATFORM);
-    std::copy_n(URPlatformsCache->begin(), NumEntries, Platforms);
-  }
-
-  if (NumPlatforms) {
-    if (*NumPlatforms == 0)
-      *NumPlatforms = URPlatformsCache->size();
-    else
-      *NumPlatforms = (std::min)(URPlatformsCache->size(), (size_t)NumEntries);
+    if (Platforms) {
+      for (uint32_t i = 0; i < std::min(nplatforms, NumEntries); ++i) {
+        Platforms[i] = cached_platforms->at(i).get();
+      }
+    }
+  } else {
+    return Adapter.PlatformCache->get_error();
   }
 
   return UR_RESULT_SUCCESS;

--- a/source/ur/ur.cpp
+++ b/source/ur/ur.cpp
@@ -22,9 +22,3 @@ bool PrintTrace = [] {
   }
   return false;
 }();
-
-// Apparatus for maintaining immutable cache of platforms.
-std::vector<ur_platform_handle_t> *URPlatformsCache =
-    new std::vector<ur_platform_handle_t>;
-SpinLock *URPlatformsCacheMutex = new SpinLock;
-bool URPlatformCachePopulated = false;


### PR DESCRIPTION
The platform cache is a global variable used exclusively by the L0 adapter, and it's protected by a loosely-associated spin lock. However, its destruction is associated with the lifetime of the adapter structure and is deleted the first time adapter refcount reaches 0. This was causing issues whenever the adapter was initialized and destroyed multiple time inside of a single process, which, for example, happens during tests.

This patch fixes the above problem by moving the platform cache from the global state into the adapter structure. This allows for a simpler implementation that no longer requires an explicit lock and instead uses lazy loading (std::call_once).

With this patch, all platform tests are now passing for L0. Closes #824