### PR TITLE
[cmake] Always generate compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
     "List of sycl targets to build CTS device binaries for")
 set(UR_CONFORMANCE_AMD_ARCH "" CACHE STRING "AMD device target ID to build CTS binaries for")
 
+# There's little reason not to generate the compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 include(Assertions)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
I can't think of a valid reason not to generate compile_commands.json and several reasons why we should

1. I don't like typing configure options that much.
2. I like editor completion to work without me having to regenerate my build.
3. It's a good way to inspect final build flags without having to query the build system.