### PR TITLE
Optimize get_logger function

### DIFF
--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -16,12 +16,12 @@ namespace logger {
 
 Logger create_logger(std::string logger_name, bool skip_prefix = false);
 
-inline Logger &get_logger(std::string name = "common") {
-    static Logger logger = create_logger(std::move(name));
+inline Logger &get_logger(const char *name = "common") {
+    static Logger logger = create_logger(name);
     return logger;
 }
 
-inline void init(std::string name) { get_logger(std::move(name)); }
+inline void init(const std::string &name) { get_logger(name.c_str()); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {


### PR DESCRIPTION
avoid creating a temporary string.

`logger::debug` is visible as a hostspot for `doCall` for certain benchmarks on `-Og`.  It's hard to estimate the actual benefit of this but on a simple microbenchmark (calling `logger::debug` in a loop) this change brings ~40% improvement.
