### PR TITLE
[L0] Cleanup Queue at Release unconditionally and reset command list after failure

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1207,6 +1207,12 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
         // Turn into a more informative end-user error.
         return UR_RESULT_ERROR_UNKNOWN;
       }
+      // Reset Command List and erase the Fence forcing the user to resubmit
+      // their commands.
+      std::vector<ur_event_handle_t> EventListToCleanup;
+      resetCommandList(CommandList, true, EventListToCleanup, false);
+      CleanupEventListFromResetCmdList(EventListToCleanup,
+                                       true /* QueueLocked */);
       return ze2urResult(ZeResult);
     }
   }

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -407,11 +407,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(
     //
     // It is possible to get to here and still have an open command list
     // if no wait or finish ever occurred for this queue.
-    if (auto Res = Queue->executeAllOpenCommandLists())
-      return Res;
+    auto Res = Queue->executeAllOpenCommandLists();
 
     // Make sure all commands get executed.
-    UR_CALL(Queue->synchronize());
+    if (Res == UR_RESULT_SUCCESS)
+      UR_CALL(Queue->synchronize());
 
     // Destroy all the fences created associated with this queue.
     for (auto it = Queue->CommandListMap.begin();


### PR DESCRIPTION
- During UR Queue Release the command lists and command queue resources need to be reset and cleared regardless of the results from the execution of OpenCommandList.
- This prevents a Queue object from being left with invalid command lists and an invalid command queue internal handle that should have been cleared at release during high memory usage.
- Reset the command list upon execution failure and make the command list available to avoid keeping invalid command lists in the queue after failures before queue release.