### PR TITLE
[gen] subprocess.run result pipes are not files

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -262,7 +262,7 @@ def generate_html(dstpath):
     if result.returncode != 0:
         print("sphinx-build returned non-zero error code.")
         print("--- output ---")
-        print(result.stderr.read().decode())
+        print(result.stderr.decode())
         raise Exception("Failed to generate html documentation.")
 
 """
@@ -277,7 +277,7 @@ def generate_pdf(dstpath):
     if result.returncode != 0:
         print("sphinx-build returned non-zero error code.")
         print("--- output ---")
-        print(result.stderr.read().decode())
+        print(result.stderr.decode())
         raise Exception("Failed to generate pdf documentation.")
 
 """


### PR DESCRIPTION
`subprocess.run` returns [CompletedProcess][1]. When used in conjunction with `subprocess.PIPE` for `stderr` or `stdout` it also has a corresponding string or bytes parameter. They are not file-like objects as in the case of `subprocess.Popen` which supports streaming pipes.

[1]: https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess.stderr