### PR TITLE
[UR] Add missing Threads library to common

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -47,3 +47,10 @@ target_link_libraries(ur_common PUBLIC
     ${CMAKE_DL_LIBS}
     ${PROJECT_NAME}::headers
 )
+
+if (UNIX)
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads REQUIRED)
+    target_link_libraries(ur_common PUBLIC Threads::Threads)
+endif()


### PR DESCRIPTION
Before https://github.com/oneapi-src/unified-runtime/pull/1216 adapters linked with disjoint_pool library that linked with Threads library.

PR #1216 replace disjoint_pool with a version from UMF library that does not link with Threads lib explicitly which leads to compilation error on xmain. Fix this by explicitly adding adding Threads to ur_common. 

Use the same logic as in https://github.com/oneapi-src/unified-runtime/blob/f15234d0b0932f7f1f5b0188b99c6d257ce2e5dd/source/common/umf_pools/CMakeLists.txt#L17