### PR TITLE
[L0] Store LastCommandEvent before unlock during queue sync

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1424,8 +1424,9 @@ ur_result_t ur_queue_handle_t_::synchronize() {
     // event.
     if (isInOrderQueue() && !LastCommandEvent->IsDiscarded) {
       if (UrL0QueueSyncNonBlocking) {
+        auto SyncZeEvent = LastCommandEvent->ZeEvent;
         this->Mutex.unlock();
-        ZE2UR_CALL(zeHostSynchronize, (LastCommandEvent->ZeEvent));
+        ZE2UR_CALL(zeHostSynchronize, (SyncZeEvent));
         this->Mutex.lock();
       } else {
         ZE2UR_CALL(zeHostSynchronize, (LastCommandEvent->ZeEvent));


### PR DESCRIPTION
- Address possible race in accessing the LastCommandEvent by storing the event in local variable for use while in unlock.