### PR TITLE
[CUDA] Use appropriate return code for out of registers kernel launch

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -237,7 +237,7 @@ setKernelParams(const ur_context_handle_t Context,
 
         if (hasExceededMaxRegistersPerBlock(Device, Kernel,
                                             KernelLocalWorkGroupSize)) {
-          return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+          return UR_RESULT_ERROR_OUT_OF_RESOURCES;
         }
       } else {
         guessLocalWorkSize(Device, ThreadsPerBlock, GlobalWorkSize, WorkDim,


### PR DESCRIPTION
This PR changes the returned error code for exiting the kernel launch entry point in CUDA when exceeding the maximum available registers for execution on the SM. Previously we were returning a misleading error code.

This change requires DPC++ to adapt the specific-error handling, see PR: https://github.com/intel/llvm/pull/12604.