### PR TITLE
[OpenCL] Modify fill emulation to work for patterns which are not powers of 2

### DIFF
--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -276,14 +276,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
       cl_ext::MemBlockingFreeName, &USMFree));
 
   cl_int ClErr = CL_SUCCESS;
-  auto HostBuffer = static_cast<unsigned char *>(
-      HostMemAlloc(CLContext, nullptr, size, 0, &ClErr));
+  auto HostBuffer =
+      static_cast<uint8_t *>(HostMemAlloc(CLContext, nullptr, size, 0, &ClErr));
   CL_RETURN_ON_FAILURE(ClErr);
 
-  auto NumChunks = size / patternSize;
-  for (size_t i = 0; i < NumChunks; i++) {
-    auto Dest = HostBuffer + i * patternSize;
-    memcpy(Dest, pPattern, patternSize);
+  auto *End = HostBuffer + size;
+  for (auto *Iter = HostBuffer; Iter < End; Iter += patternSize) {
+    std::memcpy(Iter, pPattern, patternSize);
   }
 
   cl_event CopyEvent = nullptr;


### PR DESCRIPTION
This is a follow-up of https://github.com/oneapi-src/unified-runtime/pull/1412 which added the `isPowerOf2` condition to the OpenCL fill function. This is correct since `clEnqueueMemFillINTEL_fn` only accepts such patterns.

What was not correct was the later logic for emulating filling on the host and copying it to the destination ptr. It assumed that the pattern is greater than **128 bytes** but after adding the above `isPowerOf2` condition, it could also execute for smaller patterns which are simply not powers of 2. 

So this PR fixes my introduced bugs, **intel/llvm CI:** https://github.com/intel/llvm/pull/13779