### PR TITLE
fix queue-wide barriers with multiple active command queues

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -679,6 +679,11 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
   if (Queue->hasOpenCommandList(UseCopyEngine)) {
     if (AllowBatching) {
       bool batchingAllowed = true;
+      if (ForcedCmdQueue &&
+          CommandBatch.OpenCommandList->second.ZeQueue != *ForcedCmdQueue) {
+        // Current open batch doesn't match the forced command queue
+        batchingAllowed = false;
+      }
       if (!UrL0OutOfOrderIntegratedSignalEvent &&
           Queue->Device->isIntegrated()) {
         batchingAllowed = eventCanBeBatched(Queue, UseCopyEngine,


### PR DESCRIPTION
This is another attempt to fix an issue where the L0 Adapter crashes when urEnqueueEventsWaitWithBarrier in presence of multiple active command queues with batched cmdlists.

The core issue is that the current queue implementation only allows for two command lists to be active open batches, one for copy and one for compute. If that assumption doesn't hold, the getAvailableCommandList function, when executed multiple times for a command queue of the same type, will override the active open command batch. So only the last retrieved command list can actually be batched. After this, when the code attempts to execute all the command lists it collected, with batching enabled. And this is where we hit an assert because the active open command list doesn't match what is being used.

The proper fix here is to allow open command batches for each command queue. But that's a fairly risky change to do this late in the release cycle.

My previous attempt at a fix simply disabled batching for queue-wide barriers (#1555). That introduced regressions in tests that assumed that batching happens. It might also been a performance regression.

Instead, this patch fixes getAvailableCommandList when batching is enabled and specific command queue is required, and disables batching only for cases where the open batch cmdlist is different than the one we are executing.