### PR TITLE
[SPEC] Add urProgramGetGlobalVariablePointer entrypoint

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -196,7 +196,6 @@ typedef enum ur_function_t {
     UR_FUNCTION_ADAPTER_RETAIN = 179,                                          ///< Enumerator for ::urAdapterRetain
     UR_FUNCTION_ADAPTER_GET_LAST_ERROR = 180,                                  ///< Enumerator for ::urAdapterGetLastError
     UR_FUNCTION_ADAPTER_GET_INFO = 181,                                        ///< Enumerator for ::urAdapterGetInfo
-    UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP = 182,                 ///< Enumerator for ::urCommandBufferUpdateKernelLaunchExp
     UR_FUNCTION_PROGRAM_BUILD_EXP = 197,                                       ///< Enumerator for ::urProgramBuildExp
     UR_FUNCTION_PROGRAM_COMPILE_EXP = 198,                                     ///< Enumerator for ::urProgramCompileExp
     UR_FUNCTION_PROGRAM_LINK_EXP = 199,                                        ///< Enumerator for ::urProgramLinkExp
@@ -216,11 +215,13 @@ typedef enum ur_function_t {
     UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 213,                    ///< Enumerator for ::urCommandBufferAppendUSMAdviseExp
     UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP = 214,                   ///< Enumerator for ::urEnqueueCooperativeKernelLaunchExp
     UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 215,          ///< Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
-    UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP = 216,                       ///< Enumerator for ::urCommandBufferRetainCommandExp
-    UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP = 217,                      ///< Enumerator for ::urCommandBufferReleaseCommandExp
-    UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 218,                             ///< Enumerator for ::urCommandBufferGetInfoExp
-    UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP = 219,                     ///< Enumerator for ::urCommandBufferCommandGetInfoExp
-    UR_FUNCTION_DEVICE_GET_SELECTED = 220,                                     ///< Enumerator for ::urDeviceGetSelected
+    UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER = 216,                     ///< Enumerator for ::urProgramGetGlobalVariablePointer
+    UR_FUNCTION_DEVICE_GET_SELECTED = 217,                                     ///< Enumerator for ::urDeviceGetSelected
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP = 218,                       ///< Enumerator for ::urCommandBufferRetainCommandExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP = 219,                      ///< Enumerator for ::urCommandBufferReleaseCommandExp
+    UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP = 220,                 ///< Enumerator for ::urCommandBufferUpdateKernelLaunchExp
+    UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 221,                             ///< Enumerator for ::urCommandBufferGetInfoExp
+    UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP = 222,                     ///< Enumerator for ::urCommandBufferCommandGetInfoExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -4325,6 +4326,42 @@ urProgramGetFunctionPointer(
                                   ///< otherwise ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
     const char *pFunctionName,    ///< [in] A null-terminates string denoting the mangled function name.
     void **ppFunctionPointer      ///< [out] Returns the pointer to the function if it is found in the program.
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a pointer to a device global variable.
+///
+/// @details
+///     - Retrieves a pointer to a device global variable.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+///
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceGlobalVariablePointerINTEL**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalVariableName`
+///         + `NULL == ppGlobalVariablePointerRet`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `name` is not a valid variable in the program.
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetGlobalVariablePointer(
+    ur_device_handle_t hDevice,       ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t hProgram,     ///< [in] handle of the program where the global variable is.
+    const char *pGlobalVariableName,  ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *pGlobalVariableSizeRet,   ///< [out][optional] Returns the size of the global variable if it is found
+                                      ///< in the program.
+    void **ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9469,6 +9506,18 @@ typedef struct ur_program_get_function_pointer_params_t {
     const char **ppFunctionName;
     void ***pppFunctionPointer;
 } ur_program_get_function_pointer_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urProgramGetGlobalVariablePointer
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_program_get_global_variable_pointer_params_t {
+    ur_device_handle_t *phDevice;
+    ur_program_handle_t *phProgram;
+    const char **ppGlobalVariableName;
+    size_t **ppGlobalVariableSizeRet;
+    void ***pppGlobalVariablePointerRet;
+} ur_program_get_global_variable_pointer_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urProgramGetInfo

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -330,6 +330,15 @@ typedef ur_result_t(UR_APICALL *ur_pfnProgramGetFunctionPointer_t)(
     void **);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urProgramGetGlobalVariablePointer
+typedef ur_result_t(UR_APICALL *ur_pfnProgramGetGlobalVariablePointer_t)(
+    ur_device_handle_t,
+    ur_program_handle_t,
+    const char *,
+    size_t *,
+    void **);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urProgramGetInfo
 typedef ur_result_t(UR_APICALL *ur_pfnProgramGetInfo_t)(
     ur_program_handle_t,
@@ -380,6 +389,7 @@ typedef struct ur_program_dditable_t {
     ur_pfnProgramRetain_t pfnRetain;
     ur_pfnProgramRelease_t pfnRelease;
     ur_pfnProgramGetFunctionPointer_t pfnGetFunctionPointer;
+    ur_pfnProgramGetGlobalVariablePointer_t pfnGetGlobalVariablePointer;
     ur_pfnProgramGetInfo_t pfnGetInfo;
     ur_pfnProgramGetBuildInfo_t pfnGetBuildInfo;
     ur_pfnProgramSetSpecializationConstants_t pfnSetSpecializationConstants;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -1307,6 +1307,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramReleaseParams(const struct ur_
 UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetFunctionPointerParams(const struct ur_program_get_function_pointer_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_program_get_global_variable_pointer_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintProgramGetGlobalVariablePointerParams(const struct ur_program_get_global_variable_pointer_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_program_get_info_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -837,9 +837,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_ADAPTER_GET_INFO:
         os << "UR_FUNCTION_ADAPTER_GET_INFO";
         break;
-    case UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP:
-        os << "UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP";
-        break;
     case UR_FUNCTION_PROGRAM_BUILD_EXP:
         os << "UR_FUNCTION_PROGRAM_BUILD_EXP";
         break;
@@ -897,20 +894,26 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP:
         os << "UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP";
         break;
+    case UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER:
+        os << "UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER";
+        break;
+    case UR_FUNCTION_DEVICE_GET_SELECTED:
+        os << "UR_FUNCTION_DEVICE_GET_SELECTED";
+        break;
     case UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP";
         break;
     case UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP";
         break;
+    case UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP:
+        os << "UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP";
+        break;
     case UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP";
         break;
     case UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP:
         os << "UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP";
-        break;
-    case UR_FUNCTION_DEVICE_GET_SELECTED:
-        os << "UR_FUNCTION_DEVICE_GET_SELECTED";
         break;
     default:
         os << "unknown enumerator";
@@ -10792,6 +10795,44 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_program_get_global_variable_pointer_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_program_get_global_variable_pointer_params_t *params) {
+
+    os << ".hDevice = ";
+
+    ur::details::printPtr(os,
+                          *(params->phDevice));
+
+    os << ", ";
+    os << ".hProgram = ";
+
+    ur::details::printPtr(os,
+                          *(params->phProgram));
+
+    os << ", ";
+    os << ".pGlobalVariableName = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppGlobalVariableName));
+
+    os << ", ";
+    os << ".pGlobalVariableSizeRet = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppGlobalVariableSizeRet));
+
+    os << ", ";
+    os << ".ppGlobalVariablePointerRet = ";
+
+    ur::details::printPtr(os,
+                          *(params->pppGlobalVariablePointerRet));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_program_get_info_params_t type
 /// @returns
 ///     std::ostream &
@@ -16705,6 +16746,9 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     } break;
     case UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER: {
         os << (const struct ur_program_get_function_pointer_params_t *)params;
+    } break;
+    case UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER: {
+        os << (const struct ur_program_get_global_variable_pointer_params_t *)params;
     } break;
     case UR_FUNCTION_PROGRAM_GET_INFO: {
         os << (const struct ur_program_get_info_params_t *)params;

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -311,6 +311,43 @@ params:
       desc: |
             [out] Returns the pointer to the function if it is found in the program.
 --- #--------------------------------------------------------------------------
+type: function
+desc: "Retrieves a pointer to a device global variable."
+class: $xProgram
+name: GetGlobalVariablePointer
+decl: static
+ordinal: "7"
+analogue:
+    - "**clGetDeviceGlobalVariablePointerINTEL**"
+details:
+    - "Retrieves a pointer to a device global variable."
+    - "The application may call this function from simultaneous threads for the same device."
+    - "The implementation of this function should be thread-safe."
+params:
+    - type: "$x_device_handle_t"
+      name: hDevice
+      desc: |
+            [in] handle of the device to retrieve the pointer for.
+    - type: "$x_program_handle_t"
+      name: hProgram
+      desc: |
+            [in] handle of the program where the global variable is.
+    - type: "const char*"
+      name: pGlobalVariableName
+      desc: |
+            [in] mangled name of the global variable to retrieve the pointer for.
+    - type: "size_t*"
+      name: pGlobalVariableSizeRet
+      desc: |
+        [out][optional] Returns the size of the global variable if it is found in the program.
+    - type: "void**"
+      name: ppGlobalVariablePointerRet
+      desc: |
+            [out] Returns the pointer to the global variable if it is found in the program.
+returns:
+  - $X_RESULT_ERROR_INVALID_VALUE:
+      - "`name` is not a valid variable in the program."
+--- #--------------------------------------------------------------------------
 type: enum
 desc: "Get Program object information"
 class: $xProgram

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -502,9 +502,6 @@ etors:
 - name: ADAPTER_GET_INFO
   desc: Enumerator for $xAdapterGetInfo
   value: '181'
-- name: COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP
-  desc: Enumerator for $xCommandBufferUpdateKernelLaunchExp
-  value: '182'
 - name: PROGRAM_BUILD_EXP
   desc: Enumerator for $xProgramBuildExp
   value: '197'
@@ -562,21 +559,27 @@ etors:
 - name: KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP
   desc: Enumerator for $xKernelSuggestMaxCooperativeGroupCountExp
   value: '215'
-- name: COMMAND_BUFFER_RETAIN_COMMAND_EXP
-  desc: Enumerator for $xCommandBufferRetainCommandExp
+- name: PROGRAM_GET_GLOBAL_VARIABLE_POINTER
+  desc: Enumerator for $xProgramGetGlobalVariablePointer
   value: '216'
-- name: COMMAND_BUFFER_RELEASE_COMMAND_EXP
-  desc: Enumerator for $xCommandBufferReleaseCommandExp
-  value: '217'
-- name: COMMAND_BUFFER_GET_INFO_EXP
-  desc: Enumerator for $xCommandBufferGetInfoExp
-  value: '218'
-- name: COMMAND_BUFFER_COMMAND_GET_INFO_EXP
-  desc: Enumerator for $xCommandBufferCommandGetInfoExp
-  value: '219'
 - name: DEVICE_GET_SELECTED
   desc: Enumerator for $xDeviceGetSelected
+  value: '217'
+- name: COMMAND_BUFFER_RETAIN_COMMAND_EXP
+  desc: Enumerator for $xCommandBufferRetainCommandExp
+  value: '218'
+- name: COMMAND_BUFFER_RELEASE_COMMAND_EXP
+  desc: Enumerator for $xCommandBufferReleaseCommandExp
+  value: '219'
+- name: COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP
+  desc: Enumerator for $xCommandBufferUpdateKernelLaunchExp
   value: '220'
+- name: COMMAND_BUFFER_GET_INFO_EXP
+  desc: Enumerator for $xCommandBufferGetInfoExp
+  value: '221'
+- name: COMMAND_BUFFER_COMMAND_GET_INFO_EXP
+  desc: Enumerator for $xCommandBufferCommandGetInfoExp
+  value: '222'
 ---
 type: enum
 desc: Defines structure types

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1660,20 +1660,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     bool blockingWrite, size_t count, size_t offset, const void *pSrc,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  // Since CUDA requires a the global variable to be referenced by name, we use
-  // metadata to find the correct name to access it by.
-  auto DeviceGlobalNameIt = hProgram->GlobalIDMD.find(name);
-  if (DeviceGlobalNameIt == hProgram->GlobalIDMD.end())
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  std::string DeviceGlobalName = DeviceGlobalNameIt->second;
-
-  ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     CUdeviceptr DeviceGlobal = 0;
     size_t DeviceGlobalSize = 0;
-    UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
-                                     hProgram->get(),
-                                     DeviceGlobalName.c_str()));
+    UR_CHECK_ERROR(hProgram->getGlobalVariablePointer(name, &DeviceGlobal,
+                                                      &DeviceGlobalSize));
 
     if (offset + count > DeviceGlobalSize)
       return UR_RESULT_ERROR_INVALID_VALUE;
@@ -1682,9 +1673,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         hQueue, blockingWrite, reinterpret_cast<void *>(DeviceGlobal + offset),
         pSrc, count, numEventsInWaitList, phEventWaitList, phEvent);
   } catch (ur_result_t Err) {
-    Result = Err;
+    return Err;
   }
-  return Result;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
@@ -1692,20 +1682,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     bool blockingRead, size_t count, size_t offset, void *pDst,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent) {
-  // Since CUDA requires a the global variable to be referenced by name, we use
-  // metadata to find the correct name to access it by.
-  auto DeviceGlobalNameIt = hProgram->GlobalIDMD.find(name);
-  if (DeviceGlobalNameIt == hProgram->GlobalIDMD.end())
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  std::string DeviceGlobalName = DeviceGlobalNameIt->second;
-
-  ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     CUdeviceptr DeviceGlobal = 0;
     size_t DeviceGlobalSize = 0;
-    UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
-                                     hProgram->get(),
-                                     DeviceGlobalName.c_str()));
+    UR_CHECK_ERROR(hProgram->getGlobalVariablePointer(name, &DeviceGlobal,
+                                                      &DeviceGlobalSize));
 
     if (offset + count > DeviceGlobalSize)
       return UR_RESULT_ERROR_INVALID_VALUE;
@@ -1715,9 +1696,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
         reinterpret_cast<const void *>(DeviceGlobal + offset), count,
         numEventsInWaitList, phEventWaitList, phEvent);
   } catch (ur_result_t Err) {
-    Result = Err;
+    return Err;
   }
-  return Result;
 }
 
 /// Host Pipes

--- a/source/adapters/cuda/program.hpp
+++ b/source/adapters/cuda/program.hpp
@@ -59,4 +59,8 @@ struct ur_program_handle_t_ {
   uint32_t decrementReferenceCount() noexcept { return --RefCount; }
 
   uint32_t getReferenceCount() const noexcept { return RefCount; }
+
+  ur_result_t getGlobalVariablePointer(const char *name,
+                                       CUdeviceptr *DeviceGlobal,
+                                       size_t *DeviceGlobalSize);
 };

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -93,6 +93,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
   pDdiTable->pfnLink = urProgramLink;

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1677,19 +1677,12 @@ ur_result_t deviceGlobalCopyHelper(
     bool blocking, size_t count, size_t offset, void *ptr,
     uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_event_handle_t *phEvent, GlobalVariableCopy CopyType) {
-  // Since HIP requires a the global variable to be referenced by name, we use
-  // metadata to find the correct name to access it by.
-  auto DeviceGlobalNameIt = hProgram->GlobalIDMD.find(name);
-  if (DeviceGlobalNameIt == hProgram->GlobalIDMD.end())
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  std::string DeviceGlobalName = DeviceGlobalNameIt->second;
 
   try {
-    hipDeviceptr_t DeviceGlobal = 0;
+    hipDeviceptr_t DeviceGlobal = nullptr;
     size_t DeviceGlobalSize = 0;
-    UR_CHECK_ERROR(hipModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
-                                      hProgram->get(),
-                                      DeviceGlobalName.c_str()));
+    UR_CHECK_ERROR(hProgram->getGlobalVariablePointer(name, &DeviceGlobal,
+                                                      &DeviceGlobalSize));
 
     if (offset + count > DeviceGlobalSize)
       return UR_RESULT_ERROR_INVALID_VALUE;

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -227,6 +227,25 @@ ur_result_t ur_program_handle_t_::buildProgram(const char *BuildOptions) {
   return UR_RESULT_SUCCESS;
 }
 
+ur_result_t ur_program_handle_t_::getGlobalVariablePointer(
+    const char *name, hipDeviceptr_t *DeviceGlobal, size_t *DeviceGlobalSize) {
+  // Since HIP requires a the global variable to be referenced by name, we use
+  // metadata to find the correct name to access it by.
+  auto DeviceGlobalNameIt = this->GlobalIDMD.find(name);
+  if (DeviceGlobalNameIt == this->GlobalIDMD.end())
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  std::string DeviceGlobalName = DeviceGlobalNameIt->second;
+
+  try {
+    UR_CHECK_ERROR(hipModuleGetGlobal(DeviceGlobal, DeviceGlobalSize,
+                                      this->get(), DeviceGlobalName.c_str()));
+  } catch (ur_result_t Err) {
+    return Err;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 /// Finds kernel names by searching for entry points in the PTX source, as the
 /// HIP driver API doesn't expose an operation for this.
 /// Note: This is currently only being used by the SYCL program class for the
@@ -494,4 +513,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   }
 
   return Result;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t, ur_program_handle_t hProgram,
+    const char *pGlobalVariableName, size_t *pGlobalVariableSizeRet,
+    void **ppGlobalVariablePointerRet) {
+  return hProgram->getGlobalVariablePointer(
+      pGlobalVariableName, ppGlobalVariablePointerRet, pGlobalVariableSizeRet);
 }

--- a/source/adapters/hip/program.hpp
+++ b/source/adapters/hip/program.hpp
@@ -65,4 +65,8 @@ struct ur_program_handle_t_ {
   uint32_t decrementReferenceCount() noexcept { return --RefCount; }
 
   uint32_t getReferenceCount() const noexcept { return RefCount; }
+
+  ur_result_t getGlobalVariablePointer(const char *name,
+                                       hipDeviceptr_t *DeviceGlobal,
+                                       size_t *DeviceGlobalSize);
 };

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -93,6 +93,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
   pDdiTable->pfnLink = urProgramLink;

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -581,6 +581,33 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   return ze2urResult(ZeResult);
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        Device, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        Program, ///< [in] handle of the program where the global variable is.
+    const char *GlobalVariableName, ///< [in] mangled name of the global
+                                    ///< variable to retrieve the pointer for.
+    size_t *GlobalVariableSizeRet,  ///< [out][optional] Returns the size of the
+                                    ///< global variable if it is found in the
+                                    ///< program.
+    void **GlobalVariablePointerRet ///< [out] Returns the pointer to the global
+                                    ///< variable if it is found in the program.
+) {
+  std::ignore = Device;
+  std::scoped_lock<ur_shared_mutex> lock(Program->Mutex);
+
+  ze_result_t ZeResult =
+      zeModuleGetGlobalPointer(Program->ZeModule, GlobalVariableName,
+                               GlobalVariableSizeRet, GlobalVariablePointerRet);
+
+  if (ZeResult == ZE_RESULT_ERROR_UNSUPPORTED_FEATURE) {
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
+  return ze2urResult(ZeResult);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t Program, ///< [in] handle of the Program object
     ur_program_info_t PropName,  ///< [in] name of the Program property to query

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -215,6 +215,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnRetain = urProgramRetain;
   pDdiTable->pfnRelease = urProgramRelease;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnSetSpecializationConstants =

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -130,6 +130,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   DIE_NO_IMPLEMENTATION
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t, ur_program_handle_t hProgram,
+    const char *pGlobalVariableName, size_t *pGlobalVariableSizeRet,
+    void **ppGlobalVariablePointerRet) {
+  std::ignore = hProgram;
+  std::ignore = pGlobalVariableName;
+  std::ignore = pGlobalVariableSizeRet;
+  std::ignore = ppGlobalVariablePointerRet;
+
+  DIE_NO_IMPLEMENTATION
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
                  size_t propSize, void *pPropValue, size_t *pPropSizeRet) {

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -91,6 +91,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
   pDdiTable->pfnLink = urProgramLink;

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -2001,6 +2001,39 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urProgramGetGlobalVariablePointer
+__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program where the global variable is.
+    const char *
+        pGlobalVariableName, ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *
+        pGlobalVariableSizeRet, ///< [out][optional] Returns the size of the global variable if it is found
+                                ///< in the program.
+    void **
+        ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
+    ) try {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // if the driver has created a custom function, then call it instead of using the generic path
+    auto pfnGetGlobalVariablePointer =
+        d_context.urDdiTable.Program.pfnGetGlobalVariablePointer;
+    if (nullptr != pfnGetGlobalVariablePointer) {
+        result = pfnGetGlobalVariablePointer(
+            hDevice, hProgram, pGlobalVariableName, pGlobalVariableSizeRet,
+            ppGlobalVariablePointerRet);
+    } else {
+        // generic implementation
+    }
+
+    return result;
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
 __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
@@ -6328,6 +6361,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     pDdiTable->pfnRelease = driver::urProgramRelease;
 
     pDdiTable->pfnGetFunctionPointer = driver::urProgramGetFunctionPointer;
+
+    pDdiTable->pfnGetGlobalVariablePointer =
+        driver::urProgramGetGlobalVariablePointer;
 
     pDdiTable->pfnGetInfo = driver::urProgramGetInfo;
 

--- a/source/adapters/opencl/common.hpp
+++ b/source/adapters/opencl/common.hpp
@@ -39,7 +39,7 @@
  * error is mapped to UR
  */
 #define CL_RETURN_ON_FAILURE_AND_SET_NULL(clCall, outPtr)                      \
-  if (const cl_int cl_result_macro = clCall != CL_SUCCESS) {                   \
+  if (const cl_int cl_result_macro = clCall; cl_result_macro != CL_SUCCESS) {  \
     if (outPtr != nullptr) {                                                   \
       *outPtr = nullptr;                                                       \
     }                                                                          \
@@ -197,6 +197,8 @@ CONSTFIX char SetProgramSpecializationConstantName[] =
     "clSetProgramSpecializationConstant";
 CONSTFIX char GetDeviceFunctionPointerName[] =
     "clGetDeviceFunctionPointerINTEL";
+CONSTFIX char GetDeviceGlobalVariablePointerName[] =
+    "clGetDeviceGlobalVariablePointerINTEL";
 CONSTFIX char EnqueueWriteGlobalVariableName[] =
     "clEnqueueWriteGlobalVariableINTEL";
 CONSTFIX char EnqueueReadGlobalVariableName[] =
@@ -221,6 +223,10 @@ CONSTFIX char GetCommandBufferInfoName[] = "clGetCommandBufferInfoKHR";
 using clGetDeviceFunctionPointer_fn = CL_API_ENTRY
 cl_int(CL_API_CALL *)(cl_device_id device, cl_program program,
                       const char *FuncName, cl_ulong *ret_ptr);
+
+using clGetDeviceGlobalVariablePointer_fn = CL_API_ENTRY cl_int(CL_API_CALL *)(
+    cl_device_id device, cl_program program, const char *globalVariableName,
+    size_t *globalVariableSizeRet, void **globalVariablePointerRet);
 
 using clEnqueueWriteGlobalVariable_fn = CL_API_ENTRY
 cl_int(CL_API_CALL *)(cl_command_queue, cl_program, const char *, cl_bool,
@@ -319,6 +325,8 @@ struct ExtFuncPtrCacheT {
   FuncPtrCache<clDeviceMemAllocINTEL_fn> clDeviceMemAllocINTELCache;
   FuncPtrCache<clSharedMemAllocINTEL_fn> clSharedMemAllocINTELCache;
   FuncPtrCache<clGetDeviceFunctionPointer_fn> clGetDeviceFunctionPointerCache;
+  FuncPtrCache<clGetDeviceGlobalVariablePointer_fn>
+      clGetDeviceGlobalVariablePointerCache;
   FuncPtrCache<clCreateBufferWithPropertiesINTEL_fn>
       clCreateBufferWithPropertiesINTELCache;
   FuncPtrCache<clMemBlockingFreeINTEL_fn> clMemBlockingFreeINTELCache;

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -93,6 +93,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
   pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
   pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
   pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetGlobalVariablePointer = urProgramGetGlobalVariablePointer;
   pDdiTable->pfnGetInfo = urProgramGetInfo;
   pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
   pDdiTable->pfnLink = urProgramLink;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -2957,6 +2957,63 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urProgramGetGlobalVariablePointer
+__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program where the global variable is.
+    const char *
+        pGlobalVariableName, ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *
+        pGlobalVariableSizeRet, ///< [out][optional] Returns the size of the global variable if it is found
+                                ///< in the program.
+    void **
+        ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
+) {
+    auto pfnGetGlobalVariablePointer =
+        context.urDdiTable.Program.pfnGetGlobalVariablePointer;
+
+    if (nullptr == pfnGetGlobalVariablePointer) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hDevice) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == hProgram) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == pGlobalVariableName) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == ppGlobalVariablePointerRet) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+    }
+
+    if (context.enableLifetimeValidation &&
+        !refCountContext.isReferenceValid(hDevice)) {
+        refCountContext.logInvalidReference(hDevice);
+    }
+
+    if (context.enableLifetimeValidation &&
+        !refCountContext.isReferenceValid(hProgram)) {
+        refCountContext.logInvalidReference(hProgram);
+    }
+
+    ur_result_t result = pfnGetGlobalVariablePointer(
+        hDevice, hProgram, pGlobalVariableName, pGlobalVariableSizeRet,
+        ppGlobalVariablePointerRet);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
 __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
@@ -10059,6 +10116,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
     dditable.pfnGetFunctionPointer = pDdiTable->pfnGetFunctionPointer;
     pDdiTable->pfnGetFunctionPointer =
         ur_validation_layer::urProgramGetFunctionPointer;
+
+    dditable.pfnGetGlobalVariablePointer =
+        pDdiTable->pfnGetGlobalVariablePointer;
+    pDdiTable->pfnGetGlobalVariablePointer =
+        ur_validation_layer::urProgramGetGlobalVariablePointer;
 
     dditable.pfnGetInfo = pDdiTable->pfnGetInfo;
     pDdiTable->pfnGetInfo = ur_validation_layer::urProgramGetInfo;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -2668,6 +2668,45 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urProgramGetGlobalVariablePointer
+__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program where the global variable is.
+    const char *
+        pGlobalVariableName, ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *
+        pGlobalVariableSizeRet, ///< [out][optional] Returns the size of the global variable if it is found
+                                ///< in the program.
+    void **
+        ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_device_object_t *>(hDevice)->dditable;
+    auto pfnGetGlobalVariablePointer =
+        dditable->ur.Program.pfnGetGlobalVariablePointer;
+    if (nullptr == pfnGetGlobalVariablePointer) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
+
+    // convert loader handle to platform handle
+    hProgram = reinterpret_cast<ur_program_object_t *>(hProgram)->handle;
+
+    // forward to device-platform
+    result = pfnGetGlobalVariablePointer(hDevice, hProgram, pGlobalVariableName,
+                                         pGlobalVariableSizeRet,
+                                         ppGlobalVariablePointerRet);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
 __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
@@ -8746,6 +8785,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
             pDdiTable->pfnRelease = ur_loader::urProgramRelease;
             pDdiTable->pfnGetFunctionPointer =
                 ur_loader::urProgramGetFunctionPointer;
+            pDdiTable->pfnGetGlobalVariablePointer =
+                ur_loader::urProgramGetGlobalVariablePointer;
             pDdiTable->pfnGetInfo = ur_loader::urProgramGetInfo;
             pDdiTable->pfnGetBuildInfo = ur_loader::urProgramGetBuildInfo;
             pDdiTable->pfnSetSpecializationConstants =

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3233,6 +3233,58 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a pointer to a device global variable.
+///
+/// @details
+///     - Retrieves a pointer to a device global variable.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+///
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceGlobalVariablePointerINTEL**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalVariableName`
+///         + `NULL == ppGlobalVariablePointerRet`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `name` is not a valid variable in the program.
+ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program where the global variable is.
+    const char *
+        pGlobalVariableName, ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *
+        pGlobalVariableSizeRet, ///< [out][optional] Returns the size of the global variable if it is found
+                                ///< in the program.
+    void **
+        ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
+    ) try {
+    auto pfnGetGlobalVariablePointer =
+        ur_lib::context->urDdiTable.Program.pfnGetGlobalVariablePointer;
+    if (nullptr == pfnGetGlobalVariablePointer) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnGetGlobalVariablePointer(hDevice, hProgram, pGlobalVariableName,
+                                       pGlobalVariableSizeRet,
+                                       ppGlobalVariablePointerRet);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
 ///
 /// @remarks

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -2164,6 +2164,14 @@ ur_result_t urPrintProgramGetFunctionPointerParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintProgramGetGlobalVariablePointerParams(
+    const struct ur_program_get_global_variable_pointer_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t
 urPrintProgramGetInfoParams(const struct ur_program_get_info_params_t *params,
                             char *buffer, const size_t buff_size,

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2750,6 +2750,49 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Retrieves a pointer to a device global variable.
+///
+/// @details
+///     - Retrieves a pointer to a device global variable.
+///     - The application may call this function from simultaneous threads for
+///       the same device.
+///     - The implementation of this function should be thread-safe.
+///
+/// @remarks
+///   _Analogues_
+///     - **clGetDeviceGlobalVariablePointerINTEL**
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hDevice`
+///         + `NULL == hProgram`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pGlobalVariableName`
+///         + `NULL == ppGlobalVariablePointerRet`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `name` is not a valid variable in the program.
+ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+    ur_device_handle_t
+        hDevice, ///< [in] handle of the device to retrieve the pointer for.
+    ur_program_handle_t
+        hProgram, ///< [in] handle of the program where the global variable is.
+    const char *
+        pGlobalVariableName, ///< [in] mangled name of the global variable to retrieve the pointer for.
+    size_t *
+        pGlobalVariableSizeRet, ///< [out][optional] Returns the size of the global variable if it is found
+                                ///< in the program.
+    void **
+        ppGlobalVariablePointerRet ///< [out] Returns the pointer to the global variable if it is found in the program.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Query information about a Program object
 ///
 /// @remarks

--- a/test/conformance/device_code/device_global.cpp
+++ b/test/conformance/device_code/device_global.cpp
@@ -5,7 +5,12 @@
 
 #include <sycl/sycl.hpp>
 
-sycl::ext::oneapi::experimental::device_global<int> dev_var;
+/* device_image_scope is needed to make sure that sycl generates device code
+ * with an integer global variable instead of a pointer */
+sycl::ext::oneapi::experimental::device_global<
+    int, decltype(sycl::ext::oneapi::experimental::properties(
+             sycl::ext::oneapi::experimental::device_image_scope))>
+    dev_var;
 
 int main() {
 

--- a/test/conformance/enqueue/enqueue_adapter_cuda.match
+++ b/test/conformance/enqueue/enqueue_adapter_cuda.match
@@ -1,6 +1,3 @@
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}_
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.InvalidEventWaitInvalidEvent/NVIDIA_CUDA_BACKEND___{{.*}}_
-{{OPT}}urEnqueueDeviceGetGlobalVariableWriteTest.InvalidEventWaitInvalidEvent/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchWithVirtualMemory.Success/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urEnqueueMemBufferCopyRectTest.InvalidSize/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urEnqueueMemBufferFillTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___size__256__patternSize__256

--- a/test/conformance/enqueue/enqueue_adapter_hip.match
+++ b/test/conformance/enqueue/enqueue_adapter_hip.match
@@ -1,6 +1,3 @@
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/AMD_HIP_BACKEND___{{.*}}_
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.InvalidEventWaitInvalidEvent/AMD_HIP_BACKEND___{{.*}}_
-{{OPT}}urEnqueueDeviceGetGlobalVariableWriteTest.InvalidEventWaitInvalidEvent/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urEnqueueMemBufferCopyRectTestWithParam.Success/AMD_HIP_BACKEND___{{.*}}___copy_row_2D
 {{OPT}}urEnqueueMemBufferCopyRectTestWithParam.Success/AMD_HIP_BACKEND___{{.*}}___copy_3d_2d
 {{OPT}}urEnqueueMemBufferCopyRectTest.InvalidSize/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/enqueue/enqueue_adapter_level_zero.match
+++ b/test/conformance/enqueue/enqueue_adapter_level_zero.match
@@ -1,3 +1,2 @@
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urEnqueueEventsWaitTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{Segmentation fault|Aborted}}

--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -1,4 +1,3 @@
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__OpenCL___{{.*}}
 {{OPT}}urEnqueueMemBufferCopyRectTest.InvalidSize/Intel_R__OpenCL___{{.*}}
 {{OPT}}urEnqueueMemBufferReadRectTest.InvalidSize/Intel_R__OpenCL___{{.*}}
 {{OPT}}urEnqueueMemBufferWriteRectTest.InvalidSize/Intel_R__OpenCL___{{.*}}

--- a/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
+++ b/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
@@ -20,7 +20,7 @@ TEST_P(urEnqueueDeviceGetGlobalVariableReadTest, Success) {
     // execute the kernel
     ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
                                          &global_offset, &global_size, nullptr,
-                                         1, nullptr, nullptr));
+                                         0, nullptr, nullptr));
     ASSERT_SUCCESS(urQueueFinish(queue));
 
     // read global var back to host

--- a/test/conformance/program/CMakeLists.txt
+++ b/test/conformance/program/CMakeLists.txt
@@ -11,6 +11,7 @@ add_conformance_test_with_kernels_environment(program
     urProgramCreateWithNativeHandle.cpp
     urProgramGetBuildInfo.cpp
     urProgramGetFunctionPointer.cpp
+    urProgramGetGlobalVariablePointer.cpp
     urProgramGetInfo.cpp
     urProgramGetNativeHandle.cpp
     urProgramLink.cpp

--- a/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
+++ b/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <uur/fixtures.h>
+
+using urProgramGetGlobalVariablePointerTest = uur::urGlobalVariableTest;
+
+UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urProgramGetGlobalVariablePointerTest);
+
+TEST_P(urProgramGetGlobalVariablePointerTest, Success) {
+    size_t global_variable_size = 0;
+    void *global_variable_pointer;
+    ASSERT_SUCCESS(urProgramGetGlobalVariablePointer(
+        device, program, global_var.name.c_str(), &global_variable_size,
+        &global_variable_pointer));
+    ASSERT_GT(global_variable_size, 0);
+    ASSERT_NE(global_variable_pointer, nullptr);
+}
+
+TEST_P(urProgramGetGlobalVariablePointerTest, InvalidNullHandleDevice) {
+    void *global_variable_pointer;
+    ASSERT_EQ_RESULT(urProgramGetGlobalVariablePointer(
+                         nullptr, program, global_var.name.c_str(), nullptr,
+                         &global_variable_pointer),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urProgramGetGlobalVariablePointerTest, InvalidNullHandleProgram) {
+    void *global_variable_pointer;
+    ASSERT_EQ_RESULT(urProgramGetGlobalVariablePointer(
+                         device, nullptr, global_var.name.c_str(), nullptr,
+                         &global_variable_pointer),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urProgramGetGlobalVariablePointerTest, InvalidVariableName) {
+    void *global_variable_pointer;
+    ASSERT_EQ_RESULT(
+        urProgramGetGlobalVariablePointer(device, program, "foo", nullptr,
+                                          &global_variable_pointer),
+        UR_RESULT_ERROR_INVALID_VALUE);
+}
+
+TEST_P(urProgramGetGlobalVariablePointerTest, InvalidNullPointerVariableName) {
+    void *global_variable_pointer;
+    ASSERT_EQ_RESULT(
+        urProgramGetGlobalVariablePointer(device, program, nullptr, nullptr,
+                                          &global_variable_pointer),
+        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}
+
+TEST_P(urProgramGetGlobalVariablePointerTest,
+       InvalidNullPointerVariablePointer) {
+    size_t global_variable_size = 0;
+    ASSERT_EQ_RESULT(urProgramGetGlobalVariablePointer(
+                         device, program, global_var.name.c_str(),
+                         &global_variable_size, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -477,11 +477,10 @@ void KernelsEnvironment::LoadSource(
     binary_out = binary_ptr;
 }
 
-ur_result_t KernelsEnvironment::CreateProgram(ur_platform_handle_t hPlatform,
-                                              ur_context_handle_t hContext,
-                                              ur_device_handle_t hDevice,
-                                              const std::vector<char> &binary,
-                                              ur_program_handle_t *phProgram) {
+ur_result_t KernelsEnvironment::CreateProgram(
+    ur_platform_handle_t hPlatform, ur_context_handle_t hContext,
+    ur_device_handle_t hDevice, const std::vector<char> &binary,
+    const ur_program_properties_t *properties, ur_program_handle_t *phProgram) {
     ur_platform_backend_t backend;
     if (auto error = urPlatformGetInfo(hPlatform, UR_PLATFORM_INFO_BACKEND,
                                        sizeof(ur_platform_backend_t), &backend,
@@ -493,13 +492,14 @@ ur_result_t KernelsEnvironment::CreateProgram(ur_platform_handle_t hPlatform,
         // use urProgramCreateWithBinary instead.
         if (auto error = urProgramCreateWithBinary(
                 hContext, hDevice, binary.size(),
-                reinterpret_cast<const uint8_t *>(binary.data()), nullptr,
+                reinterpret_cast<const uint8_t *>(binary.data()), properties,
                 phProgram)) {
             return error;
         }
     } else {
-        if (auto error = urProgramCreateWithIL(
-                hContext, binary.data(), binary.size(), nullptr, phProgram)) {
+        if (auto error =
+                urProgramCreateWithIL(hContext, binary.data(), binary.size(),
+                                      properties, phProgram)) {
             return error;
         }
     }

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -79,6 +79,7 @@ struct KernelsEnvironment : DevicesEnvironment {
                               ur_context_handle_t hContext,
                               ur_device_handle_t hDevice,
                               const std::vector<char> &binary,
+                              const ur_program_properties_t *properties,
                               ur_program_handle_t *phProgram);
 
     std::vector<std::string> GetEntryPointNames(std::string program);


### PR DESCRIPTION
- Adds new entrypoint `urProgramGetGlobalVariablePointer`.
- Adds conformance tests for the new entrypoint.
- Adds OpenCL, CUDA, HIP and Level Zero implementations for `urProgramGetGlobalVariablePointer`
- Fixes existing testing `urEnqueueDeviceGetGlobalVariableRead` by adding the required metadata and sycl properties to the kernel.

https://github.com/intel/llvm/pull/12496

Closes: #1214 