### PR TITLE
Document adapter logging environment variables

### DIFF
--- a/scripts/core/INTRO.rst
+++ b/scripts/core/INTRO.rst
@@ -282,6 +282,26 @@ Environment Variables
 
 Specific environment variables can be set to control the behavior of unified runtime or enable certain features.
 
+.. envvar:: UR_LOG_LEVEL_ZERO
+
+   Holds parameters for setting Unified Runtime level zero adapter logging. The syntax is described in the Logging_ section.
+
+.. envvar:: UR_LOG_CUDA
+
+   Holds parameters for setting Unified Runtime cuda adapter logging. The syntax is described in the Logging_ section.
+
+.. envvar:: UR_LOG_HIP
+
+   Holds parameters for setting Unified Runtime hip adapter logging. The syntax is described in the Logging_ section.
+
+.. envvar:: UR_LOG_OPENCL
+
+   Holds parameters for setting Unified Runtime opencl adapter logging. The syntax is described in the Logging_ section.
+
+.. envvar:: UR_LOG_NATIVE_CPU
+
+   Holds parameters for setting Unified Runtime native cpu logging. The syntax is described in the Logging_ section.
+
 .. envvar:: UR_LOG_LOADER
 
    Holds parameters for setting Unified Runtime loader logging. The syntax is described in the Logging_ section.


### PR DESCRIPTION
This PR is supposed to be merged along/after logger changes in adapters.
(https://github.com/oneapi-src/unified-runtime/pull/1359; https://github.com/oneapi-src/unified-runtime/pull/1347; https://github.com/oneapi-src/unified-runtime/pull/1345; https://github.com/oneapi-src/unified-runtime/pull/1342; https://github.com/oneapi-src/unified-runtime/pull/1032)

To prevent merge conflicts between adapter changes, I have created this PR for the documentation update. Splitting this change into commits along with the logger changes would result in needing to rebase and resolve conflicts after each PR merge, what would become cumbersome to maintain. While this approach allows for merging all changes simultaneously without any conflicts.