### PR TITLE
[Docs] Adding a missing arg to example cmake command.

### DIFF
--- a/scripts/core/CONTRIB.rst
+++ b/scripts/core/CONTRIB.rst
@@ -167,7 +167,7 @@ available.
 
 .. code-block:: console
 
-    $ cmake build/ -DUR_FORMAT_CPP_STYLE=ON
+    $ cmake -B build/ -DUR_FORMAT_CPP_STYLE=ON
 
 You can then follow the instructions below to use the ``generate`` target to
 regenerate the source.


### PR DESCRIPTION
The original command does not run at all. I think `-B` is missing. Adding it in this PR.