### PR TITLE
[CL] Update device CTS match file

### DIFF
--- a/.github/scripts/get_system_info.sh
+++ b/.github/scripts/get_system_info.sh
@@ -53,7 +53,7 @@ function system_info {
 	echo "**********/proc/meminfo**********"
 	cat /proc/meminfo
 	echo "**********build/bin/urinfo**********"
-	$(dirname "$(readlink -f "$0")")/../../build/bin/urinfo || true
+	$(dirname "$(readlink -f "$0")")/../../build/bin/urinfo --no-linear-ids --verbose || true
 	echo "******OpenCL*******"
 	# The driver version of OpenCL Graphics is the compute-runtime version
 	clinfo || echo "OpenCL not installed"

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -507,7 +507,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
           cl_adapter::cast<cl_device_id>(hDevice), {"cl_khr_fp16"}, Supported));
 
       if (!Supported) {
-        return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
       }
     }
 

--- a/test/conformance/device/device_adapter_opencl.match
+++ b/test/conformance/device/device_adapter_opencl.match
@@ -1,1 +1,0 @@
-urDeviceGetInfoTest.Success/UR_DEVICE_INFO_HALF_FP_CONFIG


### PR DESCRIPTION
This patch does three things:

1. Removes the passing OpenCL test from the device match file `urDeviceGetInfoTest.Success/UR_DEVICE_INFO_HALF_FP_CONFIG`
2. Uses `UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION` when half query is not supported
3. Adds the `--verbose` flag to `urinfo` step to provide more information when HW jobs fail.
