### PR TITLE
Fix CTS test for HIP accessors

### DIFF
--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_hip.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_hip.match
@@ -1,8 +1,3 @@
-{{OPT}}BufferFillCommandTest.UpdateParameters/AMD_HIP_BACKEND{{.*}}
-{{OPT}}BufferFillCommandTest.UpdateGlobalSize/AMD_HIP_BACKEND{{.*}}
-{{OPT}}BufferFillCommandTest.SeparateUpdateCalls/AMD_HIP_BACKEND{{.*}}
-{{OPT}}BufferFillCommandTest.OverrideUpdate/AMD_HIP_BACKEND{{.*}}
-{{OPT}}BufferFillCommandTest.OverrideArgList/AMD_HIP_BACKEND{{.*}}
 {{OPT}}USMFillCommandTest.UpdateParameters/AMD_HIP_BACKEND{{.*}}
 {{OPT}}USMMultipleFillCommandTest.UpdateAllKernels/AMD_HIP_BACKEND{{.*}}
 {{OPT}}BufferSaxpyKernelTest.UpdateParameters/AMD_HIP_BACKEND{{.*}}
@@ -14,4 +9,3 @@
 {{OPT}}urCommandBufferReleaseCommandExpTest.InvalidNullHandle/AMD_HIP_BACKEND{{.*}}
 {{OPT}}urCommandBufferRetainCommandExpTest.Success/AMD_HIP_BACKEND{{.*}}
 {{OPT}}urCommandBufferRetainCommandExpTest.InvalidNullHandle/AMD_HIP_BACKEND{{.*}}
-{{OPT}}{{Segmentation fault|Aborted}}


### PR DESCRIPTION
CTS test assumes that backend will only require a single buffer accessor offset parameter, however the HIP backend requires 3.

This should fix [sporadic failures](https://github.com/oneapi-src/unified-runtime/actions/runs/8892452470/job/24416545313) in the `BufferFillCommandTest` tests.