### PR TITLE
[CUDA][HIP]Remove EvQueued from adapters

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -21,9 +21,8 @@
 ur_event_handle_t_::ur_event_handle_t_(ur_command_t Type,
                                        ur_context_handle_t Context,
                                        ur_queue_handle_t Queue,
-                                       native_type EvEnd,
-                                       native_type EvStart, CUstream Stream,
-                                       uint32_t StreamToken)
+                                       native_type EvEnd, native_type EvStart,
+                                       CUstream Stream, uint32_t StreamToken)
     : CommandType{Type}, RefCount{1}, HasOwnership{true},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
       StreamToken{StreamToken}, EventID{0}, EvEnd{EvEnd}, EvStart{EvStart},
@@ -37,8 +36,8 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
     : CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1}, HasOwnership{false},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
       StreamToken{std::numeric_limits<uint32_t>::max()}, EventID{0},
-      EvEnd{EventNative}, EvStart{nullptr}, Queue{nullptr},
-      Stream{nullptr}, Context{Context} {
+      EvEnd{EventNative}, EvStart{nullptr}, Queue{nullptr}, Stream{nullptr},
+      Context{Context} {
   urContextRetain(Context);
 }
 

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -90,16 +90,15 @@ public:
     const bool RequiresTimings =
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
-    native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
+    native_type EvEnd = nullptr, EvStart = nullptr;
     UR_CHECK_ERROR(cuEventCreate(
         &EvEnd, RequiresTimings ? CU_EVENT_DEFAULT : CU_EVENT_DISABLE_TIMING));
 
     if (RequiresTimings) {
-      UR_CHECK_ERROR(cuEventCreate(&EvQueued, CU_EVENT_DEFAULT));
       UR_CHECK_ERROR(cuEventCreate(&EvStart, CU_EVENT_DEFAULT));
     }
     return new ur_event_handle_t_(Type, Queue->getContext(), Queue, EvEnd,
-                                  EvQueued, EvStart, Stream, StreamToken);
+                                  EvStart, Stream, StreamToken);
   }
 
   static ur_event_handle_t makeWithNative(ur_context_handle_t context,
@@ -116,7 +115,7 @@ private:
   // make_user static members in order to create a pi_event for CUDA.
   ur_event_handle_t_(ur_command_t Type, ur_context_handle_t Context,
                      ur_queue_handle_t Queue, native_type EvEnd,
-                     native_type EvQueued, native_type EvStart, CUstream Stream,
+                     native_type EvStart, CUstream Stream,
                      uint32_t StreamToken);
 
   // This constructor is private to force programmers to use the
@@ -145,9 +144,6 @@ private:
                      // a user event, this will be nullptr.
 
   native_type EvStart; // CUDA event handle associated with the start
-
-  native_type EvQueued; // CUDA event handle associated with the time
-                        // the command was enqueued
 
   ur_queue_handle_t Queue; // ur_queue_handle_t associated with the event. If
                            // this is a user event, this will be nullptr.

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -41,8 +41,8 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
     : CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1}, HasOwnership{false},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
       StreamToken{std::numeric_limits<uint32_t>::max()}, EventId{0},
-      EvEnd{EventNative}, EvStart{nullptr}, Queue{nullptr},
-      Stream{nullptr}, Context{Context} {
+      EvEnd{EventNative}, EvStart{nullptr}, Queue{nullptr}, Stream{nullptr},
+      Context{Context} {
   urContextRetain(Context);
 }
 

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -130,8 +130,6 @@ private:
 
   native_type EvStart; // HIP event handle associated with the start
 
-  native_type EvQueued; // HIP event handle associated with the time
-                        // the command was enqueued
 
   ur_queue_handle_t Queue; // ur_queue_handle_t associated with the event. If
                            // this is a user event, this will be nullptr.

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -130,7 +130,6 @@ private:
 
   native_type EvStart; // HIP event handle associated with the start
 
-
   ur_queue_handle_t Queue; // ur_queue_handle_t associated with the event. If
                            // this is a user event, this will be nullptr.
 


### PR DESCRIPTION
Remove EvQueued from the CUDA and HIP adapter.

EvQueued and EvStart are always created, recorded and destroyed at the same time, which makes one of them superfluous.

Return the elapsed time for EvStart in getQueuedTime() for CUDA instead.