### PR TITLE
[L0] Fix the multi device event cache to allocate lists as pointers

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -395,27 +395,29 @@ ur_result_t ur_context_handle_t_::finalize() {
 
   if (!DisableEventsCaching) {
     std::scoped_lock<ur_mutex> Lock(EventCacheMutex);
-    for (auto &EventCache : EventCaches) {
-      for (auto &Event : EventCache) {
+    for (auto EventCache : EventCaches) {
+      for (auto Event : *EventCache) {
         auto ZeResult = ZE_CALL_NOCHECK(zeEventDestroy, (Event->ZeEvent));
         // Gracefully handle the case that L0 was already unloaded.
         if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
           return ze2urResult(ZeResult);
         delete Event;
       }
-      EventCache.clear();
+      EventCache->clear();
+      delete EventCache;
     }
   }
   {
     std::scoped_lock<ur_mutex> Lock(ZeEventPoolCacheMutex);
-    for (auto &ZePoolCache : ZeEventPoolCache) {
-      for (auto &ZePool : ZePoolCache) {
+    for (auto ZePoolCache : ZeEventPoolCache) {
+      for (auto ZePool : *ZePoolCache) {
         auto ZeResult = ZE_CALL_NOCHECK(zeEventPoolDestroy, (ZePool));
         // Gracefully handle the case that L0 was already unloaded.
         if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
           return ze2urResult(ZeResult);
       }
-      ZePoolCache.clear();
+      ZePoolCache->clear();
+      delete ZePoolCache;
     }
   }
 

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -141,7 +141,7 @@ struct ur_context_handle_t_ : _ur_object {
   // head.
   //
   // Cache of event pools to which host-visible events are added to.
-  std::vector<std::list<ze_event_pool_handle_t>> ZeEventPoolCache{4};
+  std::vector<std::list<ze_event_pool_handle_t> *> ZeEventPoolCache;
   std::vector<std::unordered_map<ze_device_handle_t,
                                  std::list<ze_event_pool_handle_t> *>>
       ZeEventPoolCacheDeviceMap{4};
@@ -165,7 +165,7 @@ struct ur_context_handle_t_ : _ur_object {
   ur_mutex EventCacheMutex;
 
   // Caches for events.
-  std::vector<std::list<ur_event_handle_t>> EventCaches{4};
+  std::vector<std::list<ur_event_handle_t> *> EventCaches;
   std::vector<
       std::unordered_map<ur_device_handle_t, std::list<ur_event_handle_t> *>>
       EventCachesDeviceMap{4};
@@ -207,18 +207,29 @@ struct ur_context_handle_t_ : _ur_object {
 
   auto getZeEventPoolCache(bool HostVisible, bool WithProfiling,
                            ze_device_handle_t ZeDevice) {
+    // Adding 4 initial global caches for provided scope and profiling modes:
+    // Host Scope, Device Scope, with Profiling, without Profiling.
+    if (ZeEventPoolCache.empty()) {
+      for (int i = 0; i < 4; i++) {
+        std::list<ze_event_pool_handle_t> *deviceZeEventPoolCache =
+            new std::list<ze_event_pool_handle_t>;
+        ZeEventPoolCache.push_back(deviceZeEventPoolCache);
+      }
+    }
     if (HostVisible) {
       if (ZeDevice) {
         auto ZeEventPoolCacheMap = WithProfiling
                                        ? &ZeEventPoolCacheDeviceMap[0]
                                        : &ZeEventPoolCacheDeviceMap[1];
         if (ZeEventPoolCacheMap->find(ZeDevice) == ZeEventPoolCacheMap->end()) {
-          ZeEventPoolCache.emplace_back();
-          (*ZeEventPoolCacheMap)[ZeDevice] = &ZeEventPoolCache.back();
+          std::list<ze_event_pool_handle_t> *deviceZeEventPoolCache =
+              new std::list<ze_event_pool_handle_t>;
+          ZeEventPoolCache.push_back(deviceZeEventPoolCache);
+          (*ZeEventPoolCacheMap)[ZeDevice] = deviceZeEventPoolCache;
         }
         return (*ZeEventPoolCacheMap)[ZeDevice];
       } else {
-        return WithProfiling ? &ZeEventPoolCache[0] : &ZeEventPoolCache[1];
+        return WithProfiling ? ZeEventPoolCache[0] : ZeEventPoolCache[1];
       }
     } else {
       if (ZeDevice) {
@@ -226,12 +237,14 @@ struct ur_context_handle_t_ : _ur_object {
                                        ? &ZeEventPoolCacheDeviceMap[2]
                                        : &ZeEventPoolCacheDeviceMap[3];
         if (ZeEventPoolCacheMap->find(ZeDevice) == ZeEventPoolCacheMap->end()) {
-          ZeEventPoolCache.emplace_back();
-          (*ZeEventPoolCacheMap)[ZeDevice] = &ZeEventPoolCache.back();
+          std::list<ze_event_pool_handle_t> *deviceZeEventPoolCache =
+              new std::list<ze_event_pool_handle_t>;
+          ZeEventPoolCache.push_back(deviceZeEventPoolCache);
+          (*ZeEventPoolCacheMap)[ZeDevice] = deviceZeEventPoolCache;
         }
         return (*ZeEventPoolCacheMap)[ZeDevice];
       } else {
-        return WithProfiling ? &ZeEventPoolCache[2] : &ZeEventPoolCache[3];
+        return WithProfiling ? ZeEventPoolCache[2] : ZeEventPoolCache[3];
       }
     }
   }
@@ -274,29 +287,42 @@ private:
   // Get the cache of events for a provided scope and profiling mode.
   auto getEventCache(bool HostVisible, bool WithProfiling,
                      ur_device_handle_t Device) {
+    // Adding 4 initial global caches for provided scope and profiling modes:
+    // Host Scope, Device Scope, with Profiling, without Profiling.
+    if (EventCaches.empty()) {
+      for (int i = 0; i < 4; i++) {
+        std::list<ur_event_handle_t> *deviceEventCache =
+            new std::list<ur_event_handle_t>;
+        EventCaches.push_back(deviceEventCache);
+      }
+    }
     if (HostVisible) {
       if (Device) {
         auto EventCachesMap =
             WithProfiling ? &EventCachesDeviceMap[0] : &EventCachesDeviceMap[1];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          (*EventCachesMap)[Device] = &EventCaches.back();
+          std::list<ur_event_handle_t> *deviceEventCache =
+              new std::list<ur_event_handle_t>;
+          EventCaches.push_back(deviceEventCache);
+          (*EventCachesMap)[Device] = deviceEventCache;
         }
         return (*EventCachesMap)[Device];
       } else {
-        return WithProfiling ? &EventCaches[0] : &EventCaches[1];
+        return WithProfiling ? EventCaches[0] : EventCaches[1];
       }
     } else {
       if (Device) {
         auto EventCachesMap =
             WithProfiling ? &EventCachesDeviceMap[2] : &EventCachesDeviceMap[3];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          (*EventCachesMap)[Device] = &EventCaches.back();
+          std::list<ur_event_handle_t> *deviceEventCache =
+              new std::list<ur_event_handle_t>;
+          EventCaches.push_back(deviceEventCache);
+          (*EventCachesMap)[Device] = deviceEventCache;
         }
         return (*EventCachesMap)[Device];
       } else {
-        return WithProfiling ? &EventCaches[2] : &EventCaches[3];
+        return WithProfiling ? EventCaches[2] : EventCaches[3];
       }
     }
   }

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -342,7 +342,7 @@ struct ur_queue_handle_t_ : _ur_object {
   // requested type of event. Each list contains events which can be reused
   // inside all command lists in the queue as described in the 2-event model.
   // Leftover events in the cache are relased at the queue destruction.
-  std::vector<std::list<ur_event_handle_t>> EventCaches{2};
+  std::vector<std::list<ur_event_handle_t> *> EventCaches;
   std::vector<
       std::unordered_map<ur_device_handle_t, std::list<ur_event_handle_t> *>>
       EventCachesDeviceMap{2};


### PR DESCRIPTION
- fix to address a multi device crash given many devices causing a stack overflow. Event Caches per device are now explicitly allocated.