### PR TITLE
[CMake] Support external adapter source dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,16 @@ set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
 set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
     "List of sycl targets to build CTS device binaries for")
 set(UR_CONFORMANCE_AMD_ARCH "" CACHE STRING "AMD device target ID to build CTS binaries for")
+set(UR_ADAPTER_LEVEL_ZERO_SOURCE_DIR "" CACHE PATH
+    "Path to external 'level_zero' adapter source dir")
+set(UR_ADAPTER_OPENCL_SOURCE_DIR "" CACHE PATH
+    "Path to external 'opencl' adapter source dir")
+set(UR_ADAPTER_CUDA_SOURCE_DIR "" CACHE PATH
+    "Path to external 'cuda' adapter source dir")
+set(UR_ADAPTER_HIP_SOURCE_DIR "" CACHE PATH
+    "Path to external 'hip' adapter source dir")
+set(UR_ADAPTER_NATIVE_CPU_SOURCE_DIR "" CACHE PATH
+    "Path to external 'native_cpu' adapter source dir")
 
 include(Assertions)
 

--- a/source/adapters/CMakeLists.txt
+++ b/source/adapters/CMakeLists.txt
@@ -30,21 +30,37 @@ endfunction()
 
 add_subdirectory(null)
 
+function(add_ur_adapter_subdirectory name)
+    string(TOUPPER ${name} NAME)
+    if(UR_ADAPTER_${NAME}_SOURCE_DIR)
+        if(NOT IS_DIRECTORY ${UR_ADAPTER_${NAME}_SOURCE_DIR})
+            message(FATAL_ERROR
+                "UR_ADAPTER_${NAME}_SOURCE_DIR is not a directory: "
+                "${UR_ADAPTER_${NAME}_SOURCE_DIR}")
+        endif()
+        add_subdirectory(
+            "${UR_ADAPTER_${NAME}_SOURCE_DIR}"
+            "${CMAKE_CURRENT_BINARY_DIR}/${name}")
+    else()
+        add_subdirectory(${name})
+    endif()
+endfunction()
+
 if(UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_ALL)
-    add_subdirectory(level_zero)
+    add_ur_adapter_subdirectory(level_zero)
 endif()
 
 if(UR_BUILD_ADAPTER_CUDA OR UR_BUILD_ADAPTER_ALL)
-    add_subdirectory(cuda)
+    add_ur_adapter_subdirectory(cuda)
 endif()
 
 if(UR_BUILD_ADAPTER_HIP OR UR_BUILD_ADAPTER_ALL)
-    add_subdirectory(hip)
+    add_ur_adapter_subdirectory(hip)
 endif()
 
 if(UR_BUILD_ADAPTER_OPENCL OR UR_BUILD_ADAPTER_ALL)
-    add_subdirectory(opencl)
+    add_ur_adapter_subdirectory(opencl)
 endif()
 if(UR_BUILD_ADAPTER_NATIVE_CPU OR UR_BUILD_ADAPTER_ALL)
-    add_subdirectory(native_cpu)
+    add_ur_adapter_subdirectory(native_cpu)
 endif()


### PR DESCRIPTION
Allow the configuration of external source directory for any of the existing adapters. This is done via a CMake cache variable which if set will is used as the `source_dir` argument to `add_subdirectory()`, the `binary_dir` argument will also be set to the same location as a normal in-tree build. This is done via the addition of the new `add_ur_adapter_subdirectory()` helper function which also hoists the logic to enable/disable each adapter.