### PR TITLE
Change ur_native_handle_t to be uintptr_t

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -394,7 +394,7 @@ typedef struct ur_queue_handle_t_ *ur_queue_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a native object
-typedef struct ur_native_handle_t_ *ur_native_handle_t;
+typedef uintptr_t ur_native_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of a Sampler object

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -10376,8 +10376,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativePlatform = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativePlatform));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativePlatform)));
 
     os << ", ";
     os << ".hAdapter = ";
@@ -10573,8 +10573,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeContext = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeContext));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeContext)));
 
     os << ", ";
     os << ".numDevices = ";
@@ -10783,8 +10783,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeEvent = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeEvent));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeEvent)));
 
     os << ", ";
     os << ".hContext = ";
@@ -11377,8 +11377,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeProgram = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeProgram));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeProgram)));
 
     os << ", ";
     os << ".hContext = ";
@@ -11597,8 +11597,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeKernel = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeKernel));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeKernel)));
 
     os << ", ";
     os << ".hContext = ";
@@ -12046,8 +12046,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeQueue = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeQueue));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeQueue)));
 
     os << ", ";
     os << ".hContext = ";
@@ -12220,8 +12220,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeSampler = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeSampler));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeSampler)));
 
     os << ", ";
     os << ".hContext = ";
@@ -12424,8 +12424,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeMem)));
 
     os << ", ";
     os << ".hContext = ";
@@ -12456,8 +12456,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeMem)));
 
     os << ", ";
     os << ".hContext = ";
@@ -17206,8 +17206,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     os << ".hNativeDevice = ";
 
-    ur::details::printPtr(os,
-                          *(params->phNativeDevice));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phNativeDevice)));
 
     os << ", ";
     os << ".hPlatform = ";

--- a/scripts/templates/api.h.mako
+++ b/scripts/templates/api.h.mako
@@ -121,7 +121,9 @@ ${th.make_func_name(n, tags, obj)}(
     );
 ## HANDLE #####################################################################
 %elif re.match(r"handle", obj['type']):
-%if 'alias' in obj:
+%if th.type_traits.is_native_handle(obj['name']):
+typedef uintptr_t ${th.subt(n, tags, obj['name'])};
+%elif 'alias' in obj:
 typedef ${th.subt(n, tags, obj['alias'])} ${th.subt(n, tags, obj['name'])};
 %else:
 typedef struct ${th.subt(n, tags, obj['name'])}_ *${th.subt(n, tags, obj['name'])};

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -109,6 +109,7 @@ class class_traits:
 """
 class type_traits:
     RE_HANDLE   = r"(.*)handle_t"
+    RE_NATIVE_HANDLE = r"(.*)native_handle_t"
     RE_IPC      = r"(.*)ipc(.*)handle_t"
     RE_POINTER  = r"(.*\w+)\*+"
     RE_PPOINTER = r"(.*\w+)\*{2,}"
@@ -125,6 +126,13 @@ class type_traits:
     def is_handle(cls, name):
         try:
             return True if re.match(cls.RE_HANDLE, name) else False
+        except:
+            return False
+
+    @classmethod
+    def is_native_handle(cls, name):
+        try:
+            return True if re.match(cls.RE_NATIVE_HANDLE, name) else False
         except:
             return False
 

--- a/scripts/templates/print.hpp.mako
+++ b/scripts/templates/print.hpp.mako
@@ -36,6 +36,8 @@ from templates import helper as th
         ${x}::details::printPtr(os, ${caller.body()});
     %elif loop and th.type_traits.is_pointer_to_pointer(itype):
         ${x}::details::printPtr(os, ${caller.body()});
+    %elif th.type_traits.is_native_handle(itype):
+        ${x}::details::printPtr(os, reinterpret_cast<void*>(${caller.body()}));
     %elif th.type_traits.is_handle(itype):
         ${x}::details::printPtr(os, ${caller.body()});
     %elif iname and iname.startswith("pfn"):

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -1185,10 +1185,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_device_handle_t *phDevice) {
   std::ignore = pProperties;
 
-  // We can't cast between ur_native_handle_t and CUdevice, so memcpy the bits
-  // instead
-  CUdevice CuDevice = 0;
-  memcpy(&CuDevice, &hNativeDevice, sizeof(CUdevice));
+  CUdevice CuDevice = static_cast<CUdevice>(hNativeDevice);
 
   auto IsDevice = [=](std::unique_ptr<ur_device_handle_t_> &Dev) {
     return Dev->get() == CuDevice;

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -132,8 +132,7 @@ urMemGetNativeHandle(ur_mem_handle_t hMem, ur_device_handle_t Device,
                      ur_native_handle_t *phNativeMem) {
   UR_ASSERT(Device != nullptr, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   try {
-    *phNativeMem = reinterpret_cast<ur_native_handle_t>(
-        std::get<BufferMem>(hMem->Mem).getPtr(Device));
+    *phNativeMem = std::get<BufferMem>(hMem->Mem).getPtr(Device);
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -980,7 +980,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
 /// \return UR_RESULT_SUCCESS
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
     ur_device_handle_t hDevice, ur_native_handle_t *phNativeHandle) {
-  *phNativeHandle = reinterpret_cast<ur_native_handle_t>(hDevice->get());
+  *phNativeHandle = hDevice->get();
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -926,7 +926,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
   // we dont have urEventCreate, so use this check for now to know that
   // the call comes from urEventCreate()
-  if (NativeEvent == nullptr) {
+  if (reinterpret_cast<ze_event_handle_t>(NativeEvent) == nullptr) {
     UR_CALL(EventCreate(Context, nullptr, false, true, Event));
 
     (*Event)->RefCountExternal++;

--- a/source/adapters/opencl/queue.cpp
+++ b/source/adapters/opencl/queue.cpp
@@ -167,7 +167,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
   *phQueue = reinterpret_cast<ur_queue_handle_t>(hNativeQueue);
   cl_int RetErr =
-      clRetainCommandQueue(cl_adapter::cast<cl_command_queue>(hNativeQueue));
+      clRetainCommandQueue(cl_adapter::cast<cl_command_queue>(*phQueue));
   CL_RETURN_ON_FAILURE(RetErr);
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/opencl/sampler.cpp
+++ b/source/adapters/opencl/sampler.cpp
@@ -199,8 +199,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t hNativeSampler, ur_context_handle_t,
     const ur_sampler_native_properties_t *pProperties,
     ur_sampler_handle_t *phSampler) {
-  *phSampler = reinterpret_cast<ur_sampler_handle_t>(
-      cl_adapter::cast<cl_sampler>(hNativeSampler));
+  *phSampler = reinterpret_cast<ur_sampler_handle_t>(hNativeSampler);
   if (!pProperties || !pProperties->isNativeHandleOwned) {
     return urSamplerRetain(*phSampler);
   }

--- a/source/common/ur_pool_manager.hpp
+++ b/source/common/ur_pool_manager.hpp
@@ -137,7 +137,7 @@ isSharedAllocationReadOnlyOnDevice(const pool_descriptor &desc) {
 inline bool pool_descriptor::operator==(const pool_descriptor &other) const {
     const pool_descriptor &lhs = *this;
     const pool_descriptor &rhs = other;
-    ur_native_handle_t lhsNative = nullptr, rhsNative = nullptr;
+    ur_native_handle_t lhsNative = 0, rhsNative = 0;
 
     // We want to share a memory pool for sub-devices and sub-sub devices.
     // Sub-devices and sub-sub-devices might be represented by different ur_device_handle_t but
@@ -264,7 +264,7 @@ namespace std {
 /// @brief hash specialization for usm::pool_descriptor
 template <> struct hash<usm::pool_descriptor> {
     inline size_t operator()(const usm::pool_descriptor &desc) const {
-        ur_native_handle_t native = nullptr;
+        ur_native_handle_t native = 0;
         if (desc.hDevice) {
             auto ret = urDeviceGetNativeHandle(desc.hDevice, &native);
             if (ret != UR_RESULT_SUCCESS) {

--- a/test/adapters/cuda/context_tests.cpp
+++ b/test/adapters/cuda/context_tests.cpp
@@ -68,9 +68,9 @@ TEST_P(cudaUrContextCreateTest, ActiveContext) {
     ASSERT_SUCCESS_CUDA(cuCtxGetCurrent(&cudaCtx));
     ASSERT_NE(cudaCtx, nullptr);
 
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
-    ASSERT_NE(native_context, nullptr);
+    ASSERT_NE(reinterpret_cast<CUcontext>(native_context), nullptr);
     ASSERT_EQ(cudaCtx, reinterpret_cast<CUcontext>(native_context));
 }
 

--- a/test/adapters/cuda/urContextGetNativeHandle.cpp
+++ b/test/adapters/cuda/urContextGetNativeHandle.cpp
@@ -9,7 +9,7 @@ using urCudaContextGetNativeHandle = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaContextGetNativeHandle);
 
 TEST_P(urCudaContextGetNativeHandle, Success) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
     CUcontext cuda_context = reinterpret_cast<CUcontext>(native_context);
 

--- a/test/adapters/cuda/urEventGetNativeHandle.cpp
+++ b/test/adapters/cuda/urEventGetNativeHandle.cpp
@@ -21,7 +21,7 @@ TEST_P(urCudaEventGetNativeHandleTest, Success) {
                                           0, buffer_size, 0, nullptr,
                                           event.ptr()));
 
-    ur_native_handle_t native_event = nullptr;
+    ur_native_handle_t native_event = 0;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
     CUevent cuda_event = reinterpret_cast<CUevent>(native_event);
 

--- a/test/adapters/hip/urContextGetNativeHandle.cpp
+++ b/test/adapters/hip/urContextGetNativeHandle.cpp
@@ -9,7 +9,7 @@ using urHipContextGetNativeHandleTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipContextGetNativeHandleTest);
 
 TEST_P(urHipContextGetNativeHandleTest, Success) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
     hipCtx_t hip_context = reinterpret_cast<hipCtx_t>(native_context);
     std::ignore = hip_context;

--- a/test/adapters/hip/urEventGetNativeHandle.cpp
+++ b/test/adapters/hip/urEventGetNativeHandle.cpp
@@ -21,7 +21,7 @@ TEST_P(urHipEventGetNativeHandleTest, Success) {
                                           0, buffer_size, 0, nullptr,
                                           event.ptr()));
 
-    ur_native_handle_t native_event = nullptr;
+    ur_native_handle_t native_event = 0;
     ASSERT_SUCCESS(urEventGetNativeHandle(event, &native_event));
     hipEvent_t hip_event = reinterpret_cast<hipEvent_t>(native_event);
 

--- a/test/adapters/level_zero/multi_device_event_cache_tests.cpp
+++ b/test/adapters/level_zero/multi_device_event_cache_tests.cpp
@@ -55,9 +55,9 @@ TEST_F(urMultiQueueMultiDeviceEventCacheTest,
     uur::raii::Event eventWait = nullptr;
     uur::raii::Event eventWaitDummy = nullptr;
     (*ZeCallCount)["zeCommandListAppendWaitOnEvents"] = 0;
-    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context2, nullptr,
-                                                 eventWait.ptr()));
-    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context1, nullptr,
+    EXPECT_SUCCESS(
+        urEventCreateWithNativeHandle(0, context2, nullptr, eventWait.ptr()));
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(0, context1, nullptr,
                                                  eventWaitDummy.ptr()));
     EXPECT_SUCCESS(
         urEnqueueEventsWait(queue1, 1, eventWaitDummy.ptr(), eventWait.ptr()));
@@ -90,9 +90,9 @@ TEST_F(urMultiQueueMultiDeviceEventCacheTest,
     uur::raii::Event eventWait = nullptr;
     uur::raii::Event eventWaitDummy = nullptr;
     (*ZeCallCount)["zeCommandListAppendWaitOnEvents"] = 0;
-    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context2, nullptr,
-                                                 eventWait.ptr()));
-    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context1, nullptr,
+    EXPECT_SUCCESS(
+        urEventCreateWithNativeHandle(0, context2, nullptr, eventWait.ptr()));
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(0, context1, nullptr,
                                                  eventWaitDummy.ptr()));
     EXPECT_SUCCESS(
         urEnqueueEventsWait(queue1, 1, eventWaitDummy.ptr(), eventWait.ptr()));

--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@ using urContextCreateWithNativeHandleTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateWithNativeHandleTest);
 
 TEST_P(urContextCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urContextGetNativeHandle(context, &native_context));
@@ -33,7 +33,7 @@ TEST_P(urContextCreateWithNativeHandleTest, Success) {
 }
 
 TEST_P(urContextCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urContextGetNativeHandle(context, &native_context));
@@ -53,7 +53,7 @@ TEST_P(urContextCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 }
 
 TEST_P(urContextCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urContextGetNativeHandle(context, &native_context));
@@ -75,7 +75,7 @@ TEST_P(urContextCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
 }
 
 TEST_P(urContextCreateWithNativeHandleTest, InvalidNullPointerDevices) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
 
     ur_context_handle_t ctx = nullptr;
@@ -85,7 +85,7 @@ TEST_P(urContextCreateWithNativeHandleTest, InvalidNullPointerDevices) {
 }
 
 TEST_P(urContextCreateWithNativeHandleTest, InvalidNullPointerContext) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     ASSERT_SUCCESS(urContextGetNativeHandle(context, &native_context));
 
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,

--- a/test/conformance/context/urContextGetNativeHandle.cpp
+++ b/test/conformance/context/urContextGetNativeHandle.cpp
@@ -9,14 +9,14 @@ using urContextGetNativeHandleTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetNativeHandleTest);
 
 TEST_P(urContextGetNativeHandleTest, Success) {
-    ur_native_handle_t native_context = nullptr;
+    ur_native_handle_t native_context = 0;
     if (auto error = urContextGetNativeHandle(context, &native_context)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }
 }
 
 TEST_P(urContextGetNativeHandleTest, InvalidNullHandleContext) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urContextGetNativeHandle(nullptr, &native_handle));
 }

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -8,7 +8,7 @@ using urDeviceCreateWithNativeHandleTest = uur::urAllDevicesTest;
 
 TEST_F(urDeviceCreateWithNativeHandleTest, Success) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urDeviceGetNativeHandle(device, &native_handle));
@@ -31,7 +31,7 @@ TEST_F(urDeviceCreateWithNativeHandleTest, Success) {
 
 TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urDeviceGetNativeHandle(device, &native_handle));
@@ -54,7 +54,7 @@ TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 
 TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urDeviceGetNativeHandle(device, &native_handle));
@@ -77,7 +77,7 @@ TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
 
 TEST_F(urDeviceCreateWithNativeHandleTest, InvalidNullHandlePlatform) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
 
         ur_device_handle_t dev = nullptr;
@@ -89,7 +89,7 @@ TEST_F(urDeviceCreateWithNativeHandleTest, InvalidNullHandlePlatform) {
 
 TEST_F(urDeviceCreateWithNativeHandleTest, InvalidNullPointerDevice) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         ASSERT_SUCCESS(urDeviceGetNativeHandle(device, &native_handle));
 
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -8,7 +8,7 @@ using urDeviceGetNativeHandleTest = uur::urAllDevicesTest;
 
 TEST_F(urDeviceGetNativeHandleTest, Success) {
     for (auto device : devices) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         if (auto error = urDeviceGetNativeHandle(device, &native_handle)) {
             ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
         }
@@ -16,7 +16,7 @@ TEST_F(urDeviceGetNativeHandleTest, Success) {
 }
 
 TEST_F(urDeviceGetNativeHandleTest, InvalidNullHandleDevice) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urDeviceGetNativeHandle(nullptr, &native_handle));
 }

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -10,7 +10,7 @@ using urEventCreateWithNativeHandleTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
 
 TEST_P(urEventCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t native_event = nullptr;
+    ur_native_handle_t native_event = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urEventGetNativeHandle(event, &native_event));

--- a/test/conformance/event/urEventGetNativeHandle.cpp
+++ b/test/conformance/event/urEventGetNativeHandle.cpp
@@ -9,14 +9,14 @@ using urEventGetNativeHandleTest = uur::event::urEventTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetNativeHandleTest);
 
 TEST_P(urEventGetNativeHandleTest, Success) {
-    ur_native_handle_t native_event = nullptr;
+    ur_native_handle_t native_event = 0;
     if (auto error = urEventGetNativeHandle(event, &native_event)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }
 }
 
 TEST_P(urEventGetNativeHandleTest, InvalidNullHandleEvent) {
-    ur_native_handle_t native_event = nullptr;
+    ur_native_handle_t native_event = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urEventGetNativeHandle(nullptr, &native_event));
 }

--- a/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -21,7 +21,7 @@ struct urKernelCreateWithNativeHandleTest : uur::urKernelTest {
         UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::TearDown());
     }
 
-    ur_native_handle_t native_kernel_handle = nullptr;
+    ur_native_handle_t native_kernel_handle = 0;
     ur_kernel_handle_t native_kernel = nullptr;
     ur_kernel_native_properties_t properties = {
         UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES, /*sType*/

--- a/test/conformance/kernel/urKernelGetNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelGetNativeHandle.cpp
@@ -9,14 +9,14 @@ using urKernelGetNativeHandleTest = uur::urKernelTest;
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urKernelGetNativeHandleTest);
 
 TEST_P(urKernelGetNativeHandleTest, Success) {
-    ur_native_handle_t native_kernel_handle = nullptr;
+    ur_native_handle_t native_kernel_handle = 0;
     if (auto error = urKernelGetNativeHandle(kernel, &native_kernel_handle)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }
 }
 
 TEST_P(urKernelGetNativeHandleTest, InvalidNullHandleKernel) {
-    ur_native_handle_t native_kernel_handle = nullptr;
+    ur_native_handle_t native_kernel_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urKernelGetNativeHandle(nullptr, &native_kernel_handle));
 }

--- a/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@ using urMemBufferCreateWithNativeHandleTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateWithNativeHandleTest);
 
 TEST_P(urMemBufferCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t hNativeMem = nullptr;
+    ur_native_handle_t hNativeMem = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urMemGetNativeHandle(buffer, device, &hNativeMem));

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -8,7 +8,7 @@ using urMemGetNativeHandleTest = uur::urMemBufferTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetNativeHandleTest);
 
 TEST_P(urMemGetNativeHandleTest, Success) {
-    ur_native_handle_t hNativeMem = nullptr;
+    ur_native_handle_t hNativeMem = 0;
     if (auto error = urMemGetNativeHandle(buffer, device, &hNativeMem)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }

--- a/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@ using urMemImageCreateWithNativeHandleTest = uur::urMemImageTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageCreateWithNativeHandleTest);
 
 TEST_P(urMemImageCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     if (urMemGetNativeHandle(image, device, &native_handle)) {
         GTEST_SKIP();
     }

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@ using urPlatformCreateWithNativeHandleTest = uur::platform::urPlatformTest;
 
 TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
     for (auto platform : platforms) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urPlatformGetNativeHandle(platform, &native_handle));
@@ -32,7 +32,7 @@ TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
 
 TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
     for (auto platform : platforms) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urPlatformGetNativeHandle(platform, &native_handle));
@@ -57,7 +57,7 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 
 TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
     for (auto platform : platforms) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         {
             UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
                 urPlatformGetNativeHandle(platform, &native_handle));
@@ -82,7 +82,7 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
 
 TEST_F(urPlatformCreateWithNativeHandleTest, InvalidNullPointerPlatform) {
     for (auto platform : platforms) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                          urPlatformCreateWithNativeHandle(

--- a/test/conformance/platform/urPlatformGetNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformGetNativeHandle.cpp
@@ -9,7 +9,7 @@ using urPlatformGetNativeHandleTest = uur::platform::urPlatformsTest;
 
 TEST_F(urPlatformGetNativeHandleTest, Success) {
     for (auto platform : platforms) {
-        ur_native_handle_t native_handle = nullptr;
+        ur_native_handle_t native_handle = 0;
         if (auto error = urPlatformGetNativeHandle(platform, &native_handle)) {
             ASSERT_EQ(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
         }
@@ -17,7 +17,7 @@ TEST_F(urPlatformGetNativeHandleTest, Success) {
 }
 
 TEST_F(urPlatformGetNativeHandleTest, InvalidNullHandlePlatform) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urPlatformGetNativeHandle(nullptr, &native_handle));
 }

--- a/test/conformance/program/urProgramCreateWithNativeHandle.cpp
+++ b/test/conformance/program/urProgramCreateWithNativeHandle.cpp
@@ -21,7 +21,7 @@ struct urProgramCreateWithNativeHandleTest : uur::urProgramTest {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::TearDown());
     }
 
-    ur_native_handle_t native_program_handle = nullptr;
+    ur_native_handle_t native_program_handle = 0;
     ur_program_handle_t native_program = nullptr;
 };
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urProgramCreateWithNativeHandleTest);

--- a/test/conformance/program/urProgramGetNativeHandle.cpp
+++ b/test/conformance/program/urProgramGetNativeHandle.cpp
@@ -9,7 +9,7 @@ using urProgramGetNativeHandleTest = uur::urProgramTest;
 UUR_INSTANTIATE_KERNEL_TEST_SUITE_P(urProgramGetNativeHandleTest);
 
 TEST_P(urProgramGetNativeHandleTest, Success) {
-    ur_native_handle_t native_program_handle = nullptr;
+    ur_native_handle_t native_program_handle = 0;
     if (auto error =
             urProgramGetNativeHandle(program, &native_program_handle)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
@@ -17,7 +17,7 @@ TEST_P(urProgramGetNativeHandleTest, Success) {
 }
 
 TEST_P(urProgramGetNativeHandleTest, InvalidNullHandleProgram) {
-    ur_native_handle_t native_program_handle = nullptr;
+    ur_native_handle_t native_program_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urProgramGetNativeHandle(nullptr, &native_program_handle));
 }

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -8,7 +8,7 @@ using urQueueCreateWithNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueCreateWithNativeHandleTest);
 
 TEST_P(urQueueCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urQueueGetNativeHandle(queue, nullptr, &native_handle));

--- a/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -8,14 +8,14 @@ using urQueueGetNativeHandleTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetNativeHandleTest);
 
 TEST_P(urQueueGetNativeHandleTest, Success) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     if (auto error = urQueueGetNativeHandle(queue, nullptr, &native_handle)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }
 }
 
 TEST_P(urQueueGetNativeHandleTest, InvalidNullHandleQueue) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urQueueGetNativeHandle(nullptr, nullptr, &native_handle));
 }
@@ -27,7 +27,7 @@ TEST_P(urQueueGetNativeHandleTest, InvalidNullPointerNativeHandle) {
 
 TEST_P(urQueueGetNativeHandleTest, InOrderQueueSameNativeHandle) {
     ur_queue_handle_t in_order_queue;
-    ur_native_handle_t native_handle1 = nullptr, native_handle2 = nullptr;
+    ur_native_handle_t native_handle1 = 0, native_handle2 = 0;
     ASSERT_SUCCESS(urQueueCreate(context, device, nullptr, &in_order_queue));
     if (auto error =
             urQueueGetNativeHandle(in_order_queue, nullptr, &native_handle1)) {

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -10,7 +10,7 @@ using urSamplerCreateWithNativeHandleTest = uur::urSamplerTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerCreateWithNativeHandleTest);
 
 TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
-    ur_native_handle_t native_sampler = nullptr;
+    ur_native_handle_t native_sampler = 0;
     {
         UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
             urSamplerGetNativeHandle(sampler, &native_sampler));

--- a/test/conformance/sampler/urSamplerGetNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerGetNativeHandle.cpp
@@ -10,14 +10,14 @@ using urSamplerGetNativeHandleTest = uur::urSamplerTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetNativeHandleTest);
 
 TEST_P(urSamplerGetNativeHandleTest, Success) {
-    ur_native_handle_t native_sampler = nullptr;
+    ur_native_handle_t native_sampler = 0;
     if (auto error = urSamplerGetNativeHandle(sampler, &native_sampler)) {
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_UNSUPPORTED_FEATURE, error);
     }
 }
 
 TEST_P(urSamplerGetNativeHandleTest, InvalidNullHandleSampler) {
-    ur_native_handle_t native_handle = nullptr;
+    ur_native_handle_t native_handle = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urSamplerGetNativeHandle(nullptr, &native_handle));
 }


### PR DESCRIPTION
This matches the previous design in PI, which is better suited for handling underlying native types that aren't pointers (e.g. CUdevice in CUDA).

LLVM PR: https://github.com/intel/llvm/pull/13705