### PR TITLE
Add enqueue timestamp recording extension

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -221,6 +221,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 218,                             ///< Enumerator for ::urCommandBufferGetInfoExp
     UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP = 219,                     ///< Enumerator for ::urCommandBufferCommandGetInfoExp
     UR_FUNCTION_DEVICE_GET_SELECTED = 220,                                     ///< Enumerator for ::urDeviceGetSelected
+    UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP = 221,                         ///< Enumerator for ::urEnqueueTimestampRecordingExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1622,6 +1623,7 @@ typedef enum ur_device_info_t {
                                                                     ///< semaphore resources
     UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP = 0x200F,   ///< [::ur_bool_t] returns true if the device supports exporting internal
                                                                     ///< event resources
+    UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP = 0x2010,        ///< [::ur_bool_t] returns true if the device supports timestamp recording
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -5879,6 +5881,34 @@ urEventSetCallback(
     void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 );
 
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueues a timestamp recording to be stored in the resulting event.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                                              ///< pointer to a list of events that must be complete
+                                              ///< before this command can be executed. If nullptr,
+                                              ///< the numEventsInWaitList must be 0, indicating
+                                              ///< that this command does not wait on any event to
+                                              ///< complete.
+    ur_event_handle_t *phEvent                ///< [in,out] return an event object that identifies
+                                              ///< this particular command instance. This event has
+                                              ///< profiling info, even if it is not enabled on hQueue.
+);
+
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
@@ -9341,6 +9371,18 @@ typedef struct ur_event_set_callback_params_t {
     ur_event_callback_t *ppfnNotify;
     void **ppUserData;
 } ur_event_set_callback_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urEnqueueTimestampRecordingExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_enqueue_timestamp_recording_exp_t {
+    ur_queue_handle_t hQueue;
+    bool blocking;
+    uint32_t numEventsInWaitList;
+    const ur_event_handle_t *phEventWaitList;
+    ur_event_handle_t *phEvent;
+} ur_enqueue_timestamp_recording_exp_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urProgramCreateWithIL

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5554,6 +5554,7 @@ typedef enum ur_command_t {
     UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 0x1000,   ///< Event created by ::urCommandBufferEnqueueExp
     UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP = 0x2000,   ///< Event created by ::urBindlessImagesWaitExternalSemaphoreExp
     UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP = 0x2001, ///< Event created by ::urBindlessImagesSignalExternalSemaphoreExp
+    UR_COMMAND_TIMESTAMP_RECORDING_EXP = 0x2002,      ///< Event created by ::urEnqueueTimestampRecordingExp
     /// @cond
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1649,7 +1649,7 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -8751,7 +8751,7 @@ urKernelSuggestMaxCooperativeGroupCountExp(
 #pragma region enqueue timestamp recording(experimental)
 #endif
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueues a timestamp recording to be stored in the resulting event.
+/// @brief Enqueue a command for recording the device timestamp
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5881,34 +5881,6 @@ urEventSetCallback(
     void *pUserData                 ///< [in][out][optional] pointer to data to be passed to callback.
 );
 
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueues a timestamp recording to be stored in the resulting event.
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
-    bool blocking,                            ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                                              ///< pointer to a list of events that must be complete
-                                              ///< before this command can be executed. If nullptr,
-                                              ///< the numEventsInWaitList must be 0, indicating
-                                              ///< that this command does not wait on any event to
-                                              ///< complete.
-    ur_event_handle_t *phEvent                ///< [in,out] return an event object that identifies
-                                              ///< this particular command instance. This event has
-                                              ///< profiling info, even if it is not enabled on hQueue.
-);
-
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
@@ -8774,6 +8746,45 @@ urKernelSuggestMaxCooperativeGroupCountExp(
 #if !defined(__GNUC__)
 #pragma endregion
 #endif
+// Intel 'oneAPI' Unified Runtime Experimental APIs for enqueuing timestamp recordings
+#if !defined(__GNUC__)
+#pragma region enqueue timestamp recording(experimental)
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueues a timestamp recording to be stored in the resulting event.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
++///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
+    bool blocking,                            ///< [in] indicates whether the call to this function should block until
+                                              ///< until the device timestamp recording command has executed on the
+                                              ///< device.
+    uint32_t numEventsInWaitList,             ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                              ///< events that must be complete before the kernel execution.
+                                              ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+                                              ///< event.
+    ur_event_handle_t *phEvent                ///< [in,out] return an event object that identifies this particular kernel
+                                              ///< execution instance. Profiling information can be queried
+                                              ///< from this event as if `hQueue` had profiling enabled. Querying
+                                              ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+                                              ///< reports the timestamp at the time of the call to this function.
+                                              ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+                                              ///< reports the timestamp recorded when the command is executed on the device.
+);
+
+#if !defined(__GNUC__)
+#pragma endregion
+#endif
 // Intel 'oneAPI' Unified Runtime Experimental APIs for multi-device compile
 #if !defined(__GNUC__)
 #pragma region multi device compile(experimental)
@@ -9371,18 +9382,6 @@ typedef struct ur_event_set_callback_params_t {
     ur_event_callback_t *ppfnNotify;
     void **ppUserData;
 } ur_event_set_callback_params_t;
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urEnqueueTimestampRecordingExp
-/// @details Each entry is a pointer to the parameter passed to the function;
-///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_enqueue_timestamp_recording_exp_t {
-    ur_queue_handle_t *hQueue;
-    bool *blocking;
-    uint32_t *numEventsInWaitList;
-    const ur_event_handle_t **phEventWaitList;
-    ur_event_handle_t **phEvent;
-} ur_enqueue_timestamp_recording_exp_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urProgramCreateWithIL
@@ -10473,6 +10472,18 @@ typedef struct ur_enqueue_cooperative_kernel_launch_exp_params_t {
     const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;
 } ur_enqueue_cooperative_kernel_launch_exp_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urEnqueueTimestampRecordingExp
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_enqueue_timestamp_recording_exp_params_t {
+    ur_queue_handle_t *hQueue;
+    bool *blocking;
+    uint32_t *numEventsInWaitList;
+    const ur_event_handle_t **phEventWaitList;
+    ur_event_handle_t **phEvent;
+} ur_enqueue_timestamp_recording_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesUnsampledImageHandleDestroyExp

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8749,6 +8749,7 @@ urKernelSuggestMaxCooperativeGroupCountExp(
 // Intel 'oneAPI' Unified Runtime Experimental APIs for enqueuing timestamp recordings
 #if !defined(__GNUC__)
 #pragma region enqueue timestamp recording(experimental)
+#endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueues a timestamp recording to be stored in the resulting event.
 ///

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -9377,11 +9377,11 @@ typedef struct ur_event_set_callback_params_t {
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_enqueue_timestamp_recording_exp_t {
-    ur_queue_handle_t hQueue;
-    bool blocking;
-    uint32_t numEventsInWaitList;
-    const ur_event_handle_t *phEventWaitList;
-    ur_event_handle_t *phEvent;
+    ur_queue_handle_t *hQueue;
+    bool *blocking;
+    uint32_t *numEventsInWaitList;
+    const ur_event_handle_t **phEventWaitList;
+    ur_event_handle_t **phEvent;
 } ur_enqueue_timestamp_recording_exp_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8762,7 +8762,7 @@ urKernelSuggestMaxCooperativeGroupCountExp(
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
-+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -10479,11 +10479,11 @@ typedef struct ur_enqueue_cooperative_kernel_launch_exp_params_t {
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_enqueue_timestamp_recording_exp_params_t {
-    ur_queue_handle_t *hQueue;
-    bool *blocking;
-    uint32_t *numEventsInWaitList;
-    const ur_event_handle_t **phEventWaitList;
-    ur_event_handle_t **phEvent;
+    ur_queue_handle_t *phQueue;
+    bool *pblocking;
+    uint32_t *pnumEventsInWaitList;
+    const ur_event_handle_t **pphEventWaitList;
+    ur_event_handle_t **pphEvent;
 } ur_enqueue_timestamp_recording_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -236,6 +236,15 @@ typedef ur_result_t(UR_APICALL *ur_pfnEventSetCallback_t)(
     void *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueTimestampRecordingExp
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueTimestampRecordingExp_t)(
+    ur_queue_handle_t,
+    bool,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Event functions pointers
 typedef struct ur_event_dditable_t {
     ur_pfnEventGetInfo_t pfnGetInfo;
@@ -246,6 +255,7 @@ typedef struct ur_event_dditable_t {
     ur_pfnEventGetNativeHandle_t pfnGetNativeHandle;
     ur_pfnEventCreateWithNativeHandle_t pfnCreateWithNativeHandle;
     ur_pfnEventSetCallback_t pfnSetCallback;
+    ur_pfnEnqueueTimestampRecordingExp_t pfnEnqueueTimestampRecordingExp;
 } ur_event_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -236,15 +236,6 @@ typedef ur_result_t(UR_APICALL *ur_pfnEventSetCallback_t)(
     void *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urEnqueueTimestampRecordingExp
-typedef ur_result_t(UR_APICALL *ur_pfnEnqueueTimestampRecordingExp_t)(
-    ur_queue_handle_t,
-    bool,
-    uint32_t,
-    const ur_event_handle_t *,
-    ur_event_handle_t *);
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of Event functions pointers
 typedef struct ur_event_dditable_t {
     ur_pfnEventGetInfo_t pfnGetInfo;
@@ -255,7 +246,6 @@ typedef struct ur_event_dditable_t {
     ur_pfnEventGetNativeHandle_t pfnGetNativeHandle;
     ur_pfnEventCreateWithNativeHandle_t pfnCreateWithNativeHandle;
     ur_pfnEventSetCallback_t pfnSetCallback;
-    ur_pfnEnqueueTimestampRecordingExp_t pfnEnqueueTimestampRecordingExp;
 } ur_event_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1449,9 +1439,19 @@ typedef ur_result_t(UR_APICALL *ur_pfnEnqueueCooperativeKernelLaunchExp_t)(
     ur_event_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urEnqueueTimestampRecordingExp
+typedef ur_result_t(UR_APICALL *ur_pfnEnqueueTimestampRecordingExp_t)(
+    ur_queue_handle_t,
+    bool,
+    uint32_t,
+    const ur_event_handle_t *,
+    ur_event_handle_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Table of EnqueueExp functions pointers
 typedef struct ur_enqueue_exp_dditable_t {
     ur_pfnEnqueueCooperativeKernelLaunchExp_t pfnCooperativeKernelLaunchExp;
+    ur_pfnEnqueueTimestampRecordingExp_t pfnTimestampRecordingExp;
 } ur_enqueue_exp_dditable_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -1939,6 +1939,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueWriteHostPipeParams(const stru
 UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueCooperativeKernelLaunchExpParams(const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_enqueue_timestamp_recording_exp_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintEnqueueTimestampRecordingExpParams(const struct ur_enqueue_timestamp_recording_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_unsampled_image_handle_destroy_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -912,6 +912,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_DEVICE_GET_SELECTED:
         os << "UR_FUNCTION_DEVICE_GET_SELECTED";
         break;
+    case UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP:
+        os << "UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -13940,6 +13943,48 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_enqueue_timestamp_recording_exp_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_enqueue_timestamp_recording_exp_params_t *params) {
+
+    os << ".hQueue = ";
+
+    ur::details::printPtr(os,
+                          *(params->phQueue));
+
+    os << ", ";
+    os << ".blocking = ";
+
+    os << *(params->pblocking);
+
+    os << ", ";
+    os << ".numEventsInWaitList = ";
+
+    os << *(params->pnumEventsInWaitList);
+
+    os << ", ";
+    os << ".phEventWaitList = {";
+    for (size_t i = 0; *(params->pphEventWaitList) != NULL && i < *params->pnumEventsInWaitList; ++i) {
+        if (i != 0) {
+            os << ", ";
+        }
+
+        ur::details::printPtr(os,
+                              (*(params->pphEventWaitList))[i]);
+    }
+    os << "}";
+
+    os << ", ";
+    os << ".phEvent = ";
+
+    ur::details::printPtr(os,
+                          *(params->pphEvent));
+
+    return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_bindless_images_unsampled_image_handle_destroy_exp_params_t type
 /// @returns
 ///     std::ostream &
@@ -16957,6 +17002,9 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     } break;
     case UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP: {
         os << (const struct ur_enqueue_cooperative_kernel_launch_exp_params_t *)params;
+    } break;
+    case UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP: {
+        os << (const struct ur_enqueue_timestamp_recording_exp_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP: {
         os << (const struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t *)params;

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -8664,6 +8664,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value) {
     case UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP:
         os << "UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP";
         break;
+    case UR_COMMAND_TIMESTAMP_RECORDING_EXP:
+        os << "UR_COMMAND_TIMESTAMP_RECORDING_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2537,6 +2537,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     case UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP";
         break;
+    case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -4130,6 +4133,18 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
         os << ")";
     } break;
     case UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP: {
         const ur_bool_t *tptr = (const ur_bool_t *)ptr;
         if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";

--- a/scripts/core/EXP-ENQUEUE-TIMESTAMP-RECORDING.rst
+++ b/scripts/core/EXP-ENQUEUE-TIMESTAMP-RECORDING.rst
@@ -1,0 +1,67 @@
+<%
+    OneApi=tags['$OneApi']
+    x=tags['$x']
+    X=x.upper()
+%>
+
+.. _experimental-enqueue-timestamp-recording:
+
+================================================================================
+Enqueue Timestamp Recording
+================================================================================
+
+.. warning::
+
+    Experimental features:
+
+    *   May be replaced, updated, or removed at any time.
+    *   Do not require maintaining API/ABI stability of their own additions over
+        time.
+    *   Do not require conformance testing of their own additions.
+
+
+Motivation
+--------------------------------------------------------------------------------
+Currently, the only way to get timestamp information is through enabling
+profiling on a queue and retrieve the information from events coming from
+commands submitted to it. However, not all systems give full control of the
+queue construction to the programmer wanting the profiling information. To amend
+this, this extension adds the ability to enqueue a timestamp recording on any
+queue, with or without profiling enabled. This event can in turn be queried for
+the usual profiling information.
+
+
+API
+--------------------------------------------------------------------------------
+
+Enums
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ${x}_device_info_t
+    * ${X}_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP
+
+Functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* ${x}EnqueueTimestampRecordingExp
+
+Changelog
+--------------------------------------------------------------------------------
+
++-----------+------------------------+
+| Revision  | Changes                |
++===========+========================+
+| 1.0       | Initial Draft          |
++-----------+------------------------+
+
+
+Support
+--------------------------------------------------------------------------------
+
+Adapters which support this experimental feature *must* return true for the new
+`${X}_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP` device info query.
+
+
+Contributors
+--------------------------------------------------------------------------------
+
+* Steffen Larsen `steffen.larsen@intel.com <steffen.larsen@intel.com>`_

--- a/scripts/core/EXP-ENQUEUE-TIMESTAMP-RECORDING.rst
+++ b/scripts/core/EXP-ENQUEUE-TIMESTAMP-RECORDING.rst
@@ -40,6 +40,9 @@ Enums
 * ${x}_device_info_t
     * ${X}_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP
 
+* ${x}_command_t
+    * ${X}_COMMAND_TIMESTAMP_RECORDING_EXP
+
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ${x}EnqueueTimestampRecordingExp

--- a/scripts/core/exp-enqueue-timestamp-recording.yml
+++ b/scripts/core/exp-enqueue-timestamp-recording.yml
@@ -20,7 +20,7 @@ name: $x_device_info_t
 etors: 
     - name: TIMESTAMP_RECORDING_SUPPORT_EXP
       value: "0x2010"
-desc: "[$x_bool_t] returns true if the device supports timestamp recording"
+      desc: "[$x_bool_t] returns true if the device supports timestamp recording"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Enqueue a command for recording the device timestamp"

--- a/scripts/core/exp-enqueue-timestamp-recording.yml
+++ b/scripts/core/exp-enqueue-timestamp-recording.yml
@@ -1,0 +1,57 @@
+#
+# Copyright (C) 2024 Intel Corporation
+#
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# See YaML.md for syntax definition
+#
+--- #--------------------------------------------------------------------------
+type: header
+desc: "Intel $OneApi Unified Runtime Experimental APIs for enqueuing timestamp recordings"
+ordinal: "99"
+--- #--------------------------------------------------------------------------
+type: enum
+extend: true
+typed_etors: true
+desc: "Extension enums to $x_device_info_t to support timestamp recordings."
+name: $x_device_info_t
+etors: 
+    - name: TIMESTAMP_RECORDING_SUPPORT_EXP
+      value: "0x2010"
+desc: "[$x_bool_t] returns true if the device supports timestamp recording"
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Enqueue a command for recording the device timestamp"
+class: $xEnqueue
+name: EnqueueTimestampRecordingExp
+params:
+    - type: $x_queue_handle_t
+      name: hQueue
+      desc: "[in] handle of the queue object"
+    - type: bool
+      name: blocking
+      desc: |
+            [in] indicates whether the call to this function should block until
+            until the device timestamp recording command has executed on the
+            device.
+    - type: uint32_t
+      name: numEventsInWaitList
+      desc: "[in] size of the event wait list"
+    - type: "const $x_event_handle_t*"
+      name: phEventWaitList
+      desc: |
+            [in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before the kernel execution.
+            If nullptr, the numEventsInWaitList must be 0, indicating that no wait event. 
+    - type: $x_event_handle_t*
+      name: phEvent
+      desc: |
+            [in,out] return an event object that identifies this particular kernel execution instance. Profiling information can be queried
+            from this event as if `hQueue` had profiling enabled. Querying`UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+            reports the timestamp at the time of the call to this function. Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+            reports the timestamp recorded when the command is executed on the device.
+returns:
+    - $X_RESULT_ERROR_INVALID_NULL_HANDLE
+    - $X_RESULT_ERROR_INVALID_NULL_POINTER
+    - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST

--- a/scripts/core/exp-enqueue-timestamp-recording.yml
+++ b/scripts/core/exp-enqueue-timestamp-recording.yml
@@ -22,6 +22,15 @@ etors:
       value: "0x2010"
       desc: "[$x_bool_t] returns true if the device supports timestamp recording"
 --- #--------------------------------------------------------------------------
+type: enum
+extend: true
+desc: "Command Type experimental enumerations."
+name: $x_command_t
+etors:
+    - name: TIMESTAMP_RECORDING_EXP
+      value: "0x2002"
+      desc: Event created by $xEnqueueTimestampRecordingExp
+--- #--------------------------------------------------------------------------
 type: function
 desc: "Enqueue a command for recording the device timestamp"
 class: $xEnqueue

--- a/scripts/core/exp-enqueue-timestamp-recording.yml
+++ b/scripts/core/exp-enqueue-timestamp-recording.yml
@@ -25,7 +25,7 @@ etors:
 type: function
 desc: "Enqueue a command for recording the device timestamp"
 class: $xEnqueue
-name: EnqueueTimestampRecordingExp
+name: TimestampRecordingExp
 params:
     - type: $x_queue_handle_t
       name: hQueue
@@ -48,7 +48,7 @@ params:
       name: phEvent
       desc: |
             [in,out] return an event object that identifies this particular kernel execution instance. Profiling information can be queried
-            from this event as if `hQueue` had profiling enabled. Querying`UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+            from this event as if `hQueue` had profiling enabled. Querying `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
             reports the timestamp at the time of the call to this function. Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
             reports the timestamp recorded when the command is executed on the device.
 returns:

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -577,6 +577,9 @@ etors:
 - name: DEVICE_GET_SELECTED
   desc: Enumerator for $xDeviceGetSelected
   value: '220'
+- name: ENQUEUE_TIMESTAMP_RECORDING_EXP
+  desc: Enumerator for $xEnqueueTimestampRecordingExp
+  value: '221'
 ---
 type: enum
 desc: Defines structure types

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -902,6 +902,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CUDA does not support exporting semaphores or events.
     return ReturnValue(false);
   }
+  case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP: {
+    // CUDA adapter does not currently support recording timestamp events.
+    return ReturnValue(false);
+  }
   case UR_DEVICE_INFO_DEVICE_ID: {
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -903,8 +903,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(false);
   }
   case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP: {
-    // CUDA adapter does not currently support recording timestamp events.
-    return ReturnValue(false);
+    // CUDA supports recording timestamp events.
+    return ReturnValue(true);
   }
   case UR_DEVICE_INFO_DEVICE_ID: {
     int Value = 0;

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1762,6 +1762,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
 
   ur_result_t Result = UR_RESULT_SUCCESS;
+  std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
   try {
     ScopedContext Active(hQueue->getContext());
     CUstream CuStream = hQueue->getNextComputeStream();

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1757,8 +1757,31 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                               const ur_event_handle_t *, ur_event_handle_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, bool blocking, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+
+  ur_result_t Result = UR_RESULT_SUCCESS;
+  try {
+    ScopedContext Active(hQueue->getContext());
+    CUstream CuStream = hQueue->getNextComputeStream();
+
+    UR_CHECK_ERROR(enqueueEventsWait(hQueue, CuStream, numEventsInWaitList,
+                                     phEventWaitList));
+
+    RetImplEvent =
+        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
+            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
+    UR_CHECK_ERROR(RetImplEvent->start());
+    UR_CHECK_ERROR(RetImplEvent->record());
+
+    if (blocking) {
+      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+    }
+
+    *phEvent = RetImplEvent.release();
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
 }

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1756,3 +1756,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
+                               const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -218,12 +218,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                               const ur_event_handle_t *, ur_event_handle_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   try {
     auto Context = phEventWaitList[0]->getContext();

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -218,6 +218,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
+                               const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   try {
     auto Context = phEventWaitList[0]->getContext();

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -77,7 +77,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
-  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 
@@ -407,6 +406,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 
   pDdiTable->pfnCooperativeKernelLaunchExp =
       urEnqueueCooperativeKernelLaunchExp;
+  pDdiTable->pfnTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -77,6 +77,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
+  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -829,6 +829,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_COMPOSITE_DEVICE:
     // These two are exclusive of L0.
     return ReturnValue(0);
+  case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP:
+    return ReturnValue(false);
 
   // TODO: Investigate if this information is available on HIP.
   case UR_DEVICE_INFO_GPU_EU_COUNT:

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -830,7 +830,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // These two are exclusive of L0.
     return ReturnValue(0);
   case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP:
-    return ReturnValue(false);
+    return ReturnValue(true);
 
   // TODO: Investigate if this information is available on HIP.
   case UR_DEVICE_INFO_GPU_EU_COUNT:

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1912,12 +1912,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
     RetImplEvent =
         std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
-            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
+            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, HIPStream));
     UR_CHECK_ERROR(RetImplEvent->start());
     UR_CHECK_ERROR(RetImplEvent->record());
 
     if (blocking) {
-      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(HIPStream));
     }
 
     *phEvent = RetImplEvent.release();

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1901,6 +1901,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
 
   ur_result_t Result = UR_RESULT_SUCCESS;
+  std::unique_ptr<ur_event_handle_t_> RetImplEvent{nullptr};
   try {
     uint32_t StreamToken;
     ur_stream_quard Guard;

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1917,7 +1917,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     UR_CHECK_ERROR(RetImplEvent->record());
 
     if (blocking) {
-      UR_CHECK_ERROR(cuStreamSynchronize(HIPStream));
+      UR_CHECK_ERROR(hipStreamSynchronize(HIPStream));
     }
 
     *phEvent = RetImplEvent.release();

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1895,3 +1895,33 @@ void setCopyRectParams(ur_rect_region_t Region, const void *SrcPtr,
                      : (DstType == hipMemoryTypeDevice ? hipMemcpyHostToDevice
                                                        : hipMemcpyHostToHost));
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, bool blocking, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+
+  ur_result_t Result = UR_RESULT_SUCCESS;
+  try {
+    uint32_t StreamToken;
+    ur_stream_quard Guard;
+    hipStream_t HIPStream = hQueue->getNextComputeStream(
+        numEventsInWaitList, phEventWaitList, Guard, &StreamToken);
+    UR_CHECK_ERROR(enqueueEventsWait(hQueue, HIPStream, numEventsInWaitList,
+                                     phEventWaitList));
+
+    RetImplEvent =
+        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
+            UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
+    UR_CHECK_ERROR(RetImplEvent->start());
+    UR_CHECK_ERROR(RetImplEvent->record());
+
+    if (blocking) {
+      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+    }
+
+    *phEvent = RetImplEvent.release();
+  } catch (ur_result_t Err) {
+    Result = Err;
+  }
+  return Result;
+}

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -276,12 +276,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
-                               const ur_event_handle_t *, ur_event_handle_t *) {
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-}
-
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -276,6 +276,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
+                               const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
   const auto RefCount = hEvent->incrementReferenceCount();
 

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -77,7 +77,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
-  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 
@@ -377,6 +376,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 
   pDdiTable->pfnCooperativeKernelLaunchExp =
       urEnqueueCooperativeKernelLaunchExp;
+  pDdiTable->pfnTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -77,6 +77,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
+  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -852,6 +852,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT: {
     return ReturnValue(static_cast<uint32_t>(true));
   }
+  case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP: {
+    return ReturnValue(static_cast<uint32_t>(true));
+  }
 
   case UR_DEVICE_INFO_ESIMD_SUPPORT: {
     // ESIMD is only supported by Intel GPUs.

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -461,8 +461,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
 ) {
   std::shared_lock<ur_shared_mutex> EventLock(Event->Mutex);
 
-  if (Event->UrQueue &&
-      (Event->UrQueue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) == 0) {
+  // The event must either have profiling enabled or be recording timestamps.
+  bool isTimestampedEvent = Event->isTimestamped();
+  if (!Event->isProfilingEnabled() && !isTimestampedEvent) {
     return UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE;
   }
 
@@ -474,6 +475,62 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
       ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
 
   UrReturnHelper ReturnValue(PropValueSize, PropValue, PropValueSizeRet);
+
+  // For timestamped events we have the timestamps ready directly on the event
+  // handle, so we short-circuit the return.
+  if (isTimestampedEvent) {
+    uint64_t ContextStartTime = Event->RecordEventStartTimestamp;
+    switch (PropName) {
+    case UR_PROFILING_INFO_COMMAND_QUEUED:
+    case UR_PROFILING_INFO_COMMAND_SUBMIT:
+      return ReturnValue(ContextStartTime);
+    case UR_PROFILING_INFO_COMMAND_END:
+    case UR_PROFILING_INFO_COMMAND_START: {
+      // If RecordEventEndTimestamp on the event is non-zero it means it has
+      // collected the result of the queue already. In that case it has been
+      // adjusted and is ready for immediate return.
+      if (Event->RecordEventEndTimestamp)
+        return ReturnValue(Event->RecordEventEndTimestamp);
+
+      // Otherwise we need to collect it from the queue.
+      auto Entry = Event->UrQueue->EndTimeRecordings.find(Event);
+
+      // Unexpected state if there is no end-time record.
+      if (Entry == Event->UrQueue->EndTimeRecordings.end())
+        return UR_RESULT_ERROR_UNKNOWN;
+      auto &EndTimeRecording = Entry->second;
+
+      // End time needs to be adjusted for resolution and valid bits.
+      uint64_t ContextEndTime =
+          ((*EndTimeRecording.RecordEventEndTimestamp) & TimestampMaxValue) *
+          ZeTimerResolution;
+
+      // If the result is 0, we have not yet gotten results back and so we just
+      // return it.
+      if (ContextEndTime == 0)
+        return ReturnValue(ContextEndTime);
+
+      // Handle a possible wrap-around (the underlying HW counter is < 64-bit).
+      // Note, it will not report correct time if there were multiple wrap
+      // arounds, and the longer term plan is to enlarge the capacity of the
+      // HW timestamps.
+      if (ContextEndTime < ContextStartTime)
+        ContextEndTime += TimestampMaxValue * ZeTimerResolution;
+
+      // Now that we have the result, there is no need to keep it in the queue
+      // anymore, so we cache it on the event and evict the record from the
+      // queue.
+      Event->RecordEventEndTimestamp = ContextEndTime;
+      free(EndTimeRecording.RecordEventEndTimestamp);
+      Event->UrQueue->EndTimeRecordings.erase(Entry);
+
+      return ReturnValue(ContextEndTime);
+    }
+    default:
+      urPrint("urEventGetProfilingInfo: not supported ParamName\n");
+      return UR_RESULT_ERROR_INVALID_VALUE;
+    }
+  }
 
   ze_kernel_timestamp_result_t tsResult;
 
@@ -579,6 +636,62 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
     urPrint("urEventGetProfilingInfo: not supported ParamName\n");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t Queue,      ///< [in] handle of the queue object
+    bool Blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                        ///< pointer to a list of events that must be complete
+                        ///< before this command can be executed. If nullptr,
+                        ///< the numEventsInWaitList must be 0, indicating
+                        ///< that this command does not wait on any event to
+                        ///< complete.
+    ur_event_handle_t
+        *OutEvent ///< [in,out] return an event object that identifies
+                  ///< this particular command instance.
+) {
+  // Lock automatically releases when this goes out of scope.
+  std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
+
+  ur_device_handle_t Device = Queue->Device;
+
+  uint64_t DeviceStartTimestamp = 0;
+  UR_CALL(urDeviceGetGlobalTimestamps(Device, &DeviceStartTimestamp, nullptr));
+
+  bool UseCopyEngine = false;
+  _ur_ze_event_list_t TmpWaitList;
+  UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
+      NumEventsInWaitList, EventWaitList, Queue, UseCopyEngine));
+
+  // Get a new command list to be used on this call
+  ur_command_list_ptr_t CommandList{};
+  UR_CALL(Queue->Context->getAvailableCommandList(
+      Queue, CommandList, UseCopyEngine, /* AllowBatching */ false));
+
+  UR_CALL(createEventAndAssociateQueue(
+      Queue, OutEvent, UR_EXT_COMMAND_TYPE_USER, CommandList,
+      /* IsInternal */ false, /* HostVisible */ true));
+  ze_event_handle_t ZeEvent = (*OutEvent)->ZeEvent;
+  (*OutEvent)->WaitList = TmpWaitList;
+  (*OutEvent)->RecordEventStartTimestamp = DeviceStartTimestamp;
+
+  // Allocate new entry in the queue's recordings.
+  uint64_t *EndTimestampPtr = (uint64_t *)malloc(sizeof(uint64_t));
+  *EndTimestampPtr = 0;
+  Queue->EndTimeRecordings[*OutEvent] = ur_queue_handle_t_::end_time_recording{
+      EndTimestampPtr, /*EventHasDied=*/false};
+
+  ZE2UR_CALL(zeCommandListAppendWriteGlobalTimestamp,
+             (CommandList->first, EndTimestampPtr, ZeEvent,
+              (*OutEvent)->WaitList.Length, (*OutEvent)->WaitList.ZeEventList));
+
+  UR_CALL(
+      Queue->executeCommandList(CommandList, Blocking, /* OkToBatch */ false));
 
   return UR_RESULT_SUCCESS;
 }
@@ -874,6 +987,24 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
     delete Event;
   } else {
     Event->Context->addEventToContextCache(Event);
+  }
+
+  // If the event was a timestamp recording, we try to evict its entry in the
+  // queue.
+  if (Event->isTimestamped()) {
+    auto Entry = Queue->EndTimeRecordings.find(Event);
+    if (Entry != Queue->EndTimeRecordings.end()) {
+      auto &EndTimeRecording = Entry->second;
+      if ((EndTimeRecording.RecordEventEndTimestamp) == 0) {
+        // If the end time recording has not finished, we tell the queue that
+        // the event is no longer alive to avoid invalid write-backs.
+        EndTimeRecording.EventHasDied = true;
+      } else {
+        // Otherwise we evict the entry.
+        free(EndTimeRecording.RecordEventEndTimestamp);
+        Event->UrQueue->EndTimeRecordings.erase(Entry);
+      }
+    }
   }
 
   // We intentionally incremented the reference counter when an event is
@@ -1393,4 +1524,13 @@ ur_result_t _ur_ze_event_list_t::collectEventsForReleaseAndDestroyUrZeEventList(
 bool ur_event_handle_t_::isProfilingEnabled() const {
   return !UrQueue || // tentatively assume user events are profiling enabled
          (UrQueue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) != 0;
+}
+
+// Tells if this event was created as a timestamp event, allowing profiling
+// info even if profiling is not enabled.
+bool ur_event_handle_t_::isTimestamped() const {
+  // If we are recording, the start time of the event will be non-zero. The
+  // end time might still be missing, depending on whether the corresponding
+  // enqueue is still running.
+  return RecordEventStartTimestamp != 0;
 }

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -674,7 +674,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
       Queue, CommandList, UseCopyEngine, /* AllowBatching */ false));
 
   UR_CALL(createEventAndAssociateQueue(
-      Queue, OutEvent, UR_EXT_COMMAND_TYPE_USER, CommandList,
+      Queue, OutEvent, UR_COMMAND_TIMESTAMP_RECORDING_EXP, CommandList,
       /* IsInternal */ false, /* HostVisible */ true));
   ze_event_handle_t ZeEvent = (*OutEvent)->ZeEvent;
   (*OutEvent)->WaitList = TmpWaitList;

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -196,6 +196,14 @@ struct ur_event_handle_t_ : _ur_object {
   // performance
   bool IsMultiDevice = {false};
 
+  // Indicates the recorded start and end timestamps for the event. These are
+  // only set for events returned by timestamp recording enqueue functions.
+  // A non-zero value for RecordEventStartTimestamp indicates the event was the
+  // result of a timestamp recording. If RecordEventEndTimestamp is non-zero, it
+  // means the event has fetched the end-timestamp from the queue.
+  uint64_t RecordEventStartTimestamp = 0;
+  uint64_t RecordEventEndTimestamp = 0;
+
   // Besides each PI object keeping a total reference count in
   // _ur_object::RefCount we keep special track of the event *external*
   // references. This way we are able to tell when the event is not referenced
@@ -219,6 +227,10 @@ struct ur_event_handle_t_ : _ur_object {
 
   // Tells if this event is with profiling capabilities.
   bool isProfilingEnabled() const;
+
+  // Tells if this event was created as a timestamp event, allowing profiling
+  // info even if profiling is not enabled.
+  bool isTimestamped() const;
 
   // Get the host-visible event or create one and enqueue its signal.
   ur_result_t getOrCreateHostVisibleEvent(ze_event_handle_t &HostVisibleEvent);

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1306,6 +1306,35 @@ ur_result_t ur_queue_handle_t_::active_barriers::clear() {
   return UR_RESULT_SUCCESS;
 }
 
+void ur_queue_handle_t_::clearEndTimeRecordings() {
+  uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
+  const uint64_t TimestampMaxValue =
+      ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
+
+  for (auto Entry : EndTimeRecordings) {
+    auto &Event = Entry.first;
+    auto &EndTimeRecording = Entry.second;
+    if (!Entry.second.EventHasDied) {
+      // Write the result back to the event if it is not dead.
+      uint64_t ContextEndTime =
+          ((*EndTimeRecording.RecordEventEndTimestamp) & TimestampMaxValue) *
+          ZeTimerResolution;
+
+      // Handle a possible wrap-around (the underlying HW counter is < 64-bit).
+      // Note, it will not report correct time if there were multiple wrap
+      // arounds, and the longer term plan is to enlarge the capacity of the
+      // HW timestamps.
+      if (ContextEndTime < Event->RecordEventStartTimestamp)
+        ContextEndTime += TimestampMaxValue * ZeTimerResolution;
+
+      // Store it in the event.
+      Event->RecordEventEndTimestamp = ContextEndTime;
+    }
+    free(EndTimeRecording.RecordEventEndTimestamp);
+  }
+  EndTimeRecordings.clear();
+}
+
 ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
   ur_queue_handle_t UrQueue = reinterpret_cast<ur_queue_handle_t>(Queue);
 
@@ -1332,6 +1361,8 @@ ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
               return ze2urResult(ZeResult);
           }
   }
+
+  Queue->clearEndTimeRecordings();
 
   urPrint("urQueueRelease(compute) NumTimesClosedFull %d, "
           "NumTimesClosedEarly %d\n",
@@ -1462,6 +1493,11 @@ ur_result_t ur_queue_handle_t_::synchronize() {
     }
     LastCommandEvent = nullptr;
   }
+
+  // Since all timestamp recordings should have finished with the
+  // synchronizations, we can clear the map and write the results to the owning
+  // events.
+  clearEndTimeRecordings();
 
   // With the entire queue synchronized, the active barriers must be done so we
   // can remove them.

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -347,6 +347,24 @@ struct ur_queue_handle_t_ : _ur_object {
       std::unordered_map<ur_device_handle_t, std::list<ur_event_handle_t> *>>
       EventCachesDeviceMap{2};
 
+  // End-times enqueued are stored on the queue rather than on the event to
+  // avoid the event objects having been destroyed prior to the write to the
+  // end-time member.
+  struct end_time_recording {
+    // RecordEventEndTimestamp is not adjusted for valid bits nor resolution, as
+    // it is written asynchronously. We use a heap allocation for these so they
+    // do not move after the timestamp recording is given the address to write
+    // the result to.
+    uint64_t *RecordEventEndTimestamp = nullptr;
+    // The event may die before the recording has been written back. In this
+    // case the event will mark this for deletion when the queue sees fit.
+    bool EventHasDied = false;
+  };
+  std::map<ur_event_handle_t, end_time_recording> EndTimeRecordings;
+
+  // Clear the end time recording timestamps entries.
+  void clearEndTimeRecordings();
+
   // adjust the queue's batch size, knowing that the current command list
   // is being closed with a full batch.
   // For copy commands, IsCopy is set to 'true'.

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -123,6 +123,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnGetNativeHandle = urEventGetNativeHandle;
   pDdiTable->pfnCreateWithNativeHandle = urEventCreateWithNativeHandle;
   pDdiTable->pfnSetCallback = urEventSetCallback;
+  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return retVal;
 }

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -123,7 +123,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnGetNativeHandle = urEventGetNativeHandle;
   pDdiTable->pfnCreateWithNativeHandle = urEventCreateWithNativeHandle;
   pDdiTable->pfnSetCallback = urEventSetCallback;
-  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return retVal;
 }
@@ -454,6 +453,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 
   pDdiTable->pfnCooperativeKernelLaunchExp =
       urEnqueueCooperativeKernelLaunchExp;
+  pDdiTable->pfnTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -313,6 +313,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP:
     return ReturnValue(false);
 
+  case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP:
+    return ReturnValue(false);
   default:
     DIE_NO_IMPLEMENTATION;
   }

--- a/source/adapters/native_cpu/event.cpp
+++ b/source/adapters/native_cpu/event.cpp
@@ -87,3 +87,15 @@ urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
 
   DIE_NO_IMPLEMENTATION;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, bool blocking, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = blocking;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -75,6 +75,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
+  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -75,7 +75,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
-  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 
@@ -392,6 +391,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
   }
 
   pDdiTable->pfnCooperativeKernelLaunchExp = nullptr;
+  pDdiTable->pfnTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -3027,6 +3027,36 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    bool blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t
+        *phEvent ///< [in,out] return an event object that identifies
+                 ///< this particular command instance. This event has
+                 ///< profiling info, even if it is not enabled on hQueue.
+    ) try {
+    auto pfnEnqueueTimestampRecordingExp =
+        d_context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
+    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnEnqueueTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -3027,36 +3027,6 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    bool blocking,                ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out] return an event object that identifies
-                 ///< this particular command instance. This event has
-                 ///< profiling info, even if it is not enabled on hQueue.
-    ) try {
-    auto pfnEnqueueTimestampRecordingExp =
-        d_context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
-    if (nullptr == pfnEnqueueTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnEnqueueTimestampRecordingExp(
-        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
@@ -5496,6 +5466,44 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     return result;
 } catch (...) {
     return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command for recording the device timestamp
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -5469,19 +5469,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueue a command for recording the device timestamp
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
-ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool
         blocking, ///< [in] indicates whether the call to this function should block until
@@ -5512,9 +5501,7 @@ ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                                           phEventWaitList, phEvent);
     } else {
         // generic implementation
-        if (nullptr != phEvent) {
-            *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
-        }
+        *phEvent = reinterpret_cast<ur_event_handle_t>(d_context.get());
     }
 
     return result;
@@ -6077,6 +6064,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 
     pDdiTable->pfnCooperativeKernelLaunchExp =
         driver::urEnqueueCooperativeKernelLaunchExp;
+
+    pDdiTable->pfnTimestampRecordingExp =
+        driver::urEnqueueTimestampRecordingExp;
 
     return result;
 } catch (...) {

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -780,6 +780,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT: {
     return ReturnValue(false);
   }
+  case UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP: {
+    return ReturnValue(false);
+  }
   case UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED: {
     bool Supported = false;
     CL_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(

--- a/source/adapters/opencl/event.cpp
+++ b/source/adapters/opencl/event.cpp
@@ -263,3 +263,9 @@ urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
                                           CallbackType, ClCallback, Callback));
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueTimestampRecordingExp(ur_queue_handle_t, bool, uint32_t,
+                               const ur_event_handle_t *, ur_event_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -77,7 +77,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
-  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 
@@ -398,6 +397,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 
   pDdiTable->pfnCooperativeKernelLaunchExp =
       urEnqueueCooperativeKernelLaunchExp;
+  pDdiTable->pfnTimestampRecordingExp = urEnqueueTimestampRecordingExp;
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -77,6 +77,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
   pDdiTable->pfnRetain = urEventRetain;
   pDdiTable->pfnSetCallback = urEventSetCallback;
   pDdiTable->pfnWait = urEventWait;
+  pDdiTable->pfnEnqueueTimestampRecordingExp = urEnqueueTimestampRecordingExp;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3209,9 +3209,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                  ///< this particular command instance. This event has
                  ///< profiling info, even if it is not enabled on hQueue.
 ) {
-    auto pfnEnqueueTimestampRecordingExp =
-        context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
-    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+    auto pfnTimestampRecordingExp =
+        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -3221,7 +3221,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         context.notify_begin(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
                              "urEnqueueTimestampRecordingExp", &params);
 
-    ur_result_t result = pfnEnqueueTimestampRecordingExp(
+    ur_result_t result = pfnTimestampRecordingExp(
         hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback",

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3215,7 +3215,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    ur_enqueue_timestamp_recording_exp_t params = {
+    ur_enqueue_timestamp_recording_exp_params_t params = {
         &hQueue, &blocking, &numEventsInWaitList, &phEventWaitList, &phEvent};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3192,6 +3192,45 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    bool blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t
+        *phEvent ///< [in,out] return an event object that identifies
+                 ///< this particular command instance. This event has
+                 ///< profiling info, even if it is not enabled on hQueue.
+) {
+    auto pfnEnqueueTimestampRecordingExp =
+        context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
+    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    ur_enqueue_timestamp_recording_exp_t params = {
+        &hQueue, &blocking, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
+                             "urEnqueueTimestampRecordingExp", &params);
+
+    ur_result_t result = pfnEnqueueTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback",
+                       &params, &result, instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3251,52 +3251,6 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool
-        blocking, ///< [in] indicates whether the call to this function should block until
-    ///< until the device timestamp recording command has executed on the
-    ///< device.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out] return an event object that identifies this particular kernel
-                ///< execution instance. Profiling information can be queried
-    ///< from this event as if `hQueue` had profiling enabled. Querying
-    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
-    ///< reports the timestamp at the time of the call to this function.
-    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
-    ///< reports the timestamp recorded when the command is executed on the device.
-) {
-    auto pfnTimestampRecordingExp =
-        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
-
-    if (nullptr == pfnTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
-    }
-
-    ur_enqueue_timestamp_recording_exp_params_t params = {
-        &hQueue, &blocking, &numEventsInWaitList, &phEventWaitList, &phEvent};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
-                             "urEnqueueTimestampRecordingExp", &params);
-
-    ur_result_t result = pfnTimestampRecordingExp(
-        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
-
-    context.notify_end(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
-                       "urEnqueueTimestampRecordingExp", &params, &result,
-                       instance);
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
 __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
@@ -6111,6 +6065,52 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
         UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
         "urKernelSuggestMaxCooperativeGroupCountExp", &params, &result,
         instance);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+) {
+    auto pfnTimestampRecordingExp =
+        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+
+    if (nullptr == pfnTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    ur_enqueue_timestamp_recording_exp_params_t params = {
+        &hQueue, &blocking, &numEventsInWaitList, &phEventWaitList, &phEvent};
+    uint64_t instance =
+        context.notify_begin(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
+                             "urEnqueueTimestampRecordingExp", &params);
+
+    ur_result_t result = pfnTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+
+    context.notify_end(UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP,
+                       "urEnqueueTimestampRecordingExp", &params, &result,
+                       instance);
 
     return result;
 }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -4400,6 +4400,60 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    bool blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t
+        *phEvent ///< [in,out] return an event object that identifies
+                 ///< this particular command instance. This event has
+                 ///< profiling info, even if it is not enabled on hQueue.
+) {
+    auto pfnEnqueueTimestampRecordingExp =
+        context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
+    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phEvent) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
+                if (phEventWaitList[i] == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
+    }
+
+    return pfnEnqueueTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -496,7 +496,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName) {
+        if (UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
@@ -4397,60 +4397,6 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
         pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
 
     return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    bool blocking,                ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out] return an event object that identifies
-                 ///< this particular command instance. This event has
-                 ///< profiling info, even if it is not enabled on hQueue.
-) {
-    auto pfnTimestampRecordingExp =
-        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
-    if (nullptr == pfnTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    if (context.enableParameterValidation) {
-        if (NULL == hQueue) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == phEvent) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
-        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
-            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
-        }
-
-        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
-            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
-        }
-
-        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
-            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
-                if (phEventWaitList[i] == NULL) {
-                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
-                }
-            }
-        }
-    }
-
-    return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
-                                    phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8918,6 +8864,65 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+) {
+    auto pfnTimestampRecordingExp =
+        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+
+    if (nullptr == pfnTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    if (context.enableParameterValidation) {
+        if (NULL == hQueue) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
+        if (NULL == phEvent) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList > 0) {
+            for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
+                if (phEventWaitList[i] == NULL) {
+                    return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+                }
+            }
+        }
+    }
+
+    if (context.enableLifetimeValidation &&
+        !refCountContext.isReferenceValid(hQueue)) {
+        refCountContext.logInvalidReference(hQueue);
+    }
+
+    ur_result_t result = pfnTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
 __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
@@ -9725,6 +9730,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
         pDdiTable->pfnCooperativeKernelLaunchExp;
     pDdiTable->pfnCooperativeKernelLaunchExp =
         ur_validation_layer::urEnqueueCooperativeKernelLaunchExp;
+
+    dditable.pfnTimestampRecordingExp = pDdiTable->pfnTimestampRecordingExp;
+    pDdiTable->pfnTimestampRecordingExp =
+        ur_validation_layer::urEnqueueTimestampRecordingExp;
 
     return result;
 }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -4417,9 +4417,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                  ///< this particular command instance. This event has
                  ///< profiling info, even if it is not enabled on hQueue.
 ) {
-    auto pfnEnqueueTimestampRecordingExp =
-        context.urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
-    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+    auto pfnTimestampRecordingExp =
+        context.urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -4449,8 +4449,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         }
     }
 
-    return pfnEnqueueTimestampRecordingExp(
-        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                    phEventWaitList, phEvent);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4067,69 +4067,6 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    bool
-        blocking, ///< [in] indicates whether the call to this function should block until
-    ///< until the device timestamp recording command has executed on the
-    ///< device.
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-    ///< events that must be complete before the kernel execution.
-    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
-    ///< event.
-    ur_event_handle_t *
-        phEvent ///< [in,out] return an event object that identifies this particular kernel
-                ///< execution instance. Profiling information can be queried
-    ///< from this event as if `hQueue` had profiling enabled. Querying
-    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
-    ///< reports the timestamp at the time of the call to this function.
-    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
-    ///< reports the timestamp recorded when the command is executed on the device.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnTimestampRecordingExp =
-        dditable->ur.EnqueueExp.pfnTimestampRecordingExp;
-    if (nullptr == pfnTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
-
-    // convert loader handles to platform handles
-    auto phEventWaitListLocal =
-        std::vector<ur_event_handle_t>(numEventsInWaitList);
-    for (size_t i = 0; i < numEventsInWaitList; ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
-    }
-
-    // forward to device-platform
-    result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
-                                      phEventWaitListLocal.data(), phEvent);
-
-    if (UR_RESULT_SUCCESS != result) {
-        return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phEvent = reinterpret_cast<ur_event_handle_t>(
-            ur_event_factory.getInstance(*phEvent, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
 __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
@@ -7658,6 +7595,69 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     // forward to device-platform
     result = pfnSuggestMaxCooperativeGroupCountExp(
         hKernel, localWorkSize, dynamicSharedMemorySize, pGroupCountRet);
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
+    auto pfnTimestampRecordingExp =
+        dditable->ur.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal =
+        std::vector<ur_event_handle_t>(numEventsInWaitList);
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                      phEventWaitListLocal.data(), phEvent);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phEvent = reinterpret_cast<ur_event_handle_t>(
+            ur_event_factory.getInstance(*phEvent, dditable));
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3990,65 +3990,6 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    bool blocking,                ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out] return an event object that identifies
-                 ///< this particular command instance. This event has
-                 ///< profiling info, even if it is not enabled on hQueue.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-
-    // extract platform's function pointer table
-    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnTimestampRecordingExp =
-        dditable->ur.EnqueueExp.pfnTimestampRecordingExp;
-    if (nullptr == pfnTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    // convert loader handle to platform handle
-    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
-
-    // convert loader handles to platform handles
-    auto phEventWaitListLocal =
-        std::vector<ur_event_handle_t>(numEventsInWaitList);
-    for (size_t i = 0; i < numEventsInWaitList; ++i) {
-        phEventWaitListLocal[i] =
-            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
-    }
-
-    result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
-                                      phEventWaitListLocal.data(), phEvent);
-
-    if (UR_RESULT_SUCCESS != result) {
-        return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        if (nullptr != phEvent) {
-            *phEvent = reinterpret_cast<ur_event_handle_t>(
-                ur_event_factory.getInstance(*phEvent, dditable));
-        }
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
@@ -4118,6 +4059,69 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
             *phEvent = reinterpret_cast<ur_event_handle_t>(
                 ur_event_factory.getInstance(*phEvent, dditable));
         }
+    } catch (std::bad_alloc &) {
+        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    }
+
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urEnqueueTimestampRecordingExp
+__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+
+    // extract platform's function pointer table
+    auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
+    auto pfnTimestampRecordingExp =
+        dditable->ur.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    // convert loader handle to platform handle
+    hQueue = reinterpret_cast<ur_queue_object_t *>(hQueue)->handle;
+
+    // convert loader handles to platform handles
+    auto phEventWaitListLocal =
+        std::vector<ur_event_handle_t>(numEventsInWaitList);
+    for (size_t i = 0; i < numEventsInWaitList; ++i) {
+        phEventWaitListLocal[i] =
+            reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
+    }
+
+    // forward to device-platform
+    result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                      phEventWaitListLocal.data(), phEvent);
+
+    if (UR_RESULT_SUCCESS != result) {
+        return result;
+    }
+
+    try {
+        // convert platform handle to loader handle
+        *phEvent = reinterpret_cast<ur_event_handle_t>(
+            ur_event_factory.getInstance(*phEvent, dditable));
     } catch (std::bad_alloc &) {
         result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -8378,6 +8382,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
             // return pointers to loader's DDIs
             pDdiTable->pfnCooperativeKernelLaunchExp =
                 ur_loader::urEnqueueCooperativeKernelLaunchExp;
+            pDdiTable->pfnTimestampRecordingExp =
+                ur_loader::urEnqueueTimestampRecordingExp;
         } else {
             // return pointers directly to platform's DDIs
             *pDdiTable =

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4011,9 +4011,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
-    auto pfnEnqueueTimestampRecordingExp =
-        dditable->ur.EnqueueExp.pfnEnqueueTimestampRecordingExp;
-    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+    auto pfnTimestampRecordingExp =
+        dditable->ur.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -4028,9 +4028,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
             reinterpret_cast<ur_event_object_t *>(phEventWaitList[i])->handle;
     }
 
-    result =
-        pfnEnqueueTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
-                                        phEventWaitListLocal.data(), phEvent);
+    result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                      phEventWaitListLocal.data(), phEvent);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4012,7 +4012,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_queue_object_t *>(hQueue)->dditable;
     auto pfnEnqueueTimestampRecordingExp =
-        dditable->ur.Event.pfnEnqueueTimestampRecordingExp;
+        dditable->ur.EnqueueExp.pfnEnqueueTimestampRecordingExp;
     if (nullptr == pfnEnqueueTimestampRecordingExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -4706,14 +4706,14 @@ ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                  ///< this particular command instance. This event has
                  ///< profiling info, even if it is not enabled on hQueue.
     ) try {
-    auto pfnEnqueueTimestampRecordingExp =
-        ur_lib::context->urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
-    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+    auto pfnTimestampRecordingExp =
+        ur_lib::context->urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnEnqueueTimestampRecordingExp(
-        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                    phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -842,7 +842,7 @@ ur_result_t UR_APICALL urDeviceGetSelected(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -4676,49 +4676,6 @@ ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueues a timestamp recording to be stored in the resulting event.
-///
-/// @details
-///     - TODO
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    bool blocking,                ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out] return an event object that identifies
-                 ///< this particular command instance. This event has
-                 ///< profiling info, even if it is not enabled on hQueue.
-    ) try {
-    auto pfnTimestampRecordingExp =
-        ur_lib::context->urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
-    if (nullptr == pfnTimestampRecordingExp) {
-        return UR_RESULT_ERROR_UNINITIALIZED;
-    }
-
-    return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
-                                    phEventWaitList, phEvent);
-} catch (...) {
-    return exceptionToResult(std::current_exception());
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
 /// @remarks
@@ -8226,6 +8183,52 @@ ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
     return pfnSuggestMaxCooperativeGroupCountExp(
         hKernel, localWorkSize, dynamicSharedMemorySize, pGroupCountRet);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command for recording the device timestamp
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
+    ) try {
+    auto pfnTimestampRecordingExp =
+        ur_lib::context->urDdiTable.EnqueueExp.pfnTimestampRecordingExp;
+    if (nullptr == pfnTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
+                                    phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -4676,6 +4676,49 @@ ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueues a timestamp recording to be stored in the resulting event.
+///
+/// @details
+///     - TODO
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    bool blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t
+        *phEvent ///< [in,out] return an event object that identifies
+                 ///< this particular command instance. This event has
+                 ///< profiling info, even if it is not enabled on hQueue.
+    ) try {
+    auto pfnEnqueueTimestampRecordingExp =
+        ur_lib::context->urDdiTable.Event.pfnEnqueueTimestampRecordingExp;
+    if (nullptr == pfnEnqueueTimestampRecordingExp) {
+        return UR_RESULT_ERROR_UNINITIALIZED;
+    }
+
+    return pfnEnqueueTimestampRecordingExp(
+        hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
+} catch (...) {
+    return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
 /// @remarks

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -1645,6 +1645,14 @@ ur_result_t urPrintEnqueueCooperativeKernelLaunchExpParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintEnqueueTimestampRecordingExpParams(
+    const struct ur_enqueue_timestamp_recording_exp_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t
 urPrintEventGetInfoParams(const struct ur_event_get_info_params_t *params,
                           char *buffer, const size_t buff_size,

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -736,7 +736,7 @@ ur_result_t UR_APICALL urDeviceGetSelected(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -3957,41 +3957,6 @@ ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Enqueues a timestamp recording to be stored in the resulting event.
-///
-/// @details
-///     - TODO
-///
-/// @returns
-///     - ::UR_RESULT_SUCCESS
-///     - ::UR_RESULT_ERROR_UNINITIALIZED
-///     - ::UR_RESULT_ERROR_DEVICE_LOST
-///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hQueue`
-///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == phEvent`
-ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
-    bool blocking,                ///< [in] blocking or non-blocking enqueue
-    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
-    ur_event_handle_t
-        *phEvent ///< [in,out] return an event object that identifies
-                 ///< this particular command instance. This event has
-                 ///< profiling info, even if it is not enabled on hQueue.
-) {
-    ur_result_t result = UR_RESULT_SUCCESS;
-    return result;
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
 /// @remarks
@@ -6945,6 +6910,44 @@ ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
         dynamicSharedMemorySize, ///< [in] size of dynamic shared memory, for each work-group, in bytes,
     ///< that will be used when the kernel is launched
     uint32_t *pGroupCountRet ///< [out] pointer to maximum number of groups
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueue a command for recording the device timestamp
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue, ///< [in] handle of the queue object
+    bool
+        blocking, ///< [in] indicates whether the call to this function should block until
+    ///< until the device timestamp recording command has executed on the
+    ///< device.
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t *
+        phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+    ///< events that must be complete before the kernel execution.
+    ///< If nullptr, the numEventsInWaitList must be 0, indicating that no wait
+    ///< event.
+    ur_event_handle_t *
+        phEvent ///< [in,out] return an event object that identifies this particular kernel
+                ///< execution instance. Profiling information can be queried
+    ///< from this event as if `hQueue` had profiling enabled. Querying
+    ///< `UR_PROFILING_INFO_COMMAND_QUEUED` or `UR_PROFILING_INFO_COMMAND_SUBMIT`
+    ///< reports the timestamp at the time of the call to this function.
+    ///< Querying `UR_PROFILING_INFO_COMMAND_START` or `UR_PROFILING_INFO_COMMAND_END`
+    ///< reports the timestamp recorded when the command is executed on the device.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3957,6 +3957,41 @@ ur_result_t UR_APICALL urEventSetCallback(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Enqueues a timestamp recording to be stored in the resulting event.
+///
+/// @details
+///     - TODO
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hQueue`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == phEvent`
+ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+    ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
+    bool blocking,                ///< [in] blocking or non-blocking enqueue
+    uint32_t numEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t
+        *phEvent ///< [in,out] return an event object that identifies
+                 ///< this particular command instance. This event has
+                 ///< profiling info, even if it is not enabled on hQueue.
+) {
+    ur_result_t result = UR_RESULT_SUCCESS;
+    return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
 /// @remarks

--- a/test/conformance/enqueue/CMakeLists.txt
+++ b/test/conformance/enqueue/CMakeLists.txt
@@ -29,4 +29,5 @@ add_conformance_test_with_kernels_environment(enqueue
     urEnqueueUSMPrefetch.cpp
     urEnqueueReadHostPipe.cpp
     urEnqueueWriteHostPipe.cpp
+    urEnqueueTimestampRecording.cpp
     )

--- a/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -25,18 +25,19 @@ void common_check(ur_queue_handle_t queue, ur_event_handle_t event) {
     uint64_t queuedTime = 0, submitTime = 0, startTime = 0, endTime = 0;
     ASSERT_SUCCESS(
         urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_QUEUED,
-                                sizeof(uint64_t), queuedTime, nullptr));
+                                sizeof(uint64_t), &queuedTime, nullptr));
     ASSERT_SUCCESS(
         urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_SUBMIT,
-                                sizeof(uint64_t), submitTime, nullptr));
+                                sizeof(uint64_t), &submitTime, nullptr));
     ASSERT_SUCCESS(
         urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_START,
-                                sizeof(uint64_t), startTime, nullptr));
+                                sizeof(uint64_t), &startTime, nullptr));
     ASSERT_SUCCESS(
         urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_SUBMIT,
                                 sizeof(uint64_t), submitTime, nullptr));
     ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_END,
-                                           sizeof(uint64_t), endTime, nullptr));
+                                           sizeof(uint64_t), &endTime,
+                                           nullptr));
     ASSERT_TRUE(queuedTime > 0);
     ASSERT_TRUE(submitTime > 0);
     ASSERT_TRUE(startTime > 0);
@@ -47,7 +48,7 @@ void common_check(ur_queue_handle_t queue, ur_event_handle_t event) {
 }
 
 TEST_P(urEnqueueTimestampRecordingExpTest, Success) {
-    ur_event_handle_t event = nulltpr;
+    ur_event_handle_t event = nullptr;
     ASSERT_SUCCESS(
         urEnqueueTimestampRecordingExp(queue, false, 0, nullptr, &event));
     ASSERT_SUCCESS(urQueueFinish(queue));
@@ -56,7 +57,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, Success) {
 }
 
 TEST_P(urEnqueueTimestampRecordingExpTest, SuccessBlocking) {
-    ur_event_handle_t event = nulltpr;
+    ur_event_handle_t event = nullptr;
     ASSERT_SUCCESS(
         urEnqueueTimestampRecordingExp(queue, true, 0, nullptr, &event));
     common_check(queue, event);
@@ -64,7 +65,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, SuccessBlocking) {
 }
 
 TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullHandleQueue) {
-    ur_event_handle_t event = nulltpr;
+    ur_event_handle_t event = nullptr;
     ASSERT_EQ_RESULT(
         urEnqueueTimestampRecordingExp(nullptr, false, 0, nullptr, &event),
         UR_RESULT_ERROR_INVALID_NULL_HANDLE);
@@ -77,7 +78,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPointerEvent) {
 }
 
 TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPtrEventWaitList) {
-    ur_event_handle_t event = nulltpr;
+    ur_event_handle_t event = nullptr;
     ASSERT_EQ_RESULT(
         urEnqueueTimestampRecordingExp(queue, true, 1, nullptr, &event),
         UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);

--- a/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -1,0 +1,96 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <uur/fixtures.h>
+
+struct urEnqueueTimestampRecordingExpTest : uur::urQueueTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
+        bool timestamp_recording_support = false;
+        ASSERT_SUCCESS(uur::GetTimestampRecordingSupport(
+            device, timestamp_recording_support));
+        if (!timestamp_recording_support) {
+            GTEST_SKIP() << "Timestamp recording is not supported";
+        }
+    }
+
+    void TearDown() override { urQueueTest::TearDown(); }
+};
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueTimestampRecordingExpTest);
+
+void common_check(ur_queue_handle_t queue, ur_event_handle_t event) {
+    // All successful runs should return a non-zero profiling results.
+    uint64_t queuedTime = 0, submitTime = 0, startTime = 0, endTime = 0;
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_QUEUED,
+                                sizeof(uint64_t), queuedTime, nullptr));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_SUBMIT,
+                                sizeof(uint64_t), submitTime, nullptr));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_START,
+                                sizeof(uint64_t), startTime, nullptr));
+    ASSERT_SUCCESS(
+        urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_SUBMIT,
+                                sizeof(uint64_t), submitTime, nullptr));
+    ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_END,
+                                           sizeof(uint64_t), endTime, nullptr));
+    ASSERT_TRUE(queuedTime > 0);
+    ASSERT_TRUE(submitTime > 0);
+    ASSERT_TRUE(startTime > 0);
+    ASSERT_TRUE(endTime > 0);
+    ASSERT_TRUE(queuedTime == submitTime);
+    ASSERT_TRUE(startTime == endTime);
+    ASSERT_TRUE(endTime >= submitTime);
+}
+
+TEST_P(urEnqueueTimestampRecordingExpTest, Success) {
+    ur_event_handle_t event = nulltpr;
+    ASSERT_SUCCESS(
+        urEnqueueTimestampRecordingExp(queue, false, 0, nullptr, &event));
+    ASSERT_SUCCESS(urQueueFinish(queue));
+    common_check(queue, event);
+    ASSERT_SUCCESS(urEventRelease(event));
+}
+
+TEST_P(urEnqueueTimestampRecordingExpTest, SuccessBlocking) {
+    ur_event_handle_t event = nulltpr;
+    ASSERT_SUCCESS(
+        urEnqueueTimestampRecordingExp(queue, true, 0, nullptr, &event));
+    common_check(queue, event);
+    ASSERT_SUCCESS(urEventRelease(event));
+}
+
+TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullHandleQueue) {
+    ur_event_handle_t event = nulltpr;
+    ASSERT_EQ_RESULT(
+        urEnqueueTimestampRecordingExp(nullptr, false, 0, nullptr, &event),
+        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPointerEvent) {
+    ASSERT_EQ_RESULT(
+        urEnqueueTimestampRecordingExp(queue, false, 0, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}
+
+TEST_P(urEnqueueTimestampRecordingExpTest, InvalidNullPtrEventWaitList) {
+    ur_event_handle_t event = nulltpr;
+    ASSERT_EQ_RESULT(
+        urEnqueueTimestampRecordingExp(queue, true, 1, nullptr, &event),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+
+    ur_event_handle_t validEvent;
+    ASSERT_SUCCESS(urEnqueueEventsWait(queue, 0, nullptr, &validEvent));
+    ASSERT_EQ_RESULT(
+        urEnqueueTimestampRecordingExp(queue, true, 0, &validEvent, &event),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+    ASSERT_SUCCESS(urEventRelease(validEvent));
+
+    ur_event_handle_t invalidEvent = nullptr;
+    ASSERT_EQ_RESULT(
+        urEnqueueTimestampRecordingExp(queue, true, 0, &invalidEvent, &event),
+        UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
+}

--- a/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -20,7 +20,7 @@ struct urEnqueueTimestampRecordingExpTest : uur::urQueueTest {
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueTimestampRecordingExpTest);
 
-void common_check(ur_queue_handle_t queue, ur_event_handle_t event) {
+void common_check(ur_event_handle_t event) {
     // All successful runs should return a non-zero profiling results.
     uint64_t queuedTime = 0, submitTime = 0, startTime = 0, endTime = 0;
     ASSERT_SUCCESS(
@@ -32,9 +32,6 @@ void common_check(ur_queue_handle_t queue, ur_event_handle_t event) {
     ASSERT_SUCCESS(
         urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_START,
                                 sizeof(uint64_t), &startTime, nullptr));
-    ASSERT_SUCCESS(
-        urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_SUBMIT,
-                                sizeof(uint64_t), submitTime, nullptr));
     ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_END,
                                            sizeof(uint64_t), &endTime,
                                            nullptr));
@@ -52,7 +49,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, Success) {
     ASSERT_SUCCESS(
         urEnqueueTimestampRecordingExp(queue, false, 0, nullptr, &event));
     ASSERT_SUCCESS(urQueueFinish(queue));
-    common_check(queue, event);
+    common_check(event);
     ASSERT_SUCCESS(urEventRelease(event));
 }
 
@@ -60,7 +57,7 @@ TEST_P(urEnqueueTimestampRecordingExpTest, SuccessBlocking) {
     ur_event_handle_t event = nullptr;
     ASSERT_SUCCESS(
         urEnqueueTimestampRecordingExp(queue, true, 0, nullptr, &event));
-    common_check(queue, event);
+    common_check(event);
     ASSERT_SUCCESS(urEventRelease(event));
 }
 

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -395,6 +395,8 @@ ur_result_t GetDeviceMaxComputeQueueIndices(ur_device_handle_t device,
                                             uint32_t &max_indices);
 ur_result_t GetDeviceHostPipeRWSupported(ur_device_handle_t device,
                                          bool &support);
+ur_result_t GetTimestampRecordingSupport(ur_device_handle_t device,
+                                         bool &support);
 
 ur_device_partition_property_t makePartitionByCountsDesc(uint32_t count);
 

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -635,6 +635,12 @@ ur_result_t GetDeviceHostPipeRWSupported(ur_device_handle_t device,
         device, UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED, support);
 }
 
+ur_result_t GetTimestampRecordingSupport(ur_device_handle_t device,
+                                         bool &support) {
+    return GetDeviceInfo<bool>(
+        device, UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP, support);
+}
+
 ur_device_partition_property_t makePartitionByCountsDesc(uint32_t count) {
     ur_device_partition_property_t desc;
     desc.type = UR_DEVICE_PARTITION_BY_COUNTS;

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -378,5 +378,8 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
     std::cout << prefix;
     printDeviceInfo<ur_bool_t>(
         hDevice, UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice,
+                               UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP);
 }
 } // namespace urinfo


### PR DESCRIPTION
This commit adds a new extension feature for recording timestamps into events, the information from which can be queried using the existing profiling queries.