### PR TITLE
[OCL] Fix use of CL_RETURN_ON_FAILURE instead of UR_RETURN_ON_FAILURE

### DIFF
--- a/source/adapters/opencl/kernel.cpp
+++ b/source/adapters/opencl/kernel.cpp
@@ -320,7 +320,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
   switch (propName) {
   case UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS: {
     if (*(static_cast<const ur_bool_t *>(pPropValue)) == true) {
-      CL_RETURN_ON_FAILURE(usmSetIndirectAccess(hKernel));
+      UR_RETURN_ON_FAILURE(usmSetIndirectAccess(hKernel));
     }
     return UR_RESULT_SUCCESS;
   }


### PR DESCRIPTION
`usmSetIndirectAccess` returns a UR error code and not an opencl one