### PR TITLE
[L0] Create initial structure for supporting queue dispatcher

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1175,9 +1175,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
-    ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t Queue,
+    ur_exp_command_buffer_handle_t CommandBuffer, ur_queue_handle_t UrQueue,
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *Event) {
+  auto Queue = Legacy(UrQueue);
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
   // Use compute engine rather than copy engine
   const auto UseCopyEngine = false;

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -576,8 +576,8 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
   std::scoped_lock<ur_mutex> Lock(EventCacheMutex);
   ur_device_handle_t Device = nullptr;
 
-  if (!Event->IsMultiDevice && Event->UrQueue) {
-    Device = Event->UrQueue->Device;
+  if (!Event->IsMultiDevice && Legacy(Event->UrQueue)) {
+    Device = Legacy(Event->UrQueue)->Device;
   }
 
   auto Cache = getEventCache(Event->isHostVisible(),
@@ -598,10 +598,10 @@ ur_context_handle_t_::decrementUnreleasedEventsInPool(ur_event_handle_t Event) {
 
   ze_device_handle_t ZeDevice = nullptr;
   bool UsingImmediateCommandlists =
-      !Event->UrQueue || Event->UrQueue->UsingImmCmdLists;
+      !Legacy(Event->UrQueue) || Legacy(Event->UrQueue)->UsingImmCmdLists;
 
-  if (!Event->IsMultiDevice && Event->UrQueue) {
-    ZeDevice = Event->UrQueue->Device->ZeDevice;
+  if (!Event->IsMultiDevice && Legacy(Event->UrQueue)) {
+    ZeDevice = Legacy(Event->UrQueue)->Device->ZeDevice;
   }
 
   std::list<ze_event_pool_handle_t> *ZePoolCache = getZeEventPoolCache(
@@ -644,7 +644,7 @@ static const size_t CmdListsCleanupThreshold = [] {
 
 // Retrieve an available command list to be used in a PI call.
 ur_result_t ur_context_handle_t_::getAvailableCommandList(
-    ur_queue_handle_t Queue, ur_command_list_ptr_t &CommandList,
+    ur_queue_handle_legacy_t Queue, ur_command_list_ptr_t &CommandList,
     bool UseCopyEngine, uint32_t NumEventsInWaitList,
     const ur_event_handle_t *EventWaitList, bool AllowBatching,
     ze_command_queue_handle_t *ForcedCmdQueue) {

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -293,7 +293,7 @@ struct ur_context_handle_t_ : _ur_object {
   // for executing on this device. Immediate commandlists are created only
   // once for each SYCL Queue and after that they are reused.
   ur_result_t getAvailableCommandList(
-      ur_queue_handle_t Queue, ur_command_list_ptr_t &CommandList,
+      ur_queue_handle_legacy_t Queue, ur_command_list_ptr_t &CommandList,
       bool UseCopyEngine, uint32_t NumEventsInWaitList,
       const ur_event_handle_t *EventWaitList, bool AllowBatching = false,
       ze_command_queue_handle_t *ForcedCmdQueue = nullptr);

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -46,13 +46,13 @@ static const bool UseMultipleCmdlistBarriers = [] {
 }();
 
 bool WaitListEmptyOrAllEventsFromSameQueue(
-    ur_queue_handle_t Queue, uint32_t NumEventsInWaitList,
+    ur_queue_handle_legacy_t Queue, uint32_t NumEventsInWaitList,
     const ur_event_handle_t *EventWaitList) {
   if (!NumEventsInWaitList)
     return true;
 
   for (uint32_t i = 0; i < NumEventsInWaitList; ++i) {
-    if (Queue != EventWaitList[i]->UrQueue)
+    if (Queue != Legacy(EventWaitList[i]->UrQueue))
       return false;
   }
 
@@ -60,7 +60,7 @@ bool WaitListEmptyOrAllEventsFromSameQueue(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
-    ur_queue_handle_t Queue,      ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue,    ///< [in] handle of the queue object
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
         *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
@@ -72,6 +72,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular command instance.
 ) {
+  auto Queue = Legacy(UrQueue);
   if (EventWaitList) {
     bool UseCopyEngine = false;
 
@@ -152,7 +153,7 @@ static const bool InOrderBarrierBySignal = [] {
 }();
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
-    ur_queue_handle_t Queue,      ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue,    ///< [in] handle of the queue object
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
         *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
@@ -164,6 +165,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular command instance.
 ) {
+  auto Queue = Legacy(UrQueue);
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
@@ -299,8 +301,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
   for (auto &QueueMap :
        {Queue->ComputeQueueGroupsByTID, Queue->CopyQueueGroupsByTID})
     for (auto &QueueGroup : QueueMap) {
-      bool UseCopyEngine =
-          QueueGroup.second.Type != ur_queue_handle_t_::queue_type::Compute;
+      bool UseCopyEngine = QueueGroup.second.Type !=
+                           ur_queue_handle_legacy_t_::queue_type::Compute;
       if (Queue->UsingImmCmdLists) {
         // If immediate command lists are being used, each will act as their own
         // queue, so we must insert a barrier into each.
@@ -369,8 +371,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
   // Execute each command list so the barriers can be encountered.
   for (ur_command_list_ptr_t &CmdList : CmdLists) {
-    bool IsCopy =
-        CmdList->second.isCopy(reinterpret_cast<ur_queue_handle_t>(Queue));
+    bool IsCopy = CmdList->second.isCopy(
+        reinterpret_cast<ur_queue_handle_legacy_t>(Queue));
     const auto &CommandBatch =
         (IsCopy) ? Queue->CopyCommandBatch : Queue->ComputeCommandBatch;
     // Only batch if the matching CmdList is already open.
@@ -414,7 +416,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(
     // possible that this is trying to query some event's status that
     // is part of the batch.  This isn't strictly required, but it seems
     // like a reasonable thing to do.
-    auto UrQueue = Event->UrQueue;
+    auto UrQueue = Legacy(Event->UrQueue);
     if (UrQueue) {
       // Lock automatically releases when this goes out of scope.
       std::unique_lock<ur_shared_mutex> Lock(UrQueue->Mutex, std::try_to_lock);
@@ -486,8 +488,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
     return UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE;
   }
 
-  ur_device_handle_t Device =
-      Event->UrQueue ? Event->UrQueue->Device : Event->Context->Devices[0];
+  ur_device_handle_t Device = Legacy(Event->UrQueue)
+                                  ? Legacy(Event->UrQueue)->Device
+                                  : Event->Context->Devices[0];
 
   uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
   const uint64_t TimestampMaxValue =
@@ -512,10 +515,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
         return ReturnValue(Event->RecordEventEndTimestamp);
 
       // Otherwise we need to collect it from the queue.
-      auto Entry = Event->UrQueue->EndTimeRecordings.find(Event);
+      auto Entry = Legacy(Event->UrQueue)->EndTimeRecordings.find(Event);
 
       // Unexpected state if there is no end-time record.
-      if (Entry == Event->UrQueue->EndTimeRecordings.end())
+      if (Entry == Legacy(Event->UrQueue)->EndTimeRecordings.end())
         return UR_RESULT_ERROR_UNKNOWN;
       auto &EndTimeRecording = Entry->second;
 
@@ -540,7 +543,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
       // anymore, so we cache it on the event and evict the record from the
       // queue.
       Event->RecordEventEndTimestamp = ContextEndTime;
-      Event->UrQueue->EndTimeRecordings.erase(Entry);
+      Legacy(Event->UrQueue)->EndTimeRecordings.erase(Entry);
 
       return ReturnValue(ContextEndTime);
     }
@@ -659,7 +662,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
-    ur_queue_handle_t Queue,      ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue,    ///< [in] handle of the queue object
     bool Blocking,                ///< [in] blocking or non-blocking enqueue
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
@@ -673,6 +676,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
         *OutEvent ///< [in,out] return an event object that identifies
                   ///< this particular command instance.
 ) {
+  auto Queue = Legacy(UrQueue);
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
@@ -701,7 +705,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
   // Create a new entry in the queue's recordings.
   Queue->EndTimeRecordings[*OutEvent] =
-      ur_queue_handle_t_::end_time_recording{};
+      ur_queue_handle_legacy_t_::end_time_recording{};
 
   ZE2UR_CALL(zeCommandListAppendWriteGlobalTimestamp,
              (CommandList->first,
@@ -717,6 +721,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
 ur_result_t ur_event_handle_t_::getOrCreateHostVisibleEvent(
     ze_event_handle_t &ZeHostVisibleEvent) {
+  auto UrQueue = Legacy(this->UrQueue);
 
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(UrQueue->Mutex,
                                                           this->Mutex);
@@ -771,7 +776,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
 ) {
   for (uint32_t I = 0; I < NumEvents; I++) {
     auto e = EventWaitList[I];
-    if (e->UrQueue && e->UrQueue->ZeEventsScope == OnDemandHostVisibleProxy) {
+    auto UrQueue = Legacy(e->UrQueue);
+    if (UrQueue && UrQueue->ZeEventsScope == OnDemandHostVisibleProxy) {
       // Make sure to add all host-visible "proxy" event signals if needed.
       // This ensures that all signalling commands are submitted below and
       // thus proxy events can be waited without a deadlock.
@@ -788,7 +794,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
   // Submit dependent open command lists for execution, if any
   for (uint32_t I = 0; I < NumEvents; I++) {
     ur_event_handle_t_ *Event = ur_cast<ur_event_handle_t_ *>(EventWaitList[I]);
-    auto UrQueue = Event->UrQueue;
+    auto UrQueue = Legacy(Event->UrQueue);
     if (UrQueue) {
       // Lock automatically releases when this goes out of scope.
       std::scoped_lock<ur_shared_mutex> lock(UrQueue->Mutex);
@@ -796,7 +802,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
       UR_CALL(UrQueue->executeAllOpenCommandLists());
     }
   }
-  std::unordered_set<ur_queue_handle_t> Queues;
+  std::unordered_set<ur_queue_handle_legacy_t> Queues;
   for (uint32_t I = 0; I < NumEvents; I++) {
     {
       ur_event_handle_t_ *Event =
@@ -823,12 +829,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventWait(
           Event->Completed = true;
         }
       }
-      if (auto Q = Event->UrQueue) {
+      if (auto Q = Legacy(Event->UrQueue)) {
         if (Q->UsingImmCmdLists && Q->isInOrderQueue())
           // Use information about waited event to cleanup completed events in
           // the in-order queue.
           CleanupEventsInImmCmdLists(
-              Event->UrQueue, false /* QueueLocked */, false /* QueueSynced */,
+              Legacy(Event->UrQueue), false /* QueueLocked */,
+              false /* QueueSynced */,
               reinterpret_cast<ur_event_handle_t>(Event));
         else {
           // NOTE: we are cleaning up after the event here to free resources
@@ -884,7 +891,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
   // Event can potentially be in an open command-list, make sure that
   // it is submitted for execution to avoid potential deadlock if
   // interop app is going to wait for it.
-  auto Queue = Event->UrQueue;
+  auto Queue = Legacy(Event->UrQueue);
   if (Queue) {
     std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
     const auto &OpenCommandList = Queue->eventOpenCommandList(Event);
@@ -1014,7 +1021,7 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
   }
 
   // Save pointer to the queue before deleting/resetting event.
-  auto Queue = Event->UrQueue;
+  auto Queue = Legacy(Event->UrQueue);
 
   // If the event was a timestamp recording, we try to evict its entry in the
   // queue.
@@ -1028,7 +1035,7 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
         EndTimeRecording.EventHasDied = true;
       } else {
         // Otherwise we evict the entry.
-        Event->UrQueue->EndTimeRecordings.erase(Entry);
+        Legacy(Event->UrQueue)->EndTimeRecordings.erase(Entry);
       }
     }
   }
@@ -1046,8 +1053,8 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
   // created so that we can avoid ur_queue_handle_t is released before the
   // associated ur_event_handle_t is released. Here we have to decrement it so
   // ur_queue_handle_t can be released successfully.
-  if (Queue) {
-    UR_CALL(urQueueReleaseInternal(Queue));
+  if (Event->UrQueue) {
+    UR_CALL(urQueueReleaseInternal(Event->UrQueue));
   }
 
   return UR_RESULT_SUCCESS;
@@ -1091,7 +1098,7 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
   ur_kernel_handle_t AssociatedKernel = nullptr;
   // List of dependent events.
   std::list<ur_event_handle_t> EventsToBeReleased;
-  ur_queue_handle_t AssociatedQueue = nullptr;
+  ur_queue_handle_legacy_t AssociatedQueue = nullptr;
   {
     // If the Event is already locked, then continue with the cleanup, otherwise
     // block on locking the event.
@@ -1105,7 +1112,7 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
     if (Event->CleanedUp)
       return UR_RESULT_SUCCESS;
 
-    AssociatedQueue = Event->UrQueue;
+    AssociatedQueue = Legacy(Event->UrQueue);
 
     // Remember the kernel associated with this event if there is one. We are
     // going to release it later.
@@ -1222,9 +1229,9 @@ ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
 // The "HostVisible" argument specifies if event needs to be allocated from
 // a host-visible pool.
 //
-ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
-                        bool IsMultiDevice, bool HostVisible,
-                        ur_event_handle_t *RetEvent,
+ur_result_t EventCreate(ur_context_handle_t Context,
+                        ur_queue_handle_legacy_t Queue, bool IsMultiDevice,
+                        bool HostVisible, ur_event_handle_t *RetEvent,
                         bool CounterBasedEventEnabled,
                         bool ForceDisableProfiling) {
   bool ProfilingEnabled =
@@ -1311,7 +1318,7 @@ ur_result_t ur_event_handle_t_::reset() {
 
 ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
     uint32_t EventListLength, const ur_event_handle_t *EventList,
-    ur_queue_handle_t CurQueue, bool UseCopyEngine) {
+    ur_queue_handle_legacy_t CurQueue, bool UseCopyEngine) {
   this->Length = 0;
   this->ZeEventList = nullptr;
   this->UrEventList = nullptr;
@@ -1427,7 +1434,7 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
           }
         }
 
-        auto Queue = EventList[I]->UrQueue;
+        auto Queue = Legacy(EventList[I]->UrQueue);
 
         auto CurQueueDevice = CurQueue->Device;
         std::optional<std::unique_lock<ur_shared_mutex>> QueueLock =
@@ -1628,7 +1635,7 @@ ur_result_t _ur_ze_event_list_t::collectEventsForReleaseAndDestroyUrZeEventList(
 // Tells if this event is with profiling capabilities.
 bool ur_event_handle_t_::isProfilingEnabled() const {
   return !UrQueue || // tentatively assume user events are profiling enabled
-         (UrQueue->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) != 0;
+         (Legacy(UrQueue)->Properties & UR_QUEUE_FLAG_PROFILING_ENABLE) != 0;
 }
 
 // Tells if this event was created as a timestamp event, allowing profiling

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -29,9 +29,9 @@
 
 extern "C" {
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event);
-ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
-                        bool IsMultiDevice, bool HostVisible,
-                        ur_event_handle_t *RetEvent,
+ur_result_t EventCreate(ur_context_handle_t Context,
+                        ur_queue_handle_legacy_t Queue, bool IsMultiDevice,
+                        bool HostVisible, ur_event_handle_t *RetEvent,
                         bool CounterBasedEventEnabled = false,
                         bool ForceDisableProfiling = false);
 } // extern "C"
@@ -89,7 +89,7 @@ struct _ur_ze_event_list_t {
   // command-lists.
   ur_result_t createAndRetainUrZeEventList(uint32_t EventListLength,
                                            const ur_event_handle_t *EventList,
-                                           ur_queue_handle_t CurQueue,
+                                           ur_queue_handle_legacy_t CurQueue,
                                            bool UseCopyEngine);
 
   // Add all the events in this object's UrEventList to the end

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -753,12 +753,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    ur_queue_handle_t hQueue, void *pDst, void *pSrc,
+    ur_queue_handle_t hUrQueue, void *pDst, void *pSrc,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
     ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
     ur_rect_region_t hostExtent, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  auto hQueue = Legacy(hUrQueue);
   std::scoped_lock<ur_shared_mutex> Lock(hQueue->Mutex);
 
   UR_ASSERT(hQueue, UR_RESULT_ERROR_INVALID_NULL_HANDLE);

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -27,16 +27,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
   std::copy(pGlobalWorkSize, pGlobalWorkSize + workDim, GlobalWorkSize3D);
 
   ze_kernel_handle_t ZeKernel{};
-  UR_CALL(getZeKernel(hQueue, hKernel, &ZeKernel));
+  UR_CALL(getZeKernel(Legacy(hQueue), hKernel, &ZeKernel));
 
-  UR_CALL(getSuggestedLocalWorkSize(hQueue, ZeKernel, GlobalWorkSize3D,
+  UR_CALL(getSuggestedLocalWorkSize(Legacy(hQueue), ZeKernel, GlobalWorkSize3D,
                                     LocalWorkSize));
 
   std::copy(LocalWorkSize, LocalWorkSize + workDim, pSuggestedLocalWorkSize);
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t getZeKernel(ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel,
+ur_result_t getZeKernel(ur_queue_handle_legacy_t hQueue,
+                        ur_kernel_handle_t hKernel,
                         ze_kernel_handle_t *phZeKernel) {
   auto ZeDevice = hQueue->Device->ZeDevice;
 
@@ -54,7 +55,7 @@ ur_result_t getZeKernel(ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_t hQueue,
+ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_legacy_t hQueue,
                                       ze_kernel_handle_t hZeKernel,
                                       size_t GlobalWorkSize3D[3],
                                       uint32_t SuggestedLocalWorkSize3D[3]) {
@@ -101,7 +102,7 @@ ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_t hQueue,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
-    ur_queue_handle_t Queue,   ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue, ///< [in] handle of the queue object
     ur_kernel_handle_t Kernel, ///< [in] handle of the kernel object
     uint32_t WorkDim, ///< [in] number of dimensions, from 1 to 3, to specify
                       ///< the global and work-group work-items
@@ -130,6 +131,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular kernel execution instance.
 ) {
+  auto Queue = Legacy(UrQueue);
+
   ze_kernel_handle_t ZeKernel{};
   UR_CALL(getZeKernel(Queue, Kernel, &ZeKernel));
 
@@ -307,7 +310,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
-    ur_queue_handle_t Queue,   ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue, ///< [in] handle of the queue object
     ur_kernel_handle_t Kernel, ///< [in] handle of the kernel object
     uint32_t WorkDim, ///< [in] number of dimensions, from 1 to 3, to specify
                       ///< the global and work-group work-items
@@ -336,6 +339,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular kernel execution instance.
 ) {
+  auto Queue = Legacy(UrQueue);
   auto ZeDevice = Queue->Device->ZeDevice;
 
   ze_kernel_handle_t ZeKernel{};
@@ -568,7 +572,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
-    ur_queue_handle_t Queue,     ///< [in] handle of the queue to submit to.
+    ur_queue_handle_t UrQueue,   ///< [in] handle of the queue to submit to.
     ur_program_handle_t Program, ///< [in] handle of the program containing the
                                  ///< device global variable.
     const char
@@ -589,6 +593,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         *Event ///< [in,out][optional] return an event object that identifies
                ///< this particular kernel execution instance.
 ) {
+  auto Queue = Legacy(UrQueue);
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
   // Find global variable pointer
@@ -617,7 +622,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
-    ur_queue_handle_t Queue,     ///< [in] handle of the queue to submit to.
+    ur_queue_handle_t UrQueue,   ///< [in] handle of the queue to submit to.
     ur_program_handle_t Program, ///< [in] handle of the program containing the
                                  ///< device global variable.
     const char
@@ -638,6 +643,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
         *Event ///< [in,out][optional] return an event object that identifies
                ///< this particular kernel execution instance.
 ) {
+  auto Queue = Legacy(UrQueue);
 
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 

--- a/source/adapters/level_zero/kernel.hpp
+++ b/source/adapters/level_zero/kernel.hpp
@@ -108,9 +108,10 @@ struct ur_kernel_handle_t_ : _ur_object {
   ZeCache<std::string> ZeKernelName;
 };
 
-ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_t hQueue,
+ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_legacy_t hQueue,
                                       ze_kernel_handle_t hZeKernel,
                                       size_t GlobalWorkSize3D[3],
                                       uint32_t SuggestedLocalWorkSize3D[3]);
-ur_result_t getZeKernel(ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel,
+ur_result_t getZeKernel(ur_queue_handle_legacy_t hQueue,
+                        ur_kernel_handle_t hKernel,
                         ze_kernel_handle_t *phZeKernel);

--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -26,6 +26,9 @@
 
 #include "ur_level_zero.hpp"
 
+struct ur_queue_handle_legacy_t_;
+using ur_queue_handle_legacy_t = ur_queue_handle_legacy_t_ *;
+
 struct ur_device_handle_t_;
 
 bool IsDevicePointer(ur_context_handle_t Context, const void *Ptr);
@@ -44,7 +47,7 @@ const bool UseCopyEngineForD2DCopy = [] {
 // PI interfaces must have queue's and destination buffer's mutexes locked for
 // exclusive use and source buffer's mutex locked for shared use on entry.
 ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
-                                 ur_queue_handle_t Queue, void *Dst,
+                                 ur_queue_handle_legacy_t Queue, void *Dst,
                                  ur_bool_t BlockingWrite, size_t Size,
                                  const void *Src, uint32_t NumEventsInWaitList,
                                  const ur_event_handle_t *EventWaitList,
@@ -52,12 +55,13 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
                                  bool PreferCopyEngine);
 
 ur_result_t enqueueMemCopyRectHelper(
-    ur_command_t CommandType, ur_queue_handle_t Queue, const void *SrcBuffer,
-    void *DstBuffer, ur_rect_offset_t SrcOrigin, ur_rect_offset_t DstOrigin,
-    ur_rect_region_t Region, size_t SrcRowPitch, size_t DstRowPitch,
-    size_t SrcSlicePitch, size_t DstSlicePitch, ur_bool_t Blocking,
-    uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
-    ur_event_handle_t *OutEvent, bool PreferCopyEngine = false);
+    ur_command_t CommandType, ur_queue_handle_legacy_t Queue,
+    const void *SrcBuffer, void *DstBuffer, ur_rect_offset_t SrcOrigin,
+    ur_rect_offset_t DstOrigin, ur_rect_region_t Region, size_t SrcRowPitch,
+    size_t DstRowPitch, size_t SrcSlicePitch, size_t DstSlicePitch,
+    ur_bool_t Blocking, uint32_t NumEventsInWaitList,
+    const ur_event_handle_t *EventWaitList, ur_event_handle_t *OutEvent,
+    bool PreferCopyEngine = false);
 
 struct ur_mem_handle_t_ : _ur_object {
   // Keeps the PI context of this memory handle.

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -99,7 +99,7 @@ bool ur_completion_batch::checkComplete() {
   return st == COMPLETED;
 }
 
-ur_result_t ur_completion_batch::seal(ur_queue_handle_t queue,
+ur_result_t ur_completion_batch::seal(ur_queue_handle_legacy_t queue,
                                       ze_command_list_handle_t cmdlist) {
   assert(st == ACCUMULATING);
 
@@ -187,7 +187,7 @@ ur_completion_batches::ur_completion_batches() {
 }
 
 ur_result_t ur_completion_batches::tryCleanup(
-    ur_queue_handle_t queue, ze_command_list_handle_t cmdlist,
+    ur_queue_handle_legacy_t queue, ze_command_list_handle_t cmdlist,
     std::vector<ur_event_handle_t> &events,
     std::vector<ur_event_handle_t> &EventListToCleanup) {
   cleanup(events, EventListToCleanup);
@@ -229,7 +229,7 @@ void ur_completion_batches::forceReset() {
 /// the call, in case of in-order queue it allows to cleanup all preceding
 /// events.
 /// @return PI_SUCCESS if successful, PI error code otherwise.
-ur_result_t CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue,
+ur_result_t CleanupEventsInImmCmdLists(ur_queue_handle_legacy_t UrQueue,
                                        bool QueueLocked, bool QueueSynced,
                                        ur_event_handle_t CompletedEvent) {
   // Handle only immediate command lists here.
@@ -303,7 +303,7 @@ ur_result_t CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue,
 /// @param Queue Queue where we look for signalled command lists and cleanup
 /// events.
 /// @return PI_SUCCESS if successful, PI error code otherwise.
-ur_result_t resetCommandLists(ur_queue_handle_t Queue) {
+ur_result_t resetCommandLists(ur_queue_handle_legacy_t Queue) {
   // Handle immediate command lists here, they don't need to be reset and we
   // only need to cleanup events.
   if (Queue->UsingImmCmdLists) {
@@ -343,7 +343,7 @@ ur_result_t resetCommandLists(ur_queue_handle_t Queue) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(
-    ur_queue_handle_t Queue,   ///< [in] handle of the queue object
+    ur_queue_handle_t UrQueue, ///< [in] handle of the queue object
     ur_queue_info_t ParamName, ///< [in] name of the queue property to query
     size_t ParamValueSize, ///< [in] size in bytes of the queue property value
                            ///< provided
@@ -351,6 +351,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(
     size_t *ParamValueSizeRet ///< [out] size in bytes returned in queue
                               ///< property value
 ) {
+  auto Queue = Legacy(UrQueue);
 
   std::shared_lock<ur_shared_mutex> Lock(Queue->Mutex);
   UrReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
@@ -506,7 +507,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   // Create placeholder queues in the compute queue group.
   // Actual L0 queues will be created at first use.
   std::vector<ze_command_queue_handle_t> ZeComputeCommandQueues(
-      Device->QueueGroup[ur_queue_handle_t_::queue_type::Compute]
+      Device->QueueGroup[ur_queue_handle_legacy_t_::queue_type::Compute]
           .ZeProperties.numQueues,
       nullptr);
 
@@ -516,21 +517,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   size_t NumCopyGroups = 0;
   if (Device->hasMainCopyEngine()) {
     NumCopyGroups +=
-        Device->QueueGroup[ur_queue_handle_t_::queue_type::MainCopy]
+        Device->QueueGroup[ur_queue_handle_legacy_t_::queue_type::MainCopy]
             .ZeProperties.numQueues;
   }
   if (Device->hasLinkCopyEngine()) {
     NumCopyGroups +=
-        Device->QueueGroup[ur_queue_handle_t_::queue_type::LinkCopy]
+        Device->QueueGroup[ur_queue_handle_legacy_t_::queue_type::LinkCopy]
             .ZeProperties.numQueues;
   }
   std::vector<ze_command_queue_handle_t> ZeCopyCommandQueues(NumCopyGroups,
                                                              nullptr);
 
   try {
-    *Queue =
-        new ur_queue_handle_t_(ZeComputeCommandQueues, ZeCopyCommandQueues,
-                               Context, Device, true, Flags, ForceComputeIndex);
+    *Queue = new ur_queue_handle_t_(
+        std::in_place_type<ur_queue_handle_legacy_t_>, ZeComputeCommandQueues,
+        ZeCopyCommandQueues, Context, Device, true, Flags, ForceComputeIndex);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -539,7 +540,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
 
   // Do eager initialization of Level Zero handles on request.
   if (doEagerInit) {
-    ur_queue_handle_t Q = *Queue;
+    ur_queue_handle_legacy_t Q = Legacy(*Queue);
     // Creates said number of command-lists.
     auto warmupQueueGroup = [Q](bool UseCopyEngine,
                                 uint32_t RepeatCount) -> ur_result_t {
@@ -581,8 +582,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(
-    ur_queue_handle_t Queue ///< [in] handle of the queue object to get access
+    ur_queue_handle_t UrQueue ///< [in] handle of the queue object to get access
 ) {
+  auto Queue = Legacy(UrQueue);
   {
     std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
     Queue->RefCountExternal++;
@@ -592,8 +594,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(
-    ur_queue_handle_t Queue ///< [in] handle of the queue object to release
+    ur_queue_handle_t UrQueue ///< [in] handle of the queue object to release
 ) {
+  auto Queue = Legacy(UrQueue);
 
   std::vector<ur_event_handle_t> EventListToCleanup;
   {
@@ -684,16 +687,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(
     // (it was incremented when they were added to the command list).
     UR_CALL(urEventReleaseInternal(reinterpret_cast<ur_event_handle_t>(Event)));
   }
-  UR_CALL(urQueueReleaseInternal(reinterpret_cast<ur_queue_handle_t>(Queue)));
+  UR_CALL(urQueueReleaseInternal(UrQueue));
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
-    ur_queue_handle_t Queue, ///< [in] handle of the queue.
+    ur_queue_handle_t UrQueue, ///< [in] handle of the queue.
     ur_queue_native_desc_t *Desc,
     ur_native_handle_t
         *NativeQueue ///< [out] a pointer to the native handle of the queue.
 ) {
+  auto Queue = Legacy(UrQueue);
   // Lock automatically releases when this goes out of scope.
   std::shared_lock<ur_shared_mutex> lock(Queue->Mutex);
 
@@ -725,8 +729,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
   return UR_RESULT_SUCCESS;
 }
 
-void ur_queue_handle_t_::ur_queue_group_t::setImmCmdList(
-    ur_queue_handle_t queue, ze_command_list_handle_t ZeCommandList) {
+void ur_queue_handle_legacy_t_::ur_queue_group_t::setImmCmdList(
+    ur_queue_handle_legacy_t queue, ze_command_list_handle_t ZeCommandList) {
   // An immediate command list was given to us but we don't have the queue
   // descriptor information. Create a dummy and note that it is not recycleable.
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
@@ -797,15 +801,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
     try {
       ur_queue_handle_t_ *Queue = new ur_queue_handle_t_(
-          ComputeQueues, CopyQueues, Context, UrDevice, OwnNativeHandle, Flags);
+          std::in_place_type<ur_queue_handle_legacy_t_>, ComputeQueues,
+          CopyQueues, Context, UrDevice, OwnNativeHandle, Flags);
       *RetQueue = reinterpret_cast<ur_queue_handle_t>(Queue);
     } catch (const std::bad_alloc &) {
       return UR_RESULT_ERROR_OUT_OF_RESOURCES;
     } catch (...) {
       return UR_RESULT_ERROR_UNKNOWN;
     }
-    auto &InitialGroup = (*RetQueue)->ComputeQueueGroupsByTID.begin()->second;
-    InitialGroup.setImmCmdList(*RetQueue,
+    auto &InitialGroup =
+        Legacy(*RetQueue)->ComputeQueueGroupsByTID.begin()->second;
+    InitialGroup.setImmCmdList(Legacy(*RetQueue),
                                ur_cast<ze_command_list_handle_t>(NativeQueue));
   } else {
     auto ZeQueue = ur_cast<ze_command_queue_handle_t>(NativeQueue);
@@ -819,7 +825,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
     try {
       ur_queue_handle_t_ *Queue = new ur_queue_handle_t_(
-          ZeQueues, ZeroCopyQueues, Context, UrDevice, OwnNativeHandle, Flags);
+          std::in_place_type<ur_queue_handle_legacy_t_>, ZeQueues,
+          ZeroCopyQueues, Context, UrDevice, OwnNativeHandle, Flags);
       *RetQueue = reinterpret_cast<ur_queue_handle_t>(Queue);
     } catch (const std::bad_alloc &) {
       return UR_RESULT_ERROR_OUT_OF_RESOURCES;
@@ -827,7 +834,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
       return UR_RESULT_ERROR_UNKNOWN;
     }
   }
-  (*RetQueue)->UsingImmCmdLists = (NativeHandleDesc == 1);
+  Legacy(*RetQueue)->UsingImmCmdLists = (NativeHandleDesc == 1);
 
   return UR_RESULT_SUCCESS;
 }
@@ -835,28 +842,29 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t UrQueue ///< [in] handle of the queue to be finished.
 ) {
-  if (UrQueue->UsingImmCmdLists) {
+  auto Queue = Legacy(UrQueue);
+  if (Queue->UsingImmCmdLists) {
     // Lock automatically releases when this goes out of scope.
-    std::scoped_lock<ur_shared_mutex> Lock(UrQueue->Mutex);
+    std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
 
-    UR_CALL(UrQueue->synchronize());
+    UR_CALL(Queue->synchronize());
   } else {
-    std::unique_lock<ur_shared_mutex> Lock(UrQueue->Mutex);
+    std::unique_lock<ur_shared_mutex> Lock(Queue->Mutex);
     std::vector<ze_command_queue_handle_t> ZeQueues;
 
     // execute any command list that may still be open.
-    UR_CALL(UrQueue->executeAllOpenCommandLists());
+    UR_CALL(Queue->executeAllOpenCommandLists());
 
     // Make a copy of queues to sync and release the lock.
     for (auto &QueueMap :
-         {UrQueue->ComputeQueueGroupsByTID, UrQueue->CopyQueueGroupsByTID})
+         {Queue->ComputeQueueGroupsByTID, Queue->CopyQueueGroupsByTID})
       for (auto &QueueGroup : QueueMap)
         std::copy(QueueGroup.second.ZeQueues.begin(),
                   QueueGroup.second.ZeQueues.end(),
                   std::back_inserter(ZeQueues));
 
     // Remember the last command's event.
-    auto LastCommandEvent = UrQueue->LastCommandEvent;
+    auto LastCommandEvent = Queue->LastCommandEvent;
 
     // Don't hold a lock to the queue's mutex while waiting.
     // This allows continue working with the queue from other threads.
@@ -881,27 +889,28 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(
     // We can only do so if nothing else was submitted to the queue
     // while we were synchronizing it.
     if (!HoldLock) {
-      std::scoped_lock<ur_shared_mutex> Lock(UrQueue->Mutex);
-      if (LastCommandEvent == UrQueue->LastCommandEvent) {
-        UrQueue->LastCommandEvent = nullptr;
+      std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
+      if (LastCommandEvent == Queue->LastCommandEvent) {
+        Queue->LastCommandEvent = nullptr;
       }
     } else {
-      UrQueue->LastCommandEvent = nullptr;
+      Queue->LastCommandEvent = nullptr;
     }
   }
   // Reset signalled command lists and return them back to the cache of
   // available command lists. Events in the immediate command lists are cleaned
   // up in synchronize().
-  if (!UrQueue->UsingImmCmdLists) {
-    std::unique_lock<ur_shared_mutex> Lock(UrQueue->Mutex);
-    resetCommandLists(UrQueue);
+  if (!Queue->UsingImmCmdLists) {
+    std::unique_lock<ur_shared_mutex> Lock(Queue->Mutex);
+    resetCommandLists(Queue);
   }
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(
-    ur_queue_handle_t Queue ///< [in] handle of the queue to be flushed.
+    ur_queue_handle_t UrQueue ///< [in] handle of the queue to be flushed.
 ) {
+  auto Queue = Legacy(UrQueue);
   std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
   return Queue->executeAllOpenCommandLists();
 }
@@ -1060,7 +1069,7 @@ static const zeCommandListBatchConfig ZeCommandListBatchCopyConfig = [] {
   return ZeCommandListBatchConfig(IsCopy{true});
 }();
 
-ur_queue_handle_t_::ur_queue_handle_t_(
+ur_queue_handle_legacy_t_::ur_queue_handle_legacy_t_(
     std::vector<ze_command_queue_handle_t> &ComputeQueues,
     std::vector<ze_command_queue_handle_t> &CopyQueues,
     ur_context_handle_t Context, ur_device_handle_t Device,
@@ -1086,8 +1095,8 @@ ur_queue_handle_t_::ur_queue_handle_t_(
   // First, see if the queue's device allows for round-robin or it is
   // fixed to one particular compute CCS (it is so for sub-sub-devices).
   auto &ComputeQueueGroupInfo = Device->QueueGroup[queue_type::Compute];
-  ur_queue_group_t ComputeQueueGroup{reinterpret_cast<ur_queue_handle_t>(this),
-                                     queue_type::Compute};
+  ur_queue_group_t ComputeQueueGroup{
+      reinterpret_cast<ur_queue_handle_legacy_t>(this), queue_type::Compute};
   ComputeQueueGroup.ZeQueues = ComputeQueues;
   // Create space to hold immediate commandlists corresponding to the
   // ZeQueues
@@ -1133,8 +1142,8 @@ ur_queue_handle_t_::ur_queue_handle_t_(
   ComputeQueueGroupsByTID.set(ComputeQueueGroup);
 
   // Copy group initialization.
-  ur_queue_group_t CopyQueueGroup{reinterpret_cast<ur_queue_handle_t>(this),
-                                  queue_type::MainCopy};
+  ur_queue_group_t CopyQueueGroup{
+      reinterpret_cast<ur_queue_handle_legacy_t>(this), queue_type::MainCopy};
   const auto &Range = getRangeOfAllowedCopyEngines((ur_device_handle_t)Device);
   if (Range.first < 0 || Range.second < 0) {
     // We are asked not to use copy engines, just do nothing.
@@ -1181,7 +1190,7 @@ ur_queue_handle_t_::ur_queue_handle_t_(
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }
 
-void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
+void ur_queue_handle_legacy_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
   auto &CommandBatch = IsCopy ? CopyCommandBatch : ComputeCommandBatch;
   auto &ZeCommandListBatchConfig =
       IsCopy ? ZeCommandListBatchCopyConfig : ZeCommandListBatchComputeConfig;
@@ -1208,7 +1217,7 @@ void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
   }
 }
 
-void ur_queue_handle_t_::adjustBatchSizeForPartialBatch(bool IsCopy) {
+void ur_queue_handle_legacy_t_::adjustBatchSizeForPartialBatch(bool IsCopy) {
   auto &CommandBatch = IsCopy ? CopyCommandBatch : ComputeCommandBatch;
   auto &ZeCommandListBatchConfig =
       IsCopy ? ZeCommandListBatchCopyConfig : ZeCommandListBatchComputeConfig;
@@ -1234,15 +1243,14 @@ void ur_queue_handle_t_::adjustBatchSizeForPartialBatch(bool IsCopy) {
   }
 }
 
-ur_result_t
-ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
-                                       bool IsBlocking, bool OKToBatchCommand) {
+ur_result_t ur_queue_handle_legacy_t_::executeCommandList(
+    ur_command_list_ptr_t CommandList, bool IsBlocking, bool OKToBatchCommand) {
   // Do nothing if command list is already closed.
   if (CommandList->second.IsClosed)
     return UR_RESULT_SUCCESS;
 
-  bool UseCopyEngine =
-      CommandList->second.isCopy(reinterpret_cast<ur_queue_handle_t>(this));
+  bool UseCopyEngine = CommandList->second.isCopy(
+      reinterpret_cast<ur_queue_handle_legacy_t>(this));
 
   // If the current LastCommandEvent is the nullptr, then it means
   // either that no command has ever been issued to the queue
@@ -1349,7 +1357,7 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
         //
         ur_event_handle_t HostVisibleEvent;
         auto Res = createEventAndAssociateQueue(
-            reinterpret_cast<ur_queue_handle_t>(this), &HostVisibleEvent,
+            reinterpret_cast<ur_queue_handle_legacy_t>(this), &HostVisibleEvent,
             UR_EXT_COMMAND_TYPE_USER, CommandList,
             /* IsInternal */ false, /* IsMultiDevice */ true,
             /* HostVisible */ true);
@@ -1473,12 +1481,12 @@ ur_queue_handle_t_::executeCommandList(ur_command_list_ptr_t CommandList,
   return UR_RESULT_SUCCESS;
 }
 
-bool ur_queue_handle_t_::doReuseDiscardedEvents() {
+bool ur_queue_handle_legacy_t_::doReuseDiscardedEvents() {
   return ReuseDiscardedEvents && isInOrderQueue() && isDiscardEvents();
 }
 
-ur_result_t
-ur_queue_handle_t_::resetDiscardedEvent(ur_command_list_ptr_t CommandList) {
+ur_result_t ur_queue_handle_legacy_t_::resetDiscardedEvent(
+    ur_command_list_ptr_t CommandList) {
   if (LastCommandEvent && LastCommandEvent->IsDiscarded) {
     ZE2UR_CALL(zeCommandListAppendBarrier,
                (CommandList->first, nullptr, 1, &(LastCommandEvent->ZeEvent)));
@@ -1511,7 +1519,8 @@ ur_queue_handle_t_::resetDiscardedEvent(ur_command_list_ptr_t CommandList) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
+ur_result_t
+ur_queue_handle_legacy_t_::addEventToQueueCache(ur_event_handle_t Event) {
   if (!Event->IsMultiDevice) {
     auto EventCachesMap = Event->isHostVisible() ? &EventCachesDeviceMap[0]
                                                  : &EventCachesDeviceMap[1];
@@ -1527,19 +1536,19 @@ ur_result_t ur_queue_handle_t_::addEventToQueueCache(ur_event_handle_t Event) {
   return UR_RESULT_SUCCESS;
 }
 
-void ur_queue_handle_t_::active_barriers::add(ur_event_handle_t &Event) {
+void ur_queue_handle_legacy_t_::active_barriers::add(ur_event_handle_t &Event) {
   Event->RefCount.increment();
   Events.push_back(Event);
 }
 
-ur_result_t ur_queue_handle_t_::active_barriers::clear() {
+ur_result_t ur_queue_handle_legacy_t_::active_barriers::clear() {
   for (const auto &Event : Events)
     UR_CALL(urEventReleaseInternal(Event));
   Events.clear();
   return UR_RESULT_SUCCESS;
 }
 
-void ur_queue_handle_t_::clearEndTimeRecordings() {
+void ur_queue_handle_legacy_t_::clearEndTimeRecordings() {
   uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
   const uint64_t TimestampMaxValue =
       ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
@@ -1567,21 +1576,21 @@ void ur_queue_handle_t_::clearEndTimeRecordings() {
   EndTimeRecordings.clear();
 }
 
-ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
-  ur_queue_handle_t UrQueue = reinterpret_cast<ur_queue_handle_t>(Queue);
+ur_result_t urQueueReleaseInternal(ur_queue_handle_t UrQueue) {
+  ur_queue_handle_legacy_t Queue = Legacy(UrQueue);
 
-  if (!UrQueue->RefCount.decrementAndTest())
+  if (!Queue->RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
-  for (auto &Cache : UrQueue->EventCaches) {
+  for (auto &Cache : Queue->EventCaches) {
     for (auto &Event : Cache)
       UR_CALL(urEventReleaseInternal(Event));
     Cache.clear();
   }
 
-  if (UrQueue->OwnZeCommandQueue) {
+  if (Queue->OwnZeCommandQueue) {
     for (auto &QueueMap :
-         {UrQueue->ComputeQueueGroupsByTID, UrQueue->CopyQueueGroupsByTID})
+         {Queue->ComputeQueueGroupsByTID, Queue->CopyQueueGroupsByTID})
       for (auto &QueueGroup : QueueMap)
         for (auto &ZeQueue : QueueGroup.second.ZeQueues)
           if (ZeQueue) {
@@ -1596,45 +1605,45 @@ ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
 
   logger::debug("urQueueRelease(compute) NumTimesClosedFull {}, "
                 "NumTimesClosedEarly {}",
-                UrQueue->ComputeCommandBatch.NumTimesClosedFull,
-                UrQueue->ComputeCommandBatch.NumTimesClosedEarly);
+                Queue->ComputeCommandBatch.NumTimesClosedFull,
+                Queue->ComputeCommandBatch.NumTimesClosedEarly);
   logger::debug(
       "urQueueRelease(copy) NumTimesClosedFull {}, NumTimesClosedEarly {}",
-      UrQueue->CopyCommandBatch.NumTimesClosedFull,
-      UrQueue->CopyCommandBatch.NumTimesClosedEarly);
+      Queue->CopyCommandBatch.NumTimesClosedFull,
+      Queue->CopyCommandBatch.NumTimesClosedEarly);
 
   delete UrQueue;
 
   return UR_RESULT_SUCCESS;
 }
 
-bool ur_queue_handle_t_::isBatchingAllowed(bool IsCopy) const {
+bool ur_queue_handle_legacy_t_::isBatchingAllowed(bool IsCopy) const {
   auto &CommandBatch = IsCopy ? CopyCommandBatch : ComputeCommandBatch;
   return (CommandBatch.QueueBatchSize > 0 &&
           ((UrL0Serialize & UrL0SerializeBlock) == 0));
 }
 
-bool ur_queue_handle_t_::isDiscardEvents() const {
+bool ur_queue_handle_legacy_t_::isDiscardEvents() const {
   return ((this->Properties & UR_QUEUE_FLAG_DISCARD_EVENTS) != 0);
 }
 
-bool ur_queue_handle_t_::isPriorityLow() const {
+bool ur_queue_handle_legacy_t_::isPriorityLow() const {
   return ((this->Properties & UR_QUEUE_FLAG_PRIORITY_LOW) != 0);
 }
 
-bool ur_queue_handle_t_::isPriorityHigh() const {
+bool ur_queue_handle_legacy_t_::isPriorityHigh() const {
   return ((this->Properties & UR_QUEUE_FLAG_PRIORITY_HIGH) != 0);
 }
 
-bool ur_queue_handle_t_::isBatchedSubmission() const {
+bool ur_queue_handle_legacy_t_::isBatchedSubmission() const {
   return ((this->Properties & UR_QUEUE_FLAG_SUBMISSION_BATCHED) != 0);
 }
 
-bool ur_queue_handle_t_::isImmediateSubmission() const {
+bool ur_queue_handle_legacy_t_::isImmediateSubmission() const {
   return ((this->Properties & UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE) != 0);
 }
 
-bool ur_queue_handle_t_::isInOrderQueue() const {
+bool ur_queue_handle_legacy_t_::isInOrderQueue() const {
   // If out-of-order queue property is not set, then this is a in-order queue.
   return ((this->Properties & UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE) ==
           0);
@@ -1664,11 +1673,11 @@ ur_result_t CleanupEventListFromResetCmdList(
 // TODO: Event release in immediate commandlist mode is driven by the SYCL
 // runtime. Need to investigate whether relase can be done earlier, at sync
 // points such as this, to reduce total number of active Events.
-ur_result_t ur_queue_handle_t_::synchronize() {
+ur_result_t ur_queue_handle_legacy_t_::synchronize() {
   if (!Healthy)
     return UR_RESULT_SUCCESS;
 
-  auto syncImmCmdList = [](ur_queue_handle_t_ *Queue,
+  auto syncImmCmdList = [](ur_queue_handle_legacy_t_ *Queue,
                            ur_command_list_ptr_t ImmCmdList) {
     if (ImmCmdList == Queue->CommandListMap.end())
       return UR_RESULT_SUCCESS;
@@ -1759,8 +1768,9 @@ ur_result_t ur_queue_handle_t_::synchronize() {
   return UR_RESULT_SUCCESS;
 }
 
-ur_event_handle_t ur_queue_handle_t_::getEventFromQueueCache(bool IsMultiDevice,
-                                                             bool HostVisible) {
+ur_event_handle_t
+ur_queue_handle_legacy_t_::getEventFromQueueCache(bool IsMultiDevice,
+                                                  bool HostVisible) {
   std::list<ur_event_handle_t> *Cache;
 
   if (!IsMultiDevice) {
@@ -1792,7 +1802,7 @@ ur_event_handle_t ur_queue_handle_t_::getEventFromQueueCache(bool IsMultiDevice,
 // at the end of a command list batch. This will only be true if the event does
 // not have dependencies or the dependencies are not for events which exist in
 // this batch.
-bool eventCanBeBatched(ur_queue_handle_t Queue, bool UseCopyEngine,
+bool eventCanBeBatched(ur_queue_handle_legacy_t Queue, bool UseCopyEngine,
                        uint32_t NumEventsInWaitList,
                        const ur_event_handle_t *EventWaitList) {
   auto &CommandBatch =
@@ -1822,7 +1832,7 @@ bool eventCanBeBatched(ur_queue_handle_t Queue, bool UseCopyEngine,
 // dependencies, then this command can be enqueued without a signal event set in
 // a command list batch. The signal event will be appended at the end of the
 // batch to be signalled at the end of the command list.
-ur_result_t setSignalEvent(ur_queue_handle_t Queue, bool UseCopyEngine,
+ur_result_t setSignalEvent(ur_queue_handle_legacy_t Queue, bool UseCopyEngine,
                            ze_event_handle_t *ZeEvent, ur_event_handle_t *Event,
                            uint32_t NumEventsInWaitList,
                            const ur_event_handle_t *EventWaitList,
@@ -1853,7 +1863,7 @@ ur_result_t setSignalEvent(ur_queue_handle_t Queue, bool UseCopyEngine,
 //        visible pool.
 // \param HostVisible tells if the event must be created in the
 //        host-visible pool. If not set then this function will decide.
-ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
+ur_result_t createEventAndAssociateQueue(ur_queue_handle_legacy_t Queue,
                                          ur_event_handle_t *Event,
                                          ur_command_t CommandType,
                                          ur_command_list_ptr_t CommandList,
@@ -1875,7 +1885,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
                         HostVisible.value(), Event,
                         Queue->CounterBasedEventsEnabled));
 
-  (*Event)->UrQueue = Queue;
+  (*Event)->UrQueue = Queue->UnifiedHandle;
   (*Event)->CommandType = CommandType;
   (*Event)->IsDiscarded = IsInternal;
   (*Event)->IsMultiDevice = IsMultiDevice;
@@ -1914,7 +1924,7 @@ ur_result_t createEventAndAssociateQueue(ur_queue_handle_t Queue,
   return UR_RESULT_SUCCESS;
 }
 
-void ur_queue_handle_t_::CaptureIndirectAccesses() {
+void ur_queue_handle_legacy_t_::CaptureIndirectAccesses() {
   for (auto &Kernel : KernelsToBeSubmitted) {
     if (!Kernel->hasIndirectAccess())
       continue;
@@ -1938,7 +1948,8 @@ void ur_queue_handle_t_::CaptureIndirectAccesses() {
   KernelsToBeSubmitted.clear();
 }
 
-ur_result_t ur_queue_handle_t_::signalEventFromCmdListIfLastEventDiscarded(
+ur_result_t
+ur_queue_handle_legacy_t_::signalEventFromCmdListIfLastEventDiscarded(
     ur_command_list_ptr_t CommandList) {
   // We signal new event at the end of command list only if we have queue with
   // discard_events property and the last command event is discarded.
@@ -1952,7 +1963,7 @@ ur_result_t ur_queue_handle_t_::signalEventFromCmdListIfLastEventDiscarded(
   // from the host.
   ur_event_handle_t Event;
   UR_CALL(createEventAndAssociateQueue(
-      reinterpret_cast<ur_queue_handle_t>(this), &Event,
+      reinterpret_cast<ur_queue_handle_legacy_t>(this), &Event,
       UR_EXT_COMMAND_TYPE_USER, CommandList,
       /* IsInternal */ false, /* IsMultiDevice */ true,
       /* HostVisible */ false));
@@ -1964,7 +1975,7 @@ ur_result_t ur_queue_handle_t_::signalEventFromCmdListIfLastEventDiscarded(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_queue_handle_t_::executeOpenCommandList(bool IsCopy) {
+ur_result_t ur_queue_handle_legacy_t_::executeOpenCommandList(bool IsCopy) {
   auto &CommandBatch = IsCopy ? CopyCommandBatch : ComputeCommandBatch;
   // If there are any commands still in the open command list for this
   // queue, then close and execute that command list now.
@@ -1978,7 +1989,7 @@ ur_result_t ur_queue_handle_t_::executeOpenCommandList(bool IsCopy) {
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_queue_handle_t_::resetCommandList(
+ur_result_t ur_queue_handle_legacy_t_::resetCommandList(
     ur_command_list_ptr_t CommandList, bool MakeAvailable,
     std::vector<ur_event_handle_t> &EventListToCleanup, bool CheckStatus) {
   bool UseCopyEngine = CommandList->second.isCopy(this);
@@ -2079,7 +2090,7 @@ ur_result_t ur_queue_handle_t_::resetCommandList(
   return UR_RESULT_SUCCESS;
 }
 
-bool ur_command_list_info_t::isCopy(ur_queue_handle_t Queue) const {
+bool ur_command_list_info_t::isCopy(ur_queue_handle_legacy_t Queue) const {
   return ZeQueueDesc.ordinal !=
          (uint32_t)Queue->Device
              ->QueueGroup
@@ -2095,7 +2106,7 @@ void ur_command_list_info_t::append(ur_event_handle_t Event) {
 }
 
 ur_command_list_ptr_t
-ur_queue_handle_t_::eventOpenCommandList(ur_event_handle_t Event) {
+ur_queue_handle_legacy_t_::eventOpenCommandList(ur_event_handle_t Event) {
   using IsCopy = bool;
 
   if (UsingImmCmdLists) {
@@ -2120,15 +2131,15 @@ ur_queue_handle_t_::eventOpenCommandList(ur_event_handle_t Event) {
   return CommandListMap.end();
 }
 
-ur_queue_handle_t_::ur_queue_group_t &
-ur_queue_handle_t_::getQueueGroup(bool UseCopyEngine) {
+ur_queue_handle_legacy_t_::ur_queue_group_t &
+ur_queue_handle_legacy_t_::getQueueGroup(bool UseCopyEngine) {
   auto &Map = (UseCopyEngine ? CopyQueueGroupsByTID : ComputeQueueGroupsByTID);
   return Map.get();
 }
 
 // Return the index of the next queue to use based on a
 // round robin strategy and the queue group ordinal.
-uint32_t ur_queue_handle_t_::ur_queue_group_t::getQueueIndex(
+uint32_t ur_queue_handle_legacy_t_::ur_queue_group_t::getQueueIndex(
     uint32_t *QueueGroupOrdinal, uint32_t *QueueIndex, bool QueryOnly) {
   auto CurrentIndex = NextIndex;
 
@@ -2162,7 +2173,8 @@ uint32_t ur_queue_handle_t_::ur_queue_group_t::getQueueIndex(
 // This function will return one of possibly multiple available native
 // queues and the value of the queue group ordinal.
 ze_command_queue_handle_t &
-ur_queue_handle_t_::ur_queue_group_t::getZeQueue(uint32_t *QueueGroupOrdinal) {
+ur_queue_handle_legacy_t_::ur_queue_group_t::getZeQueue(
+    uint32_t *QueueGroupOrdinal) {
 
   // QueueIndex is the proper L0 index.
   // Index is the plugins concept of index, with main and link copy engines in
@@ -2207,7 +2219,7 @@ ur_queue_handle_t_::ur_queue_group_t::getZeQueue(uint32_t *QueueGroupOrdinal) {
   return ZeQueue;
 }
 
-int32_t ur_queue_handle_t_::ur_queue_group_t::getCmdQueueOrdinal(
+int32_t ur_queue_handle_legacy_t_::ur_queue_group_t::getCmdQueueOrdinal(
     ze_command_queue_handle_t CmdQueue) {
   // Find out the right queue group ordinal (first queue might be "main" or
   // "link")
@@ -2219,7 +2231,7 @@ int32_t ur_queue_handle_t_::ur_queue_group_t::getCmdQueueOrdinal(
   return Queue->Device->QueueGroup[QueueType].ZeOrdinal;
 }
 
-bool ur_queue_handle_t_::useCompletionBatching() {
+bool ur_queue_handle_legacy_t_::useCompletionBatching() {
   static bool enabled = getenv_tobool(
       "UR_L0_IMMEDIATE_COMMANDLISTS_BATCH_EVENT_COMPLETIONS", false);
   return enabled && !isInOrderQueue() && UsingImmCmdLists;
@@ -2229,7 +2241,7 @@ bool ur_queue_handle_t_::useCompletionBatching() {
 // fence tracking its completion. This command list & fence are added to the
 // map of command lists in this queue with ZeFenceInUse = false.
 // The caller must hold a lock of the queue already.
-ur_result_t ur_queue_handle_t_::createCommandList(
+ur_result_t ur_queue_handle_legacy_t_::createCommandList(
     bool UseCopyEngine, ur_command_list_ptr_t &CommandList,
     ze_command_queue_handle_t *ForcedCmdQueue) {
 
@@ -2272,8 +2284,8 @@ ur_result_t ur_queue_handle_t_::createCommandList(
 }
 
 ur_result_t
-ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
-                                         bool UseCopyEngine) {
+ur_queue_handle_legacy_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
+                                                bool UseCopyEngine) {
   // Early exit if there are no active barriers.
   if (ActiveBarriers.empty())
     return UR_RESULT_SUCCESS;
@@ -2282,7 +2294,7 @@ ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
   _ur_ze_event_list_t ActiveBarriersWaitList;
   UR_CALL(ActiveBarriersWaitList.createAndRetainUrZeEventList(
       ActiveBarriers.vector().size(), ActiveBarriers.vector().data(),
-      reinterpret_cast<ur_queue_handle_t>(this), UseCopyEngine));
+      reinterpret_cast<ur_queue_handle_legacy_t>(this), UseCopyEngine));
 
   // We can now replace active barriers with the ones in the wait list.
   UR_CALL(ActiveBarriers.clear());
@@ -2298,7 +2310,7 @@ ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
 
   ur_event_handle_t Event = nullptr;
   if (auto Res = createEventAndAssociateQueue(
-          reinterpret_cast<ur_queue_handle_t>(this), &Event,
+          reinterpret_cast<ur_queue_handle_legacy_t>(this), &Event,
           UR_EXT_COMMAND_TYPE_USER, CmdList,
           /* IsInternal */ true, /* IsMultiDevice */ true))
     return Res;
@@ -2314,7 +2326,7 @@ ur_queue_handle_t_::insertActiveBarriers(ur_command_list_ptr_t &CmdList,
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t ur_queue_handle_t_::insertStartBarrierIfDiscardEventsMode(
+ur_result_t ur_queue_handle_legacy_t_::insertStartBarrierIfDiscardEventsMode(
     ur_command_list_ptr_t &CmdList) {
   // If current command list is different from the last command list then insert
   // a barrier waiting for the last command event.
@@ -2340,7 +2352,7 @@ static const bool UseCopyEngineForInOrderQueue = [] {
           (std::stoi(CopyEngineForInOrderQueue) != 0));
 }();
 
-bool ur_queue_handle_t_::useCopyEngine(bool PreferCopyEngine) const {
+bool ur_queue_handle_legacy_t_::useCopyEngine(bool PreferCopyEngine) const {
   auto InitialCopyGroup = CopyQueueGroupsByTID.begin()->second;
   return PreferCopyEngine && InitialCopyGroup.ZeQueues.size() > 0 &&
          (!isInOrderQueue() || UseCopyEngineForInOrderQueue);
@@ -2348,7 +2360,8 @@ bool ur_queue_handle_t_::useCopyEngine(bool PreferCopyEngine) const {
 
 // This function will return one of po6ssibly multiple available
 // immediate commandlists associated with this Queue.
-ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
+ur_command_list_ptr_t &
+ur_queue_handle_legacy_t_::ur_queue_group_t::getImmCmdList() {
 
   uint32_t QueueIndex, QueueOrdinal;
   auto Index = getQueueIndex(&QueueOrdinal, &QueueIndex);
@@ -2452,7 +2465,7 @@ static const size_t ImmCmdListsEventCleanupThreshold = [] {
   return Threshold;
 }();
 
-size_t ur_queue_handle_t_::getImmdCmmdListsEventCleanupThreshold() {
+size_t ur_queue_handle_legacy_t_::getImmdCmmdListsEventCleanupThreshold() {
   return useCompletionBatching() ? CompletionEventsPerBatch
                                  : ImmCmdListsEventCleanupThreshold;
 }


### PR DESCRIPTION
This change moves all legacy queue code to a seprate class: ur_queue_handle_legacy_t_. and uses pointer to this class as a parameter in all internal functions (instead of using ur_queue_handle_t). ur_queue_handle_t is now a variant over this legacy class and a new queue dispatcher (not implemented yet). All API functions still take ur_queue_handle_t and convert it to ur_queue_handle_legacy_t using a helper function.

Once dispatcher is implemented there will be a seprate code path for each (affected) API function for legacy and new logic.