### PR TITLE
[HIP][CUDA] Remove function prototypes from enqueue.hpp

### DIFF
--- a/source/adapters/cuda/enqueue.hpp
+++ b/source/adapters/cuda/enqueue.hpp
@@ -17,11 +17,6 @@ ur_result_t enqueueEventsWait(ur_queue_handle_t CommandQueue, CUstream Stream,
                               uint32_t NumEventsInWaitList,
                               const ur_event_handle_t *EventWaitList);
 
-void guessLocalWorkSize(ur_device_handle_t Device, size_t *ThreadsPerBlock,
-                        const size_t *GlobalWorkSize, const uint32_t WorkDim,
-                        const size_t MaxThreadsPerBlock[3],
-                        ur_kernel_handle_t Kernel, uint32_t LocalSize);
-
 bool hasExceededMaxRegistersPerBlock(ur_device_handle_t Device,
                                      ur_kernel_handle_t Kernel,
                                      size_t BlockSize);

--- a/source/adapters/hip/enqueue.hpp
+++ b/source/adapters/hip/enqueue.hpp
@@ -17,11 +17,6 @@ ur_result_t enqueueEventsWait(ur_queue_handle_t CommandQueue,
                               hipStream_t Stream, uint32_t NumEventsInWaitList,
                               const ur_event_handle_t *EventWaitList);
 
-void guessLocalWorkSize(ur_device_handle_t Device, size_t *ThreadsPerBlock,
-                        const size_t *GlobalWorkSize, const uint32_t WorkDim,
-                        const size_t MaxThreadsPerBlock[3],
-                        ur_kernel_handle_t Kernel, uint32_t LocalSize);
-
 ur_result_t
 setKernelParams(const ur_device_handle_t Device, const uint32_t WorkDim,
                 const size_t *GlobalWorkOffset, const size_t *GlobalWorkSize,


### PR DESCRIPTION
These func prototypes are not needed as funcs are defined in enqueue.cpp before they are used. Addresses https://github.com/oneapi-src/unified-runtime/pull/1326#issuecomment-2008707282