### PR TITLE
Cache events instead of destroying them for CUDA

### DIFF
--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -32,6 +32,16 @@ void ur_queue_handle_t_::transferStreamWaitForBarrierIfNeeded(
   }
 }
 
+ur_queue_handle_t_::~ur_queue_handle_t_() {
+  urContextRelease(Context);
+  urDeviceRelease(Device);
+
+  while (!CachedEvents.empty()) {
+    std::unique_ptr<ur_event_handle_t_> p{CachedEvents.top()};
+    CachedEvents.pop();
+  }
+}
+
 CUstream ur_queue_handle_t_::getNextComputeStream(uint32_t *StreamToken) {
   uint32_t StreamI;
   uint32_t Token;


### PR DESCRIPTION
Don't destroy events that are not needed anymore, but put them on a stack of its associated queue (If there is one).

Use events from the stack before creating new ones.

This caching mechanism ensures that the number of CUDA API calls gets significantly reduced for event creations and destructions.