### PR TITLE
[GHA] Add "Pull Request Labeler" workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,48 @@
+# Config file for .github/workflows/labeler.yml to automatically add labels to
+# pull requests based on the globs below. For documentation see:
+# https://github.com/marketplace/actions/labeler
+---
+ci-cd:
+  - changed-files:
+    - .github/**
+
+specification:
+  - changed-files:
+    - scripts/core/**
+
+experimental:
+  - changed-files:
+    - scripts/core/EXP*.rst
+    - scripts/core/exp*.yml
+
+common:
+  - changed-files:
+    - source/common/**
+
+loader:
+  - changed-files:
+    - source/loader/**
+
+opencl:
+  - changed-files:
+    - source/adapter/opencl/**
+
+level-zero:
+  - changed-files:
+    - source/adapters/level_zero/**
+
+cuda:
+  - changed-files:
+    - source/adapters/cuda/**
+
+hip:
+  - changed-files:
+    - source/adapters/hip/**
+
+native-cpu:
+  - changed-files:
+    - source/adapters/native_cpu/**
+
+conformance:
+  - changed-files:
+    - test/conformance/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+# Automatically add labels to pull requests based on globs in the
+# .github/labeler.yml config file. For documentation see:
+# https://github.com/marketplace/actions/labeler
+---
+name: Pull Request Labeler
+
+on: [ pull_request_target ]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5


### PR DESCRIPTION
This workflow uses the [labeler](https://github.com/marketplace/actions/labeler) action to automatically add relevant labels to pull requests in order to make it easier to filter pull requests based on the files they make changes to.

Due to `pull_request_target` using the config from the base branch, this will need to be merged before it can be validated as working as stated in the [docs](https://github.com/marketplace/actions/labeler#notes-regarding-pull_request_target-event).
