### PR TITLE
[HIP] Fix memory type detection in allocation info queries and USM copy2D

### DIFF
--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -1618,25 +1618,55 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     hipPointerAttribute_t srcAttribs{};
     hipPointerAttribute_t dstAttribs{};
 
+    // Determine if pSrc and/or pDst are system allocated pageable host memory.
     bool srcIsSystemAlloc{false};
     bool dstIsSystemAlloc{false};
-
-    hipError_t hipRes{};
-    // hipErrorInvalidValue returned from hipPointerGetAttributes for a non-null
-    // pointer refers to an OS-allocation, hence pageable host memory. However,
-    // this means we cannot rely on the attributes result, hence we mark system
-    // pageable memory allocation manually as host memory. The HIP runtime can
-    // handle the registering/unregistering of the memory as long as the right
-    // copy-kind (direction) is provided to hipMemcpy2DAsync for this case.
-    hipRes = hipPointerGetAttributes(&srcAttribs, (const void *)pSrc);
-    if (hipRes == hipErrorInvalidValue && pSrc)
+    // Error code hipErrorInvalidValue returned from hipPointerGetAttributes
+    // for a non-null pointer refers to an OS-allocation, hence we can work
+    // with the assumption that this is a pointer to a pageable host memory.
+    // Since ROCm version 6.0.0, the enum hipMemoryType can also be marked as
+    // hipMemoryTypeUnregistered explicitly to relay that information better.
+    // This means we cannot rely on any attribute result, hence we just mark
+    // the pointer handle as system allocated pageable host memory.
+    // The HIP runtime can handle the registering/unregistering of the memory
+    // as long as the right copy-kind (direction) is provided to hipMemcpy2D*.
+    hipError_t hipRet = hipPointerGetAttributes(&srcAttribs, pSrc);
+    if (pSrc && hipRet == hipErrorInvalidValue)
       srcIsSystemAlloc = true;
-    hipRes = hipPointerGetAttributes(&dstAttribs, (const void *)pDst);
-    if (hipRes == hipErrorInvalidValue && pDst)
+    hipRet = hipPointerGetAttributes(&dstAttribs, (const void *)pDst);
+    if (pDst && hipRet == hipErrorInvalidValue)
       dstIsSystemAlloc = true;
+#if HIP_VERSION_MAJOR >= 6
+    srcIsSystemAlloc |= srcAttribs.type == hipMemoryTypeUnregistered;
+    dstIsSystemAlloc |= dstAttribs.type == hipMemoryTypeUnregistered;
+#endif
 
-    const unsigned int srcMemType{srcAttribs.type};
-    const unsigned int dstMemType{dstAttribs.type};
+    unsigned int srcMemType{srcAttribs.type};
+    unsigned int dstMemType{dstAttribs.type};
+
+    // ROCm 5.7.1 finally started updating the type attribute member to
+    // hipMemoryTypeManaged for shared memory allocations(hipMallocManaged).
+    // Hence, we use a separate query that verifies the pointer use via flags.
+#if HIP_VERSION >= 50700001
+    // Determine the source/destination memory type for shared allocations.
+    //
+    // NOTE: The hipPointerGetAttribute API is marked as [BETA] and fails with
+    // exit code -11 when passing a system allocated pointer to it.
+    if (!srcIsSystemAlloc && srcAttribs.isManaged) {
+      UR_ASSERT(srcAttribs.hostPointer && srcAttribs.hostPointer,
+                UR_RESULT_ERROR_INVALID_VALUE);
+      UR_CHECK_ERROR(hipPointerGetAttribute(
+          &srcMemType, HIP_POINTER_ATTRIBUTE_MEMORY_TYPE,
+          reinterpret_cast<hipDeviceptr_t>(const_cast<void *>(pSrc))));
+    }
+    if (!dstIsSystemAlloc && dstAttribs.isManaged) {
+      UR_ASSERT(dstAttribs.hostPointer && dstAttribs.devicePointer,
+                UR_RESULT_ERROR_INVALID_VALUE);
+      UR_CHECK_ERROR(
+          hipPointerGetAttribute(&dstMemType, HIP_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                 reinterpret_cast<hipDeviceptr_t>(pDst)));
+    }
+#endif
 
     const bool srcIsHost{(srcMemType == hipMemoryTypeHost) || srcIsSystemAlloc};
     const bool srcIsDevice{srcMemType == hipMemoryTypeDevice};


### PR DESCRIPTION
This PR fixes detection of the pointer type for sycl pointer allocation info queries and USM copy2D for the HIP backend.

With regards to `urUSMGetMemAllocInfo` for `UR_USM_ALLOC_INFO_TYPE`:
Takes extra care identifying unknown/unregistered memory allocations since ROCm 6.0.0 introduces `hipMemoryTypeUnregistered`, which we now use to identify system allocations and the attributes query will still return success in this case.

With regards to `urEnqueueUSMMemcpy2D`:
This is a little awkward workaround. Ideally we'd just use `hipPointerGetAttribute` but it crashes when used on system / pageable host memory hence using `hipPointerGetAttributes` to first determine that and ideally use the memory type value. From ROCm 5.7.1 we cannot rely on the memory type member of the attributes struct to detect whether it is device or host as managed allocations finally update it to managed memory type, hence we need to query the type specifically via `hipPointerGetAttribute` now knowing that the memory handle is not pageable host memory.
Ideally we'd just use allocation flags to determine the memory type and call it a day, but ROCm does not update the user-facing flags member from the attributes struct, so sadly we have no way of relying on allocation flags.

intel/llvm CI: https://github.com/intel/llvm/pull/13059