### PR TITLE
[CUDA] Remove unused function variant

### DIFF
--- a/source/adapters/cuda/tracing.cpp
+++ b/source/adapters/cuda/tracing.cpp
@@ -179,17 +179,6 @@ void unloadCUDATracingLibrary(cuda_tracing_context_t_ *Ctx) {
 #endif // XPTI_ENABLE_INSTRUMENTATION
 }
 
-void enableCUDATracing() {
-#ifdef XPTI_ENABLE_INSTRUMENTATION
-  if (!xptiTraceEnabled())
-    return;
-  static cuda_tracing_context_t_ *Ctx = nullptr;
-  if (!Ctx)
-    Ctx = createCUDATracingContext();
-  enableCUDATracing(Ctx);
-#endif
-}
-
 void enableCUDATracing(cuda_tracing_context_t_ *Ctx) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   if (!Ctx || !xptiTraceEnabled())

--- a/source/adapters/cuda/tracing.hpp
+++ b/source/adapters/cuda/tracing.hpp
@@ -18,7 +18,3 @@ void unloadCUDATracingLibrary(cuda_tracing_context_t_ *Ctx);
 
 void enableCUDATracing(cuda_tracing_context_t_ *Ctx);
 void disableCUDATracing(cuda_tracing_context_t_ *Ctx);
-
-// Deprecated. Will be removed once pi_cuda has been updated to use the variant
-// that takes a context pointer.
-void enableCUDATracing();


### PR DESCRIPTION
Following https://github.com/oneapi-src/unified-runtime/pull/1070 and https://github.com/intel/llvm/pull/12521, clean up the profiling code a bit by removing a now-unused function variant.

Run CI PR: https://github.com/intel/llvm/pull/12583