### PR TITLE
Add Legacy compatibility to Logger

### DIFF
--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -48,10 +48,42 @@ inline void always(const char *format, Args &&...args) {
     get_logger().always(format, std::forward<Args>(args)...);
 }
 
+template <typename... Args>
+inline void debug(const logger::LegacyMessage &p, const char *format,
+                  Args &&...args) {
+    get_logger().log(p, logger::Level::DEBUG, format,
+                     std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void info(logger::LegacyMessage p, const char *format, Args &&...args) {
+    get_logger().log(p, logger::Level::INFO, format,
+                     std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void warning(logger::LegacyMessage p, const char *format,
+                    Args &&...args) {
+    get_logger().log(p, logger::Level::WARN, format,
+                     std::forward<Args>(args)...);
+}
+
+template <typename... Args>
+inline void error(logger::LegacyMessage p, const char *format, Args &&...args) {
+    get_logger().log(p, logger::Level::ERR, format,
+                     std::forward<Args>(args)...);
+}
+
 inline void setLevel(logger::Level level) { get_logger().setLevel(level); }
 
 inline void setFlushLevel(logger::Level level) {
     get_logger().setFlushLevel(level);
+}
+
+template <typename T> inline std::string toHex(T t) {
+    std::stringstream s;
+    s << std::hex << t;
+    return s.str();
 }
 
 /// @brief Create an instance of the logger with parameters obtained from the respective

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -28,12 +28,7 @@ class Sink {
         }
 
         format(buffer, fmt, std::forward<Args &&>(args)...);
-
-        std::scoped_lock<std::mutex> lock(output_mutex);
-        *ostream << buffer.str();
-        if (level >= flush_level) {
-            ostream->flush();
-        }
+        print(level, buffer.str());
     }
 
     void setFlushLevel(logger::Level level) { this->flush_level = level; }
@@ -48,6 +43,14 @@ class Sink {
         : logger_name(std::move(logger_name)), skip_prefix(skip_prefix) {
         ostream = nullptr;
         flush_level = logger::Level::ERR;
+    }
+
+    virtual void print(logger::Level level, const std::string &msg) {
+        std::scoped_lock<std::mutex> lock(output_mutex);
+        *ostream << msg;
+        if (level >= flush_level) {
+            ostream->flush();
+        }
     }
 
   private:


### PR DESCRIPTION
Switching to the new logger changes API and log format, and requires changes in user code. To make the transition easier, this PR adds an option to the new logger that's print logs in the old format.