### PR TITLE
[CTS] Avoid division by zero (when there are no results)

### DIFF
--- a/scripts/ctest_parser.py
+++ b/scripts/ctest_parser.py
@@ -24,7 +24,7 @@ def get_cts_test_suite_names(working_directory):
     ]
 
 def percent(amount, total):
-    return round((amount / total) * 100, 2)
+    return round((amount / (total or 1)) * 100, 2)
 
 def summarize_results(results):
     total = results['Total']


### PR DESCRIPTION
When trying to run the CTS from a directory with no tests then the total number of tests is 0, which was causing issues when summarizing results.