### PR TITLE
Improve CTS device code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ List of options provided by CMake:
 | UR_HIP_PLATFORM         | Build HIP adapter for AMD or NVIDIA platform           | AMD/NVIDIA | AMD     |
 | UR_ENABLE_COMGR         | Enable comgr lib usage           | AMD/NVIDIA | AMD     |
 | UR_DPCXX | Path of the DPC++ compiler executable to build CTS device binaries | File path | `""` |
+| UR_DEVICE_CODE_EXTRACTOR | Path of the `clang-offload-extract` executable from the DPC++ package, required for CTS device binaries | File path | `"${dirname(UR_DPCXX)}/clang-offload-extract"` |
 | UR_DPCXX_BUILD_FLAGS | Build flags to pass to DPC++ when compiling device programs | Space-separated options list | `""` |
 | UR_SYCL_LIBRARY_DIR | Path of the SYCL runtime library directory to build CTS device binaries | Directory path | `""` |
 | UR_HIP_ROCM_DIR | Path of the default ROCm HIP installation | Directory path | `/opt/rocm` |

--- a/test/conformance/device_code/CMakeLists.txt
+++ b/test/conformance/device_code/CMakeLists.txt
@@ -10,6 +10,10 @@ else()
     set(AMD_ARCH "${UR_CONFORMANCE_AMD_ARCH}")
 endif()
 
+cmake_path(GET UR_DPCXX EXTENSION EXE)
+cmake_path(REPLACE_FILENAME UR_DPCXX "clang-offload-extract${EXE}" OUTPUT_VARIABLE DEFAULT_EXTRACTOR_NAME)
+set(UR_DEVICE_CODE_EXTRACTOR "${DEFAULT_EXTRACTOR_NAME}" CACHE PATH "Path to clang-offload-extract")
+
 if("${AMD_ARCH}" STREQUAL "" AND "${TARGET_TRIPLES}" MATCHES "amd")
     find_package(RocmAgentEnumerator)
     if(NOT ROCM_AGENT_ENUMERATOR_FOUND)
@@ -59,6 +63,8 @@ macro(add_device_binary SOURCE_FILE)
 
     foreach(TRIPLE ${TARGET_TRIPLES})
         set(EXE_PATH "${DEVICE_BINARY_DIR}/${KERNEL_NAME}_${TRIPLE}")
+        set(BIN_PATH "${DEVICE_BINARY_DIR}/${TRIPLE}.bin.0")
+
         if(${TRIPLE} MATCHES "amd")
             set(AMD_TARGET_BACKEND -Xsycl-target-backend=${TRIPLE})
             set(AMD_OFFLOAD_ARCH  --offload-arch=${AMD_ARCH})
@@ -81,17 +87,17 @@ macro(add_device_binary SOURCE_FILE)
             continue()
         endif()
 
-        add_custom_command(OUTPUT ${EXE_PATH}
+        add_custom_command(OUTPUT "${BIN_PATH}"
             COMMAND ${UR_DPCXX} -fsycl -fsycl-targets=${TRIPLE} -fsycl-device-code-split=off 
             ${AMD_TARGET_BACKEND} ${AMD_OFFLOAD_ARCH} ${AMD_NOGPULIB}
             ${DPCXX_BUILD_FLAGS_LIST} ${SOURCE_FILE} -o ${EXE_PATH}
 
-            COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} SYCL_DUMP_IMAGES=true
-            ${EXE_PATH} || exit 0
+            COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} ${UR_DEVICE_CODE_EXTRACTOR} --stem="${TRIPLE}.bin" ${EXE_PATH}
+
             WORKING_DIRECTORY "${DEVICE_BINARY_DIR}"
             DEPENDS ${SOURCE_FILE}
         )
-        add_custom_target(generate_${KERNEL_NAME}_${TRIPLE} DEPENDS ${EXE_PATH})
+        add_custom_target(generate_${KERNEL_NAME}_${TRIPLE} DEPENDS ${BIN_PATH})
         add_dependencies(generate_device_binaries generate_${KERNEL_NAME}_${TRIPLE})
     endforeach()
     list(APPEND DEVICE_CODE_SOURCES ${SOURCE_FILE})

--- a/test/conformance/program/urProgramBuild.cpp
+++ b/test/conformance/program/urProgramBuild.cpp
@@ -30,8 +30,7 @@ TEST_P(urProgramBuildTest, InvalidNullHandleProgram) {
 TEST_P(urProgramBuildTest, BuildFailure) {
     ur_program_handle_t program = nullptr;
     std::shared_ptr<std::vector<char>> il_binary;
-    uur::KernelsEnvironment::instance->LoadSource("build_failure", 0,
-                                                  il_binary);
+    uur::KernelsEnvironment::instance->LoadSource("build_failure", il_binary);
     if (!il_binary) {
         // The build failure we are testing for happens at SYCL compile time on
         // AMD and Nvidia, so no binary exists to check for a build failure

--- a/test/conformance/program/urProgramCreateWithIL.cpp
+++ b/test/conformance/program/urProgramCreateWithIL.cpp
@@ -17,7 +17,7 @@ struct urProgramCreateWithILTest : uur::urContextTest {
         if (backend == UR_PLATFORM_BACKEND_HIP) {
             GTEST_SKIP();
         }
-        uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary);
+        uur::KernelsEnvironment::instance->LoadSource("foo", il_binary);
     }
 
     void TearDown() override {

--- a/test/conformance/source/environment.cpp
+++ b/test/conformance/source/environment.cpp
@@ -367,7 +367,7 @@ KernelsEnvironment::parseKernelOptions(int argc, char **argv,
     return options;
 }
 
-std::string KernelsEnvironment::getSupportedILPostfix(uint32_t device_index) {
+std::string KernelsEnvironment::getTargetName() {
     std::stringstream IL;
 
     if (instance->GetDevices().size() == 0) {
@@ -382,66 +382,44 @@ std::string KernelsEnvironment::getSupportedILPostfix(uint32_t device_index) {
         error = "failed to get backend from platform.";
         return {};
     }
-    if (backend == UR_PLATFORM_BACKEND_HIP) {
-        return ".bin";
-    }
 
-    auto device = instance->GetDevices()[device_index];
-    std::string IL_version;
-    if (uur::GetDeviceILVersion(device, IL_version)) {
-        error = "failed to get device IL version";
+    std::string target = "";
+    switch (backend) {
+    case UR_PLATFORM_BACKEND_OPENCL:
+    case UR_PLATFORM_BACKEND_LEVEL_ZERO:
+        return "spir64";
+    case UR_PLATFORM_BACKEND_CUDA:
+        return "nvptx64-nvidia-cuda";
+    case UR_PLATFORM_BACKEND_HIP:
+        return "amdgcn-amd-amdhsa";
+    case UR_PLATFORM_BACKEND_NATIVE_CPU:
+        error = "native_cpu doesn't support kernel tests yet";
+        return {};
+    default:
+        error = "unknown target.";
         return {};
     }
-
-    // TODO: This potentially needs updating as more adapters are tested.
-    if (IL_version.find("SPIR-V") != std::string::npos) {
-        IL << ".spv";
-    } else if (IL_version.find("nvptx") != std::string::npos) {
-        IL << ".bin";
-    } else {
-        error = "Undefined IL version: " + IL_version;
-        return {};
-    }
-
-    return IL.str();
 }
 
 std::string
-KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name,
-                                        uint32_t device_index) {
+KernelsEnvironment::getKernelSourcePath(const std::string &kernel_name) {
     std::stringstream path;
     path << kernel_options.kernel_directory << "/" << kernel_name;
-    std::string il_postfix = getSupportedILPostfix(device_index);
 
-    if (il_postfix.empty()) {
+    std::string target_name = getTargetName();
+    if (target_name.empty()) {
         return {};
     }
 
-    std::string binary_name;
-    for (const auto &entry : filesystem::directory_iterator(path.str())) {
-        auto file_name = entry.path().filename().string();
-        if (file_name.find(il_postfix) != std::string::npos) {
-            binary_name = file_name;
-            break;
-        }
-    }
-
-    if (binary_name.empty()) {
-        error =
-            "failed retrieving kernel source path for kernel: " + kernel_name;
-        return {};
-    }
-
-    path << "/" << binary_name;
+    path << "/" << target_name << ".bin.0";
 
     return path.str();
 }
 
 void KernelsEnvironment::LoadSource(
-    const std::string &kernel_name, uint32_t device_index,
+    const std::string &kernel_name,
     std::shared_ptr<std::vector<char>> &binary_out) {
-    std::string source_path =
-        instance->getKernelSourcePath(kernel_name, device_index);
+    std::string source_path = instance->getKernelSourcePath(kernel_name);
 
     if (source_path.empty()) {
         FAIL() << error;

--- a/test/conformance/testing/include/uur/environment.h
+++ b/test/conformance/testing/include/uur/environment.h
@@ -72,7 +72,7 @@ struct KernelsEnvironment : DevicesEnvironment {
     virtual void SetUp() override;
     virtual void TearDown() override;
 
-    void LoadSource(const std::string &kernel_name, uint32_t device_index,
+    void LoadSource(const std::string &kernel_name,
                     std::shared_ptr<std::vector<char>> &binary_out);
 
     ur_result_t CreateProgram(ur_platform_handle_t hPlatform,
@@ -89,9 +89,8 @@ struct KernelsEnvironment : DevicesEnvironment {
   private:
     KernelOptions parseKernelOptions(int argc, char **argv,
                                      const std::string &kernels_default_dir);
-    std::string getKernelSourcePath(const std::string &kernel_name,
-                                    uint32_t device_index);
-    std::string getSupportedILPostfix(uint32_t device_index);
+    std::string getKernelSourcePath(const std::string &kernel_name);
+    std::string getTargetName();
 
     KernelOptions kernel_options;
     // mapping between kernels (full_path + kernel_name) and their saved source.

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -350,7 +350,7 @@ struct urHostPipeTest : urQueueTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urQueueTest::SetUp());
         UUR_RETURN_ON_FATAL_FAILURE(
-            uur::KernelsEnvironment::instance->LoadSource("foo", 0, il_binary));
+            uur::KernelsEnvironment::instance->LoadSource("foo", il_binary));
         ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
             platform, context, device, *il_binary, nullptr, &program));
 
@@ -1135,7 +1135,7 @@ struct urProgramTest : urQueueTest {
             GTEST_SKIP();
         }
         UUR_RETURN_ON_FATAL_FAILURE(
-            uur::KernelsEnvironment::instance->LoadSource(program_name, 0,
+            uur::KernelsEnvironment::instance->LoadSource(program_name,
                                                           il_binary));
 
         const ur_program_properties_t properties = {
@@ -1174,7 +1174,7 @@ template <class T> struct urProgramTestWithParam : urQueueTestWithParam<T> {
         }
 
         UUR_RETURN_ON_FATAL_FAILURE(
-            uur::KernelsEnvironment::instance->LoadSource(program_name, 0,
+            uur::KernelsEnvironment::instance->LoadSource(program_name,
                                                           il_binary));
         ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
             this->platform, this->context, this->device, *il_binary, nullptr,


### PR DESCRIPTION
Some improvements to the device code generation cmake:
* Use `clang-offload-extract` instead of running the binary directly.
* Set up dependencies correctly so that re-running builds will generate missing IR files if they failed to build prior.
* Dynamically generate the list of device_code files - from now on, any .cpp file in the device_code directory will automatically be treated as device code and generate IR files.

This change drops CTS support for platforms that support multiple devices with different IR types, however the build system didn't support that anyway, nor do any of our adapters.

This change requires a `clang-offload-extract` binary to be available. By default it is assumed to be in the same directory as the provided DPC++ binary (which should work for most builds), however the CMake variable `UR_DEVICE_CODE_EXTRACTOR` is provided to override this.