### PR TITLE
[cuda][hip] Removed bad event wait constraint / use scopedContext correctly.

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -220,13 +220,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(ur_event_handle_t,
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   try {
-    auto Context = phEventWaitList[0]->getContext();
-    ScopedContext Active(Context);
+    ScopedContext Active(phEventWaitList[0]->getContext());
 
-    auto WaitFunc = [Context](ur_event_handle_t Event) -> ur_result_t {
+    auto WaitFunc = [](ur_event_handle_t Event) -> ur_result_t {
       UR_ASSERT(Event, UR_RESULT_ERROR_INVALID_EVENT);
-      UR_ASSERT(Event->getContext() == Context,
-                UR_RESULT_ERROR_INVALID_CONTEXT);
 
       return Event->wait();
     };

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -190,14 +190,9 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   UR_ASSERT(numEvents > 0, UR_RESULT_ERROR_INVALID_VALUE);
 
   try {
-
-    auto Context = phEventWaitList[0]->getContext();
     ScopedContext Active(phEventWaitList[0]->getDevice());
-
-    auto WaitFunc = [Context](ur_event_handle_t Event) -> ur_result_t {
+    auto WaitFunc = [](ur_event_handle_t Event) -> ur_result_t {
       UR_ASSERT(Event, UR_RESULT_ERROR_INVALID_EVENT);
-      UR_ASSERT(Event->getContext() == Context,
-                UR_RESULT_ERROR_INVALID_CONTEXT);
 
       return Event->wait();
     };


### PR DESCRIPTION
There is no reason to not allow waits from native hip/cuda events in different sycl "contexts".
Even the sycl spec does not mandate such a thing. This constraint does not appear to be applied in L0 backend.
This also fixes scopedContext to set the per device (CU/HIP)context.

This is a fix for https://github.com/intel/llvm/issues/6749#issuecomment-1971875971