### PR TITLE
[Loader] Add Native CPU to adapter registry

### DIFF
--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -114,11 +114,13 @@ class AdapterRegistry {
     // to load the adapter.
     std::vector<std::vector<fs::path>> adaptersLoadPaths;
 
-    static constexpr std::array<const char *, 4> knownAdapterNames{
+    static constexpr std::array<const char *, 5> knownAdapterNames{
         MAKE_LIBRARY_NAME("ur_adapter_level_zero", "0"),
-        MAKE_LIBRARY_NAME("ur_adapter_hip", "0"),
         MAKE_LIBRARY_NAME("ur_adapter_opencl", "0"),
-        MAKE_LIBRARY_NAME("ur_adapter_cuda", "0")};
+        MAKE_LIBRARY_NAME("ur_adapter_cuda", "0"),
+        MAKE_LIBRARY_NAME("ur_adapter_hip", "0"),
+        MAKE_LIBRARY_NAME("ur_adapter_native_cpu", "0"),
+    };
 
     std::optional<std::vector<fs::path>> getEnvAdapterSearchPaths() {
         std::optional<std::vector<std::string>> pathStringsOpt;


### PR DESCRIPTION
This patch belatedly adds the Native CPU adapter to the list of known adapters in the adapter registry. It also reorders the adapters in the know list.
