### PR TITLE
[DeviceSanitizerLayer] Demangle the kernel name in error reporting

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.cpp
@@ -13,7 +13,6 @@
 
 #include "asan_interceptor.hpp"
 #include "ur_sanitizer_layer.hpp"
-#include <cxxabi.h>
 
 namespace ur_sanitizer_layer {
 
@@ -283,12 +282,7 @@ void SanitizerInterceptor::postLaunchKernel(ur_kernel_handle_t Kernel,
         auto KernelName = getKernelName(Kernel);
 
         // Try to demangle the kernel name
-        char *demangled_name =
-            abi::__cxa_demangle(KernelName.c_str(), nullptr, nullptr, nullptr);
-        if (demangled_name) {
-            KernelName = demangled_name;
-            free(demangled_name);
-        }
+        KernelName = DemangleName(KernelName);
 
         context.logger.always("\n====ERROR: DeviceSanitizer: {} on {}",
                               DeviceSanitizerFormat(AH->ErrorType),

--- a/source/loader/layers/sanitizer/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.cpp
@@ -13,6 +13,7 @@
 
 #include "asan_interceptor.hpp"
 #include "ur_sanitizer_layer.hpp"
+#include <cxxabi.h>
 
 namespace ur_sanitizer_layer {
 
@@ -280,6 +281,14 @@ void SanitizerInterceptor::postLaunchKernel(ur_kernel_handle_t Kernel,
         const char *File = AH->File[0] ? AH->File : "<unknown file>";
         const char *Func = AH->Func[0] ? AH->Func : "<unknown func>";
         auto KernelName = getKernelName(Kernel);
+
+        // Try to demangle the kernel name
+        char *demangled_name =
+            abi::__cxa_demangle(KernelName.c_str(), nullptr, nullptr, nullptr);
+        if (demangled_name) {
+            KernelName = demangled_name;
+            free(demangled_name);
+        }
 
         context.logger.always("\n====ERROR: DeviceSanitizer: {} on {}",
                               DeviceSanitizerFormat(AH->ErrorType),

--- a/source/loader/layers/sanitizer/common.hpp
+++ b/source/loader/layers/sanitizer/common.hpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <string>
 
 namespace ur_sanitizer_layer {
 
@@ -106,5 +107,7 @@ bool SetupShadowMem();
 bool DestroyShadowMem();
 
 void *GetMemFunctionPointer(const char *);
+
+std::string DemangleName(const std::string &name);
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/linux/san_utils.cpp
+++ b/source/loader/layers/sanitizer/linux/san_utils.cpp
@@ -15,8 +15,10 @@
 #include "ur_sanitizer_layer.hpp"
 
 #include <asm/param.h>
+#include <cxxabi.h>
 #include <dlfcn.h>
 #include <gnu/lib-names.h>
+#include <string>
 #include <sys/mman.h>
 
 extern "C" __attribute__((weak)) void __asan_init(void);
@@ -82,6 +84,17 @@ void *GetMemFunctionPointer(const char *FuncName) {
         context.logger.error("Failed to get '{}' from {}", FuncName, LIBC_SO);
     }
     return ptr;
+}
+
+std::string DemangleName(const std::string &name) {
+    std::string result = name;
+    char *demangled =
+        abi::__cxa_demangle(name.c_str(), nullptr, nullptr, nullptr);
+    if (demangled) {
+        result = demangled;
+        free(demangled);
+    }
+    return result;
 }
 
 } // namespace ur_sanitizer_layer


### PR DESCRIPTION
Try to demangle the kernel name in error reporting to improve user experience.