### PR TITLE
stop batching multiple CmdList execution when waiting for barriers

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -367,6 +367,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
                                      IsInternal));
   }
 
+  // When executing command lists, allowing batching simply means storing
+  // the CmdLists as the current open batch. That's not what we want here.
+  // Moreover, the current implementation does not allow calling
+  // executeCommandList after an earlier getAvailableCommandList returned some
+  // other CmdList.
+  OkToBatch = false;
   // Execute each command list so the barriers can be encountered.
   for (ur_command_list_ptr_t &CmdList : CmdLists)
     UR_CALL(Queue->executeCommandList(CmdList, false, OkToBatch));


### PR DESCRIPTION
The current implementation of queue command batching appears to assume that getAvailableCommandList is followed by a single executeCommandList, and it's not allowed to, for example, create a list of CmdLists for later execution. And there's an assert to check for this.

This makes sense, since it doesn't really make sense to batch things across many different CmdLists. However, the implementation of urEnqueueEventsWaitWithBarrier was doing exactly that.

This patch disables batching in executeCommandList, fixing a assert failure during urEnqueueEventsWaitWithBarrier when many potentially open command lists are in use.