### PR TITLE
[CUDA][HIP] Minimize native events recorded and created by urEnqueueTimestampRecordingExp

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -1727,7 +1727,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
             UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
     UR_CHECK_ERROR(RetImplEvent->start());
-    UR_CHECK_ERROR(RetImplEvent->record());
+    UR_CHECK_ERROR(RetImplEvent->make_end_event_same_as_start());
 
     if (blocking) {
       UR_CHECK_ERROR(cuStreamSynchronize(CuStream));

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -381,7 +381,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
       *phEvent = ur_event_handle_t_::makeNative(
           UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, CuStream, StreamToken);
       UR_CHECK_ERROR((*phEvent)->start());
-      UR_CHECK_ERROR((*phEvent)->record());
+      UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
     }
 
     return UR_RESULT_SUCCESS;
@@ -1189,7 +1189,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->record());
+        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
       } catch (ur_result_t Err) {
         Result = Err;
       }
@@ -1237,7 +1237,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->record());
+        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
       } catch (ur_result_t Err) {
         Result = Err;
       }

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -380,8 +380,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     if (phEvent) {
       *phEvent = ur_event_handle_t_::makeNative(
           UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, CuStream, StreamToken);
-      UR_CHECK_ERROR((*phEvent)->start());
-      UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+      UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
     }
 
     return UR_RESULT_SUCCESS;
@@ -1188,8 +1187,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
       try {
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
-        UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+        UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
       } catch (ur_result_t Err) {
         Result = Err;
       }
@@ -1236,8 +1234,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
       try {
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
-        UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+        UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
       } catch (ur_result_t Err) {
         Result = Err;
       }
@@ -1726,8 +1723,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     RetImplEvent =
         std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
             UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, CuStream));
-    UR_CHECK_ERROR(RetImplEvent->start());
-    UR_CHECK_ERROR(RetImplEvent->make_end_event_same_as_start());
+
+    UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
 
     if (blocking) {
       UR_CHECK_ERROR(cuStreamSynchronize(CuStream));

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -159,8 +159,8 @@ ur_result_t ur_event_handle_t_::release() {
 
   assert(Queue != nullptr);
 
-  // Avoid double free if using timestamp
-  if (!isTimestampEvent())
+  // Avoid double free
+  if (differentNativeEventsForStartAndEnd(CommandType))
     UR_CHECK_ERROR(cuEventDestroy(EvEnd));
 
   if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -129,6 +129,18 @@ ur_result_t ur_event_handle_t_::record() {
   return Result;
 }
 
+ur_result_t ur_event_handle_t_::make_end_event_same_as_start() {
+  if (isRecorded() || !isStarted()) {
+    return UR_RESULT_ERROR_INVALID_EVENT;
+  }
+  UR_ASSERT(Queue, UR_RESULT_ERROR_INVALID_QUEUE);
+
+  EvEnd = EvStart;
+  IsRecorded = true;
+
+  return UR_RESULT_SUCCESS;
+}
+
 ur_result_t ur_event_handle_t_::wait() {
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
@@ -147,7 +159,9 @@ ur_result_t ur_event_handle_t_::release() {
 
   assert(Queue != nullptr);
 
-  UR_CHECK_ERROR(cuEventDestroy(EvEnd));
+  // Avoid double free if using timestamp
+  if (!isTimestampEvent())
+    UR_CHECK_ERROR(cuEventDestroy(EvEnd));
 
   if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
     UR_CHECK_ERROR(cuEventDestroy(EvQueued));

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -49,7 +49,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
   urContextRelease(Context);
 }
 
-ur_result_t ur_event_handle_t_::start() {
+ur_result_t ur_event_handle_t_::start(bool MakeEndSameAsStart) {
   assert(!isStarted());
   ur_result_t Result = UR_RESULT_SUCCESS;
 
@@ -62,7 +62,10 @@ ur_result_t ur_event_handle_t_::start() {
   } catch (ur_result_t Err) {
     Result = Err;
   }
-
+  if (MakeEndSameAsStart) {
+    IsRecorded = true;
+    EvEnd = EvStart;
+  }
   IsStarted = true;
   return Result;
 }
@@ -127,18 +130,6 @@ ur_result_t ur_event_handle_t_::record() {
   }
 
   return Result;
-}
-
-ur_result_t ur_event_handle_t_::make_end_event_same_as_start() {
-  if (isRecorded() || !isStarted()) {
-    return UR_RESULT_ERROR_INVALID_EVENT;
-  }
-  UR_ASSERT(Queue, UR_RESULT_ERROR_INVALID_QUEUE);
-
-  EvEnd = EvStart;
-  IsRecorded = true;
-
-  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::wait() {

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -23,6 +23,8 @@ public:
 
   ur_result_t record();
 
+  ur_result_t make_end_event_same_as_start();
+
   ur_result_t wait();
 
   ur_result_t start();
@@ -91,8 +93,13 @@ public:
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
     native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
-    UR_CHECK_ERROR(cuEventCreate(
-        &EvEnd, RequiresTimings ? CU_EVENT_DEFAULT : CU_EVENT_DISABLE_TIMING));
+
+    // Timestamp will use same event for EvStart and EvEnd, so don't create
+    // EvEnd
+    if (Type != UR_COMMAND_TIMESTAMP_RECORDING_EXP)
+      UR_CHECK_ERROR(cuEventCreate(&EvEnd, RequiresTimings
+                                               ? CU_EVENT_DEFAULT
+                                               : CU_EVENT_DISABLE_TIMING));
 
     if (RequiresTimings) {
       UR_CHECK_ERROR(cuEventCreate(&EvQueued, CU_EVENT_DEFAULT));

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -23,11 +23,9 @@ public:
 
   ur_result_t record();
 
-  ur_result_t make_end_event_same_as_start();
-
   ur_result_t wait();
 
-  ur_result_t start();
+  ur_result_t start(bool MakeEndSameAsStart = false);
 
   native_type get() const noexcept { return EvEnd; };
 

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -94,9 +94,9 @@ public:
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
     native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
 
-    // Timestamp will use same event for EvStart and EvEnd, so don't create
+    // Some commands will use same event for EvStart and EvEnd, so don't create
     // EvEnd
-    if (Type != UR_COMMAND_TIMESTAMP_RECORDING_EXP)
+    if (differentNativeEventsForStartAndEnd(Type))
       UR_CHECK_ERROR(cuEventCreate(&EvEnd, RequiresTimings
                                                ? CU_EVENT_DEFAULT
                                                : CU_EVENT_DISABLE_TIMING));

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -483,7 +483,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
       *phEvent = ur_event_handle_t_::makeNative(
           UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, HIPStream, StreamToken);
       UR_CHECK_ERROR((*phEvent)->start());
-      UR_CHECK_ERROR((*phEvent)->record());
+      UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
     }
 
     return UR_RESULT_SUCCESS;
@@ -1274,7 +1274,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->record());
+        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
       } catch (ur_result_t Error) {
         Result = Error;
       }
@@ -1324,7 +1324,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
         UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->record());
+        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
       } catch (ur_result_t Error) {
         Result = Error;
       }

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -482,8 +482,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     if (phEvent) {
       *phEvent = ur_event_handle_t_::makeNative(
           UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, hQueue, HIPStream, StreamToken);
-      UR_CHECK_ERROR((*phEvent)->start());
-      UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+      UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
     }
 
     return UR_RESULT_SUCCESS;
@@ -1273,8 +1272,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
       try {
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_BUFFER_MAP, hQueue, hQueue->getNextTransferStream());
-        UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+        UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
       } catch (ur_result_t Error) {
         Result = Error;
       }
@@ -1323,8 +1321,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
       try {
         *phEvent = ur_event_handle_t_::makeNative(
             UR_COMMAND_MEM_UNMAP, hQueue, hQueue->getNextTransferStream());
-        UR_CHECK_ERROR((*phEvent)->start());
-        UR_CHECK_ERROR((*phEvent)->make_end_event_same_as_start());
+        UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
       } catch (ur_result_t Error) {
         Result = Error;
       }
@@ -1999,8 +1996,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     RetImplEvent =
         std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
             UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, HIPStream));
-    UR_CHECK_ERROR(RetImplEvent->start());
-    UR_CHECK_ERROR(RetImplEvent->make_end_event_same_as_start());
+    UR_CHECK_ERROR((*phEvent)->start(true /*MakeEndSameAsStart=*/));
 
     if (blocking) {
       UR_CHECK_ERROR(hipStreamSynchronize(HIPStream));

--- a/source/adapters/hip/enqueue.cpp
+++ b/source/adapters/hip/enqueue.cpp
@@ -2000,7 +2000,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeNative(
             UR_COMMAND_TIMESTAMP_RECORDING_EXP, hQueue, HIPStream));
     UR_CHECK_ERROR(RetImplEvent->start());
-    UR_CHECK_ERROR(RetImplEvent->record());
+    UR_CHECK_ERROR(RetImplEvent->make_end_event_same_as_start());
 
     if (blocking) {
       UR_CHECK_ERROR(hipStreamSynchronize(HIPStream));

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -58,7 +58,7 @@ ur_event_handle_t_::~ur_event_handle_t_() {
   urContextRelease(Context);
 }
 
-ur_result_t ur_event_handle_t_::start() {
+ur_result_t ur_event_handle_t_::start(bool MakeEndSameAsStart) {
   assert(!isStarted());
   ur_result_t Result = UR_RESULT_SUCCESS;
 
@@ -70,6 +70,11 @@ ur_result_t ur_event_handle_t_::start() {
     }
   } catch (ur_result_t Error) {
     Result = Error;
+  }
+
+  if (MakeEndSameAsStart) {
+    IsRecorded = true;
+    EvEnd = EvStart;
   }
 
   IsStarted = true;
@@ -161,18 +166,6 @@ ur_result_t ur_event_handle_t_::record() {
   }
 
   return Result;
-}
-
-ur_result_t ur_event_handle_t_::make_end_event_same_as_start() {
-  if (isRecorded() || !isStarted()) {
-    return UR_RESULT_ERROR_INVALID_EVENT;
-  }
-  UR_ASSERT(Queue, UR_RESULT_ERROR_INVALID_QUEUE);
-
-  EvEnd = EvStart;
-  IsRecorded = true;
-
-  return UR_RESULT_SUCCESS;
 }
 
 ur_result_t ur_event_handle_t_::wait() {

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -20,11 +20,9 @@ public:
 
   ur_result_t record();
 
-  ur_result_t make_end_event_same_as_start();
-
   ur_result_t wait();
 
-  ur_result_t start();
+  ur_result_t start(bool MakeEndSameAsStart = false);
 
   native_type get() const noexcept { return EvEnd; };
 

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -20,6 +20,8 @@ public:
 
   ur_result_t record();
 
+  ur_result_t make_end_event_same_as_start();
+
   ur_result_t wait();
 
   ur_result_t start();

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -375,3 +375,13 @@ static inline void roundToHighestFactorOfGlobalSizeIn3d(
                MaxBlockDim[2]));
   roundToHighestFactorOfGlobalSize(ThreadsPerBlock[2], GlobalSize[2]);
 }
+
+namespace {
+// Start and end events refer to the same native events for some commands
+static inline bool differentNativeEventsForStartAndEnd(ur_command_t T) {
+  return !(T & (UR_COMMAND_TIMESTAMP_RECORDING_EXP |
+                UR_COMMAND_EVENTS_WAIT_WITH_BARRIER |
+                UR_COMMAND_MEM_BUFFER_MAP | UR_COMMAND_MEM_UNMAP));
+}
+} // namespace
+

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -378,10 +378,9 @@ static inline void roundToHighestFactorOfGlobalSizeIn3d(
 
 namespace {
 // Start and end events refer to the same native events for some commands
-static inline bool differentNativeEventsForStartAndEnd(ur_command_t T) {
+inline bool differentNativeEventsForStartAndEnd(ur_command_t T) {
   return !(T & (UR_COMMAND_TIMESTAMP_RECORDING_EXP |
                 UR_COMMAND_EVENTS_WAIT_WITH_BARRIER |
                 UR_COMMAND_MEM_BUFFER_MAP | UR_COMMAND_MEM_UNMAP));
 }
 } // namespace
-


### PR DESCRIPTION
Since EvStart and EvEnd are recorded directly after one another in `urEnqueueTimestampRecordingExp`, we can just copy EvStart to make EvEnd, instead of calling cuEventRecord for both `EvStart` and `EvEnd`, one after the other.

@steffenlarsen for discussion