### PR TITLE
[HIP] Add a workaround for crashes on gfx1031

### DIFF
--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -732,7 +732,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     hipDeviceProp_t Props;
     UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
     if (strcmp(Props.gcnArchName, "gfx1031") == 0) {
-      return ReturnValue(0);
+      return ReturnValue(size_t{0});
     }
 
     size_t FreeMemory = 0;

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -730,17 +730,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // can't distinguish this condition from us doing something wrong, we can't
     // handle it gracefully.
     hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
+    UR_CHECK_ERROR(hipGetDeviceProperties(&Props, hDevice->get()));
     if (strcmp(Props.gcnArchName, "gfx1031") == 0) {
       return ReturnValue(0);
     }
 
     size_t FreeMemory = 0;
     size_t TotalMemory = 0;
-    detail::ur::assertion(hipMemGetInfo(&FreeMemory, &TotalMemory) ==
-                              hipSuccess,
-                          "failed hipMemGetInfo() API.");
+    UR_CHECK_ERROR(hipMemGetInfo(&FreeMemory, &TotalMemory));
     return ReturnValue(FreeMemory);
   }
 


### PR DESCRIPTION
When calling hipMemGetInfo, an internal problem querying the amount of available global memory causes the function to return hipErrorInvalidValue. This is indistinguishable from us doing something wrong, and it (rightly) causes an assertion failure. This is a particularly egregious issue because we query this property and crash during the execution of `sycl-ls --verbose`.

This architecture is not officially supported by HIP, so we can't file a bug and shouldn't expect an official fix for this issue any time soon. It is possible, however, that we'll need to extend this workaround with other architectures over time.