### PR TITLE
[CTS] Allow disabling the use of match files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
 set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
     "List of sycl targets to build CTS device binaries for")
 set(UR_CONFORMANCE_AMD_ARCH "" CACHE STRING "AMD device target ID to build CTS binaries for")
+option(UR_CONFORMANCE_ENABLE_MATCH_FILES "Enable CTS match files" ON)
 set(UR_ADAPTER_LEVEL_ZERO_SOURCE_DIR "" CACHE PATH
     "Path to external 'level_zero' adapter source dir")
 set(UR_ADAPTER_OPENCL_SOURCE_DIR "" CACHE PATH

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ List of options provided by CMake:
 | UR_ENABLE_SANITIZER | Enable device sanitizer layer | ON/OFF | ON |
 | UR_CONFORMANCE_TARGET_TRIPLES | SYCL triples to build CTS device binaries for | Comma-separated list | spir64 |
 | UR_CONFORMANCE_AMD_ARCH | AMD device target ID to build CTS binaries for | string | `""` |
+| UR_CONFORMANCE_ENABLE_MATCH_FILES | Enable CTS match files | ON/OFF | ON |
 | UR_BUILD_ADAPTER_L0     | Build the Level-Zero adapter            | ON/OFF     | OFF     |
 | UR_BUILD_ADAPTER_OPENCL | Build the OpenCL adapter                | ON/OFF     | OFF     |
 | UR_BUILD_ADAPTER_CUDA   | Build the CUDA adapter                  | ON/OFF     | OFF     |

--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -9,23 +9,35 @@ function(add_test_adapter name adapter)
     set(TEST_TARGET_NAME test-${name})
     set(TEST_NAME ${name}-${adapter})
 
-    add_test(NAME ${TEST_NAME}
-        COMMAND ${CMAKE_COMMAND}
-        -D TEST_FILE=${Python3_EXECUTABLE}
-        -D TEST_ARGS="${UR_CONFORMANCE_TEST_DIR}/cts_exe.py --test_command ${CMAKE_BINARY_DIR}/bin/${TEST_TARGET_NAME} --test_devices_count=${UR_TEST_DEVICES_COUNT} --test_platforms_count=${UR_TEST_PLATFORMS_COUNT}"
-        -D MODE=stdout
-        -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}_${adapter}.match
-        -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-        DEPENDS ${TEST_TARGET_NAME}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    set(TEST_COMMAND
+        "${PROJECT_BINARY_DIR}/bin/${TEST_TARGET_NAME} --test_devices_count=${UR_TEST_DEVICES_COUNT} --test_platforms_count=${UR_TEST_PLATFORMS_COUNT}"
     )
 
-    set(testEnv
-        UR_ADAPTERS_FORCE_LOAD="$<TARGET_FILE:ur_${adapter}>"
-        GTEST_COLOR=no
-    )
+    if(UR_CONFORMANCE_ENABLE_MATCH_FILES)
+        add_test(NAME ${TEST_NAME}
+            COMMAND ${CMAKE_COMMAND}
+            -D TEST_FILE=${Python3_EXECUTABLE}
+            -D TEST_ARGS="${UR_CONFORMANCE_TEST_DIR}/cts_exe.py --test_command ${TEST_COMMAND}"
+            -D MODE=stdout
+            -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}_${adapter}.match
+            -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
+            DEPENDS ${TEST_TARGET_NAME}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+    else()
+        add_test(NAME ${TEST_NAME}
+            COMMAND ${TEST_COMMAND}
+            DEPENDS ${TEST_TARGET_NAME}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+    endif()
+
+    set(TEST_ENV UR_ADAPTERS_FORCE_LOAD="$<TARGET_FILE:ur_${adapter}>")
+    if(NOT UR_CONFORMANCE_TEST_DIR)
+        list(APPEND TEST_ENV GTEST_COLOR=no)
+    endif()
     set_tests_properties(${TEST_NAME} PROPERTIES
-        ENVIRONMENT "${testEnv}"
+        ENVIRONMENT "${TEST_ENV}"
         LABELS "conformance;${adapter}")
 endfunction()
 


### PR DESCRIPTION
This patch adds a new CMake option `UR_CONFORMANCE_ENABLE_MATCH_FILES`, defaulting to `ON`, which allows developers to disable the use of match files in order to discover the true state of conformance runs.
