### PR TITLE
[CI] Skip E2E tests on forks

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -41,6 +41,7 @@ permissions:
 
 jobs:
   e2e-build-hw:
+    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
     name: Build SYCL, UR, run E2E
     strategy:
       matrix:


### PR DESCRIPTION
Added missing skip for HW-related (E2E) jobs. They will always fail on forks without this `if`.