### PR TITLE
Fix validation for urEnqueueTimestampRecordingExpTest

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8914,6 +8914,8 @@ urKernelSuggestMaxCooperativeGroupCountExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 UR_APIEXPORT ur_result_t UR_APICALL
 urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object

--- a/scripts/core/exp-enqueue-timestamp-recording.yml
+++ b/scripts/core/exp-enqueue-timestamp-recording.yml
@@ -63,4 +63,6 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_HANDLE
     - $X_RESULT_ERROR_INVALID_NULL_POINTER
-    - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+    - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
+        - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
+        - "`phEventWaitList != NULL && numEventsInWaitList == 0`"

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -8975,6 +8975,14 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
+        if (phEventWaitList == NULL && numEventsInWaitList > 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
+        if (phEventWaitList != NULL && numEventsInWaitList == 0) {
+            return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
+        }
+
         if (phEventWaitList != NULL && numEventsInWaitList > 0) {
             for (uint32_t i = 0; i < numEventsInWaitList; ++i) {
                 if (phEventWaitList[i] == NULL) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -8328,6 +8328,8 @@ ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -7047,6 +7047,8 @@ ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phEvent`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST
+///         + `phEventWaitList == NULL && numEventsInWaitList > 0`
+///         + `phEventWaitList != NULL && numEventsInWaitList == 0`
 ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool


### PR DESCRIPTION
This was failing with the HIP adapter when the pointer is null and the event wait list is not 0.