### PR TITLE
[L0] Optimize and simplify command list cache

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1021,7 +1021,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
   // Use compute engine rather than copy engine
   const auto UseCopyEngine = false;
-  auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
+
+  // TODO(cache): use getAvailableCommandList here
+  auto &QGroup = Queue->ComputeQueueGroup;
   uint32_t QueueGroupOrdinal;
   auto &ZeCommandQueue = QGroup.getZeQueue(&QueueGroupOrdinal);
 

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1062,8 +1062,6 @@ ur_device_handle_t_::useImmediateCommandLists() {
     return NotUsed;
   case 1:
     return PerQueue;
-  case 2:
-    return PerThreadPerQueue;
   default:
     return NotUsed;
   }

--- a/source/adapters/level_zero/device.hpp
+++ b/source/adapters/level_zero/device.hpp
@@ -135,10 +135,7 @@ struct ur_device_handle_t_ : _ur_object {
     // Immediate commandlists are not used.
     NotUsed = 0,
     // One set of compute and copy immediate commandlists per queue.
-    PerQueue,
-    // One set of compute and copy immediate commandlists per host thread that
-    // accesses the queue.
-    PerThreadPerQueue
+    PerQueue
   };
   // Read env settings to select immediate commandlist mode.
   ImmCmdlistMode useImmediateCommandLists();

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -281,59 +281,8 @@ struct ur_queue_handle_t_ : _ur_object {
     uint32_t NextIndex{0};
   };
 
-  // Helper class to facilitate per-thread queue groups
-  // We maintain a hashtable of queue groups if requested to do them per-thread.
-  // Otherwise it is just single entry used for all threads.
-  struct pi_queue_group_by_tid_t
-      : public std::unordered_map<std::thread::id, ur_queue_group_t> {
-    bool PerThread = false;
-
-    // Returns thread id if doing per-thread, or a generic id that represents
-    // all the threads.
-    std::thread::id tid() const {
-      return PerThread ? std::this_thread::get_id() : std::thread::id();
-    }
-
-    // Make the specified queue group be the master
-    void set(const ur_queue_group_t &QueueGroup) {
-      const auto &Device = QueueGroup.Queue->Device;
-      PerThread =
-          Device->ImmCommandListUsed == ur_device_handle_t_::PerThreadPerQueue;
-      assert(empty());
-      insert({tid(), QueueGroup});
-    }
-
-    // Get a queue group to use for this thread
-    ur_queue_group_t &get() {
-      assert(!empty());
-      auto It = find(tid());
-      if (It != end()) {
-        return It->second;
-      }
-      // Add new queue group for this thread initialized from a master entry.
-      auto QueueGroup = begin()->second;
-      // Create space for queues and immediate commandlists, which are created
-      // on demand.
-      QueueGroup.ZeQueues = std::vector<ze_command_queue_handle_t>(
-          QueueGroup.ZeQueues.size(), nullptr);
-      QueueGroup.ImmCmdLists = std::vector<ur_command_list_ptr_t>(
-          QueueGroup.ZeQueues.size(), QueueGroup.Queue->CommandListMap.end());
-
-      std::tie(It, std::ignore) = insert({tid(), QueueGroup});
-      return It->second;
-    }
-  };
-
-  // A map of compute groups containing compute queue handles, one per thread.
-  // When a queue is accessed from multiple host threads, a separate queue group
-  // is created for each thread. The key used for mapping is the thread ID.
-  pi_queue_group_by_tid_t ComputeQueueGroupsByTID;
-
-  // A group containing copy queue handles. The main copy engine, if available,
-  // comes first followed by link copy engines, if available.
-  // When a queue is accessed from multiple host threads, a separate queue group
-  // is created for each thread. The key used for mapping is the thread ID.
-  pi_queue_group_by_tid_t CopyQueueGroupsByTID;
+  ur_queue_group_t ComputeQueueGroup;
+  ur_queue_group_t CopyQueueGroup;
 
   // Keeps the PI context to which this queue belongs.
   // This field is only set at ur_queue_handle_t creation time, and cannot
@@ -375,6 +324,7 @@ struct ur_queue_handle_t_ : _ur_object {
   bool CounterBasedEventsEnabled = false;
 
   // Map of all command lists used in this queue.
+  // TODO(cache): replace this with a vector
   ur_command_list_map_t CommandListMap;
 
   // Helper data structure to hold all variables related to batching
@@ -501,6 +451,15 @@ struct ur_queue_handle_t_ : _ur_object {
 
   // Clear the end time recording timestamps entries.
   void clearEndTimeRecordings();
+
+  // get a regular command list from the cache or create a new one
+  ur_result_t initializeSingleRegularCommandList(
+      ur_queue_group_t &QueueGroup, ur_command_list_ptr_t &CommandList,
+      ze_command_queue_handle_t *ForcedCmdQueue = nullptr);
+
+  // initializes the queue with the command lists
+  ur_result_t initializeRegularCommandLists();
+  ur_result_t initializeImmediateCommandLists();
 
   // adjust the queue's batch size, knowing that the current command list
   // is being closed with a full batch.
@@ -645,10 +604,6 @@ struct ur_queue_handle_t_ : _ur_object {
 
   // Gets the open command containing the event, or CommandListMap.end()
   ur_command_list_ptr_t eventOpenCommandList(ur_event_handle_t Event);
-
-  // Return the queue group to use based on standard/immediate commandlist mode,
-  // and if immediate mode, the thread-specific group.
-  ur_queue_group_t &getQueueGroup(bool UseCopyEngine);
 
   // Helper function to create a new command-list to this queue and associated
   // fence tracking its completion. This command list & fence are added to the


### PR DESCRIPTION
- remove per thread cache: looking up the map on each call seems to introduce a lot of overhead
- create all immediate command lists and a predefined number of regular lists upfront
- add abstraction for cmd list cache in the context