### PR TITLE
[CUDA][HIP] Replace occurrences of `size_t` with `uint64_t` to improve code portability.

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -418,7 +418,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(static_cast<size_t>(Min));
   }
   case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE: {
-    return ReturnValue(0lu);
+    return ReturnValue(size_t(0));
   }
   case UR_DEVICE_INFO_MAX_SAMPLERS: {
     // This call is kind of meaningless for cuda, as samplers don't exist.
@@ -429,7 +429,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // https://docs.nvidia.com/cuda/cuda-c-programming-guide/#function-parameters
     // __global__ function parameters are passed to the device via constant
     // memory and are limited to 4 KB.
-    return ReturnValue(4000lu);
+    return ReturnValue(size_t(4000));
   }
   case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
     int MemBaseAddrAlign = 0;
@@ -542,7 +542,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION: {
     // Hard coded to value returned by clinfo for OpenCL 1.2 CUDA | GeForce GTX
     // 1060 3GB
-    return ReturnValue(1000lu);
+    return ReturnValue(size_t(1000));
   }
   case UR_DEVICE_INFO_ENDIAN_LITTLE: {
     return ReturnValue(true);
@@ -646,7 +646,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE: {
     // The minimum value for the FULL profile is 1 MB.
-    return ReturnValue(1024lu);
+    return ReturnValue(size_t(1024));
   }
   case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
     return ReturnValue(true);

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -321,7 +321,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(static_cast<size_t>(Min));
   }
   case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE: {
-    return ReturnValue(0lu);
+    return ReturnValue(size_t(0));
   }
   case UR_DEVICE_INFO_MAX_SAMPLERS: {
     // This call is kind of meaningless for HIP, as samplers don't exist.
@@ -331,7 +331,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_MAX_PARAMETER_SIZE: {
     // __global__ function parameters are passed to the device via constant
     // memory and are limited to 4 KB.
-    return ReturnValue(4000lu);
+    return ReturnValue(size_t(4000));
   }
   case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
     int MemBaseAddrAlign = 0;
@@ -442,7 +442,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION: {
     // Hard coded to value returned by clinfo for OpenCL 1.2 HIP | GeForce GTX
     // 1060 3GB
-    return ReturnValue(1000lu);
+    return ReturnValue(size_t(1000));
   }
   case UR_DEVICE_INFO_ENDIAN_LITTLE: {
     return ReturnValue(true);
@@ -569,7 +569,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE: {
     // The minimum value for the FULL profile is 1 MB.
-    return ReturnValue(1024lu);
+    return ReturnValue(size_t(1024));
   }
   case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
     return ReturnValue(true);


### PR DESCRIPTION
Replaces the usage of `size_t` with `uint64_t` to enhance the portability of the code across Windows and Linux platforms. The discrepancy in the size of `size_t (unsigned long)` between Linux and Windows environments necessitates this change for consistent behaviour.
The issue showed as a failure testing [test-e2e/Basic/info.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Basic/info.cpp) on Windows.