### PR TITLE
Fix device CTS tests for retain/release

### DIFF
--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -8,8 +8,6 @@ struct urDeviceReleaseTest : uur::urAllDevicesTest {};
 
 TEST_F(urDeviceReleaseTest, Success) {
     for (auto device : devices) {
-        ASSERT_SUCCESS(urDeviceRetain(device));
-
         uint32_t prevRefCount = 0;
         ASSERT_SUCCESS(uur::GetObjectReferenceCount(device, prevRefCount));
 
@@ -57,6 +55,8 @@ TEST_F(urDeviceReleaseTest, SuccessSubdevices) {
         ASSERT_SUCCESS(uur::GetObjectReferenceCount(sub_device, refCount));
 
         ASSERT_GT(prevRefCount, refCount);
+
+        EXPECT_SUCCESS(urDeviceRelease(sub_device));
     }
 }
 

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -20,8 +20,6 @@ TEST_F(urDeviceRetainTest, Success) {
         /* If device is a root level device, the device reference counts should
          * remain unchanged */
         ASSERT_EQ(prevRefCount, refCount);
-
-        EXPECT_SUCCESS(urDeviceRelease(device));
     }
 }
 
@@ -56,6 +54,7 @@ TEST_F(urDeviceRetainTest, SuccessSubdevices) {
 
         ASSERT_LT(prevRefCount, refCount);
 
+        EXPECT_SUCCESS(urDeviceRelease(sub_device));
         EXPECT_SUCCESS(urDeviceRelease(sub_device));
     }
 }


### PR DESCRIPTION
Device CTS tests for testing subdevices would leak memory as they are retaining a subdevice then releasing it only one time, but they should release it twice to clear the memory as the created sub-device already have a refCount of 1 after they are created.