### PR TITLE
Remove redundant semicolons

### DIFF
--- a/test/conformance/testing/include/uur/raii.h
+++ b/test/conformance/testing/include/uur/raii.h
@@ -108,7 +108,7 @@ using Program = Wrapper<ur_program_handle_t, urProgramRetain, urProgramRelease>;
 using Kernel = Wrapper<ur_kernel_handle_t, urKernelRetain, urKernelRelease>;
 using Queue = Wrapper<ur_queue_handle_t, urQueueRetain, urQueueRelease>;
 using Event = Wrapper<ur_event_handle_t, urEventRetain, urEventRelease>;
-}; // namespace raii
-}; // namespace uur
+} // namespace raii
+} // namespace uur
 
 #endif // UUR_RAII_H_INCLUDED


### PR DESCRIPTION
It's only to silence errors, found on gcc in Ubuntu 20.04: `error: extra ';' [-Werror=pedantic]`

// ref: https://github.com/lukaszstolarczuk/unified-runtime/actions/runs/7845968200/job/21411580574#step:4:274