### PR TITLE
[SanitizerLayer] Fix resource leaks in "san_utils.cpp"

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.cpp
@@ -366,8 +366,6 @@ ur_result_t SanitizerInterceptor::enqueueMemSetShadow(
         static auto MemSet =
             (void *(*)(void *, int, size_t))GetMemFunctionPointer("memset");
         if (!MemSet) {
-            context.logger.error(
-                "Failed to get 'memset' function from libc.so.6");
             return UR_RESULT_ERROR_UNKNOWN;
         }
 

--- a/source/loader/layers/sanitizer/linux/san_utils.cpp
+++ b/source/loader/layers/sanitizer/linux/san_utils.cpp
@@ -22,7 +22,7 @@ extern "C" __attribute__((weak)) void __asan_init(void);
 
 namespace ur_sanitizer_layer {
 
-bool IsInASanContext() { return __asan_init != nullptr; }
+bool IsInASanContext() { return (void *)__asan_init != nullptr; }
 
 static bool ReserveShadowMem(uptr Addr, uptr Size) {
     Size = RoundUpTo(Size, EXEC_PAGESIZE);
@@ -71,15 +71,11 @@ bool DestroyShadowMem() {
 }
 
 void *GetMemFunctionPointer(const char *FuncName) {
-    void *handle = dlopen(LIBC_SO, RTLD_LAZY);
+    void *handle = dlopen(LIBC_SO, RTLD_NOLOAD);
     if (!handle) {
-        return (void *)nullptr;
+        return nullptr;
     }
-    void *ptr = dlsym(handle, FuncName);
-    if (!ptr) {
-        return (void *)nullptr;
-    }
-    return ptr;
+    return dlsym(handle, FuncName);
 }
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/linux/san_utils.cpp
+++ b/source/loader/layers/sanitizer/linux/san_utils.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "common.hpp"
+#include "ur_sanitizer_layer.hpp"
 
 #include <asm/param.h>
 #include <dlfcn.h>
@@ -71,11 +72,16 @@ bool DestroyShadowMem() {
 }
 
 void *GetMemFunctionPointer(const char *FuncName) {
-    void *handle = dlopen(LIBC_SO, RTLD_NOLOAD);
+    void *handle = dlopen(LIBC_SO, RTLD_LAZY | RTLD_NOLOAD);
     if (!handle) {
+        context.logger.error("Failed to dlopen {}", LIBC_SO);
         return nullptr;
     }
-    return dlsym(handle, FuncName);
+    auto ptr = dlsym(handle, FuncName);
+    if (!ptr) {
+        context.logger.error("Failed to get '{}' from {}", FuncName, LIBC_SO);
+    }
+    return ptr;
 }
 
 } // namespace ur_sanitizer_layer


### PR DESCRIPTION
This resolves coverity issues:

> Resource leaks  (RESOURCE_LEAK)
>     Variable "handle" going out of scope leaks the storage it points to.

>  Incorrect expression  (BAD_COMPARE)
>     This implicit conversion to a function pointer is suspicious: "__asan_init != NULL".
