### PR TITLE
Revert "Disable fuzz tests on ubuntu-22.04 runner"

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -115,51 +115,50 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -L "umf|loader|validation|tracing|unit|urtrace"
 
-  # Disable short fuzz tests until the ubuntu-22.04 runner is fixed
-  # fuzztest-build:
-  #   name: Build and run quick fuzztest scenarios
-  #   strategy:
-  #     matrix:
-  #       build_type: [Debug, Release]
-  #       compiler: [{c: clang, cxx: clang++}]
+  fuzztest-build:
+    name: Build and run quick fuzztest scenarios
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
+        compiler: [{c: clang, cxx: clang++}]
 
-  #   runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-22.04'
 
-  #   steps:
-  #   - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-  #   - name: Install pip packages
-  #     run: pip install -r third_party/requirements.txt
+    - name: Install pip packages
+      run: pip install -r third_party/requirements.txt
 
-  #   - name: Download DPC++
-  #     run: |
-  #       sudo apt install libncurses5
-  #       wget -O ${{github.workspace}}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/sycl-nightly%2F20230626/dpcpp-compiler.tar.gz
-  #       tar -xvf ${{github.workspace}}/dpcpp_compiler.tar.gz
+    - name: Download DPC++
+      run: |
+        sudo apt install libncurses5
+        wget -O ${{github.workspace}}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/sycl-nightly%2F20230626/dpcpp-compiler.tar.gz
+        tar -xvf ${{github.workspace}}/dpcpp_compiler.tar.gz
 
-  #   - name: Setup DPC++
-  #     run: |
-  #       source ${{github.workspace}}/dpcpp_compiler/startup.sh
+    - name: Setup DPC++
+      run: |
+        source ${{github.workspace}}/dpcpp_compiler/startup.sh
 
-  #   - name: Configure CMake
-  #     run: >
-  #       cmake
-  #       -B${{github.workspace}}/build
-  #       -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
-  #       -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-  #       -DUR_ENABLE_TRACING=ON
-  #       -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
-  #       -DUR_BUILD_TESTS=ON
-  #       -DUR_USE_ASAN=ON
-  #       -DUR_USE_UBSAN=ON
-  #       -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
+    - name: Configure CMake
+      run: >
+        cmake
+        -B${{github.workspace}}/build
+        -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+        -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+        -DUR_ENABLE_TRACING=ON
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DUR_BUILD_TESTS=ON
+        -DUR_USE_ASAN=ON
+        -DUR_USE_UBSAN=ON
+        -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
 
-  #   - name: Build
-  #     run: cmake --build ${{github.workspace}}/build -j $(nproc)
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build -j $(nproc)
 
-  #   - name: Fuzz test
-  #     working-directory: ${{github.workspace}}/build
-  #     run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-short"
+    - name: Fuzz test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-short"
 
   adapter-build-hw:
     name: Build - Adapters on HW

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,6 @@ jobs:
         LD_LIBRARY_PATH=${{github.workspace}}/dpcpp_compiler/lib
         cmake --build ${{github.workspace}}/build -j $(nproc)
 
-    # Disable long fuzz tests until the ubuntu-22.04 runner is fixed
-    # - name: Fuzz long test
-    #   working-directory: ${{github.workspace}}/build
-    #   run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-long"
+    - name: Fuzz long test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-long"


### PR DESCRIPTION
Reverts oneapi-src/unified-runtime#1438

The runner issue is now fixed. Closes #1435.