### PR TITLE
[OPENCL] Remove EVENT_STATUS_QUEUED workaround

### DIFF
--- a/source/adapters/opencl/event.cpp
+++ b/source/adapters/opencl/event.cpp
@@ -170,18 +170,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
       *reinterpret_cast<ur_command_t *>(pPropValue) = convertCLCommandTypeToUR(
           *reinterpret_cast<cl_command_type *>(pPropValue));
     } else if (propName == UR_EVENT_INFO_COMMAND_EXECUTION_STATUS) {
-      /* If the CL_EVENT_COMMAND_EXECUTION_STATUS info value is CL_QUEUED,
-       * change it to CL_SUBMITTED. sycl::info::event::event_command_status has
-       * no equivalent to CL_QUEUED.
-       *
-       * FIXME UR Port: This should not be part of the UR adapter. Since
-       * PI_QUEUED exists, SYCL RT should be changed to handle this situation.
-       * In addition, SYCL RT is relying on PI_QUEUED status to make sure that
-       * the queues are flushed. */
       const auto param_value_int = static_cast<ur_event_status_t *>(pPropValue);
-      if (*param_value_int == UR_EVENT_STATUS_QUEUED) {
-        *param_value_int = UR_EVENT_STATUS_SUBMITTED;
-      } else if (*param_value_int < 0) {
+      if (*param_value_int < 0) {
         // This can contain a negative return code to signify that the command
         // terminated in an unexpected way.
         *param_value_int = UR_EVENT_STATUS_ERROR;


### PR DESCRIPTION
This PR removes the workaround introduced in https://github.com/intel/llvm/pull/9944

intel/llvm: https://github.com/intel/llvm/pull/13024