### PR TITLE
Fix Coverity wrapper escape issue

### DIFF
--- a/source/adapters/cuda/memory.hpp
+++ b/source/adapters/cuda/memory.hpp
@@ -34,7 +34,7 @@ struct BufferMem {
           MapMem(nullptr) {}
 
     BufferMap(size_t MapSize, size_t MapOffset, ur_map_flags_t MapFlags,
-              std::unique_ptr<unsigned char[]> &MapMem)
+              std::unique_ptr<unsigned char[]> &&MapMem)
         : MapSize(MapSize), MapOffset(MapOffset), MapFlags(MapFlags),
           MapMem(std::move(MapMem)) {}
 
@@ -105,7 +105,7 @@ struct BufferMem {
       auto MapMem = std::make_unique<unsigned char[]>(MapSize);
       MapPtr = MapMem.get();
       PtrToBufferMap.insert(
-          {MapPtr, BufferMap(MapSize, MapOffset, MapFlags, MapMem)});
+          {MapPtr, BufferMap(MapSize, MapOffset, MapFlags, std::move(MapMem))});
     } else {
       /// However, if HostPtr already has valid memory (e.g. pinned allocation),
       /// we can just use that memory for the mapping.


### PR DESCRIPTION
Issue was introduced in #1220 where a new allocation is created in a `std::unique_ptr` to enable buffer mapping. The `.get()` member function is called before the `std::unique_ptr` is passed into the `BufferMem` constructor. However, move semantics were not being explicitly followed. The `BufferMem` constructor was taking the `std::unique_ptr` by l-value refernece, then calling `std::move()` on it. This triggered a wrapper-escape, use-after-free defect in Coverity. This fix is to explicitly `std::move()` the `std::unique_ptr` into the `BufferMem` constructor, and also update the `BufferMem` constructor to take an r-value reference instead of an l-value reference.
