### PR TITLE
[CUDA] Refactor device initialization

### DIFF
--- a/source/adapters/cuda/device.hpp
+++ b/source/adapters/cuda/device.hpp
@@ -41,15 +41,19 @@ public:
         Platform(platform) {
 
     UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxBlockDimY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, cuDevice));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxBlockDimZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, cuDevice));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxRegsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK,
         cuDevice));
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxCapacityLocalMem,
         CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, cuDevice));
+
+    UR_CHECK_ERROR(urDeviceGetInfo(this, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
+                                   sizeof(MaxWorkItemSizes), MaxWorkItemSizes,
+                                   nullptr));
+
+    UR_CHECK_ERROR(urDeviceGetInfo(this, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+                                   sizeof(MaxWorkGroupSize), &MaxWorkGroupSize,
+                                   nullptr));
 
     // Set local mem max size if env var is present
     static const char *LocalMemSizePtrUR =
@@ -90,13 +94,6 @@ public:
   ur_platform_handle_t getPlatform() const noexcept { return Platform; };
 
   uint64_t getElapsedTime(CUevent) const;
-
-  void saveMaxWorkItemSizes(size_t Size,
-                            size_t *SaveMaxWorkItemSizes) noexcept {
-    memcpy(MaxWorkItemSizes, SaveMaxWorkItemSizes, Size);
-  };
-
-  void saveMaxWorkGroupSize(int Value) noexcept { MaxWorkGroupSize = Value; };
 
   void getMaxWorkItemSizes(size_t RetSize,
                            size_t *RetMaxWorkItemSizes) const noexcept {

--- a/source/adapters/cuda/device.hpp
+++ b/source/adapters/cuda/device.hpp
@@ -27,8 +27,6 @@ private:
   size_t MaxWorkItemSizes[MaxWorkItemDimensions];
   size_t MaxWorkGroupSize{0};
   size_t MaxAllocSize{0};
-  int MaxBlockDimY{0};
-  int MaxBlockDimZ{0};
   int MaxRegsPerBlock{0};
   int MaxCapacityLocalMem{0};
   int MaxChosenLocalMem{0};
@@ -95,16 +93,11 @@ public:
 
   uint64_t getElapsedTime(CUevent) const;
 
-  void getMaxWorkItemSizes(size_t RetSize,
-                           size_t *RetMaxWorkItemSizes) const noexcept {
-    memcpy(RetMaxWorkItemSizes, MaxWorkItemSizes, RetSize);
-  };
+  size_t getMaxWorkItemSizes(int index) const noexcept {
+    return MaxWorkItemSizes[index];
+  }
 
   size_t getMaxWorkGroupSize() const noexcept { return MaxWorkGroupSize; };
-
-  size_t getMaxBlockDimY() const noexcept { return MaxBlockDimY; };
-
-  size_t getMaxBlockDimZ() const noexcept { return MaxBlockDimZ; };
 
   size_t getMaxRegsPerBlock() const noexcept { return MaxRegsPerBlock; };
 

--- a/source/adapters/cuda/kernel.cpp
+++ b/source/adapters/cuda/kernel.cpp
@@ -68,14 +68,6 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
   case UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE: {
     size_t GlobalWorkSize[3] = {0, 0, 0};
 
-    int MaxBlockDimX{0}, MaxBlockDimY{0}, MaxBlockDimZ{0};
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxBlockDimX, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, hDevice->get()));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxBlockDimY, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, hDevice->get()));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &MaxBlockDimZ, CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, hDevice->get()));
-
     int MaxGridDimX{0}, MaxGridDimY{0}, MaxGridDimZ{0};
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxGridDimX, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, hDevice->get()));
@@ -84,9 +76,10 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &MaxGridDimZ, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, hDevice->get()));
 
-    GlobalWorkSize[0] = MaxBlockDimX * MaxGridDimX;
-    GlobalWorkSize[1] = MaxBlockDimY * MaxGridDimY;
-    GlobalWorkSize[2] = MaxBlockDimZ * MaxGridDimZ;
+    GlobalWorkSize[0] = hDevice->getMaxWorkItemSizes(0) * MaxGridDimX;
+    GlobalWorkSize[1] = hDevice->getMaxWorkItemSizes(1) * MaxGridDimY;
+    GlobalWorkSize[2] = hDevice->getMaxWorkItemSizes(2) * MaxGridDimZ;
+
     return ReturnValue(GlobalWorkSize, 3);
   }
   case UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE: {

--- a/source/adapters/cuda/platform.cpp
+++ b/source/adapters/cuda/platform.cpp
@@ -95,22 +95,6 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
 
               Platforms[i].Devices.emplace_back(new ur_device_handle_t_{
                   Device, Context, EvBase, &Platforms[i]});
-              {
-                const auto &Dev = Platforms[i].Devices.back().get();
-                size_t MaxWorkGroupSize = 0u;
-                size_t MaxThreadsPerBlock[3] = {};
-                UR_CHECK_ERROR(urDeviceGetInfo(
-                    Dev, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
-                    sizeof(MaxThreadsPerBlock), MaxThreadsPerBlock, nullptr));
-
-                UR_CHECK_ERROR(urDeviceGetInfo(
-                    Dev, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-                    sizeof(MaxWorkGroupSize), &MaxWorkGroupSize, nullptr));
-
-                Dev->saveMaxWorkItemSizes(sizeof(MaxThreadsPerBlock),
-                                          MaxThreadsPerBlock);
-                Dev->saveMaxWorkGroupSize(MaxWorkGroupSize);
-              }
             }
           } catch (const std::bad_alloc &) {
             // Signal out-of-memory situation


### PR DESCRIPTION
Some logic for device initialization was split across platform init and device init. This duplicated some calls to get info for max block dim in Y and Z dimension. This rectifies that and makes sure the max block dims are only queried once, which is called from the device constructor.