### PR TITLE
reduce number of workers for the L0 E2E job

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -46,7 +46,11 @@ on:
         description: Tests to filter out completely
         type: string
         required: false
-  
+      extra_lit_flags:
+        description: Additional llvm-lit flags to use
+        type: string
+        required: false
+
 permissions:
   contents: read
   pull-requests: write
@@ -62,7 +66,8 @@ jobs:
           str_name: "${{inputs.str_name}}",
           prefix: "${{inputs.prefix}}",
           config: "${{inputs.config}}",
-          unit: "${{inputs.unit}}"}
+          unit: "${{inputs.unit}}",
+          extra_lit_flags: "${{inputs.extra_lit_flags}}"},
         ]
         build_type: [Release]
         compiler: [{c: clang, cxx: clang++}]
@@ -167,6 +172,7 @@ jobs:
         -DSYCL_TEST_E2E_TARGETS="${{matrix.adapter.prefix}}${{matrix.adapter.str_name}}:${{matrix.adapter.unit}}"
         -DCMAKE_CXX_COMPILER="$(which clang++)"
         -DLLVM_LIT="${{github.workspace}}/sycl-repo/llvm/utils/lit/lit.py"
+        -DSYCL_E2E_TESTS_LIT_FLAGS="-sv;${{matrix.adapter.extra_lit_flags}}"
 
     - name: Set test filters for L0
       if: matrix.adapter.name == 'L0'

--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -31,3 +31,6 @@ jobs:
       xfail: "ESIMD/preemption.cpp;syclcompat/atomic/atomic_class.cpp;ProgramManager/uneven_kernel_split.cpp;Plugin/level_zero_ext_intel_queue_index.cpp;Plugin/level_zero_ext_intel_cslice.cpp;Matrix/joint_matrix_rowmajorA_rowmajorB.cpp;Matrix/element_wise_ops.cpp;Matrix/element_wise_all_ops.cpp;Matrix/SG32/element_wise_all_ops.cpp"
       # Flaky tests
       filter_out: "GroupAlgorithm/root_group.cpp|Basic/exceptions-SYCL-2020.cpp|Graph/UnsupportedDevice/device_query.cpp|Graph/RecordReplay/exception_inconsistent_contexts.cpp"
+      # These runners by default spawn upwards of 260 workers. That's too much for the GPU.
+      # We also add a time out just in case some test hangs
+      extra_lit_flags: "-j 50;--max-time 600"


### PR DESCRIPTION
This job is running on a powerful system with 200++ cores. Letting llvm-lit run with default number of workers (equal to the number of cores), starves the system of other resources, leading to hangs.