### PR TITLE
[CTS] Ensure GoogleTest does not output color

### DIFF
--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -20,8 +20,12 @@ function(add_test_adapter name adapter)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 
+    set(testEnv
+        UR_ADAPTERS_FORCE_LOAD="$<TARGET_FILE:ur_${adapter}>"
+        GTEST_COLOR=no
+    )
     set_tests_properties(${TEST_NAME} PROPERTIES
-        ENVIRONMENT "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_${adapter}>\""
+        ENVIRONMENT "${testEnv}"
         LABELS "conformance;${adapter}")
 endfunction()
 


### PR DESCRIPTION
The match files depend on the output from our GoogleTest test suites to not include ANSI color escape sequences but this setting can be controlled via environment variable `GTEST_COLOR=yes`. This can cause tests to fail even though they should not. This patch explicitly disabled color output by setting `GTEST_COLOR=no` in the test environment.
