### PR TITLE
[test] Fix infinite loop when we run out of input

### DIFF
--- a/cmake/match.py
+++ b/cmake/match.py
@@ -93,6 +93,18 @@ def main():
             print_incorrect_match(match_idx + 1, input_lines[input_idx].strip(), "");
             print_content(input_lines, match_lines, ignored_lines)
             sys.exit(1)
+        elif status == Status.INPUT_END:
+        # If we get to the end of the input, but still have pending matches,
+        # then that's a failure unless all pending matches are optional -
+        # otherwise we're done
+            while match_idx < len(match_lines):
+                if not (match_lines[match_idx].startswith(Tag.OPT.value) or
+                        match_lines[match_idx].startswith(Tag.IGNORE.value)):
+                    print_incorrect_match(match_idx + 1, "", match_lines[match_idx]);
+                    print_content(input_lines, match_lines, ignored_lines)
+                    sys.exit(1)
+                match_idx += 1
+            sys.exit(0)
 
         input_line = input_lines[input_idx].strip() if input_idx < len(input_lines) else ""
         match_line = match_lines[match_idx]


### PR DESCRIPTION
d6930c70bd7 introduced `Status.INPUT_END` but didn't introduce the means to handle that eventuality. It looks like the intention might have been to exit with success if we've got to the end of input. However, if we run out of input and still have matches pending, I'm treating this as a failure.

Infinite loop reproducer:
[_matchtmpfile.txt](https://github.com/oneapi-src/unified-runtime/files/14438706/_matchtmpfile.txt)
[input.txt](https://github.com/oneapi-src/unified-runtime/files/14438708/input.txt)
