### PR TITLE
CONTRIB: add info about workflows on forks

### DIFF
--- a/scripts/core/CONTRIB.rst
+++ b/scripts/core/CONTRIB.rst
@@ -272,6 +272,16 @@ Actions workflow and *must* be reviewed by no less than two code owners.
     files, leaving only conflicts in non-generated source files to be resolved,
     if any.
 
+By default, any new fork has all GitHub Actions workflows disabled. If you would
+like to, e.g., test your branch using our CI workflows *before* creating
+a pull request, you have to enter the *Actions* tab on your fork and enable
+workflows for this repository. When they are not needed anymore, you can disable
+them again, but it has to be done one by one. The CI on the upstream repository
+gets busy from time to time. That's why you may want to enable workflows on your
+fork to get the testing results quicker. The disadvantage of the CI on your fork
+is that it may report some failing jobs you may not expect, and it does not run
+some of the jobs (due to a lack of specific hardware from self-hosted runners).
+
 Core Features
 =============
 


### PR DESCRIPTION
Fixes #1292

// Preview on my fork: https://lukaszstolarczuk.github.io/unified-runtime/core/CONTRIB.html#forks-and-pull-requests