### PR TITLE
[L0] Disable Usage of Driver In order Lists by default

### DIFF
--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1085,7 +1085,7 @@ bool ur_device_handle_t_::useDriverInOrderLists() {
   static const bool UseDriverInOrderLists = [] {
     const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
     if (!UrRet)
-      return true;
+      return false;
     return std::atoi(UrRet) != 0;
   }();
 


### PR DESCRIPTION
- Until usage of Driver In Order lists can be confirmed stable, disable the usage of the driver in order lists by default.