### PR TITLE
[CTS] Don't use mangled global variable name

### DIFF
--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1298,7 +1298,7 @@ struct urGlobalVariableTest : uur::urKernelExecutionTest {
     void SetUp() override {
 
         program_name = "device_global";
-        global_var = {"_Z7dev_var", 0};
+        global_var = {"dev_var", 0};
 
         /* Some adapters cannot use the mangled variable name directly.
          * Instead, in order to map the mangled variable to the internal name,


### PR DESCRIPTION
In the `urGlobalVariableTest` fixture, replace the mangled variable name with the non-mangled version. This enables the test pass on Intel OpenCL Graphis driver.
