### PR TITLE
[SPEC] Change PCI address query from string to struct

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1552,7 +1552,7 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,                   ///< [::ur_device_usm_access_capability_flags_t] support USM system wide
                                                                      ///< shared memory access
     UR_DEVICE_INFO_UUID = 88,                                        ///< [uint8_t[]] return device UUID
-    UR_DEVICE_INFO_PCI_ADDRESS = 89,                                 ///< [char[]] return device PCI address
+    UR_DEVICE_INFO_PCI_ADDRESS = 89,                                 ///< [::ur_device_pci_address_t] return device PCI address
     UR_DEVICE_INFO_GPU_EU_COUNT = 90,                                ///< [uint32_t] return Intel GPU EU count
     UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH = 91,                           ///< [uint32_t] return Intel GPU EU SIMD width
     UR_DEVICE_INFO_GPU_EU_SLICES = 92,                               ///< [uint32_t] return Intel GPU number of slices
@@ -2115,6 +2115,16 @@ typedef enum ur_device_usm_access_capability_flag_t {
 } ur_device_usm_access_capability_flag_t;
 /// @brief Bit Mask for validating ur_device_usm_access_capability_flags_t
 #define UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK 0xfffffff0
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Device PCI address.
+typedef struct ur_device_pci_address_t {
+    uint32_t domain;   ///< [out] PCI domain number.
+    uint32_t bus;      ///< [out] PCI BDF bus number.
+    uint32_t device;   ///< [out] PCI BDF device number.
+    uint32_t function; ///< [out] PCI BDF device number.
+
+} ur_device_pci_address_t;
 
 #if !defined(__GNUC__)
 #pragma endregion

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -267,6 +267,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintMemoryScopeCapabilityFlags(enum ur_me
 UR_APIEXPORT ur_result_t UR_APICALL urPrintDeviceUsmAccessCapabilityFlags(enum ur_device_usm_access_capability_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_device_pci_address_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintDevicePciAddress(const struct ur_device_pci_address_t params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_context_flag_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -248,6 +248,7 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 inline std::ostream &operator<<(std::ostream &os, enum ur_memory_order_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_memory_scope_capability_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_device_usm_access_capability_flag_t value);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_device_pci_address_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_context_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_context_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_context_info_t value);
@@ -3636,9 +3637,16 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
         os << "}";
     } break;
     case UR_DEVICE_INFO_PCI_ADDRESS: {
+        const ur_device_pci_address_t *tptr = (const ur_device_pci_address_t *)ptr;
+        if (sizeof(ur_device_pci_address_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_device_pci_address_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
 
-        const char *tptr = (const char *)ptr;
-        printPtr(os, tptr);
+        os << *tptr;
+
+        os << ")";
     } break;
     case UR_DEVICE_INFO_GPU_EU_COUNT: {
         const uint32_t *tptr = (const uint32_t *)ptr;
@@ -5081,6 +5089,35 @@ inline ur_result_t printFlag<ur_device_usm_access_capability_flag_t>(std::ostrea
     return UR_RESULT_SUCCESS;
 }
 } // namespace ur::details
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_device_pci_address_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, const struct ur_device_pci_address_t params) {
+    os << "(struct ur_device_pci_address_t){";
+
+    os << ".domain = ";
+
+    os << (params.domain);
+
+    os << ", ";
+    os << ".bus = ";
+
+    os << (params.bus);
+
+    os << ", ";
+    os << ".device = ";
+
+    os << (params.device);
+
+    os << ", ";
+    os << ".function = ";
+
+    os << (params.function);
+
+    os << "}";
+    return os;
+}
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_context_flag_t type
 /// @returns

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -379,7 +379,7 @@ etors:
     - name: UUID
       desc: "[uint8_t[]] return device UUID"
     - name: PCI_ADDRESS
-      desc: "[char[]] return device PCI address"
+      desc: "[$x_device_pci_address_t] return device PCI address"
     - name: GPU_EU_COUNT
       desc: "[uint32_t] return Intel GPU EU count"
     - name: GPU_EU_SIMD_WIDTH
@@ -916,3 +916,22 @@ etors:
     - name: ATOMIC_CONCURRENT_ACCESS
       desc: "Memory can be accessed atomically and concurrently"
       value: "$X_BIT(3)"
+
+--- #--------------------------------------------------------------------------
+type: struct
+desc: Device PCI address.
+class: $xDevice
+name: $x_device_pci_address_t
+members:
+    - name: domain
+      type: uint32_t
+      desc: '[out] PCI domain number.'
+    - name: bus
+      type: uint32_t
+      desc: '[out] PCI BDF bus number.'
+    - name: device
+      type: uint32_t
+      desc: '[out] PCI BDF device number.'
+    - name: function
+      type: uint32_t
+      desc: '[out] PCI BDF device number.'

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -685,18 +685,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_DEVICE_INFO_DEVICE_ID:
     return ReturnValue(uint32_t{Device->ZeDeviceProperties->deviceId});
   case UR_DEVICE_INFO_PCI_ADDRESS: {
-    ze_pci_address_ext_t PciAddr{};
     ZeStruct<ze_pci_ext_properties_t> ZeDevicePciProperties;
-    ZeDevicePciProperties.address = PciAddr;
+    ZeDevicePciProperties.address = {};
     ZE2UR_CALL(zeDevicePciGetPropertiesExt, (ZeDevice, &ZeDevicePciProperties));
-    constexpr size_t AddressBufferSize = 13;
-    char AddressBuffer[AddressBufferSize];
-    std::snprintf(AddressBuffer, AddressBufferSize, "%04x:%02x:%02x.%01x",
-                  ZeDevicePciProperties.address.domain,
-                  ZeDevicePciProperties.address.bus,
-                  ZeDevicePciProperties.address.device,
-                  ZeDevicePciProperties.address.function);
-    return ReturnValue(AddressBuffer);
+    ur_device_pci_address_t UrPciAddr{
+        /*.domain = */ ZeDevicePciProperties.address.domain,
+        /*.bus = */ ZeDevicePciProperties.address.bus,
+        /*.device = */ ZeDevicePciProperties.address.device,
+        /*.function = */ ZeDevicePciProperties.address.function,
+    };
+    return ReturnValue(UrPciAddr);
   }
 
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -282,6 +282,14 @@ ur_result_t urPrintDeviceUsmAccessCapabilityFlags(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintDevicePciAddress(const struct ur_device_pci_address_t params,
+                                    char *buffer, const size_t buff_size,
+                                    size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t urPrintContextFlags(enum ur_context_flag_t value, char *buffer,
                                 const size_t buff_size, size_t *out_size) {
     std::stringstream ss;

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -260,7 +260,8 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
     std::cout << prefix;
     printDeviceUUID(hDevice, UR_DEVICE_INFO_UUID);
     std::cout << prefix;
-    printDeviceInfo<char[]>(hDevice, UR_DEVICE_INFO_PCI_ADDRESS);
+    printDeviceInfo<ur_device_pci_address_t>(hDevice,
+                                             UR_DEVICE_INFO_PCI_ADDRESS);
     std::cout << prefix;
     printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_EU_COUNT);
     std::cout << prefix;


### PR DESCRIPTION
The `UR_DEVICE_INFO_PCI_ADDRESS` query previously returned a string of the form `"DDDD:BB:SS.F"` whereas Level Zero and OpenCL (via the `cl_khr_pci_bus_info` extension) return structs with each field separated out. Additionally, CUDA and HIP both support querying the domain, bus, and device ID's individually.

For applications which want to make decisions based on a devices PCI address requiring to parse a string is not ideal. As such, this patch changes the return type of the `UR_DEVICE_INFO_PCI_ADDRESS` to a struct to more closely align with the Level Zero and OpenCL specifications. Adapter implementations are also updated to align with the spec change.
