### PR TITLE
[CI] Fix and extend E2E on PRs

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -66,10 +66,6 @@ jobs:
         ls -la ./
         rm -rf ./* || true
 
-    - uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7 # v2.0.0
-      id: comment-branch
-      if: ${{ always() && inputs.trigger != 'schedule' }}
-
     - name: Add comment to PR
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       if: ${{ always() && inputs.trigger != 'schedule' }}
@@ -90,7 +86,18 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ur-repo
-        ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+    # On issue_comment trigger (for PRs) we need to fetch special ref for
+    # proper PR's merge commit. Note, this ref may be absent if the PR is already merged.
+    - name: Fetch PR's merge commit
+      if: ${{ inputs.trigger != 'schedule' }}
+      working-directory: ${{github.workspace}}/ur-repo
+      env:
+        PR_NO: ${{github.event.issue.number}}
+      run: |
+        git fetch -- https://github.com/${{github.repository}} +refs/pull/${PR_NO}/*:refs/remotes/origin/pr/${PR_NO}/*
+        git checkout origin/pr/${PR_NO}/merge
+        git rev-parse origin/pr/${PR_NO}/merge
 
     - name: Checkout SYCL
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -198,8 +198,9 @@ jobs:
         script: |
           const adapter = '${{ matrix.adapter.name }}';
           const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-          const status = '${{ steps.tests.outcome }}';
-          const body = `E2E ${adapter} build: \n${url}\n Status: ${status}`;
+          const test_status = '${{ steps.tests.outcome }}';
+          const job_status = '${{ job.status }}';
+          const body = `E2E ${adapter} build:\n${url}\nJob status: ${job_status}. Test status: ${test_status}`;
 
           github.rest.issues.createComment({
             issue_number: context.issue.number,


### PR DESCRIPTION
Right now, E2E workflows don't run at all for PR's (triggered via comments), because git is failing to checkout proper ref.

Example of failed CI: https://github.com/oneapi-src/unified-runtime/actions/runs/8157313297/job/22296700396#step:5:60

// tested on my fork:
// https://github.com/lukaszstolarczuk/unified-runtime/actions/runs/8173691655/job/22346695074#step:5:29
// https://github.com/lukaszstolarczuk/unified-runtime/pull/5#issuecomment-1981003486