### PR TITLE
[L0] Fix regular in order command list reuse given inorder queue

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -712,6 +712,11 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
 
     for (auto ZeCommandListIt = ZeCommandListCache.begin();
          ZeCommandListIt != ZeCommandListCache.end(); ++ZeCommandListIt) {
+      // If this is an InOrder Queue, then only allow lists which are in order.
+      if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue() &&
+          !(ZeCommandListIt->second.InOrderList)) {
+        continue;
+      }
       auto &ZeCommandList = ZeCommandListIt->first;
       auto it = Queue->CommandListMap.find(ZeCommandList);
       if (it != Queue->CommandListMap.end()) {
@@ -765,6 +770,12 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
     // Make sure this is the command list type needed.
     if (UseCopyEngine != it->second.isCopy(Queue))
       continue;
+
+    // If this is an InOrder Queue, then only allow lists which are in order.
+    if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue() &&
+        !(it->second.IsInOrderList)) {
+      continue;
+    }
 
     ze_result_t ZeResult =
         ZE_CALL_NOCHECK(zeFenceQueryStatus, (it->second.ZeFence));

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -27,6 +27,11 @@
 
 #include <umf_helpers.hpp>
 
+struct l0_command_list_cache_info {
+  ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
+  bool InOrderList = false;
+};
+
 struct ur_context_handle_t_ : _ur_object {
   ur_context_handle_t_(ze_context_handle_t ZeContext, uint32_t NumDevices,
                        const ur_device_handle_t *Devs, bool OwnZeContext)
@@ -87,11 +92,11 @@ struct ur_context_handle_t_ : _ur_object {
   //
   std::unordered_map<ze_device_handle_t,
                      std::list<std::pair<ze_command_list_handle_t,
-                                         ZeStruct<ze_command_queue_desc_t>>>>
+                                         l0_command_list_cache_info>>>
       ZeComputeCommandListCache;
   std::unordered_map<ze_device_handle_t,
                      std::list<std::pair<ze_command_list_handle_t,
-                                         ZeStruct<ze_command_queue_desc_t>>>>
+                                         l0_command_list_cache_info>>>
       ZeCopyCommandListCache;
 
   // Store USM pool for USM shared and device allocations. There is 1 memory

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -65,6 +65,8 @@ struct ur_command_list_info_t {
   // the make_queue API the descriptor is unavailable so a dummy descriptor is
   // used and then this entry is marked as not eligible for recycling.
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
+  // Indicates if this is an inorder list
+  bool IsInOrderList{false};
   bool CanReuse{true};
 
   // Helper functions to tell if this is a copy command-list.


### PR DESCRIPTION
- Fix command lists cache usage such that given an inorder queue and in order lists is requested, then only in order lists can be used from the cache.