### PR TITLE
[Common] Don't include Windows.h in ur_util.hpp

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -9,6 +9,8 @@ add_subdirectory(umf_pools)
 add_ur_library(ur_common STATIC
     umf_helpers.hpp
     ur_pool_manager.hpp
+    ur_util.cpp
+    ur_util.hpp
     $<$<PLATFORM_ID:Windows>:windows/ur_lib_loader.cpp>
     $<$<PLATFORM_ID:Linux,Darwin>:linux/ur_lib_loader.cpp>
 )

--- a/source/common/ur_lib_loader.hpp
+++ b/source/common/ur_lib_loader.hpp
@@ -12,7 +12,11 @@
 
 #include <memory>
 
-#include "ur_util.hpp"
+#if _WIN32
+#include <windows.h>
+#else
+#define HMODULE void *
+#endif
 
 namespace ur_loader {
 

--- a/source/common/ur_util.cpp
+++ b/source/common/ur_util.cpp
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright (C) 2022-2023 Intel Corporation
+ *
+ * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See LICENSE.TXT
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ */
+
+#include "ur_util.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
+#else
+
+#include <unistd.h>
+int ur_getpid(void) { return static_cast<int>(getpid()); }
+#endif
+
+std::optional<std::string> ur_getenv(const char *name) {
+#if defined(_WIN32)
+    constexpr int buffer_size = 1024;
+    char buffer[buffer_size];
+    auto rc = GetEnvironmentVariableA(name, buffer, buffer_size);
+    if (0 != rc && rc < buffer_size) {
+        return std::string(buffer);
+    } else if (rc >= buffer_size) {
+        std::stringstream ex_ss;
+        ex_ss << "Environment variable " << name << " value too long!"
+              << " Maximum length is " << buffer_size - 1 << " characters.";
+        throw std::invalid_argument(ex_ss.str());
+    }
+    return std::nullopt;
+#else
+    const char *tmp_env = getenv(name);
+    if (tmp_env != nullptr) {
+        return std::string(tmp_env);
+    } else {
+        return std::nullopt;
+    }
+#endif
+}

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -21,14 +21,7 @@
 #include <string>
 #include <vector>
 
-#ifdef _WIN32
-#include <windows.h>
-inline int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
-#else
-
-#include <unistd.h>
-inline int ur_getpid(void) { return static_cast<int>(getpid()); }
-#endif
+int ur_getpid(void);
 
 /* for compatibility with non-clang compilers */
 #if defined(__has_feature)
@@ -61,7 +54,6 @@ inline int ur_getpid(void) { return static_cast<int>(getpid()); }
 #if defined(_WIN32)
 #define MAKE_LIBRARY_NAME(NAME, VERSION) NAME ".dll"
 #else
-#define HMODULE void *
 #if defined(__APPLE__)
 #define MAKE_LIBRARY_NAME(NAME, VERSION) "lib" NAME "." VERSION ".dylib"
 #else
@@ -93,29 +85,7 @@ inline std::string create_library_path(const char *name, const char *path) {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-inline std::optional<std::string> ur_getenv(const char *name) {
-#if defined(_WIN32)
-    constexpr int buffer_size = 1024;
-    char buffer[buffer_size];
-    auto rc = GetEnvironmentVariableA(name, buffer, buffer_size);
-    if (0 != rc && rc < buffer_size) {
-        return std::string(buffer);
-    } else if (rc >= buffer_size) {
-        std::stringstream ex_ss;
-        ex_ss << "Environment variable " << name << " value too long!"
-              << " Maximum length is " << buffer_size - 1 << " characters.";
-        throw std::invalid_argument(ex_ss.str());
-    }
-    return std::nullopt;
-#else
-    const char *tmp_env = getenv(name);
-    if (tmp_env != nullptr) {
-        return std::string(tmp_env);
-    } else {
-        return std::nullopt;
-    }
-#endif
-}
+std::optional<std::string> ur_getenv(const char *name);
 
 inline bool getenv_tobool(const char *name) {
     auto env = ur_getenv(name);

--- a/source/loader/layers/validation/backtrace_win.cpp
+++ b/source/loader/layers/validation/backtrace_win.cpp
@@ -9,8 +9,9 @@
  */
 #include "backtrace.hpp"
 
-#include <DbgHelp.h>
 #include <Windows.h>
+// Windows.h must be included before DbgHelp.h
+#include <DbgHelp.h>
 #include <vector>
 
 namespace ur_validation_layer {


### PR DESCRIPTION
Avoid transitively including Windows.h in headers which include ur_util.hpp.
