### PR TITLE
add compute benchmark workflow for L0

### DIFF
--- a/.github/scripts/compute_benchmarks.py
+++ b/.github/scripts/compute_benchmarks.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024 Intel Corporation
+# Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+# See LICENSE.TXT
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import os
+import subprocess  # nosec B404
+import csv
+import argparse
+import io
+import json
+from pathlib import Path
+
+# Function to run the benchmark with the given parameters and environment variables
+def run_benchmark(directory, ioq, env_vars):
+    env = os.environ.copy()
+    env.update(env_vars)
+    command = [
+        f"{directory}/api_overhead_benchmark_sycl",
+        "--test=SubmitKernel",
+        f"--Ioq={ioq}",
+        "--DiscardEvents=0",
+        "--MeasureCompletion=0",
+        "--iterations=10000",
+        "--Profiling=0",
+        "--NumKernels=10",
+        "--KernelExecTime=1",
+        "--csv",
+        "--noHeaders"
+    ]
+    result = subprocess.run(command, capture_output=True, text=True, env=env)  # nosec B603
+    return command, result.stdout
+
+# Function to parse the CSV output and extract the mean execution time
+def parse_output(output):
+    # Use StringIO to turn the string output into a file-like object for the csv reader
+    csv_file = io.StringIO(output)
+    reader = csv.reader(csv_file)
+
+    # Skip the header row
+    next(reader, None)
+    data_row = next(reader, None)
+    if data_row is None:
+        raise ValueError("Benchmark output does not contain data.")
+    try:
+        name = data_row[0] # Name of the benchmark is the first value
+        mean = float(data_row[1]) # Mean is the second value
+        return (name, mean)
+    except ValueError:
+        raise ValueError(f"Could not convert mean execution time to float: '{data_row[1]}'")
+    except IndexError:
+        raise ValueError("Data row does not contain enough values.")
+
+# Function to generate the mermaid bar chart script
+def generate_mermaid_script(labels, chart_data):
+    mermaid_script=f"""
+---
+config:
+    gantt:
+        rightPadding: 10
+        leftPadding: 120
+        sectionFontSize: 10
+        numberSectionStyles: 2
+---
+gantt
+    title api_overhead_benchmark_sycl, mean execution time per 10 kernels (μs)
+    todayMarker off
+    dateFormat  X
+    axisFormat %s
+"""
+    for label in labels:
+        nbars = 0
+        print_label = label.replace(" ", "<br>")
+        mermaid_script += f"""
+    section {print_label}
+"""
+        for (name, data) in chart_data:
+            if data is not None:
+                if label in data:
+                    nbars += 1
+                    mean = data[label]
+                    crit = "crit," if name == "This PR" else ""
+                    mermaid_script += f"""
+        {name} ({mean} us)   : {crit} 0, {int(mean)}
+"""
+        padding = 4 - nbars
+        if padding > 0:
+            for _ in range(padding):
+                mermaid_script += f"""
+    -   : 0, 0
+"""
+
+    return mermaid_script
+
+# Function to generate the markdown collapsible sections for each variant
+def generate_markdown_details(variant_details):
+    markdown_sections = []
+    for label, command, env_vars, output in variant_details:
+        env_vars_str = '\n'.join(f"{key}={value}" for key, value in env_vars.items())
+        markdown_sections.append(f"""
+<details>
+<summary>{label}</summary>
+
+#### Environment Variables:
+{env_vars_str}
+
+#### Command:
+{' '.join(command)}
+
+#### Output:
+{output}
+
+</details>
+""")
+    return "\n".join(markdown_sections)
+
+# Function to generate the full markdown
+def generate_markdown_with_mermaid_chart(mermaid_script, variant_details):
+    return f"""
+# Benchmark Results
+```mermaid
+{mermaid_script}
+```
+## Details
+{generate_markdown_details(variant_details)}
+"""
+
+def save_benchmark_results(save_name, benchmark_data):
+    benchmarks_dir = Path.home() / 'benchmarks'
+    benchmarks_dir.mkdir(exist_ok=True)
+    file_path = benchmarks_dir / f"{save_name}.json"
+    with file_path.open('w') as file:
+        json.dump(benchmark_data, file, indent=4)
+    print(f"Benchmark results saved to {file_path}")
+
+def load_benchmark_results(compare_name):
+    benchmarks_dir = Path.home() / 'benchmarks'
+    file_path = benchmarks_dir / f"{compare_name}.json"
+    if file_path.exists():
+        with file_path.open('r') as file:
+            return json.load(file)
+    else:
+        return None
+
+def main(directory, additional_env_vars, save_name, compare_names):
+    variants = [
+        (1, {'UR_L0_USE_IMMEDIATE_COMMANDLISTS': '0'}, "Imm-CmdLists-OFF"),
+        (0, {'UR_L0_USE_IMMEDIATE_COMMANDLISTS': '0'}, "Imm-CmdLists-OFF"),
+        (1, {'UR_L0_USE_IMMEDIATE_COMMANDLISTS': '1'}, ""),
+        (0, {'UR_L0_USE_IMMEDIATE_COMMANDLISTS': '1'}, ""),
+    ]
+
+    # Run benchmarks and collect means, labels, and variant details
+    means = []
+    labels = []
+    variant_details = []
+    for ioq, env_vars, extra_label in variants:
+        merged_env_vars = {**env_vars, **additional_env_vars}
+        command, output = run_benchmark(directory, ioq, merged_env_vars)
+        (label, mean) = parse_output(output)
+        label += f" {extra_label}"
+        means.append(mean)
+        labels.append(label)
+        variant_details.append((label, command, merged_env_vars, output))
+
+    benchmark_data = {label: mean for label, mean in zip(labels, means)}
+
+    chart_data = [("This PR", benchmark_data)]
+    for name in compare_names:
+        chart_data.append((name, load_benchmark_results(name)))
+
+    if save_name:
+        save_benchmark_results(save_name, benchmark_data)
+
+    mermaid_script = generate_mermaid_script(labels, chart_data)
+
+    markdown_content = generate_markdown_with_mermaid_chart(mermaid_script, variant_details)
+
+    with open('benchmark_results.md', 'w') as file:
+        file.write(markdown_content)
+
+    print("Markdown with benchmark results has been written to benchmark_results.md")
+
+def validate_and_parse_env_args(env_args):
+    env_vars = {}
+    for arg in env_args:
+        if '=' not in arg:
+            raise ValueError(f"Environment variable argument '{arg}' is not in the form Variable=Value.")
+        key, value = arg.split('=', 1)
+        env_vars[key] = value
+    return env_vars
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run benchmarks and generate a Mermaid bar chart script.')
+    parser.add_argument('benchmark_directory', type=str, help='The directory where the benchmarks are located.')
+    parser.add_argument("--env", type=str, help='Use env variable for a benchmark run.', action="append", default=[])
+    parser.add_argument("--save", type=str, help='Save the results for comparison under a specified name.')
+    parser.add_argument("--compare", type=str, help='Compare results against previously saved data.', action="append", default=["baseline"])
+
+    args = parser.parse_args()
+
+    additional_env_vars = validate_and_parse_env_args(args.env)
+
+    main(args.benchmark_directory, additional_env_vars, args.save, args.compare)

--- a/.github/workflows/benchmarks_core.yml
+++ b/.github/workflows/benchmarks_core.yml
@@ -1,0 +1,199 @@
+name: Compute Benchmarks
+
+on:
+  # this workflow can by only triggered by other workflows
+  # for example by: e2e_cuda.yml or e2e_opencl.yml
+  workflow_call:
+    # acceptable input from adapter-specific workflows
+    inputs:
+      name:
+        description: Adapter name
+        type: string
+        required: true
+      str_name:
+        description: Formatted adapter name
+        type: string
+        required: true
+      config:
+        description: Params for sycl configuration
+        type: string
+        required: true
+      unit:
+        description: Test unit (cpu/gpu)
+        type: string
+        required: true
+      runner_tag:
+        description: Tag defined for the runner
+        type: string
+        required: true
+      trigger:
+        description: Type of workflow trigger
+        type: string
+        required: true
+      comment:
+        description: Text if triggered by a comment
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  e2e-build-hw:
+    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
+    name: Build SYCL, UR, run Compute Benchmarks
+    strategy:
+      matrix:
+        adapter: [
+          {name: "${{inputs.name}}",
+          str_name: "${{inputs.str_name}}",
+          config: "${{inputs.config}}",
+          unit: "${{inputs.unit}}"}
+        ]
+        build_type: [Release]
+        compiler: [{c: clang, cxx: clang++}]
+
+    runs-on: ${{inputs.runner_tag}}
+
+    steps:
+    # Workspace on self-hosted runners is not cleaned automatically.
+    # We have to delete the files created outside of using actions.
+    - name: Cleanup self-hosted workspace
+      if: always()
+      run: |
+        ls -la ./
+        rm -rf ./* || true
+
+    - name: Add comment to PR
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ always() && inputs.trigger != 'schedule' }}
+      with:
+        script: |
+          const adapter = '${{ matrix.adapter.name }}';
+          const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+          const body = `Compute Benchmarks ${adapter} run: \n${url}`;
+
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          })
+
+    - name: Checkout UR
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        path: ur-repo
+
+    # On issue_comment trigger (for PRs) we need to fetch special ref for
+    # proper PR's merge commit. Note, this ref may be absent if the PR is already merged.
+    - name: Fetch PR's merge commit
+      if: ${{ inputs.trigger != 'schedule' }}
+      working-directory: ${{github.workspace}}/ur-repo
+      env:
+        PR_NO: ${{github.event.issue.number}}
+      run: |
+        git fetch -- https://github.com/${{github.repository}} +refs/pull/${PR_NO}/*:refs/remotes/origin/pr/${PR_NO}/*
+        git checkout origin/pr/${PR_NO}/merge
+        git rev-parse origin/pr/${PR_NO}/merge
+
+    - name: Checkout SYCL
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: intel/llvm
+        ref: refs/heads/sycl
+        path: sycl-repo
+        fetch-depth: 1
+        fetch-tags: false
+
+    - name: Set CUDA env vars
+      if: matrix.adapter.name == 'CUDA'
+      run: |
+        echo "CUDA_LIB_PATH=/usr/local/cuda/lib64/stubs" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    - name: Configure SYCL
+      run: >
+        python3 sycl-repo/buildbot/configure.py
+        -t ${{matrix.build_type}}
+        -o ${{github.workspace}}/sycl_build
+        --cmake-gen "Ninja"
+        --ci-defaults ${{matrix.adapter.config}}
+        --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
+        --cmake-opt="-DSYCL_PI_TESTS=OFF"
+        --cmake-opt="-DSYCL_PI_UR_USE_FETCH_CONTENT=OFF"
+        --cmake-opt="-DSYCL_PI_UR_SOURCE_DIR=${{github.workspace}}/ur-repo/"
+        --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache
+        --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+    - name: Build SYCL
+      run: cmake --build ${{github.workspace}}/sycl_build -j
+
+    - name: Set additional env. vars
+      run: |
+        echo "${{github.workspace}}/sycl_build/bin" >> $GITHUB_PATH
+        echo "LD_LIBRARY_PATH=${{github.workspace}}/sycl_build/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+    # Running (newly built) sycl-ls sets up some extra variables
+    - name: Setup SYCL variables
+      run: |
+        which clang++ sycl-ls
+        SYCL_PI_TRACE=-1 sycl-ls
+
+    - name: Checkout Compute Benchmarks
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: intel/compute-benchmarks
+        path: compute-benchmarks-repo
+        submodules: recursive
+
+    - name: Configure Compute Benchmarks
+      run: >
+        cmake
+        -B ${{github.workspace}}/compute-benchmarks-build/
+        -S ${{github.workspace}}/compute-benchmarks-repo/
+        -DCMAKE_BUILD_TYPE=Release
+        -DBUILD_SYCL=ON
+        -DSYCL_COMPILER_ROOT=${{github.workspace}}/sycl_build
+        -DALLOW_WARNINGS=ON
+
+    - name: Build Compute Benchmarks
+      run: cmake --build ${{github.workspace}}/compute-benchmarks-build/ -j
+
+    - name: Set oneAPI Device Selector
+      run: |
+        echo "ONEAPI_DEVICE_SELECTOR=${{ matrix.adapter.str_name }}:${{ matrix.adapter.unit }}" >> $GITHUB_ENV
+
+    - name: Extract arguments from comment
+      id: args
+      run: echo "ARGS=$(echo '${{ inputs.comment }}' | sed -n 's/.*\/benchmarks-[^ ]* \(.*\)/\1/p')" >> $GITHUB_ENV
+
+    - name: Run SYCL API Overhead benchmark
+      id: benchmarks
+      run: ${{github.workspace}}/ur-repo/.github/scripts/compute_benchmarks.py ${{github.workspace}}/compute-benchmarks-build/bin/ $ARGS
+
+    - name: Add comment to PR
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ always() && inputs.trigger != 'schedule' }}
+      with:
+        script: |
+          let markdown = ""
+          try {
+            const fs = require('fs');
+            markdown = fs.readFileSync('benchmark_results.md', 'utf8');
+          } catch(err) {
+          }
+
+          const adapter = '${{ matrix.adapter.name }}';
+          const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+          const test_status = '${{ steps.benchmarks.outcome }}';
+          const job_status = '${{ job.status }}';
+          const body = `Compute Benchmarks ${adapter} run:\n${url}\nJob status: ${job_status}. Test status: ${test_status}.\n ${markdown}`;
+
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          })

--- a/.github/workflows/benchmarks_level_zero.yml
+++ b/.github/workflows/benchmarks_level_zero.yml
@@ -1,0 +1,26 @@
+name: Compute Benchmarks Level Zero
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  e2e-build-hw:
+    # trigger only if PR comment contains "benchmarks-level-zero"
+    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/benchmarks-level-zero'))}}
+    name: Start benchmarks job
+    # use core flow, run it with L0 specific parameters
+    uses: ./.github/workflows/benchmarks_core.yml
+    # parameters that we pass to the core flow
+    with:
+      name: "L0"
+      runner_tag: "L0_PERF"
+      str_name: "level_zero"
+      config: ""
+      unit: "gpu"
+      trigger: "${{github.event_name}}"
+      comment: ${{github.event.comment.body}}


### PR DESCRIPTION
This patch adds a script for running compute-benchmarks, https://github.com/intel/compute-benchmarks/, and a corresponding GH Actions workflow that runs those benchmarks when prompted to do so with a comment, like so:

/benchmarks-level-zero --env UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_EVENT_COMPLETIONS=1

Additional arguments can be appended to the end of the line. After the build if finished, the results will be presented through a comment.

For now, this runs only a single scenario, api_overhead_benchmark_sycl with SubmitKernel test, but will expand over time to cover more.
