### PR TITLE
[DeviceSanitizer] Remove device global "__AsanDeviceGlobalCount"

### DIFF
--- a/source/loader/layers/sanitizer/asan_libdevice.hpp
+++ b/source/loader/layers/sanitizer/asan_libdevice.hpp
@@ -93,7 +93,6 @@ constexpr auto kSPIR_AsanShadowMemoryGlobalEnd = "__AsanShadowMemoryGlobalEnd";
 constexpr auto kSPIR_DeviceType = "__DeviceType";
 constexpr auto kSPIR_AsanDebug = "__AsanDebug";
 
-constexpr auto kSPIR_AsanDeviceGlobalCount = "__AsanDeviceGlobalCount";
 constexpr auto kSPIR_AsanDeviceGlobalMetadata = "__AsanDeviceGlobalMetadata";
 
 inline const char *ToString(DeviceSanitizerMemoryType MemoryType) {


### PR DESCRIPTION
Now UR already implemented API "urProgramGetGlobalVariablePointer", so we can use it to query the size of device globals. After that, we can remove "__AsanDeviceGlobalCount".