### PR TITLE
[HIP] Fix context devices property return value

### DIFF
--- a/source/adapters/hip/context.cpp
+++ b/source/adapters/hip/context.cpp
@@ -78,7 +78,8 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(static_cast<uint32_t>(hContext->Devices.size()));
   case UR_CONTEXT_INFO_DEVICES:
-    return ReturnValue(hContext->getDevices());
+    return ReturnValue(hContext->getDevices().data(),
+                       hContext->getDevices().size());
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
     return ReturnValue(hContext->getReferenceCount());
   case UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES:

--- a/test/conformance/context/context_adapter_hip.match
+++ b/test/conformance/context/context_adapter_hip.match
@@ -1,4 +1,3 @@
 urContextCreateWithNativeHandleTest.Success/AMD_HIP_BACKEND___{{.*}}_
 urContextCreateWithNativeHandleTest.SuccessWithOwnedNativeHandle/AMD_HIP_BACKEND___{{.*}}_
 urContextCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle/AMD_HIP_BACKEND___{{.*}}_
-urContextGetInfoTestWithInfoParam.Success/AMD_HIP_BACKEND___{{.*}}


### PR DESCRIPTION
This showed up in the UR CTS, it was returning a vector instead of the expected C array.