### PR TITLE
[L0] move adapter init into its constructor from urAdapterGet

### DIFF
--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -17,6 +17,7 @@
 using PlatformVec = std::vector<std::unique_ptr<ur_platform_handle_t_>>;
 
 struct ur_adapter_handle_t_ {
+  ur_adapter_handle_t_();
   std::atomic<uint32_t> RefCount = 0;
   std::mutex Mutex;
 

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -29,7 +29,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
 ) {
   // Platform handles are cached for reuse. This is to ensure consistent
   // handle pointers across invocations and to improve retrieval performance.
-  if (const auto *cached_platforms = Adapter.PlatformCache->get_value()) {
+  if (const auto *cached_platforms = Adapter.PlatformCache->get_value();
+      cached_platforms) {
     uint32_t nplatforms = (uint32_t)cached_platforms->size();
     if (NumPlatforms) {
       *NumPlatforms = nplatforms;


### PR DESCRIPTION
This restores the old behavior where urAdapterGet was essentially a noop. Hopefully fixes the issue on intel/llvm (https://github.com/intel/llvm/pull/12658).