### PR TITLE
[L0] fix caching internal events

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1493,7 +1493,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   // ur_event_handle_t objects. We destroy corresponding ze_event by releasing
   // events from the events cache at queue destruction. Event in the cache owns
   // the Level Zero event.
-  if (IsInternal)
+  if (Queue->isDiscardEvents() && IsInternal)
     (*Event)->OwnNativeHandle = false;
 
   // Append this Event to the CommandList, if any


### PR DESCRIPTION
When the L0 adapter enqueues an operation, it creates an event for its own bookkeeping needs and to optionally notify the application about completion. These events are periodically cleaned up and the event objects themselves are cached to be reused. Or at least they are supposed to be. If the enqueue does not specify a user event (i.e., the event is L0 internal) the event is destroyed and the L0 event handle is simply leaked in urEventReleaseInternal. This means that every `MaxNumEventsPerPool` enqueue calls (256 by default) a new event pool is created.

This patch fixes the above problem by making such internal events own the native L0 handles, enabling them to be cached.

I found this problem in the microbenchmark from #1286. This patch nearly triples its performance on some systems.
