### PR TITLE
[CTS] Fix resource leaks

### DIFF
--- a/test/adapters/cuda/context_tests.cpp
+++ b/test/adapters/cuda/context_tests.cpp
@@ -6,6 +6,7 @@
 #include "context.hpp"
 #include "fixtures.h"
 #include "queue.hpp"
+#include "uur/raii.h"
 #include <thread>
 
 using cudaUrContextCreateTest = uur::urDeviceTest;
@@ -14,14 +15,13 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaUrContextCreateTest);
 constexpr unsigned int known_cuda_api_version = 3020;
 
 TEST_P(cudaUrContextCreateTest, CreateWithChildThread) {
-
-    ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    uur::raii::Context context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));
     ASSERT_NE(context, nullptr);
 
     // Retrieve the CUDA context to check information is correct
     auto checkValue = [=] {
-        CUcontext cudaContext = context->get();
+        CUcontext cudaContext = context.handle->get();
         unsigned int version = 0;
         EXPECT_SUCCESS_CUDA(cuCtxGetApiVersion(cudaContext, &version));
         EXPECT_EQ(version, known_cuda_api_version);
@@ -39,27 +39,26 @@ TEST_P(cudaUrContextCreateTest, CreateWithChildThread) {
 
     auto callContextFromOtherThread = std::thread(checkValue);
     callContextFromOtherThread.join();
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(cudaUrContextCreateTest, ActiveContext) {
-    ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    uur::raii::Context context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));
     ASSERT_NE(context, nullptr);
 
-    ur_queue_handle_t queue = nullptr;
+    uur::raii::Queue queue = nullptr;
     ur_queue_properties_t queue_props{UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
                                       nullptr, 0};
-    ASSERT_SUCCESS(urQueueCreate(context, device, &queue_props, &queue));
+    ASSERT_SUCCESS(urQueueCreate(context, device, &queue_props, queue.ptr()));
     ASSERT_NE(queue, nullptr);
 
     // check that the queue has the correct context
     ASSERT_EQ(context, queue->getContext());
 
     // create a buffer
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 1024,
-                                     nullptr, &buffer));
+                                     nullptr, buffer.ptr()));
     ASSERT_NE(buffer, nullptr);
 
     // check that the context is now the active CUDA context
@@ -71,11 +70,6 @@ TEST_P(cudaUrContextCreateTest, ActiveContext) {
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
     ASSERT_NE(native_context, nullptr);
     ASSERT_EQ(cudaCtx, reinterpret_cast<CUcontext>(native_context));
-
-    // release resources
-    ASSERT_SUCCESS(urMemRelease(buffer));
-    ASSERT_SUCCESS(urQueueRelease(queue));
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(cudaUrContextCreateTest, ContextLifetimeExisting) {
@@ -89,13 +83,13 @@ TEST_P(cudaUrContextCreateTest, ContextLifetimeExisting) {
     ASSERT_EQ(original, current);
 
     // create a UR context
-    ur_context_handle_t context;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    uur::raii::Context context;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));
     ASSERT_NE(context, nullptr);
 
     // create a queue with the context
-    ur_queue_handle_t queue;
-    ASSERT_SUCCESS(urQueueCreate(context, device, nullptr, &queue));
+    uur::raii::Queue queue;
+    ASSERT_SUCCESS(urQueueCreate(context, device, nullptr, queue.ptr()));
     ASSERT_NE(queue, nullptr);
 
     // ensure the queue has the correct context
@@ -109,19 +103,16 @@ TEST_P(cudaUrContextCreateTest, ContextLifetimeExisting) {
     // check that context is now the active cuda context
     ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&current));
     ASSERT_EQ(current, context->get());
-
-    ASSERT_SUCCESS(urQueueRelease(queue));
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(cudaUrContextCreateTest, ThreadedContext) {
     // create two new UR contexts
-    ur_context_handle_t context1;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context1));
+    uur::raii::Context context1;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context1.ptr()));
     ASSERT_NE(context1, nullptr);
 
-    ur_context_handle_t context2;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context2));
+    uur::raii::Context context2;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context2.ptr()));
     ASSERT_NE(context2, nullptr);
 
     // setup synchronization variables between the main thread and
@@ -138,23 +129,22 @@ TEST_P(cudaUrContextCreateTest, ThreadedContext) {
     auto test_thread = std::thread([&] {
         CUcontext current = nullptr;
 
-        // create a queue with the first context
-        ur_queue_handle_t queue;
-        ASSERT_SUCCESS(urQueueCreate(context1, device, nullptr, &queue));
-        ASSERT_NE(queue, nullptr);
+        {
+            // create a queue with the first context
+            uur::raii::Queue queue;
+            ASSERT_SUCCESS(
+                urQueueCreate(context1, device, nullptr, queue.ptr()));
+            ASSERT_NE(queue, nullptr);
 
-        // ensure that the queue has the correct context
-        ASSERT_EQ(context1, queue->getContext());
+            // ensure that the queue has the correct context
+            ASSERT_EQ(context1, queue->getContext());
 
-        // create a buffer to set context1 as the active context
-        ur_mem_handle_t buffer;
-        ASSERT_SUCCESS(urMemBufferCreate(context1, UR_MEM_FLAG_READ_WRITE, 1024,
-                                         nullptr, &buffer));
-        ASSERT_NE(buffer, nullptr);
-
-        // release the mem and queue
-        ASSERT_SUCCESS(urMemRelease(buffer));
-        ASSERT_SUCCESS(urQueueRelease(queue));
+            // create a buffer to set context1 as the active context
+            uur::raii::Mem buffer;
+            ASSERT_SUCCESS(urMemBufferCreate(context1, UR_MEM_FLAG_READ_WRITE,
+                                             1024, nullptr, buffer.ptr()));
+            ASSERT_NE(buffer, nullptr);
+        }
 
         // mark the first set of processing as done and notify the main thread
         std::unique_lock<std::mutex> lock(m);
@@ -166,31 +156,31 @@ TEST_P(cudaUrContextCreateTest, ThreadedContext) {
         lock.lock();
         cv.wait(lock, [&] { return released; });
 
-        // create a queue with the 2nd context
-        ASSERT_SUCCESS(urQueueCreate(context2, device, nullptr, &queue));
-        ASSERT_NE(queue, nullptr);
+        {
+            // create a queue with the 2nd context
+            uur::raii::Queue queue = nullptr;
+            ASSERT_SUCCESS(
+                urQueueCreate(context2, device, nullptr, queue.ptr()));
+            ASSERT_NE(queue, nullptr);
 
-        // ensure queue has correct context
-        ASSERT_EQ(context2, queue->getContext());
+            // ensure queue has correct context
+            ASSERT_EQ(context2, queue->getContext());
 
-        // create a buffer to set the active context
-        ASSERT_SUCCESS(urMemBufferCreate(context2, UR_MEM_FLAG_READ_WRITE, 1024,
-                                         nullptr, &buffer));
+            // create a buffer to set the active context
+            uur::raii::Mem buffer = nullptr;
+            ASSERT_SUCCESS(urMemBufferCreate(context2, UR_MEM_FLAG_READ_WRITE,
+                                             1024, nullptr, buffer.ptr()));
 
-        // check that the 2nd context is now tha active cuda context
-        ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&current));
-        ASSERT_EQ(current, context2->get());
-
-        // release
-        ASSERT_SUCCESS(urMemRelease(buffer));
-        ASSERT_SUCCESS(urQueueRelease(queue));
+            // check that the 2nd context is now tha active cuda context
+            ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&current));
+            ASSERT_EQ(current, context2->get());
+        }
     });
 
     // wait for the thread to be done with the first queue to release the first
     // context
     std::unique_lock<std::mutex> lock(m);
     cv.wait(lock, [&] { return thread_done; });
-    ASSERT_SUCCESS(urContextRelease(context1));
 
     // notify the other thread that the context was released
     released = true;
@@ -199,6 +189,4 @@ TEST_P(cudaUrContextCreateTest, ThreadedContext) {
 
     // wait for the thread to finish
     test_thread.join();
-
-    ASSERT_SUCCESS(urContextRelease(context2));
 }

--- a/test/adapters/cuda/memory_tests.cpp
+++ b/test/adapters/cuda/memory_tests.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/raii.h"
 
 using cudaMemoryTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaMemoryTest);
@@ -18,10 +19,8 @@ TEST_P(cudaMemoryTest, urMemBufferNoActiveContext) {
         ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&current));
     } while (current != nullptr);
 
-    ur_mem_handle_t mem;
+    uur::raii::Mem mem;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, memSize,
-                                     nullptr, &mem));
+                                     nullptr, mem.ptr()));
     ASSERT_NE(mem, nullptr);
-
-    ASSERT_SUCCESS(urMemRelease(mem));
 }

--- a/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
+++ b/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
@@ -4,21 +4,21 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/raii.h"
 
 using urCudaEventCreateWithNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventCreateWithNativeHandleTest);
 
 TEST_P(urCudaEventCreateWithNativeHandleTest, Success) {
-
     CUevent cuda_event;
     ASSERT_SUCCESS_CUDA(cuEventCreate(&cuda_event, CU_EVENT_DEFAULT));
 
     ur_native_handle_t native_event =
         reinterpret_cast<ur_native_handle_t>(cuda_event);
 
-    ur_event_handle_t event = nullptr;
-    ASSERT_SUCCESS(
-        urEventCreateWithNativeHandle(native_event, context, nullptr, &event));
+    uur::raii::Event event = nullptr;
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(native_event, context, nullptr,
+                                                 event.ptr()));
 
-    ASSERT_SUCCESS(urEventRelease(event));
+    ASSERT_SUCCESS_CUDA(cuEventDestroy(cuda_event));
 }

--- a/test/adapters/cuda/urEventGetNativeHandle.cpp
+++ b/test/adapters/cuda/urEventGetNativeHandle.cpp
@@ -4,27 +4,26 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/raii.h"
 
 using urCudaEventGetNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventGetNativeHandleTest);
 
 TEST_P(urCudaEventGetNativeHandleTest, Success) {
     constexpr size_t buffer_size = 1024;
-    ur_mem_handle_t mem = nullptr;
+    uur::raii::Mem mem = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &mem));
+                                     buffer_size, nullptr, mem.ptr()));
 
-    ur_event_handle_t event = nullptr;
+    uur::raii::Event event = nullptr;
     uint8_t pattern = 6;
     ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, mem, &pattern, sizeof(pattern),
-                                          0, buffer_size, 0, nullptr, &event));
+                                          0, buffer_size, 0, nullptr,
+                                          event.ptr()));
 
     ur_native_handle_t native_event = nullptr;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
     CUevent cuda_event = reinterpret_cast<CUevent>(native_event);
 
     ASSERT_SUCCESS_CUDA(cuEventSynchronize(cuda_event));
-
-    ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_SUCCESS(urMemRelease(mem));
 }

--- a/test/adapters/hip/test_context.cpp
+++ b/test/adapters/hip/test_context.cpp
@@ -8,17 +8,18 @@
 #include "context.hpp"
 #include "fixtures.h"
 #include "queue.hpp"
+#include "uur/raii.h"
 
 using urHipContextTest = uur::urDeviceTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipContextTest);
 
 TEST_P(urHipContextTest, ActiveContexts) {
-    ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    uur::raii::Context context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));
     ASSERT_NE(context, nullptr);
 
-    ur_queue_handle_t queue = nullptr;
-    ASSERT_SUCCESS(urQueueCreate(context, device, nullptr, &queue));
+    uur::raii::Queue queue = nullptr;
+    ASSERT_SUCCESS(urQueueCreate(context, device, nullptr, queue.ptr()));
     ASSERT_NE(queue, nullptr);
 
     // ensure that the queue has the correct context
@@ -31,18 +32,15 @@ TEST_P(urHipContextTest, ActiveContexts) {
     if (context->getDevices().size() == 1) {
         ASSERT_EQ(hipContext, context->getDevices()[0]->getNativeContext());
     }
-
-    ASSERT_SUCCESS(urQueueRelease(queue));
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(urHipContextTest, ActiveContextsThreads) {
-    ur_context_handle_t context1 = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context1));
+    uur::raii::Context context1 = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context1.ptr()));
     ASSERT_NE(context1, nullptr);
 
-    ur_context_handle_t context2 = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context2));
+    uur::raii::Context context2 = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context2.ptr()));
     ASSERT_NE(context2, nullptr);
 
     // setup synchronization
@@ -53,20 +51,22 @@ TEST_P(urHipContextTest, ActiveContextsThreads) {
 
     auto test_thread = std::thread([&] {
         hipCtx_t current = nullptr;
-        ur_queue_handle_t queue = nullptr;
-        ASSERT_SUCCESS(urQueueCreate(context1, device, nullptr, &queue));
-        ASSERT_NE(queue, nullptr);
+        {
+            uur::raii::Queue queue = nullptr;
+            ASSERT_SUCCESS(
+                urQueueCreate(context1, device, nullptr, queue.ptr()));
+            ASSERT_NE(queue, nullptr);
 
-        // ensure queue has the correct context
-        ASSERT_EQ(queue->getContext(), context1);
+            // ensure queue has the correct context
+            ASSERT_EQ(queue->getContext(), context1);
 
-        // check that the first context is now the active HIP context
-        ASSERT_SUCCESS_HIP(hipCtxGetCurrent(&current));
-        if (context1->getDevices().size() == 1) {
-            ASSERT_EQ(current, context1->getDevices()[0]->getNativeContext());
+            // check that the first context is now the active HIP context
+            ASSERT_SUCCESS_HIP(hipCtxGetCurrent(&current));
+            if (context1->getDevices().size() == 1) {
+                ASSERT_EQ(current,
+                          context1->getDevices()[0]->getNativeContext());
+            }
         }
-
-        ASSERT_SUCCESS(urQueueRelease(queue));
 
         // mark the first set of processing as done and notify the main thread
         {
@@ -81,27 +81,28 @@ TEST_P(urHipContextTest, ActiveContextsThreads) {
             cv.wait(lock, [&] { return released; });
         }
 
-        // create a queue with the 2nd context
-        queue = nullptr;
-        ASSERT_SUCCESS(urQueueCreate(context2, device, nullptr, &queue));
-        ASSERT_NE(queue, nullptr);
+        {
+            // create a queue with the 2nd context
+            uur::raii::Queue queue = nullptr;
+            ASSERT_SUCCESS(
+                urQueueCreate(context2, device, nullptr, queue.ptr()));
+            ASSERT_NE(queue, nullptr);
 
-        // ensure the queue has the correct context
-        ASSERT_EQ(queue->getContext(), context2);
+            // ensure the queue has the correct context
+            ASSERT_EQ(queue->getContext(), context2);
 
-        // check that the second context is now the active HIP context
-        ASSERT_SUCCESS_HIP(hipCtxGetCurrent(&current));
-        if (context2->getDevices().size() == 1) {
-            ASSERT_EQ(current, context2->getDevices()[0]->getNativeContext());
+            // check that the second context is now the active HIP context
+            ASSERT_SUCCESS_HIP(hipCtxGetCurrent(&current));
+            if (context2->getDevices().size() == 1) {
+                ASSERT_EQ(current,
+                          context2->getDevices()[0]->getNativeContext());
+            }
         }
-
-        ASSERT_SUCCESS(urQueueRelease(queue));
     });
 
     // wait for the thread to be done with the first queue
     std::unique_lock<std::mutex> lock(mtx);
     cv.wait(lock, [&] { return thread_done; });
-    ASSERT_SUCCESS(urContextRelease(context1));
 
     released = true;
     lock.unlock();
@@ -109,7 +110,5 @@ TEST_P(urHipContextTest, ActiveContextsThreads) {
 
     // wait for thread to finish
     test_thread.join();
-
-    ASSERT_SUCCESS(urContextRelease(context2));
 }
 #pragma GCC diagnostic pop

--- a/test/adapters/hip/urEventGetNativeHandle.cpp
+++ b/test/adapters/hip/urEventGetNativeHandle.cpp
@@ -4,27 +4,26 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/raii.h"
 
 using urHipEventGetNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipEventGetNativeHandleTest);
 
 TEST_P(urHipEventGetNativeHandleTest, Success) {
     constexpr size_t buffer_size = 1024;
-    ur_mem_handle_t mem = nullptr;
+    uur::raii::Mem mem = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &mem));
+                                     buffer_size, nullptr, mem.ptr()));
 
-    ur_event_handle_t event = nullptr;
+    uur::raii::Event event = nullptr;
     uint8_t pattern = 6;
     ASSERT_SUCCESS(urEnqueueMemBufferFill(queue, mem, &pattern, sizeof(pattern),
-                                          0, buffer_size, 0, nullptr, &event));
+                                          0, buffer_size, 0, nullptr,
+                                          event.ptr()));
 
     ur_native_handle_t native_event = nullptr;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
     hipEvent_t hip_event = reinterpret_cast<hipEvent_t>(native_event);
 
     ASSERT_SUCCESS_HIP(hipEventSynchronize(hip_event));
-
-    ASSERT_SUCCESS(urEventRelease(event));
-    ASSERT_SUCCESS(urMemRelease(mem));
 }

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -3,31 +3,30 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <uur/fixtures.h>
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using urContextCreateTest = uur::urDeviceTest;
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateTest);
 
 TEST_P(urContextCreateTest, Success) {
-    ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));
+    uur::raii::Context context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));
     ASSERT_NE(nullptr, context);
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(urContextCreateTest, SuccessWithProperties) {
     ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES};
-    ur_context_handle_t context = nullptr;
-    ASSERT_SUCCESS(urContextCreate(1, &device, &properties, &context));
+    uur::raii::Context context = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &device, &properties, context.ptr()));
     ASSERT_NE(nullptr, context);
-    ASSERT_SUCCESS(urContextRelease(context));
 }
 
 TEST_P(urContextCreateTest, InvalidNullPointerDevices) {
-    ur_context_handle_t context = nullptr;
+    uur::raii::Context context = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                     urContextCreate(1, nullptr, nullptr, &context));
+                     urContextCreate(1, nullptr, nullptr, context.ptr()));
 }
 
 TEST_P(urContextCreateTest, InvalidNullPointerContext) {
@@ -41,9 +40,8 @@ TEST_F(urContextCreateMultiDeviceTest, Success) {
     if (devices.size() < 2) {
         GTEST_SKIP();
     }
-    ur_context_handle_t context = nullptr;
+    uur::raii::Context context = nullptr;
     ASSERT_SUCCESS(urContextCreate(static_cast<uint32_t>(devices.size()),
-                                   devices.data(), nullptr, &context));
+                                   devices.data(), nullptr, context.ptr()));
     ASSERT_NE(nullptr, context);
-    ASSERT_SUCCESS(urContextRelease(context));
 }

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include "uur/raii.h"
 
 using urEventCreateWithNativeHandleTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
@@ -18,15 +19,13 @@ TEST_P(urEventCreateWithNativeHandleTest, Success) {
     // `nullptr` since this could be a valid representation within a backend.
     // We can however convert the native_handle back into a unified-runtime handle
     // and perform some query on it to verify that it works.
-    ur_event_handle_t evt = nullptr;
-    ASSERT_SUCCESS(
-        urEventCreateWithNativeHandle(native_event, context, nullptr, &evt));
+    uur::raii::Event evt = nullptr;
+    ASSERT_SUCCESS(urEventCreateWithNativeHandle(native_event, context, nullptr,
+                                                 evt.ptr()));
     ASSERT_NE(evt, nullptr);
 
     ur_execution_info_t exec_info;
     ASSERT_SUCCESS(urEventGetInfo(evt, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
                                   sizeof(ur_execution_info_t), &exec_info,
                                   nullptr));
-
-    ASSERT_SUCCESS(urEventRelease(evt));
 }

--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -2,7 +2,9 @@
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#include <uur/fixtures.h>
+
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using urMemBufferCreateTestWithFlagsParam =
     uur::urContextTestWithParam<ur_mem_flag_t>;
@@ -16,28 +18,27 @@ UUR_TEST_SUITE_P(urMemBufferCreateWithFlagsTest,
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithFlagsTest, Success) {
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_SUCCESS(
-        urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
+        urMemBufferCreate(context, getParam(), 4096, nullptr, buffer.ptr()));
     ASSERT_NE(nullptr, buffer);
-    ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 TEST_P(urMemBufferCreateWithFlagsTest, InvalidNullHandleContext) {
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urMemBufferCreate(nullptr, getParam(), 4096, nullptr, &buffer));
+        urMemBufferCreate(nullptr, getParam(), 4096, nullptr, buffer.ptr()));
 }
 
 using urMemBufferCreateTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateTest);
 
 TEST_P(urMemBufferCreateTest, InvalidEnumerationFlags) {
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemBufferCreate(context, UR_MEM_FLAG_FORCE_UINT32, 4096,
-                                       nullptr, &buffer));
+                                       nullptr, buffer.ptr()));
 }
 
 using urMemBufferCreateWithHostPtrFlagsTest =
@@ -48,10 +49,10 @@ UUR_TEST_SUITE_P(urMemBufferCreateWithHostPtrFlagsTest,
                  uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithHostPtrFlagsTest, InvalidHostPtr) {
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_HOST_PTR,
-        urMemBufferCreate(context, getParam(), 4096, nullptr, &buffer));
+        urMemBufferCreate(context, getParam(), 4096, nullptr, buffer.ptr()));
 }
 
 TEST_P(urMemBufferCreateWithFlagsTest, InvalidNullPointerBuffer) {
@@ -61,8 +62,8 @@ TEST_P(urMemBufferCreateWithFlagsTest, InvalidNullPointerBuffer) {
 }
 
 TEST_P(urMemBufferCreateWithFlagsTest, InvalidBufferSizeZero) {
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_EQ_RESULT(
         UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
-        urMemBufferCreate(context, getParam(), 0, nullptr, &buffer));
+        urMemBufferCreate(context, getParam(), 0, nullptr, buffer.ptr()));
 }

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -3,7 +3,8 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <uur/fixtures.h>
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using urMemBufferPartitionTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
@@ -11,50 +12,49 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
 TEST_P(urMemBufferPartitionTest, Success) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               1024};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_SUCCESS(urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                         UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                        &partition));
+                                        partition.ptr()));
     ASSERT_NE(partition, nullptr);
-    ASSERT_SUCCESS(urMemRelease(partition));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullHandleBuffer) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               1024};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urMemBufferPartition(nullptr, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                          &partition));
+                                          partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidEnumerationFlags) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               1024};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_FORCE_UINT32,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                          &partition));
+                                          partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidEnumerationBufferCreateType) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               1024};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_FORCE_UINT32,
-                                          &region, &partition));
+                                          &region, partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullPointerBufferCreateInfo) {
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, nullptr,
-                                          &partition));
+                                          partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidNullPointerMem) {
@@ -68,36 +68,35 @@ TEST_P(urMemBufferPartitionTest, InvalidNullPointerMem) {
 
 TEST_P(urMemBufferPartitionTest, InvalidBufferSize) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0, 0};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                          &partition));
+                                          partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidValueCreateType) {
     // create a read only buffer
-    ur_mem_handle_t ro_buffer = nullptr;
+    uur::raii::Mem ro_buffer = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_ONLY, 4096,
-                                     nullptr, &ro_buffer));
+                                     nullptr, ro_buffer.ptr()));
 
     // attempting to partition it into a RW buffer should fail
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               1024};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
                      urMemBufferPartition(ro_buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                          &partition));
-    ASSERT_SUCCESS(urMemRelease(ro_buffer));
+                                          partition.ptr()));
 }
 
 TEST_P(urMemBufferPartitionTest, InvalidValueBufferCreateInfoOutOfBounds) {
     ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0,
                               8192};
-    ur_mem_handle_t partition = nullptr;
+    uur::raii::Mem partition = nullptr;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_BUFFER_SIZE,
                      urMemBufferPartition(buffer, UR_MEM_FLAG_READ_WRITE,
                                           UR_BUFFER_CREATE_TYPE_REGION, &region,
-                                          &partition));
+                                          partition.ptr()));
 }

--- a/test/conformance/queue/urQueueFinish.cpp
+++ b/test/conformance/queue/urQueueFinish.cpp
@@ -2,22 +2,24 @@
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#include <uur/fixtures.h>
+
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using urQueueFinishTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFinishTest);
 
 TEST_P(urQueueFinishTest, Success) {
     constexpr size_t buffer_size = 1024;
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+                                     buffer_size, nullptr, buffer.ptr()));
 
-    ur_event_handle_t event = nullptr;
+    uur::raii::Event event = nullptr;
     std::vector<uint8_t> data(buffer_size, 42);
     ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
                                            0, 1024, data.data(), 0, nullptr,
-                                           &event));
+                                           event.ptr()));
 
     ASSERT_SUCCESS(urQueueFinish(queue));
 
@@ -26,9 +28,6 @@ TEST_P(urQueueFinishTest, Success) {
     ASSERT_SUCCESS(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_EXECUTION_STATUS,
                                   sizeof(exec_status), &exec_status, nullptr));
     ASSERT_EQ(exec_status, UR_EXECUTION_INFO_COMPLETE);
-
-    ASSERT_SUCCESS(urMemRelease(buffer));
-    ASSERT_SUCCESS(urEventRelease(event));
 }
 
 TEST_P(urQueueFinishTest, InvalidNullHandleQueue) {

--- a/test/conformance/queue/urQueueFlush.cpp
+++ b/test/conformance/queue/urQueueFlush.cpp
@@ -2,16 +2,18 @@
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#include <uur/fixtures.h>
+
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using urQueueFlushTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFlushTest);
 
 TEST_P(urQueueFlushTest, Success) {
     constexpr size_t buffer_size = 1024;
-    ur_mem_handle_t buffer = nullptr;
+    uur::raii::Mem buffer = nullptr;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
-                                     buffer_size, nullptr, &buffer));
+                                     buffer_size, nullptr, buffer.ptr()));
 
     std::vector<uint8_t> data(buffer_size, 42);
     ASSERT_SUCCESS(urEnqueueMemBufferWrite(queue, buffer, /* blocking */ false,
@@ -19,7 +21,6 @@ TEST_P(urQueueFlushTest, Success) {
                                            nullptr));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
-    ASSERT_SUCCESS(urMemRelease(buffer));
 }
 
 TEST_P(urQueueFlushTest, InvalidNullHandleQueue) {

--- a/test/conformance/sampler/urSamplerCreate.cpp
+++ b/test/conformance/sampler/urSamplerCreate.cpp
@@ -3,7 +3,8 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <uur/fixtures.h>
+#include "uur/fixtures.h"
+#include "uur/raii.h"
 
 using SamplerCreateParamTy =
     std::tuple<bool, ur_sampler_addressing_mode_t, ur_sampler_filter_mode_t>;
@@ -56,10 +57,9 @@ TEST_P(urSamplerCreateTestWithParam, Success) {
         filter_mode,                    /* filterMode */
     };
 
-    ur_sampler_handle_t hSampler = nullptr;
-    ASSERT_SUCCESS(urSamplerCreate(context, &sampler_desc, &hSampler));
+    uur::raii::Sampler hSampler = nullptr;
+    ASSERT_SUCCESS(urSamplerCreate(context, &sampler_desc, hSampler.ptr()));
     ASSERT_NE(hSampler, nullptr);
-    EXPECT_SUCCESS(urSamplerRelease(hSampler));
 }
 
 using urSamplerCreateTest = uur::urContextTest;
@@ -73,8 +73,8 @@ TEST_P(urSamplerCreateTest, InvalidNullHandleContext) {
         UR_SAMPLER_ADDRESSING_MODE_CLAMP, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_LINEAR,    /* filterMode */
     };
-    ur_sampler_handle_t hSampler = nullptr;
-    ASSERT_EQ_RESULT(urSamplerCreate(nullptr, &sampler_desc, &hSampler),
+    uur::raii::Sampler hSampler = nullptr;
+    ASSERT_EQ_RESULT(urSamplerCreate(nullptr, &sampler_desc, hSampler.ptr()),
                      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
@@ -86,8 +86,8 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
         UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_LINEAR,           /* filterMode */
     };
-    ur_sampler_handle_t hSampler = nullptr;
-    ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, &hSampler),
+    uur::raii::Sampler hSampler = nullptr;
+    ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
@@ -98,7 +98,7 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
         UR_SAMPLER_ADDRESSING_MODE_CLAMP,    /* addressing mode */
         UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */
     };
-    ur_sampler_handle_t hSampler = nullptr;
-    ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, &hSampler),
+    uur::raii::Sampler hSampler = nullptr;
+    ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }

--- a/test/conformance/testing/include/uur/raii.h
+++ b/test/conformance/testing/include/uur/raii.h
@@ -1,0 +1,114 @@
+// Copyright (C) 2022-2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef UUR_RAII_H_INCLUDED
+#define UUR_RAII_H_INCLUDED
+
+#include "ur_api.h"
+#include <cstddef>
+#include <utility>
+
+namespace uur {
+namespace raii {
+template <class URHandleT, ur_result_t (*retain)(URHandleT),
+          ur_result_t (*release)(URHandleT)>
+struct Wrapper {
+    using handle_t = URHandleT;
+
+    handle_t handle;
+
+    Wrapper() : handle(nullptr) {}
+    explicit Wrapper(handle_t handle) : handle(handle) {}
+    ~Wrapper() {
+        if (handle) {
+            release(handle);
+        }
+    }
+
+    Wrapper(const Wrapper &other) : handle(other.handle) { retain(handle); }
+    Wrapper(Wrapper &&other) : handle(other.handle) { other.handle = nullptr; }
+    Wrapper(std::nullptr_t) : handle(nullptr) {}
+
+    Wrapper &operator=(const Wrapper &other) {
+        if (handle) {
+            release(handle);
+        }
+        handle = other.handle;
+        retain(handle);
+        return *this;
+    }
+    Wrapper &operator=(Wrapper &&other) {
+        if (handle) {
+            release(handle);
+        }
+        handle = other.handle;
+        other.handle = nullptr;
+        return *this;
+    }
+    Wrapper &operator=(std::nullptr_t) {
+        if (handle) {
+            release(handle);
+        }
+        new (this) Wrapper(nullptr);
+        return *this;
+    }
+
+    handle_t *ptr() { return &handle; }
+    handle_t get() { return handle; }
+    handle_t operator->() { return handle; }
+    operator handle_t() { return handle; }
+
+    friend bool operator==(const Wrapper &lhs, const Wrapper &rhs) {
+        return lhs.handle == rhs.handle;
+    }
+    friend bool operator==(const Wrapper &lhs, const handle_t &rhs) {
+        return lhs.handle == rhs;
+    }
+    friend bool operator==(const handle_t &lhs, const Wrapper &rhs) {
+        return lhs == rhs.handle;
+    }
+    friend bool operator==(const Wrapper &lhs, const std::nullptr_t &rhs) {
+        return lhs.handle == rhs;
+    }
+    friend bool operator==(const std::nullptr_t &lhs, const Wrapper &rhs) {
+        return lhs == rhs.handle;
+    }
+
+    friend bool operator!=(const Wrapper &lhs, const Wrapper &rhs) {
+        return lhs.handle != rhs.handle;
+    }
+    friend bool operator!=(const Wrapper &lhs, const handle_t &rhs) {
+        return lhs.handle != rhs;
+    }
+    friend bool operator!=(const handle_t &lhs, const Wrapper &rhs) {
+        return lhs != rhs.handle;
+    }
+    friend bool operator!=(const Wrapper &lhs, const std::nullptr_t &rhs) {
+        return lhs.handle != rhs;
+    }
+    friend bool operator!=(const std::nullptr_t &lhs, const Wrapper &rhs) {
+        return lhs != rhs.handle;
+    }
+};
+
+using LoaderConfig = Wrapper<ur_loader_config_handle_t, urLoaderConfigRetain,
+                             urLoaderConfigRelease>;
+using Adapter = Wrapper<ur_adapter_handle_t, urAdapterRetain, urAdapterRelease>;
+using Device = Wrapper<ur_device_handle_t, urDeviceRetain, urDeviceRelease>;
+using Context = Wrapper<ur_context_handle_t, urContextRetain, urContextRelease>;
+using Mem = Wrapper<ur_mem_handle_t, urMemRetain, urMemRelease>;
+using Sampler = Wrapper<ur_sampler_handle_t, urSamplerRetain, urSamplerRelease>;
+using USMPool =
+    Wrapper<ur_usm_pool_handle_t, urUSMPoolRetain, urUSMPoolRelease>;
+using PhysicalMem = Wrapper<ur_physical_mem_handle_t, urPhysicalMemRetain,
+                            urPhysicalMemRelease>;
+using Program = Wrapper<ur_program_handle_t, urProgramRetain, urProgramRelease>;
+using Kernel = Wrapper<ur_kernel_handle_t, urKernelRetain, urKernelRelease>;
+using Queue = Wrapper<ur_queue_handle_t, urQueueRetain, urQueueRelease>;
+using Event = Wrapper<ur_event_handle_t, urEventRetain, urEventRelease>;
+}; // namespace raii
+}; // namespace uur
+
+#endif // UUR_RAII_H_INCLUDED

--- a/test/conformance/virtual_memory/urPhysicalMemCreate.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemCreate.cpp
@@ -2,7 +2,8 @@
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#include <uur/fixtures.h>
+
+#include "uur/fixtures.h"
 
 struct urPhysicalMemCreateTest
     : uur::urVirtualMemGranularityTestWithParam<size_t> {
@@ -13,29 +14,33 @@ struct urPhysicalMemCreateTest
         size = getParam() * granularity;
     }
 
+    void TearDown() override {
+        if (physical_mem) {
+            ASSERT_SUCCESS(urPhysicalMemRelease(physical_mem));
+        }
+        uur::urVirtualMemGranularityTestWithParam<size_t>::TearDown();
+    }
+
     size_t size;
+    ur_physical_mem_handle_t physical_mem = nullptr;
 };
 
 UUR_TEST_SUITE_P(urPhysicalMemCreateTest, ::testing::Values(1, 2, 3, 7, 12, 44),
                  uur::deviceTestWithParamPrinter<size_t>);
 
 TEST_P(urPhysicalMemCreateTest, Success) {
-    ur_physical_mem_handle_t physical_mem = nullptr;
     ASSERT_SUCCESS(
         urPhysicalMemCreate(context, device, size, nullptr, &physical_mem));
     ASSERT_NE(physical_mem, nullptr);
-    EXPECT_SUCCESS(urPhysicalMemRelease(physical_mem));
 }
 
 TEST_P(urPhysicalMemCreateTest, InvalidNullHandleContext) {
-    ur_physical_mem_handle_t physical_mem = nullptr;
     ASSERT_EQ_RESULT(
         urPhysicalMemCreate(nullptr, device, size, nullptr, &physical_mem),
         UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urPhysicalMemCreateTest, InvalidNullHandleDevice) {
-    ur_physical_mem_handle_t physical_mem = nullptr;
     ASSERT_EQ_RESULT(
         urPhysicalMemCreate(context, nullptr, size, nullptr, &physical_mem),
         UR_RESULT_ERROR_INVALID_NULL_HANDLE);
@@ -52,7 +57,6 @@ TEST_P(urPhysicalMemCreateTest, InvalidSize) {
         GTEST_SKIP()
             << "A granularity of 1 means that any size will be accepted.";
     }
-    ur_physical_mem_handle_t physical_mem = nullptr;
     size_t invalid_size = size - 1;
     ASSERT_EQ_RESULT(urPhysicalMemCreate(context, device, invalid_size, nullptr,
                                          &physical_mem),

--- a/test/layers/tracing/codeloc.cpp
+++ b/test/layers/tracing/codeloc.cpp
@@ -10,6 +10,7 @@
  *
  */
 
+#include "uur/raii.h"
 #include <gtest/gtest.h>
 #include <ur_api.h>
 
@@ -26,12 +27,11 @@ struct ur_code_location_t test_callback(void *userdata) {
 }
 
 TEST(LoaderCodeloc, NullCallback) {
-    ur_loader_config_handle_t loader_config;
-    ASSERT_EQ(urLoaderConfigCreate(&loader_config), UR_RESULT_SUCCESS);
+    uur::raii::LoaderConfig loader_config;
+    ASSERT_EQ(urLoaderConfigCreate(loader_config.ptr()), UR_RESULT_SUCCESS);
     ASSERT_EQ(
         urLoaderConfigSetCodeLocationCallback(loader_config, nullptr, nullptr),
         UR_RESULT_ERROR_INVALID_NULL_POINTER);
-    urLoaderConfigRelease(loader_config);
 }
 
 TEST(LoaderCodeloc, NullHandle) {
@@ -41,13 +41,12 @@ TEST(LoaderCodeloc, NullHandle) {
 }
 
 TEST(LoaderCodeloc, Success) {
-    ur_loader_config_handle_t loader_config;
-    ASSERT_EQ(urLoaderConfigCreate(&loader_config), UR_RESULT_SUCCESS);
+    uur::raii::LoaderConfig loader_config;
+    ASSERT_EQ(urLoaderConfigCreate(loader_config.ptr()), UR_RESULT_SUCCESS);
     ASSERT_EQ(urLoaderConfigSetCodeLocationCallback(loader_config,
                                                     test_callback, nullptr),
               UR_RESULT_SUCCESS);
     urLoaderInit(0, loader_config);
     uint32_t nadapters;
     urAdapterGet(0, nullptr, &nadapters);
-    urLoaderConfigRelease(loader_config);
 }


### PR DESCRIPTION
This patch introduces the `uur::raii::Wrapper<T>` object and per handle
aliases (`uur::raii::Context` for `ur_context_handle_t` etc.) to replace
instances of the following pattern in test bodies:

```cpp
TEST(Context, Example) {
    ur_context_handle_t context = nullptr;
    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, &context));

    // potential resource leak as `ASSERT_*` returns from this function
    ASSERT_TRUE(might_be_false);

    urContextRelease(context);
}
```

With the following:

```cpp
TEST(Context, Example) {
    uur::raii::Context context = nullptr;
    ASSERT_SUCCESS(urContextCreate(1, &device, nullptr, context.ptr()));

    // no leak because the destructor releases the context
    ASSERT_TRUE(might_be_false);
}
```
