### PR TITLE
[HIP] Use context to get active device

### DIFF
--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -190,7 +190,7 @@ urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   UR_ASSERT(numEvents > 0, UR_RESULT_ERROR_INVALID_VALUE);
 
   try {
-    ScopedContext Active(phEventWaitList[0]->getDevice());
+    ScopedContext Active(phEventWaitList[0]->getContext()->getDevices()[0]);
     auto WaitFunc = [](ur_event_handle_t Event) -> ur_result_t {
       UR_ASSERT(Event, UR_RESULT_ERROR_INVALID_EVENT);
 


### PR DESCRIPTION
An event made with a native handle will not have an initialized queue, which the event uses for `ur_event_handle_t::getDevice()`. So it is better to get the scoped context device through the context, which is always guaranteed to be initialized.