### PR TITLE
[Spec Constants] Improved handling of invalid spec. constants

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -510,6 +510,7 @@ typedef enum ur_result_t {
     UR_RESULT_ERROR_LAYER_NOT_PRESENT = 67,                                   ///< A requested layer was not found by the loader.
     UR_RESULT_ERROR_IN_EVENT_LIST_EXEC_STATUS = 68,                           ///< An event in the provided wait list has ::UR_EVENT_STATUS_ERROR.
     UR_RESULT_ERROR_DEVICE_NOT_AVAILABLE = 69,                                ///< Device in question has `::UR_DEVICE_INFO_AVAILABLE == false`
+    UR_RESULT_ERROR_INVALID_SPEC_ID = 70,                                     ///< A specialization constant identifier is not valid.
     UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP = 0x1000,                      ///< Invalid Command-Buffer
     UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP = 0x1001,           ///< Sync point is not valid for the command-buffer
     UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_WAIT_LIST_EXP = 0x1002, ///< Sync point wait list is invalid
@@ -4649,6 +4650,11 @@ typedef struct ur_specialization_constant_info_t {
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 UR_APIEXPORT ur_result_t UR_APICALL
 urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram,                           ///< [in] handle of the Program object
@@ -5240,6 +5246,11 @@ urKernelSetArgMemObj(
 ///         + `count == 0`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 ///         + If ::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel,                             ///< [in] handle of the kernel object

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -1591,6 +1591,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_result_t value) {
     case UR_RESULT_ERROR_DEVICE_NOT_AVAILABLE:
         os << "UR_RESULT_ERROR_DEVICE_NOT_AVAILABLE";
         break;
+    case UR_RESULT_ERROR_INVALID_SPEC_ID:
+        os << "UR_RESULT_ERROR_INVALID_SPEC_ID";
+        break;
     case UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP:
         os << "UR_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP";
         break;

--- a/scripts/core/common.yml
+++ b/scripts/core/common.yml
@@ -282,6 +282,8 @@ etors:
       desc: "An event in the provided wait list has $X_EVENT_STATUS_ERROR."
     - name: ERROR_DEVICE_NOT_AVAILABLE
       desc: "Device in question has `$X_DEVICE_INFO_AVAILABLE == false`"
+    - name: ERROR_INVALID_SPEC_ID
+      desc: "A specialization constant identifier is not valid."
     - name: ERROR_UNKNOWN
       value: "0x7ffffffe"
       desc: "Unknown or internal error"

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -475,6 +475,11 @@ returns:
         - "`count == 0`"
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If $X_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false"
+    - $X_RESULT_ERROR_INVALID_VALUE:
+        - "A pSpecConstant entry contains a size that does not match that of the specialization constant in the module."
+        - "A pSpecConstant entry contains a nullptr pValue."
+    - $X_RESULT_ERROR_INVALID_SPEC_ID:
+        - "Any id specified in a pSpecConstant entry is not a valid specialization constant identifier."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Return platform native kernel handle."

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -542,6 +542,11 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`count == 0`"
+    - $X_RESULT_ERROR_INVALID_VALUE:
+        - "A pSpecConstant entry contains a size that does not match that of the specialization constant in the module."
+        - "A pSpecConstant entry contains a nullptr pValue."
+    - $X_RESULT_ERROR_INVALID_SPEC_ID:
+        - "Any id specified in a pSpecConstant entry is not a valid specialization constant identifier."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Return program native program handle."

--- a/source/adapters/cuda/kernel.cpp
+++ b/source/adapters/cuda/kernel.cpp
@@ -472,3 +472,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
             pSuggestedLocalWorkSize);
   return Result;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t, uint32_t, const ur_specialization_constant_info_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -124,7 +124,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
   pDdiTable->pfnGetSuggestedLocalWorkSize = urKernelGetSuggestedLocalWorkSize;
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/native_cpu/kernel.cpp
+++ b/source/adapters/native_cpu/kernel.cpp
@@ -286,7 +286,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
   std::ignore = count;
   std::ignore = pSpecConstants;
 
-  DIE_NO_IMPLEMENTATION
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(

--- a/source/adapters/opencl/common.cpp
+++ b/source/adapters/opencl/common.cpp
@@ -95,6 +95,8 @@ ur_result_t mapCLErrorToUR(cl_int Result) {
     return UR_RESULT_ERROR_INVALID_QUEUE;
   case CL_INVALID_ARG_SIZE:
     return UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE;
+  case CL_INVALID_SPEC_ID:
+    return UR_RESULT_ERROR_INVALID_SPEC_ID;
   default:
     return UR_RESULT_ERROR_UNKNOWN;
   }

--- a/source/adapters/opencl/kernel.cpp
+++ b/source/adapters/opencl/kernel.cpp
@@ -427,3 +427,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
       pGlobalWorkSize, pSuggestedLocalWorkSize));
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t, uint32_t, const ur_specialization_constant_info_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -124,7 +124,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
   pDdiTable->pfnGetSuggestedLocalWorkSize = urKernelGetSuggestedLocalWorkSize;
   return UR_RESULT_SUCCESS;
 }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3488,6 +3488,11 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
@@ -4082,6 +4087,11 @@ ur_result_t UR_APICALL urKernelSetArgMemObj(
 ///         + `count == 0`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 ///         + If ::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -2983,6 +2983,11 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
@@ -3473,6 +3478,11 @@ ur_result_t UR_APICALL urKernelSetArgMemObj(
 ///         + `count == 0`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
 ///         + If ::UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS query is false
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + A pSpecConstant entry contains a size that does not match that of the specialization constant in the module.
+///         + A pSpecConstant entry contains a nullptr pValue.
+///     - ::UR_RESULT_ERROR_INVALID_SPEC_ID
+///         + Any id specified in a pSpecConstant entry is not a valid specialization constant identifier.
 ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array

--- a/test/conformance/kernel/kernel_adapter_native_cpu.match
+++ b/test/conformance/kernel/kernel_adapter_native_cpu.match
@@ -172,6 +172,10 @@ urKernelSetSpecializationConstantsTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU
 urKernelSetSpecializationConstantsTest.InvalidNullHandleKernel/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelSetSpecializationConstantsTest.InvalidNullPointerSpecConstants/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelSetSpecializationConstantsTest.InvalidSizeCount/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+urKernelSetSpecializationConstantsTest.InvalidValueSize/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+urKernelSetSpecializationConstantsTest.InvalidValueId/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+urKernelSetSpecializationConstantsTest.InvalidValuePtr/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+urKernelSetSpecializationConstantsNegativeTest.Unsupported/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelGetSuggestedLocalWorkSizeTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelGetSuggestedLocalWorkSizeTest.Success2D/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelGetSuggestedLocalWorkSizeTest.Success3D/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
+++ b/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
@@ -27,6 +27,28 @@ struct urKernelSetSpecializationConstantsTest : uur::urBaseKernelExecutionTest {
 };
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urKernelSetSpecializationConstantsTest);
 
+struct urKernelSetSpecializationConstantsNegativeTest
+    : uur::urBaseKernelExecutionTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelExecutionTest::SetUp());
+        bool supports_kernel_spec_constant = false;
+        ASSERT_SUCCESS(urDeviceGetInfo(
+            device, UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS,
+            sizeof(supports_kernel_spec_constant),
+            &supports_kernel_spec_constant, nullptr));
+        if (supports_kernel_spec_constant) {
+            GTEST_SKIP() << "Device supports setting kernel spec constants.";
+        }
+        Build();
+    }
+
+    uint32_t spec_value = 42;
+    ur_specialization_constant_info_t info = {0, sizeof(spec_value),
+                                              &spec_value};
+};
+UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(
+    urKernelSetSpecializationConstantsNegativeTest);
+
 TEST_P(urKernelSetSpecializationConstantsTest, Success) {
     ASSERT_SUCCESS(urKernelSetSpecializationConstants(kernel, 1, &info));
 
@@ -34,6 +56,11 @@ TEST_P(urKernelSetSpecializationConstantsTest, Success) {
     AddBuffer1DArg(sizeof(spec_value), &buffer);
     Launch1DRange(1);
     ValidateBuffer<uint32_t>(buffer, sizeof(spec_value), spec_value);
+}
+
+TEST_P(urKernelSetSpecializationConstantsNegativeTest, Unsupported) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE,
+                     urKernelSetSpecializationConstants(kernel, 1, &info));
 }
 
 TEST_P(urKernelSetSpecializationConstantsTest, InvalidNullHandleKernel) {
@@ -50,4 +77,24 @@ TEST_P(urKernelSetSpecializationConstantsTest,
 TEST_P(urKernelSetSpecializationConstantsTest, InvalidSizeCount) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urKernelSetSpecializationConstants(kernel, 0, &info));
+}
+
+TEST_P(urKernelSetSpecializationConstantsTest, InvalidValueSize) {
+    ur_specialization_constant_info_t bad_info = {0, 0x1000, &spec_value};
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urKernelSetSpecializationConstants(kernel, 1, &bad_info));
+}
+
+TEST_P(urKernelSetSpecializationConstantsTest, InvalidValueId) {
+    ur_specialization_constant_info_t bad_info = {999, sizeof(spec_value),
+                                                  &spec_value};
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SPEC_ID,
+                     urKernelSetSpecializationConstants(kernel, 1, &bad_info));
+}
+
+TEST_P(urKernelSetSpecializationConstantsTest, InvalidValuePtr) {
+    ur_specialization_constant_info_t bad_info = {0, sizeof(spec_value),
+                                                  nullptr};
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urKernelSetSpecializationConstants(kernel, 1, &bad_info));
 }

--- a/test/conformance/program/program_adapter_cuda.match
+++ b/test/conformance/program/program_adapter_cuda.match
@@ -10,5 +10,8 @@ urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_
 urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES
 {{OPT}}urProgramSetSpecializationConstantsTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramSetSpecializationConstantsTest.UseDefaultValue/NVIDIA_CUDA_BACKEND___{{.*}}
-urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/NVIDIA_CUDA_BACKEND___{{.*}}
-urProgramSetMultipleSpecializationConstantsTest.SingleCall/NVIDIA_CUDA_BACKEND___{{.*}}
+urProgramSetSpecializationConstantsTest.InvalidValueSize/NVIDIA_CUDA_BACKEND___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValueId/NVIDIA_CUDA_BACKEND___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValuePtr/NVIDIA_CUDA_BACKEND___{{.*}}_
+urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/NVIDIA_CUDA_BACKEND___{{.*}}_
+urProgramSetMultipleSpecializationConstantsTest.SingleCall/NVIDIA_CUDA_BACKEND___{{.*}}_

--- a/test/conformance/program/program_adapter_hip.match
+++ b/test/conformance/program/program_adapter_hip.match
@@ -9,7 +9,11 @@ urProgramGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_N
 # HIP hasn't implemented urProgramLink
 {{OPT}}urProgramLinkTest.Success/AMD_HIP_BACKEND___{{.*}}_
 
+# Hip doesn't support specialization constants
 urProgramSetSpecializationConstantsTest.Success/AMD_HIP_BACKEND___{{.*}}_
 urProgramSetSpecializationConstantsTest.UseDefaultValue/AMD_HIP_BACKEND___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValueSize/AMD_HIP_BACKEND___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValueId/AMD_HIP_BACKEND___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValuePtr/AMD_HIP_BACKEND___{{.*}}_
 urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/AMD_HIP_BACKEND___{{.*}}_
 urProgramSetMultipleSpecializationConstantsTest.SingleCall/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/program/program_adapter_level_zero.match
+++ b/test/conformance/program/program_adapter_level_zero.match
@@ -7,3 +7,6 @@ urProgramGetFunctionPointerTest.InvalidKernelName/Intel_R__oneAPI_Unified_Runtim
 urProgramGetNativeHandleTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urProgramLinkErrorTest.LinkFailure/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urProgramLinkErrorTest.SetOutputOnLinkError/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValueSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}
+urProgramSetSpecializationConstantsTest.InvalidValueId/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}
+urProgramSetSpecializationConstantsTest.InvalidValuePtr/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}

--- a/test/conformance/program/program_adapter_level_zero_v2.match
+++ b/test/conformance/program/program_adapter_level_zero_v2.match
@@ -7,3 +7,6 @@ urProgramGetFunctionPointerTest.InvalidKernelName/Intel_R__oneAPI_Unified_Runtim
 urProgramGetNativeHandleTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urProgramLinkErrorTest.LinkFailure/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urProgramLinkErrorTest.SetOutputOnLinkError/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValueSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}
+urProgramSetSpecializationConstantsTest.InvalidValueId/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
+urProgramSetSpecializationConstantsTest.InvalidValuePtr/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -140,6 +140,9 @@
 {{OPT}}urProgramSetSpecializationConstantsTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramSetSpecializationConstantsTest.InvalidNullPointerSpecConstants/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramSetSpecializationConstantsTest.InvalidSizeCount/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+{{OPT}}urProgramSetSpecializationConstantsTest.InvalidValueSize/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+{{OPT}}urProgramSetSpecializationConstantsTest.InvalidValueId/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+{{OPT}}urProgramSetSpecializationConstantsTest.InvalidValuePtr/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramSetMultipleSpecializationConstantsTest.SingleCall/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}{{Segmentation fault|Aborted}}

--- a/test/conformance/program/urProgramSetSpecializationConstants.cpp
+++ b/test/conformance/program/urProgramSetSpecializationConstants.cpp
@@ -141,3 +141,26 @@ TEST_P(urProgramSetSpecializationConstantsTest, InvalidSizeCount) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                      urProgramSetSpecializationConstants(program, 0, &info));
 }
+
+TEST_P(urProgramSetSpecializationConstantsTest, InvalidValueSize) {
+    ur_specialization_constant_info_t bad_info = {0, 0x1000, &spec_value};
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_VALUE,
+        urProgramSetSpecializationConstants(program, 1, &bad_info));
+}
+
+TEST_P(urProgramSetSpecializationConstantsTest, InvalidValueId) {
+    ur_specialization_constant_info_t bad_info = {999, sizeof(spec_value),
+                                                  &spec_value};
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_SPEC_ID,
+        urProgramSetSpecializationConstants(program, 1, &bad_info));
+}
+
+TEST_P(urProgramSetSpecializationConstantsTest, InvalidValuePtr) {
+    ur_specialization_constant_info_t bad_info = {0, sizeof(spec_value),
+                                                  nullptr};
+    ASSERT_EQ_RESULT(
+        UR_RESULT_ERROR_INVALID_VALUE,
+        urProgramSetSpecializationConstants(program, 1, &bad_info));
+}


### PR DESCRIPTION
Two main changes to how `Kernel/ProgramSetSpecializationConstants` are handled:
* They may now output either `INVALID_VALUE` or the new `INVALID_SPEC_ID` when the provided list is invalid.
* The OpenCL and level 0 adapters now respond to `UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS` with `false` rather than erroring out. This fixes some tests that were incorrectly not being skipped.
* `urKernelSetSpecializationConstants` now "implemented" (as a function that returns `UNSUPPORTED_FEATURE` for opencl and cuda.