### PR TITLE
[CUDA] Remove the support of concurrent atomic access to host allocated pinned memory.

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -691,8 +691,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         // respect to other CPUs and GPUs in the system
         Value = UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS |
                 UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_ACCESS |
-                UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_CONCURRENT_ACCESS |
-                UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS;
+                UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_CONCURRENT_ACCESS;
       } else {
         // on GPU architectures with compute capability lower than 6.x, atomic
         // operations from the GPU to CPU memory will not be atomic with respect


### PR DESCRIPTION
Addresses the removal of `UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS` from the supported features of host memory. This change is prompted by the incompatibility of CUDA with concurrent atomic access between host and device to pinned memory.

The CUDA adapter uses `cuMemAllocHost` for host memory allocation, which allocates page-locked host memory. However, this type of memory does not support concurrent atomic access, as detailed in this [related discussion](https://stackoverflow.com/questions/23193151/atomic-operations-in-cuda-kernels-on-mapped-pinned-host-memory-to-do-or-not-to).

Furthermore, this issue shows in [SYCL-CTS-USM](https://github.com/KhronosGroup/SYCL-CTS/blob/9ea1b1cdda5689a14e42e83050637428298b838b/tests/usm/usm_atomic_access.h#L164) when `check_atomic_access` is specialized with `sycl::usm::alloc::host`.