### PR TITLE
[SPEC] Fix queue handle class

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -9377,6 +9377,83 @@ typedef struct ur_kernel_suggest_max_cooperative_group_count_exp_params_t {
 } ur_kernel_suggest_max_cooperative_group_count_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueGetInfo
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_get_info_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_queue_info_t *ppropName;
+    size_t *ppropSize;
+    void **ppPropValue;
+    size_t **ppPropSizeRet;
+} ur_queue_get_info_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueCreate
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_create_params_t {
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_queue_properties_t **ppProperties;
+    ur_queue_handle_t **pphQueue;
+} ur_queue_create_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueRetain
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_retain_params_t {
+    ur_queue_handle_t *phQueue;
+} ur_queue_retain_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueRelease
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_release_params_t {
+    ur_queue_handle_t *phQueue;
+} ur_queue_release_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueGetNativeHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_get_native_handle_params_t {
+    ur_queue_handle_t *phQueue;
+    ur_queue_native_desc_t **ppDesc;
+    ur_native_handle_t **pphNativeQueue;
+} ur_queue_get_native_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueCreateWithNativeHandle
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_create_with_native_handle_params_t {
+    ur_native_handle_t *phNativeQueue;
+    ur_context_handle_t *phContext;
+    ur_device_handle_t *phDevice;
+    const ur_queue_native_properties_t **ppProperties;
+    ur_queue_handle_t **pphQueue;
+} ur_queue_create_with_native_handle_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueFinish
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_finish_params_t {
+    ur_queue_handle_t *phQueue;
+} ur_queue_finish_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urQueueFlush
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_queue_flush_params_t {
+    ur_queue_handle_t *phQueue;
+} ur_queue_flush_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urSamplerCreate
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
@@ -10039,83 +10116,6 @@ typedef struct ur_enqueue_cooperative_kernel_launch_exp_params_t {
     const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;
 } ur_enqueue_cooperative_kernel_launch_exp_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueGetInfo
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_get_info_params_t {
-    ur_queue_handle_t *phQueue;
-    ur_queue_info_t *ppropName;
-    size_t *ppropSize;
-    void **ppPropValue;
-    size_t **ppPropSizeRet;
-} ur_queue_get_info_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueCreate
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_create_params_t {
-    ur_context_handle_t *phContext;
-    ur_device_handle_t *phDevice;
-    const ur_queue_properties_t **ppProperties;
-    ur_queue_handle_t **pphQueue;
-} ur_queue_create_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueRetain
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_retain_params_t {
-    ur_queue_handle_t *phQueue;
-} ur_queue_retain_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueRelease
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_release_params_t {
-    ur_queue_handle_t *phQueue;
-} ur_queue_release_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueGetNativeHandle
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_get_native_handle_params_t {
-    ur_queue_handle_t *phQueue;
-    ur_queue_native_desc_t **ppDesc;
-    ur_native_handle_t **pphNativeQueue;
-} ur_queue_get_native_handle_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueCreateWithNativeHandle
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_create_with_native_handle_params_t {
-    ur_native_handle_t *phNativeQueue;
-    ur_context_handle_t *phContext;
-    ur_device_handle_t *phDevice;
-    const ur_queue_native_properties_t **ppProperties;
-    ur_queue_handle_t **pphQueue;
-} ur_queue_create_with_native_handle_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueFinish
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_finish_params_t {
-    ur_queue_handle_t *phQueue;
-} ur_queue_finish_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urQueueFlush
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_queue_flush_params_t {
-    ur_queue_handle_t *phQueue;
-} ur_queue_flush_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesUnsampledImageHandleDestroyExp

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -657,6 +657,93 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetKernelExpProcAddrTable_t)(
     ur_kernel_exp_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueGetInfo
+typedef ur_result_t(UR_APICALL *ur_pfnQueueGetInfo_t)(
+    ur_queue_handle_t,
+    ur_queue_info_t,
+    size_t,
+    void *,
+    size_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueCreate
+typedef ur_result_t(UR_APICALL *ur_pfnQueueCreate_t)(
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_queue_properties_t *,
+    ur_queue_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueRetain
+typedef ur_result_t(UR_APICALL *ur_pfnQueueRetain_t)(
+    ur_queue_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueRelease
+typedef ur_result_t(UR_APICALL *ur_pfnQueueRelease_t)(
+    ur_queue_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueGetNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
+    ur_queue_handle_t,
+    ur_queue_native_desc_t *,
+    ur_native_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueCreateWithNativeHandle
+typedef ur_result_t(UR_APICALL *ur_pfnQueueCreateWithNativeHandle_t)(
+    ur_native_handle_t,
+    ur_context_handle_t,
+    ur_device_handle_t,
+    const ur_queue_native_properties_t *,
+    ur_queue_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueFinish
+typedef ur_result_t(UR_APICALL *ur_pfnQueueFinish_t)(
+    ur_queue_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urQueueFlush
+typedef ur_result_t(UR_APICALL *ur_pfnQueueFlush_t)(
+    ur_queue_handle_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Queue functions pointers
+typedef struct ur_queue_dditable_t {
+    ur_pfnQueueGetInfo_t pfnGetInfo;
+    ur_pfnQueueCreate_t pfnCreate;
+    ur_pfnQueueRetain_t pfnRetain;
+    ur_pfnQueueRelease_t pfnRelease;
+    ur_pfnQueueGetNativeHandle_t pfnGetNativeHandle;
+    ur_pfnQueueCreateWithNativeHandle_t pfnCreateWithNativeHandle;
+    ur_pfnQueueFinish_t pfnFinish;
+    ur_pfnQueueFlush_t pfnFlush;
+} ur_queue_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Queue table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetQueueProcAddrTable(
+    ur_api_version_t version,      ///< [in] API version requested
+    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
+);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetQueueProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
+    ur_api_version_t,
+    ur_queue_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urSamplerCreate
 typedef ur_result_t(UR_APICALL *ur_pfnSamplerCreate_t)(
     ur_context_handle_t,
@@ -1375,93 +1462,6 @@ urGetEnqueueExpProcAddrTable(
 typedef ur_result_t(UR_APICALL *ur_pfnGetEnqueueExpProcAddrTable_t)(
     ur_api_version_t,
     ur_enqueue_exp_dditable_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueGetInfo
-typedef ur_result_t(UR_APICALL *ur_pfnQueueGetInfo_t)(
-    ur_queue_handle_t,
-    ur_queue_info_t,
-    size_t,
-    void *,
-    size_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueCreate
-typedef ur_result_t(UR_APICALL *ur_pfnQueueCreate_t)(
-    ur_context_handle_t,
-    ur_device_handle_t,
-    const ur_queue_properties_t *,
-    ur_queue_handle_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueRetain
-typedef ur_result_t(UR_APICALL *ur_pfnQueueRetain_t)(
-    ur_queue_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueRelease
-typedef ur_result_t(UR_APICALL *ur_pfnQueueRelease_t)(
-    ur_queue_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueGetNativeHandle
-typedef ur_result_t(UR_APICALL *ur_pfnQueueGetNativeHandle_t)(
-    ur_queue_handle_t,
-    ur_queue_native_desc_t *,
-    ur_native_handle_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueCreateWithNativeHandle
-typedef ur_result_t(UR_APICALL *ur_pfnQueueCreateWithNativeHandle_t)(
-    ur_native_handle_t,
-    ur_context_handle_t,
-    ur_device_handle_t,
-    const ur_queue_native_properties_t *,
-    ur_queue_handle_t *);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueFinish
-typedef ur_result_t(UR_APICALL *ur_pfnQueueFinish_t)(
-    ur_queue_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urQueueFlush
-typedef ur_result_t(UR_APICALL *ur_pfnQueueFlush_t)(
-    ur_queue_handle_t);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Table of Queue functions pointers
-typedef struct ur_queue_dditable_t {
-    ur_pfnQueueGetInfo_t pfnGetInfo;
-    ur_pfnQueueCreate_t pfnCreate;
-    ur_pfnQueueRetain_t pfnRetain;
-    ur_pfnQueueRelease_t pfnRelease;
-    ur_pfnQueueGetNativeHandle_t pfnGetNativeHandle;
-    ur_pfnQueueCreateWithNativeHandle_t pfnCreateWithNativeHandle;
-    ur_pfnQueueFinish_t pfnFinish;
-    ur_pfnQueueFlush_t pfnFlush;
-} ur_queue_dditable_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Exported function for filling application's Queue table
-///        with current process' addresses
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-UR_DLLEXPORT ur_result_t UR_APICALL
-urGetQueueProcAddrTable(
-    ur_api_version_t version,      ///< [in] API version requested
-    ur_queue_dditable_t *pDdiTable ///< [in,out] pointer to table of DDI function pointers
-);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urGetQueueProcAddrTable
-typedef ur_result_t(UR_APICALL *ur_pfnGetQueueProcAddrTable_t)(
-    ur_api_version_t,
-    ur_queue_dditable_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesUnsampledImageHandleDestroyExp
@@ -2310,13 +2310,13 @@ typedef struct ur_dditable_t {
     ur_program_exp_dditable_t ProgramExp;
     ur_kernel_dditable_t Kernel;
     ur_kernel_exp_dditable_t KernelExp;
+    ur_queue_dditable_t Queue;
     ur_sampler_dditable_t Sampler;
     ur_mem_dditable_t Mem;
     ur_physical_mem_dditable_t PhysicalMem;
     ur_global_dditable_t Global;
     ur_enqueue_dditable_t Enqueue;
     ur_enqueue_exp_dditable_t EnqueueExp;
-    ur_queue_dditable_t Queue;
     ur_bindless_images_exp_dditable_t BindlessImagesExp;
     ur_usm_dditable_t USM;
     ur_usm_exp_dditable_t USMExp;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -1419,6 +1419,70 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSetSpecializationConstantsParam
 UR_APIEXPORT ur_result_t UR_APICALL urPrintKernelSuggestMaxCooperativeGroupCountExpParams(const struct ur_kernel_suggest_max_cooperative_group_count_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_get_info_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetInfoParams(const struct ur_queue_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_create_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateParams(const struct ur_queue_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_retain_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueRetainParams(const struct ur_queue_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_release_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueReleaseParams(const struct ur_queue_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_get_native_handle_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetNativeHandleParams(const struct ur_queue_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_create_with_native_handle_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateWithNativeHandleParams(const struct ur_queue_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_finish_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFinishParams(const struct ur_queue_finish_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_queue_flush_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFlushParams(const struct ur_queue_flush_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_sampler_create_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1817,70 +1881,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueWriteHostPipeParams(const stru
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueCooperativeKernelLaunchExpParams(const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_get_info_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetInfoParams(const struct ur_queue_get_info_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_create_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateParams(const struct ur_queue_create_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_retain_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueRetainParams(const struct ur_queue_retain_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_release_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueReleaseParams(const struct ur_queue_release_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_get_native_handle_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueGetNativeHandleParams(const struct ur_queue_get_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_create_with_native_handle_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueCreateWithNativeHandleParams(const struct ur_queue_create_with_native_handle_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_finish_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFinishParams(const struct ur_queue_finish_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_queue_flush_params_t struct
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_INVALID_SIZE
-///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintQueueFlushParams(const struct ur_queue_flush_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_unsampled_image_handle_destroy_exp_params_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -10904,6 +10904,192 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_get_info_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_get_info_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    os << ", ";
+    os << ".propName = ";
+
+    os << *(params->ppropName);
+
+    os << ", ";
+    os << ".propSize = ";
+
+    os << *(params->ppropSize);
+
+    os << ", ";
+    os << ".pPropValue = ";
+    ur::details::printTagged(os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
+
+    os << ", ";
+    os << ".pPropSizeRet = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppPropSizeRet));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_create_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_create_params_t *params) {
+
+    os << ".hContext = ";
+
+    ur::details::printPtr(os,
+                          *(params->phContext));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur::details::printPtr(os,
+                          *(params->phDevice));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppProperties));
+
+    os << ", ";
+    os << ".phQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->pphQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_retain_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_retain_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_release_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_release_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_get_native_handle_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_get_native_handle_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    os << ", ";
+    os << ".pDesc = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppDesc));
+
+    os << ", ";
+    os << ".phNativeQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->pphNativeQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_create_with_native_handle_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_create_with_native_handle_params_t *params) {
+
+    os << ".hNativeQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phNativeQueue));
+
+    os << ", ";
+    os << ".hContext = ";
+
+    ur::details::printPtr(os,
+                          *(params->phContext));
+
+    os << ", ";
+    os << ".hDevice = ";
+
+    ur::details::printPtr(os,
+                          *(params->phDevice));
+
+    os << ", ";
+    os << ".pProperties = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppProperties));
+
+    os << ", ";
+    os << ".phQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->pphQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_finish_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_finish_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_queue_flush_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_flush_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_sampler_create_params_t type
 /// @returns
 ///     std::ostream &
@@ -13216,192 +13402,6 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     ur::details::printPtr(os,
                           *(params->pphEvent));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_get_info_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_get_info_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
-
-    os << ", ";
-    os << ".propName = ";
-
-    os << *(params->ppropName);
-
-    os << ", ";
-    os << ".propSize = ";
-
-    os << *(params->ppropSize);
-
-    os << ", ";
-    os << ".pPropValue = ";
-    ur::details::printTagged(os, *(params->ppPropValue), *(params->ppropName), *(params->ppropSize));
-
-    os << ", ";
-    os << ".pPropSizeRet = ";
-
-    ur::details::printPtr(os,
-                          *(params->ppPropSizeRet));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_create_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_create_params_t *params) {
-
-    os << ".hContext = ";
-
-    ur::details::printPtr(os,
-                          *(params->phContext));
-
-    os << ", ";
-    os << ".hDevice = ";
-
-    ur::details::printPtr(os,
-                          *(params->phDevice));
-
-    os << ", ";
-    os << ".pProperties = ";
-
-    ur::details::printPtr(os,
-                          *(params->ppProperties));
-
-    os << ", ";
-    os << ".phQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->pphQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_retain_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_retain_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_release_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_release_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_get_native_handle_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_get_native_handle_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
-
-    os << ", ";
-    os << ".pDesc = ";
-
-    ur::details::printPtr(os,
-                          *(params->ppDesc));
-
-    os << ", ";
-    os << ".phNativeQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->pphNativeQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_create_with_native_handle_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_create_with_native_handle_params_t *params) {
-
-    os << ".hNativeQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phNativeQueue));
-
-    os << ", ";
-    os << ".hContext = ";
-
-    ur::details::printPtr(os,
-                          *(params->phContext));
-
-    os << ", ";
-    os << ".hDevice = ";
-
-    ur::details::printPtr(os,
-                          *(params->phDevice));
-
-    os << ", ";
-    os << ".pProperties = ";
-
-    ur::details::printPtr(os,
-                          *(params->ppProperties));
-
-    os << ", ";
-    os << ".phQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->pphQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_finish_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_finish_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
-
-    return os;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_queue_flush_params_t type
-/// @returns
-///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_queue_flush_params_t *params) {
-
-    os << ".hQueue = ";
-
-    ur::details::printPtr(os,
-                          *(params->phQueue));
 
     return os;
 }
@@ -16087,6 +16087,30 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     case UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP: {
         os << (const struct ur_kernel_suggest_max_cooperative_group_count_exp_params_t *)params;
     } break;
+    case UR_FUNCTION_QUEUE_GET_INFO: {
+        os << (const struct ur_queue_get_info_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_CREATE: {
+        os << (const struct ur_queue_create_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_RETAIN: {
+        os << (const struct ur_queue_retain_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_RELEASE: {
+        os << (const struct ur_queue_release_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE: {
+        os << (const struct ur_queue_get_native_handle_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE: {
+        os << (const struct ur_queue_create_with_native_handle_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_FINISH: {
+        os << (const struct ur_queue_finish_params_t *)params;
+    } break;
+    case UR_FUNCTION_QUEUE_FLUSH: {
+        os << (const struct ur_queue_flush_params_t *)params;
+    } break;
     case UR_FUNCTION_SAMPLER_CREATE: {
         os << (const struct ur_sampler_create_params_t *)params;
     } break;
@@ -16236,30 +16260,6 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     } break;
     case UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP: {
         os << (const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_GET_INFO: {
-        os << (const struct ur_queue_get_info_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_CREATE: {
-        os << (const struct ur_queue_create_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_RETAIN: {
-        os << (const struct ur_queue_retain_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_RELEASE: {
-        os << (const struct ur_queue_release_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE: {
-        os << (const struct ur_queue_get_native_handle_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE: {
-        os << (const struct ur_queue_create_with_native_handle_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_FINISH: {
-        os << (const struct ur_queue_finish_params_t *)params;
-    } break;
-    case UR_FUNCTION_QUEUE_FLUSH: {
-        os << (const struct ur_queue_flush_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP: {
         os << (const struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t *)params;

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 Intel Corporation
+# Copyright (C) 2022-2024 Intel Corporation
 #
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
@@ -102,7 +102,7 @@ name: "$x_kernel_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
 desc: "Handle of a queue object"
-class: $xPlatform
+class: $xQueue
 name: "$x_queue_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle


### PR DESCRIPTION
Make queue handle a part of queue class. It's required by https://github.com/oneapi-src/unified-runtime/pull/1121 to correctly track the queue object handles.