### PR TITLE
Fix memory leak in UR CTS tests

### DIFF
--- a/source/adapters/opencl/context.cpp
+++ b/source/adapters/opencl/context.cpp
@@ -134,9 +134,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t hNativeContext, uint32_t, const ur_device_handle_t *,
-    const ur_context_native_properties_t *, ur_context_handle_t *phContext) {
+    const ur_context_native_properties_t *pProperties,
+    ur_context_handle_t *phContext) {
 
   *phContext = reinterpret_cast<ur_context_handle_t>(hNativeContext);
+  if (!pProperties || !pProperties->isNativeHandleOwned) {
+    return urContextRetain(*phContext);
+  }
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/opencl/sampler.cpp
+++ b/source/adapters/opencl/sampler.cpp
@@ -197,8 +197,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t hNativeSampler, ur_context_handle_t,
-    const ur_sampler_native_properties_t *, ur_sampler_handle_t *phSampler) {
+    const ur_sampler_native_properties_t *pProperties,
+    ur_sampler_handle_t *phSampler) {
   *phSampler = reinterpret_cast<ur_sampler_handle_t>(
       cl_adapter::cast<cl_sampler>(hNativeSampler));
+  if (!pProperties || !pProperties->isNativeHandleOwned) {
+    return urSamplerRetain(*phSampler);
+  }
   return UR_RESULT_SUCCESS;
 }

--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -27,4 +27,6 @@ TEST_P(urContextCreateWithNativeHandleTest, Success) {
     uint32_t n_devices = 0;
     ASSERT_SUCCESS(urContextGetInfo(ctx, UR_CONTEXT_INFO_NUM_DEVICES,
                                     sizeof(uint32_t), &n_devices, nullptr));
+
+    ASSERT_SUCCESS(urContextRelease(ctx));
 }

--- a/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -84,4 +84,6 @@ TEST_P(urEnqueueEventsWaitTest, InvalidNullPtrEventWaitList) {
     ur_event_handle_t inv_evt = nullptr;
     ASSERT_EQ_RESULT(urEnqueueEventsWait(queue1, 1, &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -94,4 +94,6 @@ TEST_P(urEnqueueEventsWaitWithBarrierTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(
         urEnqueueEventsWaitWithBarrier(queue1, 1, &inv_evt, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -62,6 +62,7 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullPtrEventWaitList) {
                                            &global_offset, &global_size,
                                            nullptr, 1, &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidWorkDimension) {

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -79,6 +79,8 @@ TEST_P(urEnqueueMemBufferCopyTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(urEnqueueMemBufferCopy(queue, src_buffer, dst_buffer, 0, 0,
                                             size, 1, &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferCopyTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -226,6 +226,8 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
                                                 src_region, size, size, size,
                                                 size, 1, &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 using urEnqueueMemBufferCopyRectMultiDeviceTest =

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -189,6 +189,7 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullPtrEventWaitList) {
                                             sizeof(uint32_t), 0, size, 1,
                                             &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
     ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -193,6 +193,8 @@ TEST_P(urEnqueueMemBufferMapTest, InvalidNullPtrEventWaitList) {
                                            UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE,
                                            0, size, 1, &inv_evt, nullptr, &map),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferMapTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -55,6 +55,8 @@ TEST_P(urEnqueueMemBufferReadTest, InvalidNullPtrEventWaitList) {
                                             output.data(), 1, &inv_evt,
                                             nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferReadTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -183,6 +183,8 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
                                    host_offset, region, size, size, size, size,
                                    dst.data(), 1, &inv_evt, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 using urEnqueueMemBufferReadRectMultiDeviceTest =

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -67,6 +67,8 @@ TEST_P(urEnqueueMemBufferWriteTest, InvalidNullPtrEventWaitList) {
                                              input.data(), 1, &inv_evt,
                                              nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferWriteTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -190,6 +190,8 @@ TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullPtrEventWaitList) {
                                     host_offset, region, size, size, size, size,
                                     src.data(), 1, &inv_evt, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -239,6 +239,8 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidNullPtrEventWaitList) {
                                            {0, 0, 0}, size, 1, &inv_evt,
                                            nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageCopyTest, InvalidSize) {

--- a/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -75,6 +75,8 @@ TEST_P(urEnqueueMemImageReadTest, InvalidNullPtrEventWaitList) {
                                            region1D, 0, 0, output.data(), 1,
                                            &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageReadTest, InvalidOrigin1D) {

--- a/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -72,6 +72,8 @@ TEST_P(urEnqueueMemImageWriteTest, InvalidNullPtrEventWaitList) {
                                             region1D, 0, 0, input.data(), 1,
                                             &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }
 
 TEST_P(urEnqueueMemImageWriteTest, InvalidOrigin1D) {

--- a/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -55,4 +55,6 @@ TEST_P(urEnqueueMemUnmapTest, InvalidNullPtrEventWaitList) {
     ASSERT_EQ_RESULT(
         urEnqueueMemUnmap(queue, buffer, map, 1, &inv_evt, nullptr),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -82,4 +82,6 @@ TEST_P(urEnqueueReadHostPipeTest, InvalidEventWaitList) {
                                            /*blocking*/ true, &buffer, size, 1,
                                            &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -128,4 +128,6 @@ TEST_P(urEnqueueUSMPrefetchTest, InvalidEventWaitList) {
                                           UR_USM_MIGRATION_FLAG_DEFAULT, 1,
                                           &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -82,4 +82,6 @@ TEST_P(urEnqueueWriteHostPipeTest, InvalidEventWaitList) {
                                             /*blocking*/ true, &buffer, size, 1,
                                             &inv_evt, nullptr),
                      UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ASSERT_SUCCESS(urEventRelease(validEvent));
 }

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -16,6 +16,7 @@ TEST_P(urMemBufferPartitionTest, Success) {
                                         UR_BUFFER_CREATE_TYPE_REGION, &region,
                                         &partition));
     ASSERT_NE(partition, nullptr);
+    ASSERT_SUCCESS(urMemRelease(partition));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullHandleBuffer) {
@@ -88,6 +89,7 @@ TEST_P(urMemBufferPartitionTest, InvalidValueCreateType) {
                      urMemBufferPartition(ro_buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
                                           &partition));
+    ASSERT_SUCCESS(urMemRelease(ro_buffer));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidValueBufferCreateInfoOutOfBounds) {

--- a/test/conformance/queue/urQueueFinish.cpp
+++ b/test/conformance/queue/urQueueFinish.cpp
@@ -26,6 +26,9 @@ TEST_P(urQueueFinishTest, Success) {
     ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
                                   sizeof(exec_status), &exec_status, nullptr));
     ASSERT_EQ(exec_status, UR_EXECUTION_INFO_COMPLETE);
+
+    ASSERT_SUCCESS(urMemRelease(buffer));
+    ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urQueueFinishTest, InvalidNullHandleQueue) {

--- a/test/conformance/queue/urQueueFlush.cpp
+++ b/test/conformance/queue/urQueueFlush.cpp
@@ -19,6 +19,7 @@ TEST_P(urQueueFlushTest, Success) {
                                            nullptr));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
+    ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 TEST_P(urQueueFlushTest, InvalidNullHandleQueue) {

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -29,4 +29,5 @@ TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
     ASSERT_SUCCESS(urSamplerGetInfo(hSampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
                                     sizeof(addr_mode), &addr_mode, nullptr));
     ASSERT_EQ(addr_mode, sampler_desc.addressingMode);
+    ASSERT_SUCCESS(urSamplerRelease(hSampler));
 }

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -30,6 +30,7 @@ TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
 
     ASSERT_NE(ptr, nullptr);
     ASSERT_SUCCESS(urUSMFree(context, ptr));
+    ASSERT_SUCCESS(urEventRelease(event));
 }
 TEST_P(urUSMFreeTest, SuccessHostAlloc) {
     ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
@@ -52,6 +53,7 @@ TEST_P(urUSMFreeTest, SuccessHostAlloc) {
 
     ASSERT_NE(ptr, nullptr);
     ASSERT_SUCCESS(urUSMFree(context, ptr));
+    ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
@@ -81,6 +83,7 @@ TEST_P(urUSMFreeTest, SuccessSharedAlloc) {
 
     ASSERT_NE(ptr, nullptr);
     ASSERT_SUCCESS(urUSMFree(context, ptr));
+    ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urUSMFreeTest, InvalidNullContext) {


### PR DESCRIPTION
This PR fixes some of missing release calls that could cause memory leak, in particular:
* Add `urEventRelease` to release event handle created from enqueue calls.
* Release the Context and Sampler handles that was created from native handles in `CreateWithNativeHandle` tests.
* Release Mem buffer that was created from partitioning a memory.

[Intel/llvm testing](https://github.com/intel/llvm/pull/12465)