### PR TITLE
[L0] delete platforms on teardown

### DIFF
--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -25,4 +25,4 @@ struct ur_adapter_handle_t_ {
   ZeCache<Result<PlatformVec>> PlatformCache;
 };
 
-extern ur_adapter_handle_t_ Adapter;
+ur_adapter_handle_t getAdapter(bool initIfNull = true);

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1441,8 +1441,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
   // "NativeHandle" must already be in the cache. If it is not, this must not be
   // a valid Level Zero device.
 
+  auto Adapter = getAdapter();
+
   ur_device_handle_t Dev = nullptr;
-  if (const auto *platforms = Adapter.PlatformCache->get_value()) {
+  if (const auto *platforms = Adapter->PlatformCache->get_value()) {
     for (const auto &p : *platforms) {
       Dev = p->getDeviceFromNativeHandle(ZeDevice);
       if (Dev) {
@@ -1453,7 +1455,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
       }
     }
   } else {
-    return Adapter.PlatformCache->get_error();
+    return Adapter->PlatformCache->get_error();
   }
 
   if (Dev == nullptr)

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -27,9 +27,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
     uint32_t *NumPlatforms ///< [out][optional] returns the total number of
                            ///< platforms available.
 ) {
+  auto Adapter = getAdapter();
+
   // Platform handles are cached for reuse. This is to ensure consistent
   // handle pointers across invocations and to improve retrieval performance.
-  if (const auto *cached_platforms = Adapter.PlatformCache->get_value();
+  if (const auto *cached_platforms = Adapter->PlatformCache->get_value();
       cached_platforms) {
     uint32_t nplatforms = (uint32_t)cached_platforms->size();
     if (NumPlatforms) {
@@ -41,7 +43,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
       }
     }
   } else {
-    return Adapter.PlatformCache->get_error();
+    return Adapter->PlatformCache->get_error();
   }
 
   return UR_RESULT_SUCCESS;
@@ -133,7 +135,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
   auto ZeDriver = ur_cast<ze_driver_handle_t>(NativePlatform);
 
   uint32_t NumPlatforms = 0;
-  ur_adapter_handle_t AdapterHandle = &Adapter;
+  ur_adapter_handle_t AdapterHandle = getAdapter();
   UR_CALL(urPlatformGet(&AdapterHandle, 1, 0, nullptr, &NumPlatforms));
 
   if (NumPlatforms) {

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -569,7 +569,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   // Maybe this is not completely correct.
   uint32_t NumEntries = 1;
   ur_platform_handle_t Platform{};
-  ur_adapter_handle_t AdapterHandle = &Adapter;
+  ur_adapter_handle_t AdapterHandle = getAdapter();
   UR_CALL(urPlatformGet(&AdapterHandle, 1, NumEntries, &Platform, nullptr));
 
   ur_device_handle_t UrDevice = Device;


### PR DESCRIPTION
This is an alternative to #1417 that uses atomics to ensure the adapter is deleted exactly once only when urAdapterRelease is called.