### PR TITLE
Fix counting variables for CTS

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,9 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG        release-1.12.1
 )
+
+set(UR_TEST_DEVICES_COUNT 1 CACHE STRING "Count of devices on which conformance and adapters tests will be run")
+set(UR_TEST_PLATFORMS_COUNT 1 CACHE STRING "Count of platforms on which conformance and adapters tests will be run")
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/test/adapters/CMakeLists.txt
+++ b/test/adapters/CMakeLists.txt
@@ -31,7 +31,9 @@ function(add_adapter_test name)
         ${PROJECT_NAME}::common
         GTest::gtest)
 
-    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>)
+    add_test(NAME ${target} COMMAND $<TARGET_FILE:${target}>
+        --devices_count=${UR_TEST_DEVICES_COUNT}
+        --platforms_count=${UR_TEST_DEVICES_COUNT})
     set_tests_properties(${target} PROPERTIES
         LABELS "adapter-specific;${name}"
         ENVIRONMENT "${args_ENVIRONMENT}")

--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set(UR_CONFORMANCE_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(UR_TEST_DEVICES_COUNT 1 CACHE STRING "Count of devices on which CTS will be run")
-set(UR_TEST_PLATFORMS_COUNT 1 CACHE STRING "Count of platforms on which CTS will be run")
 
 function(add_test_adapter name adapter)
     set(TEST_TARGET_NAME test-${name})

--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 set(UR_CONFORMANCE_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-option(UR_TEST_DEVICES_COUNT "Count of devices on which CTS will be run" 1)
-option(UR_TEST_PLATFORMS_COUNT "Count of platforms on which CTS will be run" 1)
+set(UR_TEST_DEVICES_COUNT 1 CACHE STRING "Count of devices on which CTS will be run")
+set(UR_TEST_PLATFORMS_COUNT 1 CACHE STRING "Count of platforms on which CTS will be run")
 
 function(add_test_adapter name adapter)
     set(TEST_TARGET_NAME test-${name})

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -12,11 +12,11 @@ in a particular group for the corresponding adapter.
 
 ## How to set test device/platform name or limit the test devices/platforms count
 
-To limit how many devices/platforms you want to run the CTS on,
-use CMake option UR_TEST_DEVICES_COUNT or
+To limit how many devices/platforms you want to run the conformance and
+adapters tests on, use CMake option UR_TEST_DEVICES_COUNT or
 UR_TEST_PLATFORMS_COUNT. If you want to run the tests on
 all available devices/platforms, set 0. The default value is 1.
 If you run binaries for the tests, you can use the parameter
 `--platforms_count=COUNT` or `--devices_count=COUNT`.
-To set test device/platform name you want to run the CTS on, use
+To set test device/platform name you want to run the tests on, use
 parameter `--platform=NAME` or `--device=NAME`.


### PR DESCRIPTION
Some tests don't work on supermicro machine:
https://github.com/oneapi-src/unified-runtime/actions/runs/7559294673/job/20587325535

This PR fixes it.