### PR TITLE
[CI] Fix failing nightly build

### DIFF
--- a/test/fuzz/urFuzz.cpp
+++ b/test/fuzz/urFuzz.cpp
@@ -38,14 +38,18 @@ int ur_device_get(TestState &state) {
         return -1;
     }
 
-    ur_result_t res = urDeviceGet(state.platforms[state.platform_num],
-                                  state.device_type, state.num_entries,
-                                  state.devices.data(), &state.num_devices);
+    ur_result_t res = UR_RESULT_SUCCESS;
+    if (state.devices.size() == 0) {
+        res = urDeviceGet(state.platforms[state.platform_num],
+                          state.device_type, 0, nullptr, &state.num_devices);
+        state.devices.resize(state.num_devices);
+    } else {
+        res =
+            urDeviceGet(state.platforms[state.platform_num], state.device_type,
+                        state.num_entries, state.devices.data(), nullptr);
+    }
     if (res != UR_RESULT_SUCCESS) {
         return -1;
-    }
-    if (state.devices.size() != state.num_devices) {
-        state.devices.resize(state.num_devices);
     }
 
     return 0;


### PR DESCRIPTION
Changes from commit 019551c in `urDeviceGet()` validation resulted in a failure to create devices successfully in fuzz tests. This resulted in generating plenty of calls to `urPlatformGet()`. The size of the input generated by fuzzer most probably led to going out of memory (available to the fuzzer).