### PR TITLE
[GHA] Use `-GNinja` in nightly workflow

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -115,6 +115,7 @@ jobs:
       run: >
         cmake
         -B build
+        -GNinja
         -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
         -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}


### PR DESCRIPTION
Workaround an upstream LLVM change which does not play well with the default `-G"Unix Makefiles"` CMake generator by using `-GNinja` instead.
