### PR TITLE
increase search characters limit for license verification

### DIFF
--- a/scripts/verify_license.py
+++ b/scripts/verify_license.py
@@ -12,7 +12,7 @@ import argparse
 
 def verify_file_has_license(file):
     with open(file, 'r') as in_file:
-        contents = in_file.read(300)
+        contents = in_file.read(400)
         if "SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception" not in contents:
             raise Exception(f"{file} does not contain a license!")
 


### PR DESCRIPTION
limit of 300 was preventing https://github.com/oneapi-src/unified-runtime/pull/1401 from passing the license verification test.