### PR TITLE
[Bindless][CUDA] Add support for cubemaps

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -278,6 +278,7 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR = 0x2003,                          ///< ::ur_exp_file_descriptor_t
     UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE = 0x2004,                             ///< ::ur_exp_win32_handle_t
     UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES = 0x2005,                       ///< ::ur_exp_sampler_addr_modes_t
+    UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES = 0x2006,               ///< ::ur_exp_sampler_cubemap_properties_t
     /// @cond
     UR_STRUCTURE_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1625,6 +1626,10 @@ typedef enum ur_device_info_t {
                                                                     ///< semaphore resources
     UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP = 0x200F,   ///< [::ur_bool_t] returns true if the device supports exporting internal
                                                                     ///< event resources
+    UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP = 0x2010,                    ///< [::ur_bool_t] returns true if the device supports allocating and
+                                                                    ///< accessing cubemap resources
+    UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP = 0x2011, ///< [::ur_bool_t] returns true if the device supports sampling cubemapped
+                                                                    ///< images across face boundaries
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -1650,7 +1655,7 @@ typedef enum ur_device_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -2421,13 +2426,14 @@ typedef enum ur_mem_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Memory types
 typedef enum ur_mem_type_t {
-    UR_MEM_TYPE_BUFFER = 0,         ///< Buffer object
-    UR_MEM_TYPE_IMAGE2D = 1,        ///< 2D image object
-    UR_MEM_TYPE_IMAGE3D = 2,        ///< 3D image object
-    UR_MEM_TYPE_IMAGE2D_ARRAY = 3,  ///< 2D image array object
-    UR_MEM_TYPE_IMAGE1D = 4,        ///< 1D image object
-    UR_MEM_TYPE_IMAGE1D_ARRAY = 5,  ///< 1D image array object
-    UR_MEM_TYPE_IMAGE1D_BUFFER = 6, ///< 1D image buffer object
+    UR_MEM_TYPE_BUFFER = 0,                 ///< Buffer object
+    UR_MEM_TYPE_IMAGE2D = 1,                ///< 2D image object
+    UR_MEM_TYPE_IMAGE3D = 2,                ///< 3D image object
+    UR_MEM_TYPE_IMAGE2D_ARRAY = 3,          ///< 2D image array object
+    UR_MEM_TYPE_IMAGE1D = 4,                ///< 1D image object
+    UR_MEM_TYPE_IMAGE1D_ARRAY = 5,          ///< 1D image array object
+    UR_MEM_TYPE_IMAGE1D_BUFFER = 6,         ///< 1D image buffer object
+    UR_MEM_TYPE_IMAGE_CUBEMAP_EXP = 0x2000, ///< Experimental cubemap image object
     /// @cond
     UR_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7242,6 +7248,17 @@ typedef enum ur_exp_image_copy_flag_t {
 #define UR_EXP_IMAGE_COPY_FLAGS_MASK 0xfffffff8
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Sampler cubemap seamless filtering mode.
+typedef enum ur_exp_sampler_cubemap_filter_mode_t {
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED = 0, ///< Disable seamless filtering
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS = 1,   ///< Enable Seamless filtering
+    /// @cond
+    UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_sampler_cubemap_filter_mode_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief File descriptor
 typedef struct ur_exp_file_descriptor_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
@@ -7294,6 +7311,21 @@ typedef struct ur_exp_sampler_addr_modes_t {
     ur_sampler_addressing_mode_t addrModes[3]; ///< [in] Specify the address mode of the sampler per dimension
 
 } ur_exp_sampler_addr_modes_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Describes cubemap sampler properties
+///
+/// @details
+///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
+///       as part of a `pNext` chain.
+typedef struct ur_exp_sampler_cubemap_properties_t {
+    ur_structure_type_t stype;                              ///< [in] type of this structure, must be
+                                                            ///< ::UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
+    void *pNext;                                            ///< [in,out][optional] pointer to extension-specific structure
+    ur_exp_sampler_cubemap_filter_mode_t cubemapFilterMode; ///< [in] enables or disables seamless cubemap filtering between cubemap
+                                                            ///< faces
+
+} ur_exp_sampler_cubemap_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Describes an interop memory resource descriptor

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -883,6 +883,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintUsmMigrationFlags(enum ur_usm_migrati
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpImageCopyFlags(enum ur_exp_image_copy_flag_t value, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_exp_sampler_cubemap_filter_mode_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerCubemapFilterMode(enum ur_exp_sampler_cubemap_filter_mode_t value, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_exp_file_descriptor_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -913,6 +921,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerMipProperties(const struct 
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerAddrModes(const struct ur_exp_sampler_addr_modes_t params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_exp_sampler_cubemap_properties_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerCubemapProperties(const struct ur_exp_sampler_cubemap_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_exp_interop_mem_desc_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -320,10 +320,12 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_execution_info_t value
 inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_usm_migration_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_image_copy_flag_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_filter_mode_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_file_descriptor_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_win32_handle_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_mip_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_addr_modes_t params);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_cubemap_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_mem_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_semaphore_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_info_t value);
@@ -1068,6 +1070,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_structure_type_t value
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES:
         os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES";
         break;
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES:
+        os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1317,6 +1322,11 @@ inline ur_result_t printStruct(std::ostream &os, const void *ptr) {
 
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES: {
         const ur_exp_sampler_addr_modes_t *pstruct = (const ur_exp_sampler_addr_modes_t *)ptr;
+        printPtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES: {
+        const ur_exp_sampler_cubemap_properties_t *pstruct = (const ur_exp_sampler_cubemap_properties_t *)ptr;
         printPtr(os, pstruct);
     } break;
     default:
@@ -2545,6 +2555,12 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
         break;
     case UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP";
+        break;
+    case UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP";
+        break;
+    case UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -4150,6 +4166,30 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
 
         os << ")";
     } break;
+    case UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    case UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
     default:
         os << "unknown enumerator";
         return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -5325,6 +5365,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_mem_type_t value) {
         break;
     case UR_MEM_TYPE_IMAGE1D_BUFFER:
         os << "UR_MEM_TYPE_IMAGE1D_BUFFER";
+        break;
+    case UR_MEM_TYPE_IMAGE_CUBEMAP_EXP:
+        os << "UR_MEM_TYPE_IMAGE_CUBEMAP_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -9137,6 +9180,24 @@ inline ur_result_t printFlag<ur_exp_image_copy_flag_t>(std::ostream &os, uint32_
 }
 } // namespace ur::details
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_exp_sampler_cubemap_filter_mode_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_filter_mode_t value) {
+    switch (value) {
+    case UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED:
+        os << "UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED";
+        break;
+    case UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS:
+        os << "UR_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_exp_file_descriptor_t type
 /// @returns
 ///     std::ostream &
@@ -9254,6 +9315,31 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_sampler_ad
         os << (params.addrModes[i]);
     }
     os << "}";
+
+    os << "}";
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_exp_sampler_cubemap_properties_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_sampler_cubemap_properties_t params) {
+    os << "(struct ur_exp_sampler_cubemap_properties_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur::details::printStruct(os,
+                             (params.pNext));
+
+    os << ", ";
+    os << ".cubemapFilterMode = ";
+
+    os << (params.cubemapFilterMode);
 
     os << "}";
     return os;

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -50,6 +50,7 @@ Runtime:
   * Sampled images
   * Unsampled images
   * Mipmaps
+  * Cubemaps
   * USM backed images
 
 * Interoperability support
@@ -69,6 +70,7 @@ Enums
     ${X}_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
     ${X}_STRUCTURE_TYPE_EXP_WIN32_HANDLE
     ${X}_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
+    ${X}_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
 
 * ${x}_device_info_t
     * ${X}_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP
@@ -87,6 +89,8 @@ Enums
     * ${X}_DEVICE_INFO_INTEROP_MEMORY_EXPORT_SUPPORT_EXP
     * ${X}_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP
     * ${X}_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP
+    * ${X}_DEVICE_INFO_CUBEMAP_SUPPORT_EXP
+    * ${X}_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP
 
 * ${x}_command_t
     * ${X}_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP
@@ -96,6 +100,10 @@ Enums
     * ${X}_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE
     * ${X}_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST
     * ${X}_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE
+
+* ${x}_exp_sampler_cubemap_filter_mode_t
+    * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS
+    * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED
 
 * ${x}_function_t
     * ${X}_FUNCTION_USM_PITCHED_ALLOC_EXP
@@ -117,6 +125,9 @@ Enums
     * ${X}_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
 
+* ${x}_mem_type_t
+    * ${X}_MEM_TYPE_IMAGE_CUBEMAP_EXP
+
 Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ${x}_exp_sampler_mip_properties_t
@@ -129,6 +140,7 @@ Types
 * ${x}_exp_file_descriptor_t
 * ${x}_exp_win32_handle_t
 * ${x}_exp_sampler_addr_modes_t
+* ${x}_exp_sampler_cubemap_properties_t
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -184,6 +196,9 @@ Changelog
 +------------------------------------------------------------------------+
 | 9.0      | Remove layered image properties struct.                     |
 +------------------------------------------------------------------------+
+| 10.0     | Added cubemap image type, sampling properties, and device   |
+|          | queries.                                                    |
++----------+-------------------------------------------------------------+
 
 Contributors
 --------------------------------------------------------------------------------

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -86,6 +86,12 @@ etors:
     - name: INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP
       value: "0x200F"
       desc: "[$x_bool_t] returns true if the device supports exporting internal event resources"
+    - name: CUBEMAP_SUPPORT_EXP
+      value: "0x2010"
+      desc: "[$x_bool_t] returns true if the device supports allocating and accessing cubemap resources"
+    - name: CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP
+      value: "0x2011"
+      desc: "[$x_bool_t] returns true if the device supports sampling cubemapped images across face boundaries"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -110,6 +116,9 @@ etors:
     - name: EXP_SAMPLER_ADDR_MODES
       desc: $x_exp_sampler_addr_modes_t
       value: "0x2005"
+    - name: EXP_SAMPLER_CUBEMAP_PROPERTIES
+      desc: $x_exp_sampler_cubemap_properties_t
+      value: "0x2006"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -134,6 +143,25 @@ etors:
     desc: "Device to host"
   - name: DEVICE_TO_DEVICE
     desc: "Device to device"
+--- #--------------------------------------------------------------------------
+type: enum
+extend: True
+desc: "Memory types"
+name: $x_mem_type_t
+etors:
+    - name: IMAGE_CUBEMAP_EXP
+      value: "0x2000"
+      desc: "Experimental cubemap image object"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Sampler cubemap seamless filtering mode."
+class: $xBindlessImages
+name: $x_exp_sampler_cubemap_filter_mode_t
+etors:
+  - name: DISJOINTED
+    desc: "Disable seamless filtering"
+  - name: SEAMLESS
+    desc: "Enable Seamless filtering"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "File descriptor"
@@ -187,6 +215,19 @@ members:
     - type: $x_sampler_addressing_mode_t[3]
       name: addrModes
       desc: "[in] Specify the address mode of the sampler per dimension"
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes cubemap sampler properties"
+details:
+    - Specify these properties in $xSamplerCreate via $x_sampler_desc_t as part
+      of a `pNext` chain.
+class: $xBindlessImages
+name: $x_exp_sampler_cubemap_properties_t
+base: $x_base_properties_t
+members:
+    - type: $x_exp_sampler_cubemap_filter_mode_t
+      name: cubemapFilterMode
+      desc: "[in] enables or disables seamless cubemap filtering between cubemap faces"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Describes an interop memory resource descriptor"

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -917,6 +917,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CUDA does not support exporting semaphores or events.
     return ReturnValue(false);
   }
+  case UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP: {
+    // CUDA supports cubemaps.
+    return ReturnValue(true);
+  }
+  case UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP: {
+    // CUDA supports cubemap seamless filtering.
+    return ReturnValue(true);
+  }
   case UR_DEVICE_INFO_DEVICE_ID: {
     int Value = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -44,6 +44,11 @@ urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
       Sampler->Props |= SamplerAddrModes->addrModes[0] << 2;
       Sampler->Props |= SamplerAddrModes->addrModes[1] << 5;
       Sampler->Props |= SamplerAddrModes->addrModes[2] << 8;
+    } else if (BaseDesc->stype ==
+               UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES) {
+      const ur_exp_sampler_cubemap_properties_t *SamplerCubemapProperties =
+          reinterpret_cast<const ur_exp_sampler_cubemap_properties_t *>(pNext);
+      Sampler->Props |= SamplerCubemapProperties->cubemapFilterMode << 12;
     }
     pNext = const_cast<void *>(BaseDesc->pNext);
   }

--- a/source/adapters/cuda/sampler.hpp
+++ b/source/adapters/cuda/sampler.hpp
@@ -15,7 +15,8 @@
 /// Sampler property layout:
 /// |     <bits>     | <usage>
 /// -----------------------------------
-/// |  31 30 ... 12  | N/A
+/// |  31 30 ... 13  | N/A
+/// |       12       | cubemap filter mode
 /// |       11       | mip filter mode
 /// |    10 9 8      | addressing mode 3
 /// |     7 6 5      | addressing mode 2
@@ -59,5 +60,10 @@ struct ur_sampler_handle_t_ {
 
   ur_sampler_filter_mode_t getMipFilterMode() const noexcept {
     return static_cast<ur_sampler_filter_mode_t>((Props >> 11) & 0b1);
+  }
+
+  ur_exp_sampler_cubemap_filter_mode_t getCubemapFilterMode() const noexcept {
+    return static_cast<ur_exp_sampler_cubemap_filter_mode_t>((Props >> 12) &
+                                                             0b1);
   }
 };

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -496,7 +496,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName) {
+        if (UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -842,7 +842,7 @@ ur_result_t UR_APICALL urDeviceGetSelected(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -887,6 +887,14 @@ ur_result_t urPrintExpImageCopyFlags(enum ur_exp_image_copy_flag_t value,
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintExpSamplerCubemapFilterMode(
+    enum ur_exp_sampler_cubemap_filter_mode_t value, char *buffer,
+    const size_t buff_size, size_t *out_size) {
+    std::stringstream ss;
+    ss << value;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t
 urPrintExpFileDescriptor(const struct ur_exp_file_descriptor_t params,
                          char *buffer, const size_t buff_size,
@@ -916,6 +924,14 @@ ur_result_t
 urPrintExpSamplerAddrModes(const struct ur_exp_sampler_addr_modes_t params,
                            char *buffer, const size_t buff_size,
                            size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintExpSamplerCubemapProperties(
+    const struct ur_exp_sampler_cubemap_properties_t params, char *buffer,
+    const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;
     return str_copy(&ss, buffer, buff_size, out_size);

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -736,7 +736,7 @@ ur_result_t UR_APICALL urDeviceGetSelected(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hDevice`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP < propName`
+///         + `::UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -378,5 +378,10 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
     std::cout << prefix;
     printDeviceInfo<ur_bool_t>(
         hDevice, UR_DEVICE_INFO_INTEROP_SEMAPHORE_EXPORT_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP);
+    std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(
+        hDevice, UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP);
 }
 } // namespace urinfo


### PR DESCRIPTION
Add enum to ur_mem_type_t to represent cubemap image type

Add device aspects for cubemap support:

 - UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP
 - UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP

Add structs/enums for cubemap sampling:

 - ur_exp_sampler_cubemap_properties_t struct to enable seamless filtering between cubemap faces
 - ur_exp_sampler_cubemap_filter_mode_t enum to enable distinguishing between cubemap seamless filtering options

Corresponding DPC++ PR: https://github.com/intel/llvm/pull/12996