### PR TITLE
[CTS] Treat skipped tests as passes

### DIFF
--- a/scripts/ctest_parser.py
+++ b/scripts/ctest_parser.py
@@ -33,8 +33,8 @@ def summarize_results(results):
     total_failed = len(results['Failed'])
     total_crashed = total - (total_passed + total_skipped + total_failed)
 
-    pass_rate_incl_skipped = percent(total_passed, total)
-    pass_rate_excl_skipped = percent(total_passed, total - total_skipped)
+    pass_rate_incl_skipped = percent(total_passed + total_skipped, total)
+    pass_rate_excl_skipped = percent(total_passed, total)
 
     skipped_rate = percent(total_skipped, total)
     failed_rate = percent(total_failed, total)


### PR DESCRIPTION
The conformance tests skip tests when a devices returns `UR_RESULT_ERROR_UNSUPPORTED_FEATURE` and the feature under test is optional. As such, skipped tests count as passes because the device has exhibiting valid behaviour. This patch changes how CTS pass rates are calculated to match.