### PR TITLE
[L0] Use relative includes for adapter internals

### DIFF
--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#pragma once
 
 #include "logger/ur_logger.hpp"
 #include <atomic>

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -13,9 +13,9 @@
 #include <mutex>
 #include <string.h>
 
-#include "adapters/level_zero/queue.hpp"
 #include "context.hpp"
 #include "logger/ur_logger.hpp"
+#include "queue.hpp"
 #include "ur_level_zero.hpp"
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -16,8 +16,8 @@
 #include <vector>
 
 #include "adapter.hpp"
-#include "adapters/level_zero/event.hpp"
 #include "common.hpp"
+#include "event.hpp"
 #include "queue.hpp"
 #include "ur_api.h"
 #include "ur_level_zero.hpp"


### PR DESCRIPTION
Fix build issues when using decoupled adapter fetch in intel/llvm by using relative include paths instead of longer explicit paths. This was causing redefinitions of objects. This patch also adds a missing `#pragma once` from the `adapter.hpp` header.
