### PR TITLE
[CI] Add Native CPU to e2e nightly job.

### DIFF
--- a/.github/workflows/e2e_nightly.yml
+++ b/.github/workflows/e2e_nightly.yml
@@ -16,6 +16,7 @@ jobs:
         adapter: [
           {name: CUDA, str_name: cuda, prefix: "ext_oneapi_", config: "--cuda --hip", unit: "gpu"},
           {name: OPENCL, str_name: opencl, prefix: "", config: "", unit: "cpu"}
+          {name: NATIVE_CPU, str_name: nativecpu, prefix: "", config: "", unit: "cpu"}
         ]
         build_type: [Release]
         compiler: [{c: clang, cxx: clang++}]


### PR DESCRIPTION
I've placed this PR into draft for the time being as there is significant work required to support the e2e tests for the Native CPU adapter.