### PR TITLE
Add output validation checks for getInfo tests and a small USM spec fix

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3449,7 +3449,7 @@ urUSMHostAlloc(
     ur_context_handle_t hContext,  ///< [in] handle of the context object
     const ur_usm_desc_t *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
     ur_usm_pool_handle_t pool,     ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                   ///< [in] size in bytes of the USM memory object to be allocated
+    size_t size,                   ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem                   ///< [out] pointer to USM host memory object
 );
 
@@ -3497,7 +3497,7 @@ urUSMDeviceAlloc(
     ur_device_handle_t hDevice,    ///< [in] handle of the device object
     const ur_usm_desc_t *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
     ur_usm_pool_handle_t pool,     ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                   ///< [in] size in bytes of the USM memory object to be allocated
+    size_t size,                   ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem                   ///< [out] pointer to USM device memory object
 );
 
@@ -3546,7 +3546,7 @@ urUSMSharedAlloc(
     ur_device_handle_t hDevice,    ///< [in] handle of the device object
     const ur_usm_desc_t *pUSMDesc, ///< [in][optional] Pointer to USM memory allocation descriptor.
     ur_usm_pool_handle_t pool,     ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
-    size_t size,                   ///< [in] size in bytes of the USM memory object to be allocated
+    size_t size,                   ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem                   ///< [out] pointer to USM shared memory object
 );
 
@@ -4117,6 +4117,8 @@ urProgramCreateWithIL(
 ///     - Following a successful call to this entry point, `phProgram` will
 ///       contain a binary of type ::UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT or
 ///       ::UR_PROGRAM_BINARY_TYPE_LIBRARY for `hDevice`.
+///     - The device specified by `hDevice` must be device associated with
+///       context.
 ///
 /// @remarks
 ///   _Analogues_

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -128,6 +128,7 @@ analogue:
 details:
     - "The application may call this function from simultaneous threads."
     - "Following a successful call to this entry point, `phProgram` will contain a binary of type $X_PROGRAM_BINARY_TYPE_COMPILED_OBJECT or $X_PROGRAM_BINARY_TYPE_LIBRARY for `hDevice`."
+    - "The device specified by `hDevice` must be device associated with context."
 params:
     - type: $x_context_handle_t
       name: hContext

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -248,7 +248,7 @@ params:
       desc: "[in][optional] Pointer to a pool created using urUSMPoolCreate"
     - type: "size_t"
       name: size
-      desc: "[in] size in bytes of the USM memory object to be allocated"
+      desc: "[in] minimum size in bytes of the USM memory object to be allocated"
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM host memory object"
@@ -293,7 +293,7 @@ params:
       desc: "[in][optional] Pointer to a pool created using urUSMPoolCreate"
     - type: "size_t"
       name: size
-      desc: "[in] size in bytes of the USM memory object to be allocated"
+      desc: "[in] minimum size in bytes of the USM memory object to be allocated"
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM device memory object"
@@ -339,7 +339,7 @@ params:
       desc: "[in][optional] Pointer to a pool created using urUSMPoolCreate"
     - type: "size_t"
       name: size
-      desc: "[in] size in bytes of the USM memory object to be allocated"
+      desc: "[in] minimum size in bytes of the USM memory object to be allocated"
     - type: void**
       name: ppMem
       desc: "[out] pointer to USM shared memory object"

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -368,7 +368,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   case UR_PROGRAM_INFO_NUM_DEVICES:
     return ReturnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
-    return ReturnValue(hProgram->getDevice(), 1);
+    return ReturnValue(hProgram->getContext()->getDevices()[0], 1);
   case UR_PROGRAM_INFO_SOURCE:
     return ReturnValue(hProgram->Binary);
   case UR_PROGRAM_INFO_BINARY_SIZES:

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -368,7 +368,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   case UR_PROGRAM_INFO_NUM_DEVICES:
     return ReturnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
-    return ReturnValue(hProgram->getContext()->getDevices()[0], 1);
+    return ReturnValue(&hProgram->getContext()->getDevices()[0], 1);
   case UR_PROGRAM_INFO_SOURCE:
     return ReturnValue(hProgram->Binary);
   case UR_PROGRAM_INFO_BINARY_SIZES:

--- a/source/adapters/native_cpu/context.cpp
+++ b/source/adapters/native_cpu/context.cpp
@@ -53,7 +53,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_DEVICES:
     return returnValue(hContext->_device);
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
-    return returnValue(nullptr);
+    return returnValue(uint32_t{hContext->getReferenceCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     return returnValue(true);
   case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -1268,7 +1268,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1296,7 +1296,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1324,7 +1324,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -1331,7 +1331,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
@@ -1363,7 +1363,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
@@ -1396,7 +1396,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1768,7 +1768,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
 ) {
     auto pfnHostAlloc = context.urDdiTable.USM.pfnHostAlloc;
@@ -1825,7 +1825,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
 ) {
     auto pfnDeviceAlloc = context.urDdiTable.USM.pfnDeviceAlloc;
@@ -1892,7 +1892,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     auto pfnSharedAlloc = context.urDdiTable.USM.pfnSharedAlloc;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -1712,7 +1712,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1747,7 +1747,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1785,7 +1785,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2204,7 +2204,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
     ) try {
     auto pfnHostAlloc = ur_lib::context->urDdiTable.USM.pfnHostAlloc;
@@ -2263,7 +2263,7 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
     ) try {
     auto pfnDeviceAlloc = ur_lib::context->urDdiTable.USM.pfnDeviceAlloc;
@@ -2323,7 +2323,7 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
     ) try {
     auto pfnSharedAlloc = ur_lib::context->urDdiTable.USM.pfnSharedAlloc;
@@ -2940,6 +2940,8 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
 ///     - Following a successful call to this entry point, `phProgram` will
 ///       contain a binary of type ::UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT or
 ///       ::UR_PROGRAM_BINARY_TYPE_LIBRARY for `hDevice`.
+///     - The device specified by `hDevice` must be device associated with
+///       context.
 ///
 /// @remarks
 ///   _Analogues_

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1892,7 +1892,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1945,7 +1945,7 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM device memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -1999,7 +1999,7 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_usm_pool_handle_t
         pool, ///< [in][optional] Pointer to a pool created using urUSMPoolCreate
     size_t
-        size, ///< [in] size in bytes of the USM memory object to be allocated
+        size, ///< [in] minimum size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2503,6 +2503,8 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
 ///     - Following a successful call to this entry point, `phProgram` will
 ///       contain a binary of type ::UR_PROGRAM_BINARY_TYPE_COMPILED_OBJECT or
 ///       ::UR_PROGRAM_BINARY_TYPE_LIBRARY for `hDevice`.
+///     - The device specified by `hDevice` must be device associated with
+///       context.
 ///
 /// @remarks
 ///   _Analogues_

--- a/test/conformance/context/context_adapter_native_cpu.match
+++ b/test/conformance/context/context_adapter_native_cpu.match
@@ -1,3 +1,1 @@
-urContextReleaseTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU_
-urContextRetainTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU_
 urContextSetExtendedDeleterTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU_

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -271,6 +271,13 @@ TEST_P(urDeviceGetInfoTest, Success) {
             std::vector<char> info_data(size);
             ASSERT_SUCCESS(urDeviceGetInfo(device, info_type, size,
                                            info_data.data(), nullptr));
+
+            if (info_type == UR_DEVICE_INFO_PLATFORM) {
+                auto returned_platform =
+                    reinterpret_cast<ur_platform_handle_t *>(info_data.data());
+                ASSERT_EQ(*returned_platform, platform);
+            }
+
         } else {
             ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
         }

--- a/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/test/conformance/kernel/urKernelGetInfo.cpp
@@ -24,6 +24,28 @@ TEST_P(urKernelGetInfoTest, Success) {
     property_value.resize(property_size);
     ASSERT_SUCCESS(urKernelGetInfo(kernel, property_name, property_size,
                                    property_value.data(), nullptr));
+    switch (property_name) {
+    case UR_KERNEL_INFO_CONTEXT: {
+        auto returned_context =
+            reinterpret_cast<ur_context_handle_t *>(property_value.data());
+        ASSERT_EQ(context, *returned_context);
+        break;
+    }
+    case UR_KERNEL_INFO_PROGRAM: {
+        auto returned_program =
+            reinterpret_cast<ur_program_handle_t *>(property_value.data());
+        ASSERT_EQ(program, *returned_program);
+        break;
+    }
+    case UR_KERNEL_INFO_REFERENCE_COUNT: {
+        auto returned_reference_count =
+            reinterpret_cast<uint32_t *>(property_value.data());
+        ASSERT_GT(*returned_reference_count, 0U);
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 TEST_P(urKernelGetInfoTest, InvalidNullHandleKernel) {

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -31,6 +31,22 @@ TEST_P(urMemGetInfoTest, Success) {
 
     std::vector<uint8_t> info_data(size);
     ASSERT_SUCCESS(urMemGetInfo(buffer, info, size, info_data.data(), nullptr));
+
+    switch (info) {
+    case UR_MEM_INFO_CONTEXT: {
+        auto returned_context =
+            reinterpret_cast<ur_context_handle_t *>(info_data.data());
+        ASSERT_EQ(context, *returned_context);
+        break;
+    }
+    case UR_MEM_INFO_SIZE: {
+        auto returned_size = reinterpret_cast<size_t *>(info_data.data());
+        ASSERT_GE(*returned_size, allocation_size);
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 TEST_P(urMemGetInfoTest, InvalidNullHandleMemory) {

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -32,6 +32,54 @@ TEST_P(urProgramGetInfoTest, Success) {
     property_value.resize(property_size);
     ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
                                     property_value.data(), nullptr));
+    switch (property_name) {
+    case UR_PROGRAM_INFO_REFERENCE_COUNT: {
+        auto returned_reference_count =
+            reinterpret_cast<uint32_t *>(property_value.data());
+        ASSERT_GT(*returned_reference_count, 0U);
+        break;
+    }
+    case UR_PROGRAM_INFO_CONTEXT: {
+        auto returned_context =
+            reinterpret_cast<ur_context_handle_t *>(property_value.data());
+        ASSERT_EQ(context, *returned_context);
+        break;
+    }
+    case UR_PROGRAM_INFO_NUM_DEVICES: {
+        auto returned_num_of_devices =
+            reinterpret_cast<uint32_t *>(property_value.data());
+        ASSERT_GE(uur::DevicesEnvironment::instance->devices.size(),
+                  *returned_num_of_devices);
+        break;
+    }
+    case UR_PROGRAM_INFO_DEVICES: {
+        auto returned_devices =
+            reinterpret_cast<ur_device_handle_t *>(property_value.data());
+        size_t devices_count = property_size / sizeof(ur_device_handle_t);
+        ASSERT_GT(devices_count, 0);
+        for (uint32_t i = 0; i < devices_count; i++) {
+            auto &devices = uur::DevicesEnvironment::instance->devices;
+            auto queried_device =
+                std::find(devices.begin(), devices.end(), returned_devices[i]);
+            EXPECT_TRUE(queried_device != devices.end());
+        }
+        break;
+    }
+    case UR_PROGRAM_INFO_NUM_KERNELS: {
+        auto returned_num_of_kernels =
+            reinterpret_cast<uint32_t *>(property_value.data());
+        ASSERT_GT(*returned_num_of_kernels, 0U);
+        break;
+    }
+    case UR_PROGRAM_INFO_KERNEL_NAMES: {
+        auto returned_kernel_names =
+            reinterpret_cast<char *>(property_value.data());
+        ASSERT_STRNE(returned_kernel_names, "");
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 TEST_P(urProgramGetInfoTest, InvalidNullHandleProgram) {

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -42,6 +42,29 @@ TEST_P(urQueueGetInfoTestWithInfoParam, Success) {
         std::vector<uint8_t> data(size);
         ASSERT_SUCCESS(
             urQueueGetInfo(queue, info_type, size, data.data(), nullptr));
+
+        switch (info_type) {
+        case UR_QUEUE_INFO_CONTEXT: {
+            auto returned_context =
+                reinterpret_cast<ur_context_handle_t *>(data.data());
+            ASSERT_EQ(context, *returned_context);
+            break;
+        }
+        case UR_QUEUE_INFO_DEVICE: {
+            auto returned_device =
+                reinterpret_cast<ur_device_handle_t *>(data.data());
+            ASSERT_EQ(*returned_device, device);
+            break;
+        }
+        case UR_QUEUE_INFO_REFERENCE_COUNT: {
+            auto returned_reference_count =
+                reinterpret_cast<uint32_t *>(data.data());
+            ASSERT_GT(*returned_reference_count, 0U);
+            break;
+        }
+        default:
+            break;
+        }
     } else {
         ASSERT_EQ_RESULT(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
     }

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -260,7 +260,7 @@ template <class T> struct urMemBufferTestWithParam : urContextTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
         ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_READ_WRITE,
-                                         4096, nullptr, &buffer));
+                                         allocation_size, nullptr, &buffer));
         ASSERT_NE(nullptr, buffer);
     }
 
@@ -271,6 +271,7 @@ template <class T> struct urMemBufferTestWithParam : urContextTestWithParam<T> {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
     }
     ur_mem_handle_t buffer = nullptr;
+    size_t allocation_size = 4096;
 };
 
 template <class T> struct urMemImageTestWithParam : urContextTestWithParam<T> {

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -45,6 +45,38 @@ TEST_P(urUSMGetMemAllocInfoTest, Success) {
     std::vector<uint8_t> info_data(size);
     ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size,
                                         info_data.data(), nullptr));
+    switch (alloc_info) {
+    case UR_USM_ALLOC_INFO_DEVICE: {
+        auto returned_device =
+            reinterpret_cast<ur_device_handle_t *>(info_data.data());
+        ASSERT_EQ(*returned_device, device);
+        break;
+    }
+    case UR_USM_ALLOC_INFO_SIZE: {
+        auto returned_size = reinterpret_cast<size_t *>(info_data.data());
+        ASSERT_GE(*returned_size, allocation_size);
+        break;
+    }
+    case UR_USM_ALLOC_INFO_BASE_PTR: {
+        auto returned_ptr = reinterpret_cast<void **>(info_data.data());
+        ASSERT_EQ(*returned_ptr, ptr);
+        break;
+    }
+    case UR_USM_ALLOC_INFO_POOL: {
+        auto returned_pool =
+            reinterpret_cast<ur_usm_pool_handle_t *>(info_data.data());
+        ASSERT_EQ(*returned_pool, pool);
+        break;
+    }
+    case UR_USM_ALLOC_INFO_TYPE: {
+        auto returned_type =
+            reinterpret_cast<ur_usm_type_t *>(info_data.data());
+        ASSERT_EQ(*returned_type, UR_USM_TYPE_DEVICE);
+        break;
+    }
+    default:
+        break;
+    }
 }
 
 using urUSMGetMemAllocInfoNegativeTest = uur::urUSMDeviceAllocTest;


### PR DESCRIPTION
This PR fixes: 
* Some genInfo tests was only checking that the query was returning successfully, however wasn't validating the output. This PR add some validation to some of the queries to validate the output. Some queries like device queries couldn't be validated as they depend on the device properties that could be queried through UR backend, so the CTS won't be able to validate those. The queries that is validated in this PR is only the ones that their info was passed on the creation of the handle so the CTS should already have a copy of the output, like querying the context devices or the allocated buffer size.
* USM allocation UR entries was not mentioning in the spec that allocations could be bigger than the size that was specified, as different backends have different behaviour on this regard. So, add a mention for that in the spec.
* Native CPU backend was not reporting `Reference counting` for context handles, so add that as it should be already have a reference handling mechanism.
* Change hip adapter `urProgramGetInfo` to return the context device when queried about the program devices.

resolves [#1191](https://github.com/oneapi-src/unified-runtime/issues/1191)

[intel/llvm](https://github.com/intel/llvm/pull/12782) testing for the small adapters change