### PR TITLE
[UR] Restrict accepted types for the argument of isPowerOf2 to integral

### DIFF
--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -336,7 +336,8 @@ roundToHighestFactorOfGlobalSize(size_t &ThreadsPerBlockInDim,
 }
 
 // Returns whether or not Value is a power of 2
-template <typename T> inline bool isPowerOf2(const T &Value) {
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+bool isPowerOf2(const T &Value) {
   return Value && !(Value & (Value - 1));
 }
 


### PR DESCRIPTION
The `isPowerOf2` utility function is only meant to work on _integrals_, so this change just disables other allowed specializations.