### PR TITLE
[HIP] Implement kernel set spec constant query

### DIFF
--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -761,6 +761,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(int32_t{1});
   }
 
+  case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS: {
+    return ReturnValue(ur_bool_t{false});
+  }
+
   case UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
     ur_memory_order_capability_flags_t Capabilities =
         UR_MEMORY_ORDER_CAPABILITY_FLAG_RELAXED |

--- a/test/conformance/kernel/kernel_adapter_hip.match
+++ b/test/conformance/kernel/kernel_adapter_hip.match
@@ -12,7 +12,3 @@ urKernelSetArgMemObjTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_
 urKernelSetArgPointerNegativeTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_
 urKernelSetArgValueTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_
 urKernelSetArgValueTest.InvalidKernelArgumentSize/AMD_HIP_BACKEND___{{.*}}_
-urKernelSetSpecializationConstantsTest.Success/AMD_HIP_BACKEND___{{.*}}_
-urKernelSetSpecializationConstantsTest.InvalidNullHandleKernel/AMD_HIP_BACKEND___{{.*}}_
-urKernelSetSpecializationConstantsTest.InvalidNullPointerSpecConstants/AMD_HIP_BACKEND___{{.*}}_
-urKernelSetSpecializationConstantsTest.InvalidSizeCount/AMD_HIP_BACKEND___{{.*}}_


### PR DESCRIPTION
Handle the `UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS` device query to report the feature is not supported. This also causes the `urKernelSetSpecializationConstants` tests to be skipped.

https://github.com/intel/llvm/pull/13809
