### PR TITLE
[L0] optimize # of event status queries through batching

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -13,6 +13,7 @@
 #include <mutex>
 #include <string.h>
 
+#include "adapters/level_zero/queue.hpp"
 #include "context.hpp"
 #include "ur_level_zero.hpp"
 
@@ -596,29 +597,6 @@ ur_context_handle_t_::decrementUnreleasedEventsInPool(ur_event_handle_t Event) {
   return UR_RESULT_SUCCESS;
 }
 
-// Get value of the threshold for number of events in immediate command lists.
-// If number of events in the immediate command list exceeds this threshold then
-// cleanup process for those events is executed.
-static const size_t ImmCmdListsEventCleanupThreshold = [] {
-  const char *UrRet =
-      std::getenv("UR_L0_IMMEDIATE_COMMANDLISTS_EVENT_CLEANUP_THRESHOLD");
-  const char *PiRet = std::getenv(
-      "SYCL_PI_LEVEL_ZERO_IMMEDIATE_COMMANDLISTS_EVENT_CLEANUP_THRESHOLD");
-  const char *ImmCmdListsEventCleanupThresholdStr =
-      UrRet ? UrRet : (PiRet ? PiRet : nullptr);
-  static constexpr int Default = 1000;
-  if (!ImmCmdListsEventCleanupThresholdStr)
-    return Default;
-
-  int Threshold = std::atoi(ImmCmdListsEventCleanupThresholdStr);
-
-  // Basically disable threshold if negative value is provided.
-  if (Threshold < 0)
-    return INT_MAX;
-
-  return Threshold;
-}();
-
 // Get value of the threshold for number of active command lists allowed before
 // we start heuristically cleaning them up.
 static const size_t CmdListsCleanupThreshold = [] {
@@ -648,8 +626,8 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
   // Immediate commandlists have been pre-allocated and are always available.
   if (Queue->UsingImmCmdLists) {
     CommandList = Queue->getQueueGroup(UseCopyEngine).getImmCmdList();
-    if (CommandList->second.EventList.size() >
-        ImmCmdListsEventCleanupThreshold) {
+    if (CommandList->second.EventList.size() >=
+        Queue->getImmdCmmdListsEventCleanupThreshold()) {
       std::vector<ur_event_handle_t> EventListToCleanup;
       Queue->resetCommandList(CommandList, false, EventListToCleanup);
       CleanupEventListFromResetCmdList(EventListToCleanup, true);
@@ -743,11 +721,13 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
         ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
         ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
         ZeQueueDesc.ordinal = QueueGroupOrdinal;
+
         CommandList =
             Queue->CommandListMap
                 .emplace(ZeCommandList,
-                         ur_command_list_info_t{ZeFence, true, false,
-                                                ZeCommandQueue, ZeQueueDesc})
+                         ur_command_list_info_t(ZeFence, true, false,
+                                                ZeCommandQueue, ZeQueueDesc,
+                                                Queue->useCompletionBatching()))
                 .first;
       }
       ZeCommandListCache.erase(ZeCommandListIt);

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <climits>
 #include <mutex>
+#include <optional>
 #include <string.h>
 
 #include "command_buffer.hpp"
@@ -1129,6 +1130,7 @@ ur_result_t ur_event_handle_t_::reset() {
   RefCountExternal = 0;
   RefCount.reset();
   CommandList = std::nullopt;
+  completionBatch = std::nullopt;
 
   if (!isHostVisible())
     HostVisibleEvent = nullptr;

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -222,6 +222,10 @@ struct ur_event_handle_t_ : _ur_object {
 
   // Get the host-visible event or create one and enqueue its signal.
   ur_result_t getOrCreateHostVisibleEvent(ze_event_handle_t &HostVisibleEvent);
+
+  // completion batch for this event. Only used for out-of-order immediate
+  // command lists.
+  std::optional<ur_completion_batch_it> completionBatch;
 };
 
 // Helper function to implement zeHostSynchronize.

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -10,13 +10,214 @@
 
 #include <algorithm>
 #include <climits>
+#include <cstdint>
 #include <optional>
 #include <string.h>
+#include <vector>
 
 #include "adapter.hpp"
+#include "adapters/level_zero/event.hpp"
 #include "common.hpp"
 #include "queue.hpp"
+#include "ur_api.h"
 #include "ur_level_zero.hpp"
+#include "ur_util.hpp"
+#include "ze_api.h"
+
+// Hard limit for the event completion batches.
+static const uint64_t CompletionBatchesMax = [] {
+  // Default value chosen empirically to maximize the number of asynchronous
+  // in-flight operations and avoid excessive synchronous waits.
+
+  return getenv_to_unsigned("UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_MAX")
+      .value_or(10);
+}();
+
+static const uint64_t CompletionEventsPerBatch = [] {
+  // The number of events to accumulate in each batch prior to waiting for
+  // completion.
+  return getenv_to_unsigned("UR_L0_IMMEDIATE_COMMANDLISTS_EVENTS_PER_BATCH")
+      .value_or(256);
+}();
+
+ur_completion_batch::ur_completion_batch()
+    : barrierEvent(nullptr), st(EMPTY), numEvents(0) {}
+
+ur_completion_batch::~ur_completion_batch() {
+  if (barrierEvent)
+    urEventReleaseInternal(barrierEvent);
+}
+
+bool ur_completion_batch::isFull() {
+  assert(st == ACCUMULATING);
+
+  return numEvents >= CompletionEventsPerBatch;
+}
+
+void ur_completion_batch::append() {
+  assert(st == ACCUMULATING);
+  numEvents++;
+}
+
+ur_result_t ur_completion_batch::reset() {
+  st = EMPTY;
+  numEvents = 0;
+
+  // we reuse the UR event handle but reset the internal level-zero one
+  if (barrierEvent)
+    ZE2UR_CALL(zeEventHostReset, (barrierEvent->ZeEvent));
+
+  return UR_RESULT_SUCCESS;
+}
+
+void ur_completion_batch::use() {
+  assert(st == EMPTY);
+  st = ACCUMULATING;
+}
+
+ur_completion_batch::state ur_completion_batch::getState() { return st; }
+
+ur_completion_batch::state ur_completion_batch::queryState() {
+  if (st == SEALED) {
+    checkComplete();
+  }
+
+  return st;
+}
+
+bool ur_completion_batch::checkComplete() {
+  assert(st == COMPLETED || st == SEALED);
+
+  if (st == COMPLETED)
+    return true;
+
+  auto zeResult = ZE_CALL_NOCHECK(zeEventQueryStatus, (barrierEvent->ZeEvent));
+  if (zeResult == ZE_RESULT_SUCCESS) {
+    st = COMPLETED;
+  }
+
+  return st == COMPLETED;
+}
+
+ur_result_t ur_completion_batch::seal(ur_queue_handle_t queue,
+                                      ze_command_list_handle_t cmdlist) {
+  assert(st == ACCUMULATING);
+
+  if (!barrierEvent) {
+    UR_CALL(EventCreate(queue->Context, queue, false, true, &barrierEvent));
+  }
+
+  // Instead of collecting all the batched events, we simply issue a global
+  // barrier for all prior events on the command list. This is simpler and
+  // showed to be faster in practice.
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (cmdlist, barrierEvent->ZeEvent, 0, nullptr));
+
+  st = SEALED;
+
+  return UR_RESULT_SUCCESS;
+}
+
+void ur_completion_batches::append(ur_event_handle_t event) {
+  active->append();
+  event->completionBatch = active;
+}
+
+void ur_completion_batches::moveCompletedEvents(
+    ur_completion_batch_it it, std::vector<ur_event_handle_t> &events,
+    std::vector<ur_event_handle_t> &EventListToCleanup) {
+  // This works by tagging all events belonging to a batch, and then removing
+  // all events in a vector with the tag (iterator) of the active batch.
+  // This could be optimized to remove a specific range of entries if we had a
+  // guarantee that all the appended events in the vector remain there in the
+  // same order. Unfortunately that is not simple to enforce.
+  // TODO: An even better approach would be to split the EventList vector into
+  // smaller batch-sized ones, but that would require a significant refactor.
+
+  auto end = std::remove_if(events.begin(), events.end(), [&](auto &event) {
+    if (event->completionBatch == it) {
+      EventListToCleanup.push_back(event);
+      return true;
+    } else {
+      return false;
+    }
+  });
+  events.erase(end, events.end());
+}
+
+ur_result_t ur_completion_batches::cleanup(
+    std::vector<ur_event_handle_t> &events,
+    std::vector<ur_event_handle_t> &EventListToCleanup) {
+  bool cleaned = false;
+  while (!sealed.empty()) {
+    auto oldest_sealed = sealed.front();
+    if (oldest_sealed->queryState() == ur_completion_batch::COMPLETED) {
+      sealed.pop();
+      moveCompletedEvents(oldest_sealed, events, EventListToCleanup);
+      UR_CALL(oldest_sealed->reset());
+      cleaned = true;
+    } else {
+      break;
+    }
+  }
+
+  return cleaned ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_OUT_OF_RESOURCES;
+}
+
+std::optional<ur_completion_batch_it>
+ur_completion_batches::findFirstEmptyBatchOrCreate() {
+  for (auto it = batches.begin(); it != batches.end(); ++it) {
+    if (it->getState() == ur_completion_batch::EMPTY) {
+      return it;
+    }
+  }
+
+  // try creating a new batch if allowed by the limit.
+  if (batches.size() < CompletionBatchesMax) {
+    return batches.emplace(batches.end());
+  }
+
+  return std::nullopt;
+}
+
+ur_completion_batches::ur_completion_batches() {
+  // Batches are created lazily on-demand. Start with just one.
+  active = batches.emplace(batches.begin());
+  active->use();
+}
+
+ur_result_t ur_completion_batches::tryCleanup(
+    ur_queue_handle_t queue, ze_command_list_handle_t cmdlist,
+    std::vector<ur_event_handle_t> &events,
+    std::vector<ur_event_handle_t> &EventListToCleanup) {
+  cleanup(events, EventListToCleanup);
+
+  if (active->isFull()) {
+    auto next_batch = findFirstEmptyBatchOrCreate();
+    if (!next_batch) {
+      return UR_RESULT_ERROR_OUT_OF_RESOURCES; // EWOULDBLOCK
+    }
+
+    UR_CALL(active->seal(queue, cmdlist));
+    sealed.push(active);
+    active = *next_batch;
+    active->use();
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+void ur_completion_batches::forceReset() {
+  for (auto &b : batches) {
+    b.reset();
+  }
+  while (!sealed.empty()) {
+    sealed.pop();
+  }
+
+  active = batches.begin();
+  active->use();
+}
 
 /// @brief Cleanup events in the immediate lists of the queue.
 /// @param Queue Queue where events need to be cleaned up.
@@ -424,6 +625,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(
       // If the fence is a nullptr we are using immediate commandlists,
       // otherwise regular commandlists which use a fence.
       if (it->second.ZeFence == nullptr || it->second.ZeFenceInUse) {
+        // Destroy completions batches if they are being used. This needs
+        // to happen prior to resetCommandList so that all events are
+        // checked.
+        it->second.completions.reset();
         Queue->resetCommandList(it, true, EventListToCleanup);
       }
       // TODO: remove "if" when the problem is fixed in the level zero
@@ -520,16 +725,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
 }
 
 void ur_queue_handle_t_::ur_queue_group_t::setImmCmdList(
-    ze_command_list_handle_t ZeCommandList) {
+    ur_queue_handle_t queue, ze_command_list_handle_t ZeCommandList) {
   // An immediate command list was given to us but we don't have the queue
   // descriptor information. Create a dummy and note that it is not recycleable.
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
+
   ImmCmdLists = std::vector<ur_command_list_ptr_t>(
       1,
       Queue->CommandListMap
           .insert(std::pair<ze_command_list_handle_t, ur_command_list_info_t>{
               ZeCommandList,
-              {nullptr, true, false, nullptr, ZeQueueDesc, false}})
+              ur_command_list_info_t(nullptr, true, false, nullptr, ZeQueueDesc,
+                                     queue->useCompletionBatching(), false)})
           .first);
 }
 
@@ -597,7 +804,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
       return UR_RESULT_ERROR_UNKNOWN;
     }
     auto &InitialGroup = (*RetQueue)->ComputeQueueGroupsByTID.begin()->second;
-    InitialGroup.setImmCmdList(ur_cast<ze_command_list_handle_t>(NativeQueue));
+    InitialGroup.setImmCmdList(*RetQueue,
+                               ur_cast<ze_command_list_handle_t>(NativeQueue));
   } else {
     auto ZeQueue = ur_cast<ze_command_queue_handle_t>(NativeQueue);
     // Assume this is the "0" index queue in the compute command-group.
@@ -1408,6 +1616,9 @@ ur_result_t ur_queue_handle_t_::synchronize() {
     // Cleanup all events from the synced command list.
     CleanupEventListFromResetCmdList(ImmCmdList->second.EventList, true);
     ImmCmdList->second.EventList.clear();
+    if (auto &completions = ImmCmdList->second.completions; completions) {
+      completions->forceReset();
+    }
     return UR_RESULT_SUCCESS;
   };
 
@@ -1687,6 +1898,14 @@ ur_result_t ur_queue_handle_t_::resetCommandList(
       }
       return UR_RESULT_SUCCESS;
     }
+
+    if (auto &completions = CommandList->second.completions; completions) {
+      if (completions->tryCleanup(this, CommandList->first, EventList,
+                                  EventListToCleanup) == UR_RESULT_SUCCESS) {
+        return UR_RESULT_SUCCESS;
+      }
+    }
+
     // For immediate commandlist reset only those events that have signalled.
     for (auto it = EventList.begin(); it != EventList.end();) {
       // Break early as soon as we found first incomplete event because next
@@ -1726,6 +1945,13 @@ bool ur_command_list_info_t::isCopy(ur_queue_handle_t Queue) const {
              ->QueueGroup
                  [ur_device_handle_t_::queue_group_info_t::type::Compute]
              .ZeOrdinal;
+}
+
+void ur_command_list_info_t::append(ur_event_handle_t Event) {
+  if (completions) {
+    completions->append(Event);
+  }
+  EventList.push_back(Event);
 }
 
 ur_command_list_ptr_t
@@ -1853,6 +2079,12 @@ int32_t ur_queue_handle_t_::ur_queue_group_t::getCmdQueueOrdinal(
   return Queue->Device->QueueGroup[QueueType].ZeOrdinal;
 }
 
+bool ur_queue_handle_t_::useCompletionBatching() {
+  static bool enabled = getenv_tobool(
+      "UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_EVENT_COMPLETIONS", false);
+  return enabled && !isInOrderQueue() && UsingImmCmdLists;
+}
+
 // Helper function to create a new command-list to this queue and associated
 // fence tracking its completion. This command list & fence are added to the
 // map of command lists in this queue with ZeFenceInUse = false.
@@ -1887,10 +2119,12 @@ ur_result_t ur_queue_handle_t_::createCommandList(
   ZE2UR_CALL(zeFenceCreate, (ZeCommandQueue, &ZeFenceDesc, &ZeFence));
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
   ZeQueueDesc.ordinal = QueueGroupOrdinal;
+
   std::tie(CommandList, std::ignore) = CommandListMap.insert(
       std::pair<ze_command_list_handle_t, ur_command_list_info_t>(
-          ZeCommandList,
-          {ZeFence, false, false, ZeCommandQueue, ZeQueueDesc, IsInOrderList}));
+          ZeCommandList, ur_command_list_info_t(
+                             ZeFence, false, false, ZeCommandQueue, ZeQueueDesc,
+                             useCompletionBatching(), true, IsInOrderList)));
 
   UR_CALL(insertStartBarrierIfDiscardEventsMode(CommandList));
   UR_CALL(insertActiveBarriers(CommandList, UseCopyEngine));
@@ -2042,12 +2276,43 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
                     (Queue->Context->ZeContext, Queue->Device->ZeDevice,
                      &ZeCommandQueueDesc, &ZeCommandList));
   }
+
   ImmCmdLists[Index] =
       Queue->CommandListMap
           .insert(std::pair<ze_command_list_handle_t, ur_command_list_info_t>{
               ZeCommandList,
-              {nullptr, true, false, nullptr, ZeCommandQueueDesc}})
+              ur_command_list_info_t(nullptr, true, false, nullptr,
+                                     ZeCommandQueueDesc,
+                                     Queue->useCompletionBatching())})
           .first;
 
   return ImmCmdLists[Index];
+}
+
+// Get value of the threshold for number of events in immediate command lists.
+// If number of events in the immediate command list exceeds this threshold then
+// cleanup process for those events is executed.
+static const size_t ImmCmdListsEventCleanupThreshold = [] {
+  const char *UrRet =
+      std::getenv("UR_L0_IMMEDIATE_COMMANDLISTS_EVENT_CLEANUP_THRESHOLD");
+  const char *PiRet = std::getenv(
+      "SYCL_PI_LEVEL_ZERO_IMMEDIATE_COMMANDLISTS_EVENT_CLEANUP_THRESHOLD");
+  const char *ImmCmdListsEventCleanupThresholdStr =
+      UrRet ? UrRet : (PiRet ? PiRet : nullptr);
+  static constexpr int Default = 1000;
+  if (!ImmCmdListsEventCleanupThresholdStr)
+    return Default;
+
+  int Threshold = std::atoi(ImmCmdListsEventCleanupThresholdStr);
+
+  // Basically disable threshold if negative value is provided.
+  if (Threshold < 0)
+    return INT_MAX;
+
+  return Threshold;
+}();
+
+size_t ur_queue_handle_t_::getImmdCmmdListsEventCleanupThreshold() {
+  return useCompletionBatching() ? CompletionEventsPerBatch
+                                 : ImmCmdListsEventCleanupThreshold;
 }

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -13,6 +13,7 @@
 #include <list>
 #include <map>
 #include <optional>
+#include <queue>
 #include <stdarg.h>
 #include <string>
 #include <unordered_map>
@@ -30,6 +31,124 @@ extern "C" {
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue);
 } // extern "C"
 
+struct ur_completion_batch;
+using ur_completion_batch_list = std::list<ur_completion_batch>;
+using ur_completion_batch_it = ur_completion_batch_list::iterator;
+
+// Event completion batch for aggregating status checks of many events into
+// a single one through a barrier. Batches can be continuously reused.
+// Batches start empty and accumulate events, get sealed (which issues
+// an asynchronous barrier on the command list), and then must be waited on
+// for all the events to complete.
+struct ur_completion_batch {
+  ur_completion_batch();
+  ~ur_completion_batch();
+
+  enum state {
+    EMPTY,        // use() -> ACCUMULATING
+    ACCUMULATING, // append() -> full -> seal() -> SEALED
+    SEALED,       // checkComplete() -> COMPLETED
+    COMPLETED,    // reset() -> EMPTY
+  };
+
+  // Returns the state of the batch. Might be stale.
+  state getState();
+
+  // Return the most up-to-date state of the batch. Might query the state of the
+  // underlying barrier event.
+  state queryState();
+
+  // Must be called on any completion batch prior to being used for events.
+  void use();
+
+  // Checks whether the batch is at capacity. This is a soft limit and can be
+  // exceeded if necessary.
+  bool isFull();
+
+  // Appends an event to the batch.
+  void append();
+
+  // Seals the event batch and appends a barrier to the command list.
+  // Adding any further events after this, but before reset, is undefined.
+  ur_result_t seal(ur_queue_handle_t queue, ze_command_list_handle_t cmdlist);
+
+  // Resets a complete batch back to an empty state. Cleanups internal state
+  // but keeps allocated resources for reuse.
+  ur_result_t reset();
+
+private:
+  // Checks whether all the events in the batch have completed. Might query
+  // the underlying event status. Can only be called on a sealed batch.
+  bool checkComplete();
+
+  // Internal barrier event that is signaled on completion of the batched
+  // events.
+  ur_event_handle_t barrierEvent;
+
+  // Current batch state. Don't use directly.
+  state st;
+
+  // Number of accumulated events.
+  size_t numEvents;
+};
+
+// A collection of event completion batches. Manages querying event status
+// in batches of events instead of individually, reducing the number of total
+// queries necessary to determine whether a set of events have signaled.
+struct ur_completion_batches {
+  // This structure should never be copied because it contains a stable iterator
+  // into a list. Copying it would likely result in unexpected behavior.
+  ur_completion_batches(const ur_completion_batches &) = delete;
+  ur_completion_batches &operator=(const ur_completion_batches &) = delete;
+  ur_completion_batches(ur_completion_batches &&) = default;
+  ur_completion_batches &operator=(ur_completion_batches &&) = default;
+
+  ur_completion_batches();
+
+  // Cleans up completed batches, and, if the currently active batch
+  // is full, attempts to find an empty batch to be used as active.
+  // If one is found, the current one is sealed, and the new one is
+  // set as active. Otherwise, UR_RESULT_ERROR_OUT_OF_RESOURCES is
+  // returned to indicate that there are no batches available.
+  // This is safe, but will increase how many events are associated
+  // with the active batch.
+  ur_result_t tryCleanup(ur_queue_handle_t queue,
+                         ze_command_list_handle_t cmdlist,
+                         std::vector<ur_event_handle_t> &EventList,
+                         std::vector<ur_event_handle_t> &EventListToCleanup);
+
+  // Adds an event to the the active batch.
+  // Ideally, all events that are appended here are then provided in the
+  // vector for cleanup. Otherwise the event batch will simply ignore
+  // missing events when it comes time for cleanup.
+  void append(ur_event_handle_t event);
+
+  // Resets all the batches without waiting for event completion.
+  // Only safe when the command list was fully synchronized through
+  // other means.
+  void forceReset();
+
+private:
+  // Checks the state of all previously sealed batches. If any are complete,
+  // moves the associated events from the EventList to EventListToCleanup,
+  // and then resets the batch for reuse.
+  ur_result_t cleanup(std::vector<ur_event_handle_t> &EventList,
+                      std::vector<ur_event_handle_t> &EventListToCleanup);
+
+  // Moves the completed events from EventList to EventListToCleanup.
+  void moveCompletedEvents(ur_completion_batch_it it,
+                           std::vector<ur_event_handle_t> &EventList,
+                           std::vector<ur_event_handle_t> &EventListToCleanup);
+
+  // Find or creates an empty batch. This might fail if there are now empty
+  // batches and a batch limit has been reached.
+  std::optional<ur_completion_batch_it> findFirstEmptyBatchOrCreate();
+
+  ur_completion_batch_list batches;
+  std::queue<ur_completion_batch_it> sealed;
+  ur_completion_batch_it active;
+};
+
 ur_result_t resetCommandLists(ur_queue_handle_t Queue);
 ur_result_t
 CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue, bool QueueLocked = false,
@@ -40,23 +159,35 @@ CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue, bool QueueLocked = false,
 // This is because command-lists are re-used across multiple queues
 // in the same context.
 struct ur_command_list_info_t {
+  ur_command_list_info_t(ze_fence_handle_t ZeFence, bool ZeFenceInUse,
+                         bool IsClosed, ze_command_queue_handle_t ZeQueue,
+                         ZeStruct<ze_command_queue_desc_t> ZeQueueDesc,
+                         bool UseCompletionBatching, bool CanReuse = true,
+                         bool IsInOrderList = false)
+      : ZeFence(ZeFence), ZeFenceInUse(ZeFenceInUse), IsClosed(IsClosed),
+        ZeQueue(ZeQueue), ZeQueueDesc(ZeQueueDesc),
+        IsInOrderList(IsInOrderList), CanReuse(CanReuse) {
+    if (UseCompletionBatching) {
+      completions = ur_completion_batches();
+    }
+  }
   // The Level-Zero fence that will be signalled at completion.
   // Immediate commandlists do not have an associated fence.
   // A nullptr for the fence indicates that this is an immediate commandlist.
-  ze_fence_handle_t ZeFence{nullptr};
+  ze_fence_handle_t ZeFence;
   // Record if the fence is in use.
   // This is needed to avoid leak of the tracked command-list if the fence
   // was not yet signaled at the time all events in that list were already
   // completed (we are polling the fence at events completion). The fence
   // may be still "in-use" due to sporadic delay in HW.
-  bool ZeFenceInUse{false};
+  bool ZeFenceInUse;
 
   // Indicates if command list is in closed state. This is needed to avoid
   // appending commands to the closed command list.
-  bool IsClosed{false};
+  bool IsClosed;
 
   // Record the queue to which the command list will be submitted.
-  ze_command_queue_handle_t ZeQueue{nullptr};
+  ze_command_queue_handle_t ZeQueue;
 
   // Record the queue descriptor fields used when creating the command list
   // because we cannot recover these fields from the command list. Immediate
@@ -66,20 +197,24 @@ struct ur_command_list_info_t {
   // used and then this entry is marked as not eligible for recycling.
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
   // Indicates if this is an inorder list
-  bool IsInOrderList{false};
-  bool CanReuse{true};
+  bool IsInOrderList;
+  bool CanReuse;
 
   // Helper functions to tell if this is a copy command-list.
   bool isCopy(ur_queue_handle_t Queue) const;
+
+  // An optional event completion batching mechanism for out-of-order immediate
+  // command lists.
+  std::optional<ur_completion_batches> completions;
 
   // Keeps events created by commands submitted into this command-list.
   // TODO: use this for explicit wait/cleanup of events at command-list
   // completion.
   // TODO: use this for optimizing events in the same command-list, e.g.
   // only have last one visible to the host.
-  std::vector<ur_event_handle_t> EventList{};
+  std::vector<ur_event_handle_t> EventList;
   size_t size() const { return EventList.size(); }
-  void append(ur_event_handle_t Event) { EventList.push_back(Event); }
+  void append(ur_event_handle_t Event);
 };
 
 // The map type that would track all command-lists in a queue.
@@ -134,7 +269,7 @@ struct ur_queue_handle_t_ : _ur_object {
     ze_command_queue_handle_t &getZeQueue(uint32_t *QueueGroupOrdinal);
 
     // This function sets an immediate commandlist from the interop interface.
-    void setImmCmdList(ze_command_list_handle_t);
+    void setImmCmdList(ur_queue_handle_t queue, ze_command_list_handle_t);
 
     // This function returns the next immediate commandlist to use.
     ur_command_list_ptr_t &getImmCmdList();
@@ -526,6 +661,13 @@ struct ur_queue_handle_t_ : _ur_object {
   bool isProfilingEnabled() {
     return ((this->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) != 0);
   }
+
+  // Checks whether this queue supports and uses event completion batching.
+  // Can be true only when using out-of-order immediate command lists.
+  bool useCompletionBatching();
+
+  // Threshold for cleaning up the EventList for immediate command lists.
+  size_t getImmdCmmdListsEventCleanupThreshold();
 };
 
 // This helper function creates a ur_event_handle_t and associate a


### PR DESCRIPTION
Currently, for out-of-order immediate commandlists, each enqueued
operation creates an event on an internal vector to indicate
when that operation is completed. When that vector reaches
1k (by default) entries, each event is individually queried
for status and, if it completed, is cleaned up and removed.
This is causing latency spikes for enqueue operations and
reduces overall performance when using short-lived operations.

This patch introduces an event batching mechanism, where instead
of querying each event individually, the adapter will group
events in batches of 512 entries (by default) that will be
queried collectively with the use of a barrier.

Most of the credit goes to Michal Mrozek <michal.mrozek@intel.com>
for profiling the problem and proposing a solution.

This new mechanism is disabled by default. To use it, this patch
is adding three new env variables:

- UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_EVENT_COMPLETIONS. Enables
  event completion batching. Defaults to off.
- UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_MAX. Controls the maximum
  number of batches for grouping the events. If there are no batches
  available, the adapter will fallback to querying events
  individually. Defaults to 10.
- UR_L0_IMMEDIATE_COMMANDLISTS_EVENTS_PER_BATCH. The number of
  events in each batch. Once a batch reaches this threshold,
  the adapter appends a barrier to the command list,
  and then another batch is selected to group incoming events.
  Defaults to 512.

Early results show appreciable reduction in enqueue tail latency,
but more experiments are needed.