### PR TITLE
[CUDA][HIP] Add Event Caching

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -275,13 +275,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
           urQueueRelease(Queue);
         }
         urContextRelease(Context);
-
-        return UR_RESULT_SUCCESS;
       }
-    } catch (...) {
-      return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+    } catch (ur_result_t Err) {
+      return Err;
     }
-    return UR_RESULT_ERROR_INVALID_EVENT;
   }
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -42,11 +42,32 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
   urContextRetain(Context);
 }
 
+void ur_event_handle_t_::reset() {
+  RefCount = 0;
+  HasBeenWaitedOn = false;
+  IsRecorded = false;
+  IsStarted = false;
+  Queue = nullptr;
+  Context = nullptr;
+}
+
 ur_event_handle_t_::~ur_event_handle_t_() {
+  if (HasOwnership) {
+    if (EvEnd)
+      UR_CHECK_ERROR(cuEventDestroy(EvEnd));
+
+    if (EvQueued)
+      UR_CHECK_ERROR(cuEventDestroy(EvQueued));
+
+    if (EvStart)
+      UR_CHECK_ERROR(cuEventDestroy(EvStart));
+  }
   if (Queue != nullptr) {
     urQueueRelease(Queue);
   }
-  urContextRelease(Context);
+  if (Context != nullptr) {
+    urContextRelease(Context);
+  }
 }
 
 ur_result_t ur_event_handle_t_::start() {
@@ -139,22 +160,6 @@ ur_result_t ur_event_handle_t_::wait() {
   }
 
   return Result;
-}
-
-ur_result_t ur_event_handle_t_::release() {
-  if (!backendHasOwnership())
-    return UR_RESULT_SUCCESS;
-
-  assert(Queue != nullptr);
-
-  UR_CHECK_ERROR(cuEventDestroy(EvEnd));
-
-  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-    UR_CHECK_ERROR(cuEventDestroy(EvQueued));
-    UR_CHECK_ERROR(cuEventDestroy(EvStart));
-  }
-
-  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
@@ -257,7 +262,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
     ur_result_t Result = UR_RESULT_ERROR_INVALID_EVENT;
     try {
       ScopedContext Active(hEvent->getContext());
-      Result = hEvent->release();
+    if (!hEvent->backendHasOwnership()) {
+      Result = UR_RESULT_SUCCESS;
+    }
+    else {
+      assert(hEvent->getQueue() != nullptr);
+      assert(hEvent->getContext() != nullptr);
+
+      auto queue = event_ptr->getQueue();
+      auto context = event_ptr->getContext();
+
+      event_ptr->reset();
+      queue->CachedEvents.emplace(event_ptr.release());
+      urQueueRelease(queue);
+      urContextRelease(context);
+      Result = UR_RESULT_SUCCESS;
+    }
     } catch (...) {
       Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
     }

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -281,8 +281,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
     } catch (...) {
       return UR_RESULT_ERROR_OUT_OF_RESOURCES;
     }
+    return UR_RESULT_ERROR_INVALID_EVENT;
   }
-  return UR_RESULT_ERROR_INVALID_EVENT;
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -122,6 +122,8 @@ public:
     return new ur_event_handle_t_(context, eventNative);
   }
 
+  // Resets attributes of an event.
+  // Throws an error if its RefCount is not 0.
   void reset();
 
   ~ur_event_handle_t_();

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -36,8 +36,10 @@ ur_queue_handle_t_::~ur_queue_handle_t_() {
   urContextRelease(Context);
   urDeviceRelease(Device);
 
-  while (has_cached_events()) {
-    get_cached_event();
+  std::lock_guard<std::mutex> CacheGuard(CacheMutex);
+  while (!CachedEvents.empty()) {
+    std::unique_ptr<ur_event_handle_t_> Ev{CachedEvents.top()};
+    CachedEvents.pop();
   }
 }
 

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -32,6 +32,16 @@ void ur_queue_handle_t_::transferStreamWaitForBarrierIfNeeded(
   }
 }
 
+ur_queue_handle_t_::~ur_queue_handle_t_() {
+  urContextRelease(Context);
+  urDeviceRelease(Device);
+
+  while (!CachedEvents.empty()) {
+    std::unique_ptr<ur_event_handle_t_> p{CachedEvents.top()};
+    CachedEvents.pop();
+  }
+}
+
 CUstream ur_queue_handle_t_::getNextComputeStream(uint32_t *StreamToken) {
   uint32_t StreamI;
   uint32_t Token;

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -36,9 +36,8 @@ ur_queue_handle_t_::~ur_queue_handle_t_() {
   urContextRelease(Context);
   urDeviceRelease(Device);
 
-  while (!CachedEvents.empty()) {
-    std::unique_ptr<ur_event_handle_t_> p{CachedEvents.top()};
-    CachedEvents.pop();
+  while (has_cached_events()) {
+    get_cached_event();
   }
 }
 

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -262,7 +262,7 @@ struct ur_queue_handle_t_ {
   // Returns and removes an event from the CachedEvents stack.
   ur_event_handle_t get_cached_event() {
     std::lock_guard<std::mutex> CacheGuard(CacheMutex);
-    assert(has_cached_events());
+    assert(!CachedEvents.empty());
     auto RetEv = CachedEvents.top();
     CachedEvents.pop();
     return RetEv;

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -249,7 +249,10 @@ struct ur_queue_handle_t_ {
 
   bool backendHasOwnership() const noexcept { return HasOwnership; }
 
-  bool has_cached_events() const { return !CachedEvents.empty(); }
+  bool has_cached_events() {
+    std::lock_guard<std::mutex> CacheGuard(CacheMutex);
+    return !CachedEvents.empty();
+  }
 
   void cache_event(ur_event_handle_t Event) {
     std::lock_guard<std::mutex> CacheGuard(CacheMutex);
@@ -260,8 +263,8 @@ struct ur_queue_handle_t_ {
   ur_event_handle_t get_cached_event() {
     std::lock_guard<std::mutex> CacheGuard(CacheMutex);
     assert(has_cached_events());
-    auto retEv = CachedEvents.top();
+    auto RetEv = CachedEvents.top();
     CachedEvents.pop();
-    return retEv;
+    return RetEv;
   }
 };

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -312,13 +312,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
           urQueueRelease(Queue);
         }
         urContextRelease(Context);
-
-        return UR_RESULT_SUCCESS;
       }
-    } catch (...) {
-      return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+    } catch (ur_result_t Err) {
+      return Err;
     }
-    return UR_RESULT_ERROR_INVALID_EVENT;
   }
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -47,11 +47,32 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
   urContextRetain(Context);
 }
 
+void ur_event_handle_t_::reset() {
+  RefCount = 0;
+  HasBeenWaitedOn = false;
+  IsRecorded = false;
+  IsStarted = false;
+  Queue = nullptr;
+  Context = nullptr;
+}
+
 ur_event_handle_t_::~ur_event_handle_t_() {
+  if (HasOwnership) {
+    if (EvEnd)
+      UR_CHECK_ERROR(hipEventDestroy(EvEnd));
+
+    if (EvQueued)
+      UR_CHECK_ERROR(hipEventDestroy(EvQueued));
+
+    if (EvStart)
+      UR_CHECK_ERROR(hipEventDestroy(EvStart));
+  }
   if (Queue != nullptr) {
     urQueueRelease(Queue);
   }
-  urContextRelease(Context);
+  if (Context != nullptr) {
+    urContextRelease(Context);
+  }
 }
 
 ur_result_t ur_event_handle_t_::start() {
@@ -171,21 +192,6 @@ ur_result_t ur_event_handle_t_::wait() {
   return Result;
 }
 
-ur_result_t ur_event_handle_t_::release() {
-  if (!backendHasOwnership())
-    return UR_RESULT_SUCCESS;
-
-  assert(Queue != nullptr);
-  UR_CHECK_ERROR(hipEventDestroy(EvEnd));
-
-  if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-    UR_CHECK_ERROR(hipEventDestroy(EvQueued));
-    UR_CHECK_ERROR(hipEventDestroy(EvStart));
-  }
-
-  return UR_RESULT_SUCCESS;
-}
-
 UR_APIEXPORT ur_result_t UR_APICALL
 urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
   UR_ASSERT(numEvents > 0, UR_RESULT_ERROR_INVALID_VALUE);
@@ -293,7 +299,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
     std::unique_ptr<ur_event_handle_t_> event_ptr{hEvent};
     ur_result_t Result = UR_RESULT_ERROR_INVALID_EVENT;
     try {
-      Result = hEvent->release();
+      if (!hEvent->backendHasOwnership()) {
+        Result = UR_RESULT_SUCCESS;
+      } else {
+        assert(hEvent->getQueue() != nullptr);
+        assert(hEvent->getContext() != nullptr);
+
+        auto queue = event_ptr->getQueue();
+        auto context = event_ptr->getContext();
+
+        event_ptr->reset();
+        queue->CachedEvents.emplace(event_ptr.release());
+        urQueueRelease(queue);
+        urContextRelease(context);
+        Result = UR_RESULT_SUCCESS;
+      }
     } catch (...) {
       Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
     }

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -318,8 +318,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
     } catch (...) {
       return UR_RESULT_ERROR_OUT_OF_RESOURCES;
     }
+    return UR_RESULT_ERROR_INVALID_EVENT;
   }
-  return UR_RESULT_ERROR_INVALID_EVENT;
+  return UR_RESULT_SUCCESS;
 }
 
 /// Gets the native HIP handle of a UR event object

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -299,7 +299,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
   // decrement ref count. If it is 0, delete the event.
   if (hEvent->decrementReferenceCount() == 0) {
     std::unique_ptr<ur_event_handle_t_> event_ptr{hEvent};
-    ur_result_t Result = UR_RESULT_ERROR_INVALID_EVENT;
     try {
       if (!hEvent->backendHasOwnership()) {
         return UR_RESULT_SUCCESS;

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -106,6 +106,8 @@ public:
     return new ur_event_handle_t_(context, eventNative);
   }
 
+  // Resets attributes of an event.
+  // Throws an error if its RefCount is not 0.
   void reset();
 
   ~ur_event_handle_t_();

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -28,6 +28,16 @@ void ur_queue_handle_t_::transferStreamWaitForBarrierIfNeeded(
   }
 }
 
+ur_queue_handle_t_::~ur_queue_handle_t_() {
+  urContextRelease(Context);
+  urDeviceRelease(Device);
+
+  while (!CachedEvents.empty()) {
+    std::unique_ptr<ur_event_handle_t_> p{CachedEvents.top()};
+    CachedEvents.pop();
+  }
+}
+
 hipStream_t ur_queue_handle_t_::getNextComputeStream(uint32_t *StreamToken) {
   uint32_t Stream_i;
   uint32_t Token;

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -32,8 +32,10 @@ ur_queue_handle_t_::~ur_queue_handle_t_() {
   urContextRelease(Context);
   urDeviceRelease(Device);
 
-  while (has_cached_events()) {
-    get_cached_event();
+  std::lock_guard<std::mutex> CacheGuard(CacheMutex);
+  while (!CachedEvents.empty()) {
+    std::unique_ptr<ur_event_handle_t_> Ev{CachedEvents.top()};
+    CachedEvents.pop();
   }
 }
 

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -32,9 +32,8 @@ ur_queue_handle_t_::~ur_queue_handle_t_() {
   urContextRelease(Context);
   urDeviceRelease(Device);
 
-  while (!CachedEvents.empty()) {
-    std::unique_ptr<ur_event_handle_t_> p{CachedEvents.top()};
-    CachedEvents.pop();
+  while (has_cached_events()) {
+    get_cached_event();
   }
 }
 

--- a/source/adapters/hip/queue.hpp
+++ b/source/adapters/hip/queue.hpp
@@ -259,7 +259,7 @@ struct ur_queue_handle_t_ {
   // Returns and removes an event from the CachedEvents stack.
   ur_event_handle_t get_cached_event() {
     std::lock_guard<std::mutex> CacheGuard(CacheMutex);
-    assert(has_cached_events());
+    assert(!CachedEvents.empty());
     auto RetEv = CachedEvents.top();
     CachedEvents.pop();
     return RetEv;


### PR DESCRIPTION
Don't destroy events that are not needed anymore, but put them on a stack
of its associated queue (If there is one).

Use events from the stack before creating new ones.

Make the operations for putting events onto the stack and retrieving them
atomic to ensure thread safety.

This caching mechanism ensures that the number of CUDA API calls gets
significantly reduced for event creations and destructions.