### PR TITLE
[CI] Update short fuzztest to include verbose output in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -158,7 +158,7 @@ jobs:
 
     - name: Fuzz test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-short"
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-short" --verbose
 
   adapter-build-hw:
     name: Build - Adapters on HW


### PR DESCRIPTION
This is for having more info about short fuzz tests failures while trying to fix #1435 .
It should be also nice to have a verbose output for future failure cases.