### PR TITLE
[HIP] Fix host ptr unmap with offset

### DIFF
--- a/source/adapters/hip/memory.hpp
+++ b/source/adapters/hip/memory.hpp
@@ -126,7 +126,7 @@ public:
   void unmap(void *) noexcept {
     assert(MapPtr != nullptr);
 
-    if (MapPtr != HostPtr) {
+    if (MapPtr != (static_cast<char *>(HostPtr) + MapOffset)) {
       free(MapPtr);
     }
     MapPtr = nullptr;


### PR DESCRIPTION
The current code would cause crashes in the enqueue UR CTS as it would try to free a pointer at an offset in the host pointer.

This is a quick fix so the CTS doesn't crash but ideally we should port the following CUDA adapter to HIP which would also fix the crash:
* https://github.com/oneapi-src/unified-runtime/pull/1220