### PR TITLE
[CUDA] Fix resource leaks in adapter tests

### DIFF
--- a/test/adapters/cuda/context_tests.cpp
+++ b/test/adapters/cuda/context_tests.cpp
@@ -96,9 +96,9 @@ TEST_P(cudaUrContextCreateTest, ContextLifetimeExisting) {
     ASSERT_EQ(context, queue->getContext());
 
     // create a buffer in the context to set the context as active
-    ur_mem_handle_t buffer;
+    uur::raii::Mem buffer;
     ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 1024,
-                                     nullptr, &buffer));
+                                     nullptr, buffer.ptr()));
 
     // check that context is now the active cuda context
     ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&current));

--- a/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
+++ b/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
@@ -9,16 +9,27 @@
 using urCudaEventCreateWithNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventCreateWithNativeHandleTest);
 
+struct RAIICUevent {
+    CUevent handle = nullptr;
+
+    ~RAIICUevent() {
+        if (handle) {
+            cuEventDestroy(handle);
+        }
+    }
+
+    CUevent *ptr() { return &handle; }
+    CUevent get() { return handle; }
+};
+
 TEST_P(urCudaEventCreateWithNativeHandleTest, Success) {
-    CUevent cuda_event;
-    ASSERT_SUCCESS_CUDA(cuEventCreate(&cuda_event, CU_EVENT_DEFAULT));
+    RAIICUevent cuda_event;
+    ASSERT_SUCCESS_CUDA(cuEventCreate(cuda_event.ptr(), CU_EVENT_DEFAULT));
 
     ur_native_handle_t native_event =
-        reinterpret_cast<ur_native_handle_t>(cuda_event);
+        reinterpret_cast<ur_native_handle_t>(cuda_event.get());
 
     uur::raii::Event event = nullptr;
     EXPECT_SUCCESS(urEventCreateWithNativeHandle(native_event, context, nullptr,
                                                  event.ptr()));
-
-    ASSERT_SUCCESS_CUDA(cuEventDestroy(cuda_event));
 }


### PR DESCRIPTION
Fix issues missed by #1284:

* Use RAII wrapper for CUevent in `urCudaEventCreateWithNativeHandleTest.Success`.
* Use `uur::raii::Mem` in the `cudaUrContextCreateTest.ContextLifetimeExisting`.
