### PR TITLE
Optimization for SYCL out of order queue 

### DIFF
--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -80,6 +80,8 @@ struct ur_command_list_info_t {
   void append(ur_event_handle_t Event) { EventList.push_back(Event); }
 };
 
+// The map type that would track all internal events in a queue.
+using ur_event_map_t = std::unordered_map<ze_event_handle_t, uint32_t>;
 // The map type that would track all command-lists in a queue.
 using ur_command_list_map_t =
     std::unordered_map<ze_command_list_handle_t, ur_command_list_info_t>;
@@ -186,6 +188,9 @@ struct ur_queue_handle_t_ : _ur_object {
       return It->second;
     }
   };
+  uint32_t CmdListEnqueued = 0;
+  // for the last cmdlist to wait for all other events so it has host scope.
+  ur_event_map_t AppendedEventsMap;
 
   // A map of compute groups containing compute queue handles, one per thread.
   // When a queue is accessed from multiple host threads, a separate queue group


### PR DESCRIPTION
have to iron out a few more things, but the initial concept is this: 
for regular commandlist, we want to give the events device scope thus avoiding L3 flush. To achieve this, I have a list of all events with device scope being kept track on within the queue. When we get to the last one, we want that commandlist's event to have host scope and also to wait for all other device scoped events.
Note to self: need to find out how to get total number of commandlists within a queue