### PR TITLE
[Security] Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/third_party" # Location of package manifests
+    schedule:
+      interval: "daily"
+    # Allow up to 5 open pull requests for pip dependencies
+    open-pull-requests-limit: 5


### PR DESCRIPTION
The dependabot.yml configuration is required by Scorecard. For now, it adds a simple pip dependencies update (open PR if a new version is available). In the future, the configuration can be expanded to include other package-ecosystems or add limitations.