### PR TITLE
[L0] fix waiting on non-owned native handle events

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -625,13 +625,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
                        ///< events to wait for completion
 ) {
   for (uint32_t I = 0; I < NumEvents; I++) {
-    if (EventWaitList[I]->UrQueue->ZeEventsScope == OnDemandHostVisibleProxy) {
+    auto e = EventWaitList[I];
+    if (e->UrQueue && e->UrQueue->ZeEventsScope == OnDemandHostVisibleProxy) {
       // Make sure to add all host-visible "proxy" event signals if needed.
       // This ensures that all signalling commands are submitted below and
       // thus proxy events can be waited without a deadlock.
       //
-      ur_event_handle_t_ *Event =
-          ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
+      ur_event_handle_t_ *Event = ur_cast<ur_event_handle_t_ *>(e);
       if (!Event->hasExternalRefs())
         die("urEventsWait must not be called for an internal event");
 
@@ -781,6 +781,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     UREvent = new ur_event_handle_t_(ZeEvent, nullptr /* ZeEventPool */,
                                      Context, UR_EXT_COMMAND_TYPE_USER,
                                      Properties->isNativeHandleOwned);
+
+    UREvent->RefCountExternal++;
 
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;


### PR DESCRIPTION
L0 adapter makes optimizations based on whether an event has any external references. The adapter keeps track of this based on a reference count. This reference count wasn't being properly set when first creating an event based on a native handle, leading to code incorrectly assuming that the event was internal and had no external references, which ultimately led to segfaults.

This patch sets the refcount to 1 when first creating an event, solving the problem. It also adds a missing null-check to make user native handle events even work.