### PR TITLE
[OpenCL] Revert urMemBufferCreate extension function lookup error

### DIFF
--- a/source/adapters/opencl/memory.cpp
+++ b/source/adapters/opencl/memory.cpp
@@ -232,11 +232,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     clCreateBufferWithPropertiesINTEL_fn FuncPtr = nullptr;
     cl_context CLContext = cl_adapter::cast<cl_context>(hContext);
     // First we need to look up the function pointer
-    UR_RETURN_ON_FAILURE(
+    RetErr =
         cl_ext::getExtFuncFromContext<clCreateBufferWithPropertiesINTEL_fn>(
             CLContext,
             cl_ext::ExtFuncPtrCache->clCreateBufferWithPropertiesINTELCache,
-            cl_ext::CreateBufferWithPropertiesName, &FuncPtr));
+            cl_ext::CreateBufferWithPropertiesName, &FuncPtr);
     if (FuncPtr) {
       std::vector<cl_mem_properties_intel> PropertiesIntel;
       auto Prop = static_cast<ur_base_properties_t *>(pProperties->pNext);


### PR DESCRIPTION
This commit reverts the urMemBufferCreate changes for returning function lookup error in https://github.com/oneapi-src/unified-runtime/pull/1448 as the function had a fallback path which is no longer taken.