### PR TITLE
[UTIL] Make sure Windows.h doesn't define min

### DIFF
--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -22,6 +22,9 @@
 #include <vector>
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 inline int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
 #else


### PR DESCRIPTION
Define `NOMINMAX` before including Windows.h to fix the building in
https://github.com/intel/llvm/pull/12375.
