### PR TITLE
[NFC] Bump CMake verson to 0.10.0

### DIFF
--- a/.github/scripts/get_system_info.sh
+++ b/.github/scripts/get_system_info.sh
@@ -53,7 +53,7 @@ function system_info {
 	echo "**********/proc/meminfo**********"
 	cat /proc/meminfo
 	echo "**********build/bin/urinfo**********"
-	$(dirname "$(readlink -f "$0")")/../../build/bin/urinfo || true
+	$(dirname "$(readlink -f "$0")")/../../build/bin/urinfo --no-linear-ids --verbose || true
 	echo "******OpenCL*******"
 	# The driver version of OpenCL Graphics is the compute-runtime version
 	clinfo || echo "OpenCL not installed"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
-project(unified-runtime VERSION 0.9.0)
+project(unified-runtime VERSION 0.10.0)
 
 include(GNUInstallDirs)
 include(CheckCXXSourceCompiles)

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  * @file ur_api.h
- * @version v0.9-r0
+ * @version v0.10-r0
  *
  */
 #ifndef UR_API_H_INCLUDED
@@ -1098,11 +1098,12 @@ urPlatformGetInfo(
 ///     - API versions contain major and minor attributes, use
 ///       ::UR_MAJOR_VERSION and ::UR_MINOR_VERSION
 typedef enum ur_api_version_t {
-    UR_API_VERSION_0_6 = UR_MAKE_VERSION(0, 6),     ///< version 0.6
-    UR_API_VERSION_0_7 = UR_MAKE_VERSION(0, 7),     ///< version 0.7
-    UR_API_VERSION_0_8 = UR_MAKE_VERSION(0, 8),     ///< version 0.8
-    UR_API_VERSION_0_9 = UR_MAKE_VERSION(0, 9),     ///< version 0.9
-    UR_API_VERSION_CURRENT = UR_MAKE_VERSION(0, 9), ///< latest known version
+    UR_API_VERSION_0_6 = UR_MAKE_VERSION(0, 6),      ///< version 0.6
+    UR_API_VERSION_0_7 = UR_MAKE_VERSION(0, 7),      ///< version 0.7
+    UR_API_VERSION_0_8 = UR_MAKE_VERSION(0, 8),      ///< version 0.8
+    UR_API_VERSION_0_9 = UR_MAKE_VERSION(0, 9),      ///< version 0.9
+    UR_API_VERSION_0_10 = UR_MAKE_VERSION(0, 10),    ///< version 0.10
+    UR_API_VERSION_CURRENT = UR_MAKE_VERSION(0, 10), ///< latest known version
     /// @cond
     UR_API_VERSION_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  * @file ur_ddi.h
- * @version v0.9-r0
+ * @version v0.10-r0
  *
  */
 #ifndef UR_DDI_H_INCLUDED

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  * @file ur_print.hpp
- * @version v0.9-r0
+ * @version v0.10-r0
  *
  */
 #ifndef UR_PRINT_HPP

--- a/scripts/Doxyfile
+++ b/scripts/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Intel One API Unified Runtime API"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.9
+PROJECT_NUMBER         = v0.10
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -140,6 +140,9 @@ etors:
     - name: "0_9"
       value: "$X_MAKE_VERSION( 0, 9 )"
       desc: "version 0.9"
+    - name: "0_10"
+      value: "$X_MAKE_VERSION( 0, 10 )"
+      desc: "version 0.10"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Returns the API version supported by the specified platform"

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import util
 import re
+from parse_specs import Version
 
 RE_ENABLE   = r"^\#\#\s*\-\-validate\s*\=\s*on$"
 RE_DISABLE  = r"^\#\#\s*\-\-validate\s*\=\s*off$"
@@ -87,7 +88,7 @@ def _make_ref(symbol, symbol_type, meta):
     generate a valid reStructuredText file
 """
 def _generate_valid_rst(fin, fout, namespace, tags, ver, rev, meta, fast_mode):
-    ver=float(ver)
+    ver = Version(ver)
     enable = True
     code_block = False
 

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -6,20 +6,23 @@
  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """
+
 import os
 import generate_ids
 import util
 import re
 import hashlib
 import json
-import yaml
 import copy
 from templates.helper import param_traits, type_traits, value_traits
 import ctypes
 import itertools
+from typing import Optional
+from version import Version
 
-default_version = "0.9"
-all_versions = ["0.6", "0.7", "0.8", "0.9"]
+
+default_version = Version("0.10")
+all_versions = [Version(ver) for ver in ["0.6", "0.7", "0.8", "0.9", "0.10"]]
 
 """
     preprocess object
@@ -105,14 +108,14 @@ def _validate_doc(f, d, tags, line_num, meta):
                 raise Exception(prefix+"'version' must be a string: '%s'"%type(d['version']))
 
             try:
-                version = str(float(d['version']))
+                version = str(d['version'])
             except:
                 version = None
 
             if version != d['version']:
                 raise Exception(prefix+"'version' invalid value: '%s'"%d['version'])
 
-        return float(d.get('version', base_version))
+        return Version(d.get('version', base_version))
 
     def __validate_tag(d, key, tags, case):
         for x in tags:
@@ -127,7 +130,7 @@ def _validate_doc(f, d, tags, line_num, meta):
                     raise Exception(prefix+"'version' must be a string: '%s'"%type(k))
 
                 try:
-                    version = str(float(k))
+                    version = str(k)
                 except:
                     version = None
 
@@ -212,8 +215,8 @@ def _validate_doc(f, d, tags, line_num, meta):
         typed = d.get('typed_etors', False)
 
         value = -1
-        d_ver = d.get('version', default_version)
-        max_ver = float(d_ver)
+        d_ver = Version(d.get('version', default_version))
+        max_ver = d_ver
         for i, item in enumerate(d['etors']):
             prefix="'etors'[%s] "%i
             if not isinstance(item, dict):
@@ -300,8 +303,8 @@ def _validate_doc(f, d, tags, line_num, meta):
         if not isinstance(d['members'], list):
             raise Exception("'members' must be a sequence: '%s'"%type(d['members']))
 
-        d_ver = d.get('version', default_version)
-        max_ver = float(d_ver)
+        d_ver = Version(d.get('version', default_version))
+        max_ver = d_ver
         for i, item in enumerate(d['members']):
             prefix="'members'[%s] "%i
             if not isinstance(item, dict):
@@ -342,8 +345,8 @@ def _validate_doc(f, d, tags, line_num, meta):
         if not isinstance(d['params'], list):
             raise Exception("'params' must be a sequence: '%s'"%type(d['params']))
 
-        d_ver = d.get('version', default_version)
-        max_ver = float(d_ver)
+        d_ver = Version(d.get('version', default_version))
+        max_ver = d_ver
         min = {'[in]': None, '[out]': None, '[in,out]': None}
         for i, item in enumerate(d['params']):
             prefix="'params'[%s] "%i
@@ -501,24 +504,23 @@ def _validate_doc(f, d, tags, line_num, meta):
 """
     filters object by version
 """
-def _filter_version(d, max_ver):
-    ver = float(d.get('version', default_version))
+def _filter_version(d, max_ver: Version) -> Optional[dict]:
+    ver = Version(d.get('version', default_version))
     if ver > max_ver:
         return None
 
-    def __filter_desc(d):
+    def __filter_desc(d) -> dict:
         if 'desc' in d and isinstance(d['desc'], dict):
             for k, v in d['desc'].items():
-                if float(k) <= max_ver:
-                    desc = v
-            d['desc'] = desc
+                if Version(k) <= max_ver:
+                    d['desc'] = v
         return d
 
     flt = []
     type = d['type']
     if 'enum' == type:
         for e in d['etors']:
-            ver = float(e.get('version', default_version))
+            ver = Version(e.get('version', default_version))
             if ver <= max_ver:
                 flt.append(__filter_desc(e))
         if d['name'].endswith('version_t'):
@@ -531,14 +533,14 @@ def _filter_version(d, max_ver):
 
     elif 'function' == type:
         for p in d['params']:
-            ver = float(p.get('version', default_version))
+            ver = Version(p.get('version', default_version))
             if ver <= max_ver:
                 flt.append(__filter_desc(p))
         d['params'] = flt
 
     elif 'struct' == type or 'union' == type or 'class' == type:
         for m in d.get('members',[]):
-            ver = float(m.get('version', default_version))
+            ver = Version(m.get('version', default_version))
             if ver <= max_ver:
                 flt.append(__filter_desc(m))
         d['members'] = flt
@@ -548,15 +550,15 @@ def _filter_version(d, max_ver):
 """
     creates docs per version
 """
-def _make_versions(d, max_ver):
+def _make_versions(d, max_ver : Version) -> list[Version]:
     docs = []
     type = d['type']
     if 'function' == type or 'struct' == type:
         for ver in all_versions:
-            if float(ver) > max_ver:
+            if ver > max_ver:
                 break
 
-            dv = _filter_version(copy.deepcopy(d), float(ver))
+            dv = _filter_version(copy.deepcopy(d), ver)
             if not dv:
                 continue
 
@@ -936,7 +938,7 @@ def parse(section, version, tags, meta, ref):
             if not _validate_doc(f, d, tags, line_nums[i], meta):
                 continue
 
-            d = _filter_version(d, float(version))
+            d = _filter_version(d, version)
             if not d:
                 continue
 
@@ -948,7 +950,10 @@ def parse(section, version, tags, meta, ref):
             # extract header from objects
             if re.match(r"header", d['type']):
                 header = d
-                header['ordinal'] = int(int(header.get('ordinal',"1000")) * float(header.get('version',"1.0")))
+                header["ordinal"] = int(
+                    int(header.get("ordinal", "1000"))
+                    * Version(header.get("version", "1.0")).major
+                )
                 header['ordinal'] *= 1000 if re.match(r"extension", header.get('desc',"").lower()) else 1
                 header['ordinal'] *= 1000 if re.match(r"experimental", header.get('desc',"").lower()) else 1
                 basename = os.path.splitext(os.path.basename(f))[0]
@@ -961,7 +966,7 @@ def parse(section, version, tags, meta, ref):
                 for c in '_-':
                     name = name.replace(c, ' ')
             elif header:
-                for d in _make_versions(d, float(version)):
+                for d in _make_versions(d, version):
                     objects.append(d)
                     meta = _generate_meta(d, header['ordinal'], meta)
 

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -12,6 +12,7 @@ import util
 
 # allow imports from top-level scripts directory
 sys.path.append("..")
+from version import Version
 
 """
     Extracts traits from a spec object
@@ -1081,15 +1082,20 @@ Public:
 def get_class_function_objs(specs, cname, version = None):
     objects = []
     for s in specs:
-        for obj in s['objects']:
+        for obj in s["objects"]:
             is_function = obj_traits.is_function(obj)
             match_cls = cname == obj_traits.class_name(obj)
             if is_function and match_cls:
                 if version is None:
                     objects.append(obj)
-                elif float(obj.get('version',"1.0")) <= version:
+                elif Version(obj.get("version", "1.0")) <= version:
                     objects.append(obj)
-    return sorted(objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))
+    return sorted(
+        objects,
+        key=lambda obj: (Version(obj.get("version", "1.0")).major * 10000)
+        + int(obj.get("ordinal", "100")),
+    )
+
 
 """
 Public:
@@ -1107,8 +1113,16 @@ def get_class_function_objs_exp(specs, cname):
                     exp_objects.append(obj)
                 else:
                     objects.append(obj)
-    objects = sorted(objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))
-    exp_objects = sorted(exp_objects, key=lambda obj: (float(obj.get('version',"1.0"))*10000) + int(obj.get('ordinal',"100")))
+    objects = sorted(
+        objects,
+        key=lambda obj: (Version(obj.get("version", "1.0")).major * 10000)
+        + int(obj.get("ordinal", "100")),
+    )
+    exp_objects = sorted(
+        exp_objects,
+        key=lambda obj: (Version(obj.get("version", "1.0")).major * 10000)
+        + int(obj.get("ordinal", "100")),
+    )
     return objects, exp_objects
 
 """
@@ -1222,7 +1236,7 @@ Public:
 def get_pfncbtables(specs, meta, namespace, tags):
     tables = []
     for cname in sorted(meta['class'], key=lambda x: meta['class'][x]['ordinal']):
-        objs = get_class_function_objs(specs, cname, 1.0)
+        objs = get_class_function_objs(specs, cname, Version('1.0'))
         if len(objs) > 0:
             name = get_table_name(namespace, tags, {'class': cname})
             print(name)

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,41 @@
+"""
+Copyright (C) 2024 Intel Corporation
+
+Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+See LICENSE.TXT
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""
+
+import functools
+import re
+
+
+@functools.total_ordering
+class Version:
+    def __init__(self, version: str):
+        assert isinstance(version, (str, Version))
+        if isinstance(version, str):
+            self.str = version
+            match = re.match(r"^(\d+)\.(\d+)$", self.str)
+            assert isinstance(match, re.Match)
+            self.major = int(match.groups()[0])
+            self.minor = int(match.groups()[1])
+        else:
+            self.str = version.str
+            self.major = version.major
+            self.minor = version.minor
+
+    def __eq__(self, other) -> bool:
+        assert isinstance(other, Version)
+        return self.major == other.major and self.minor == other.minor
+
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, Version):
+            import ipdb; ipdb.set_trace()
+        return self.major < other.major or (
+            self.major == other.major and self.minor < other.minor
+        )
+
+    def __str__(self) -> str:
+        return self.str

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -507,7 +507,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
           cl_adapter::cast<cl_device_id>(hDevice), {"cl_khr_fp16"}, Supported));
 
       if (!Supported) {
-        return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
       }
     }
 

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
  * @file ur_api.cpp
- * @version v0.9-r0
+ * @version v0.10-r0
  *
  */
 #include "ur_api.h"

--- a/test/conformance/device/device_adapter_opencl.match
+++ b/test/conformance/device/device_adapter_opencl.match
@@ -1,1 +1,0 @@
-urDeviceGetInfoTest.Success/UR_DEVICE_INFO_HALF_FP_CONFIG


### PR DESCRIPTION
Bumping to v0.10.0 exposed a bug in the spec generation scripts where versions were being converted to `float` and then used doing version comparisons. Converting `0.10` to `float` results in `0.1` which is an incorrect representation of that version. To address this the scripts have been updated, including the new `Version` class which handles version comparisons, to never use `float` to represent versions.
