### PR TITLE
[conformance] Don't give tests latitude to segfault

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_cuda.match
+++ b/test/conformance/enqueue/enqueue_adapter_cuda.match
@@ -56,4 +56,3 @@
 {{OPT}}urEnqueueUSMMemcpy2DNegativeTest.InvalidEventWaitList/NVIDIA_CUDA_BACKEND___{{.*}}___pitch__1__width__1__height__1
 {{OPT}}urEnqueueUSMPrefetchWithParamTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_USM_MIGRATION_FLAG_DEFAULT
 {{OPT}}urEnqueueUSMPrefetchWithParamTest.CheckWaitEvent/NVIDIA_CUDA_BACKEND___{{.*}}___UR_USM_MIGRATION_FLAG_DEFAULT
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/enqueue/enqueue_adapter_hip.match
+++ b/test/conformance/enqueue/enqueue_adapter_hip.match
@@ -84,4 +84,3 @@
 {{OPT}}urEnqueueUSMPrefetchWithParamTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_USM_MIGRATION_FLAG_DEFAULT
 {{OPT}}urEnqueueUSMPrefetchWithParamTest.CheckWaitEvent/AMD_HIP_BACKEND___{{.*}}___UR_USM_MIGRATION_FLAG_DEFAULT
 {{OPT}}urEnqueueUSMPrefetchTest.InvalidSizeTooLarge/AMD_HIP_BACKEND___{{.*}}_
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/enqueue/enqueue_adapter_level_zero.match
+++ b/test/conformance/enqueue/enqueue_adapter_level_zero.match
@@ -1,3 +1,2 @@
 {{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urEnqueueEventsWaitTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
-{{Segmentation fault|Aborted}}

--- a/test/conformance/enqueue/enqueue_adapter_native_cpu.match
+++ b/test/conformance/enqueue/enqueue_adapter_native_cpu.match
@@ -1,1 +1,0 @@
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/event/event_adapter_level_zero.match
+++ b/test/conformance/event/event_adapter_level_zero.match
@@ -1,4 +1,3 @@
 {{OPT}}urEventGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_EVENT_INFO_COMMAND_TYPE
 {{OPT}}urEventGetProfilingInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_PROFILING_INFO_COMMAND_QUEUED
 {{OPT}}urEventGetProfilingInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_PROFILING_INFO_COMMAND_SUBMIT
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_hip.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_hip.match
@@ -1,4 +1,3 @@
-{{OPT}}{{Segmentation fault|Aborted}}
 {{OPT}}BufferFillCommandTest.UpdateParameters/AMD_HIP_BACKEND{{.*}}
 {{OPT}}BufferFillCommandTest.UpdateGlobalSize/AMD_HIP_BACKEND{{.*}}
 {{OPT}}BufferFillCommandTest.SeparateUpdateCalls/AMD_HIP_BACKEND{{.*}}

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
@@ -1,1 +1,0 @@
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/kernel/kernel_adapter_cuda.match
+++ b/test/conformance/kernel/kernel_adapter_cuda.match
@@ -6,4 +6,3 @@
 {{OPT}}urKernelSetArgPointerNegativeTest.InvalidKernelArgumentIndex/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urKernelSetArgSamplerTest.InvalidKernelArgumentIndex/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urKernelSetArgValueTest.InvalidKernelArgumentIndex/NVIDIA_CUDA_BACKEND___{{.*}}_
-{{OPT}}Segmentation fault

--- a/test/conformance/kernel/kernel_adapter_hip.match
+++ b/test/conformance/kernel/kernel_adapter_hip.match
@@ -22,4 +22,3 @@
 {{OPT}}urKernelSetSpecializationConstantsTest.InvalidNullHandleKernel/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urKernelSetSpecializationConstantsTest.InvalidNullPointerSpecConstants/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urKernelSetSpecializationConstantsTest.InvalidSizeCount/AMD_HIP_BACKEND___{{.*}}_
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/kernel/kernel_adapter_native_cpu.match
+++ b/test/conformance/kernel/kernel_adapter_native_cpu.match
@@ -1,1 +1,0 @@
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/memory/memory_adapter_level_zero.match
+++ b/test/conformance/memory/memory_adapter_level_zero.match
@@ -6,4 +6,3 @@ urMemBufferPartitionTest.InvalidBufferSize/Intel_R__oneAPI_Unified_Runtime_over_
 urMemBufferPartitionTest.InvalidValueCreateType/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE
-{{Segmentation fault|Aborted}}

--- a/test/conformance/program/program_adapter_hip.match
+++ b/test/conformance/program/program_adapter_hip.match
@@ -22,4 +22,3 @@
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES
 {{OPT}}urProgramLinkTest.Success/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramSetSpecializationConstantsTest.Success/AMD_HIP_BACKEND___{{.*}}_
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -1,1 +1,0 @@
-{{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/queue/queue_adapter_level_zero.match
+++ b/test/conformance/queue/queue_adapter_level_zero.match
@@ -1,1 +1,0 @@
-{{Segmentation fault|Aborted}}


### PR DESCRIPTION
There is no point in running a test if it's allowed to segfault (unless maybe we're testing an operating system kernel). If a test can optionally segfault, it's worse than not running the test at all and only serves the illusion of test coverage and progress.