### PR TITLE
[HIP][CUDA] Refactor using profiling events 

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -55,8 +55,7 @@ ur_result_t ur_event_handle_t_::start() {
 
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-      // NOTE: This relies on the default stream to be unused.
-      UR_CHECK_ERROR(cuEventRecord(EvQueued, 0));
+      UR_CHECK_ERROR(cuEventRecord(EvQueued, Queue->getProfilingStream()));
       UR_CHECK_ERROR(cuEventRecord(EvStart, Stream));
     }
   } catch (ur_result_t Err) {

--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -55,7 +55,7 @@ ur_result_t ur_event_handle_t_::start() {
 
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-      UR_CHECK_ERROR(cuEventRecord(EvQueued, Queue->getProfilingStream()));
+      UR_CHECK_ERROR(cuEventRecord(EvQueued, Queue->getHostSubmitTimeStream()));
       UR_CHECK_ERROR(cuEventRecord(EvStart, Stream));
     }
   } catch (ur_result_t Err) {

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -91,7 +91,7 @@ public:
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
     if (RequiresTimings) {
-      Queue->createProfilingStream();
+      Queue->createHostSubmitTimeStream();
     }
     native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
     UR_CHECK_ERROR(cuEventCreate(

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -90,6 +90,9 @@ public:
     const bool RequiresTimings =
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
+    if (RequiresTimings) {
+      Queue->createProfilingStream();
+    }
     native_type EvEnd = nullptr, EvQueued = nullptr, EvStart = nullptr;
     UR_CHECK_ERROR(cuEventCreate(
         &EvEnd, RequiresTimings ? CU_EVENT_DEFAULT : CU_EVENT_DISABLE_TIMING));

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -201,6 +201,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       UR_CHECK_ERROR(cuStreamDestroy(S));
     });
 
+    if (hQueue->IsProfStreamCreated) {
+      UR_CHECK_ERROR(cuStreamSynchronize(hQueue->getProfilingStream()));
+      UR_CHECK_ERROR(cuStreamDestroy(hQueue->getProfilingStream()));
+    }
+
     return UR_RESULT_SUCCESS;
   } catch (ur_result_t Err) {
     return Err;

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -201,9 +201,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       UR_CHECK_ERROR(cuStreamDestroy(S));
     });
 
-    if (hQueue->IsProfStreamCreated) {
-      UR_CHECK_ERROR(cuStreamSynchronize(hQueue->getProfilingStream()));
-      UR_CHECK_ERROR(cuStreamDestroy(hQueue->getProfilingStream()));
+    if (hQueue->getHostSubmitTimeStream() != CUstream{0}) {
+      UR_CHECK_ERROR(cuStreamSynchronize(hQueue->getHostSubmitTimeStream()));
+      UR_CHECK_ERROR(cuStreamDestroy(hQueue->getHostSubmitTimeStream()));
     }
 
     return UR_RESULT_SUCCESS;

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -104,9 +104,9 @@ struct ur_queue_handle_t_ {
   native_type get() { return getNextComputeStream(); };
   ur_device_handle_t getDevice() const noexcept { return Device; };
 
-  // Function which creates the profiling stream. Called only if profiling is
-  // enabled.
-  void createProfilingStream() {
+  // Function which creates the profiling stream. Called only from makeNative
+  // event when profiling is required.
+  void createHostSubmitTimeStream() {
     static std::once_flag HostSubmitTimeStreamFlag;
     std::call_once(HostSubmitTimeStreamFlag, [&]() {
       UR_CHECK_ERROR(cuStreamCreateWithPriority(&HostSubmitTimeStream,

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -29,8 +29,9 @@ struct ur_queue_handle_t_ {
 
   std::vector<native_type> ComputeStreams;
   std::vector<native_type> TransferStreams;
-  // Stream used for recording EvQueue. It is created only if profiling is
-  // enabled - either for the queue or per event.
+  // Stream used for recording EvQueue, which holds information about when the
+  // command in question is enqueued on host, as opposed to started. It is
+  // created only if profiling is enabled - either for queue or per event.
   native_type HostSubmitTimeStream{0};
   // delay_compute_ keeps track of which streams have been recently reused and
   // their next use should be delayed. If a stream has been recently reused it

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -69,8 +69,8 @@ struct ur_queue_handle_t_ {
                      ur_context_handle_t_ *Context, ur_device_handle_t_ *Device,
                      unsigned int Flags, ur_queue_flags_t URFlags, int Priority,
                      bool BackendOwns = true)
-      : ComputeStreams{std::move(ComputeStreams)},
-        TransferStreams{std::move(TransferStreams)},
+      : ComputeStreams{std::move(ComputeStreams)}, TransferStreams{std::move(
+                                                       TransferStreams)},
         DelayCompute(this->ComputeStreams.size(), false),
         ComputeAppliedBarrier(this->ComputeStreams.size()),
         TransferAppliedBarrier(this->TransferStreams.size()), Context{Context},

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -29,10 +29,9 @@ struct ur_queue_handle_t_ {
 
   std::vector<native_type> ComputeStreams;
   std::vector<native_type> TransferStreams;
-  // Stream used solely when profiling is enabled
-  native_type ProfStream;
-  bool IsProfStreamCreated{false};
-  std::once_flag ProfStreamFlag;
+  // Stream used for recording EvQueue. It is created only if profiling is
+  // enabled - either for the queue or per event.
+  native_type HostSubmitTimeStream{0};
   // delay_compute_ keeps track of which streams have been recently reused and
   // their next use should be delayed. If a stream has been recently reused it
   // will be skipped the next time it would be selected round-robin style. When
@@ -108,14 +107,14 @@ struct ur_queue_handle_t_ {
   // Function which creates the profiling stream. Called only if profiling is
   // enabled.
   void createProfilingStream() {
-    std::call_once(ProfStreamFlag, [&]() {
-      UR_CHECK_ERROR(
-          cuStreamCreateWithPriority(&ProfStream, CU_STREAM_NON_BLOCKING, 0));
-      IsProfStreamCreated = true;
+    static std::once_flag HostSubmitTimeStreamFlag;
+    std::call_once(HostSubmitTimeStreamFlag, [&]() {
+      UR_CHECK_ERROR(cuStreamCreateWithPriority(&HostSubmitTimeStream,
+                                                CU_STREAM_NON_BLOCKING, 0));
     });
   }
 
-  native_type getProfilingStream() { return ProfStream; }
+  native_type getHostSubmitTimeStream() { return HostSubmitTimeStream; }
 
   bool hasBeenSynchronized(uint32_t StreamToken) {
     // stream token not associated with one of the compute streams

--- a/source/adapters/cuda/queue.hpp
+++ b/source/adapters/cuda/queue.hpp
@@ -32,6 +32,7 @@ struct ur_queue_handle_t_ {
   // Stream used solely when profiling is enabled
   native_type ProfStream;
   bool IsProfStreamCreated{false};
+  std::once_flag ProfStreamFlag;
   // delay_compute_ keeps track of which streams have been recently reused and
   // their next use should be delayed. If a stream has been recently reused it
   // will be skipped the next time it would be selected round-robin style. When
@@ -107,7 +108,6 @@ struct ur_queue_handle_t_ {
   // Function which creates the profiling stream. Called only if profiling is
   // enabled.
   void createProfilingStream() {
-    static std::once_flag ProfStreamFlag;
     std::call_once(ProfStreamFlag, [&]() {
       UR_CHECK_ERROR(
           cuStreamCreateWithPriority(&ProfStream, CU_STREAM_NON_BLOCKING, 0));

--- a/source/adapters/hip/context.cpp
+++ b/source/adapters/hip/context.cpp
@@ -47,18 +47,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
     // Create a scoped context.
     ContextPtr = std::unique_ptr<ur_context_handle_t_>(
         new ur_context_handle_t_{phDevices, DeviceCount});
-
-    static std::once_flag InitFlag;
-    std::call_once(
-        InitFlag,
-        [](ur_result_t &) {
-          // Use default stream to record base event counter
-          UR_CHECK_ERROR(hipEventCreateWithFlags(&ur_platform_handle_t_::EvBase,
-                                                 hipEventDefault));
-          UR_CHECK_ERROR(hipEventRecord(ur_platform_handle_t_::EvBase, 0));
-        },
-        RetErr);
-
     *phContext = ContextPtr.release();
   } catch (ur_result_t Err) {
     RetErr = Err;

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -20,6 +20,18 @@ int getAttribute(ur_device_handle_t Device, hipDeviceAttribute_t Attribute) {
   return Value;
 }
 
+uint64_t ur_device_handle_t_::getElapsedTime(hipEvent_t ev) const {
+  float Milliseconds = 0.0f;
+
+  // hipEventSynchronize waits till the event is ready for call to
+  // hipEventElapsedTime.
+  UR_CHECK_ERROR(hipEventSynchronize(EvBase));
+  UR_CHECK_ERROR(hipEventSynchronize(ev));
+  UR_CHECK_ERROR(hipEventElapsedTime(&Milliseconds, EvBase, ev));
+
+  return static_cast<uint64_t>(Milliseconds * 1.0e6);
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                                     ur_device_info_t propName,
                                                     size_t propSize,
@@ -995,11 +1007,7 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
   if (pDeviceTimestamp) {
     UR_CHECK_ERROR(hipEventCreateWithFlags(&Event, hipEventDefault));
     UR_CHECK_ERROR(hipEventRecord(Event));
-    UR_CHECK_ERROR(hipEventSynchronize(Event));
-    float ElapsedTime = 0.0f;
-    UR_CHECK_ERROR(hipEventElapsedTime(&ElapsedTime,
-                                       ur_platform_handle_t_::EvBase, Event));
-    *pDeviceTimestamp = (uint64_t)(ElapsedTime * (double)1e6);
+    *pDeviceTimestamp = hDevice->getElapsedTime(Event);
   }
 
   if (pHostTimestamp) {

--- a/source/adapters/hip/device.hpp
+++ b/source/adapters/hip/device.hpp
@@ -25,7 +25,9 @@ private:
   std::atomic_uint32_t RefCount;
   ur_platform_handle_t Platform;
   hipCtx_t HIPContext;
+  hipEvent_t EvBase; // HIP event used as base counter
   uint32_t DeviceIndex;
+
   int MaxWorkGroupSize{0};
   int MaxBlockDimX{0};
   int MaxBlockDimY{0};
@@ -36,9 +38,10 @@ private:
 
 public:
   ur_device_handle_t_(native_type HipDevice, hipCtx_t Context,
-                      ur_platform_handle_t Platform, uint32_t DeviceIndex)
+                      hipEvent_t EvBase, ur_platform_handle_t Platform,
+                      uint32_t DeviceIndex)
       : HIPDevice(HipDevice), RefCount{1}, Platform(Platform),
-        HIPContext(Context), DeviceIndex(DeviceIndex) {
+        HIPContext(Context), EvBase(EvBase), DeviceIndex(DeviceIndex) {
 
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxWorkGroupSize, hipDeviceAttributeMaxThreadsPerBlock, HIPDevice));
@@ -67,6 +70,8 @@ public:
   uint32_t getReferenceCount() const noexcept { return RefCount; }
 
   ur_platform_handle_t getPlatform() const noexcept { return Platform; };
+
+  uint64_t getElapsedTime(hipEvent_t) const;
 
   hipCtx_t getNativeContext() const noexcept { return HIPContext; };
 

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -90,44 +90,18 @@ bool ur_event_handle_t_::isCompleted() const {
 }
 
 uint64_t ur_event_handle_t_::getQueuedTime() const {
-  float MilliSeconds = 0.0f;
   assert(isStarted());
-
-  // hipEventSynchronize waits till the event is ready for call to
-  // hipEventElapsedTime.
-  UR_CHECK_ERROR(hipEventSynchronize(EvStart));
-  UR_CHECK_ERROR(hipEventSynchronize(EvEnd));
-
-  UR_CHECK_ERROR(hipEventElapsedTime(&MilliSeconds, EvStart, EvEnd));
-  return static_cast<uint64_t>(MilliSeconds * 1.0e6);
+  return Queue->getDevice()->getElapsedTime(EvQueued);
 }
 
 uint64_t ur_event_handle_t_::getStartTime() const {
-  float MiliSeconds = 0.0f;
   assert(isStarted());
-
-  // hipEventSynchronize waits till the event is ready for call to
-  // hipEventElapsedTime.
-  UR_CHECK_ERROR(hipEventSynchronize(ur_platform_handle_t_::EvBase));
-  UR_CHECK_ERROR(hipEventSynchronize(EvStart));
-
-  UR_CHECK_ERROR(hipEventElapsedTime(&MiliSeconds,
-                                     ur_platform_handle_t_::EvBase, EvStart));
-  return static_cast<uint64_t>(MiliSeconds * 1.0e6);
+  return Queue->getDevice()->getElapsedTime(EvStart);
 }
 
 uint64_t ur_event_handle_t_::getEndTime() const {
-  float MiliSeconds = 0.0f;
   assert(isStarted() && isRecorded());
-
-  // hipEventSynchronize waits till the event is ready for call to
-  // hipEventElapsedTime.
-  UR_CHECK_ERROR(hipEventSynchronize(ur_platform_handle_t_::EvBase));
-  UR_CHECK_ERROR(hipEventSynchronize(EvEnd));
-
-  UR_CHECK_ERROR(
-      hipEventElapsedTime(&MiliSeconds, ur_platform_handle_t_::EvBase, EvEnd));
-  return static_cast<uint64_t>(MiliSeconds * 1.0e6);
+  return Queue->getDevice()->getElapsedTime(EvEnd);
 }
 
 ur_result_t ur_event_handle_t_::record() {

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -51,7 +51,7 @@ ur_result_t ur_event_handle_t_::start() {
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
       // NOTE: This relies on the default stream to be unused.
-      UR_CHECK_ERROR(hipEventRecord(EvQueued, 0));
+      UR_CHECK_ERROR(hipEventRecord(EvQueued, Queue->getProfilingStream()));
       UR_CHECK_ERROR(hipEventRecord(EvStart, Stream));
     }
   } catch (ur_result_t Error) {

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -21,8 +21,8 @@ ur_event_handle_t_::ur_event_handle_t_(ur_command_t Type,
                                        uint32_t StreamToken)
     : CommandType{Type}, RefCount{1}, HasOwnership{true},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
-      StreamToken{StreamToken}, EventId{0}, EvEnd{EvEnd}, EvQueued{EvQueued},
-      EvStart{EvStart}, Queue{Queue}, Stream{Stream}, Context{Context} {
+      StreamToken{StreamToken}, EventId{0}, EvEnd{EvEnd}, EvStart{EvStart},
+      EvQueued{EvQueued}, Queue{Queue}, Stream{Stream}, Context{Context} {
   urQueueRetain(Queue);
   urContextRetain(Context);
 }
@@ -50,7 +50,6 @@ ur_result_t ur_event_handle_t_::start() {
 
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-      // NOTE: This relies on the default stream to be unused.
       UR_CHECK_ERROR(hipEventRecord(EvQueued, Queue->getProfilingStream()));
       UR_CHECK_ERROR(hipEventRecord(EvStart, Stream));
     }

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -50,7 +50,8 @@ ur_result_t ur_event_handle_t_::start() {
 
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE || isTimestampEvent()) {
-      UR_CHECK_ERROR(hipEventRecord(EvQueued, Queue->getProfilingStream()));
+      UR_CHECK_ERROR(
+          hipEventRecord(EvQueued, Queue->getHostSubmitTimeStream()));
       UR_CHECK_ERROR(hipEventRecord(EvStart, Stream));
     }
   } catch (ur_result_t Error) {

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -83,6 +83,9 @@ public:
     const bool RequiresTimings =
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
+    if (RequiresTimings) {
+      Queue->createProfilingStream();
+    }
     native_type EvEnd{nullptr}, EvQueued{nullptr}, EvStart{nullptr};
     UR_CHECK_ERROR(hipEventCreateWithFlags(
         &EvEnd, RequiresTimings ? hipEventDefault : hipEventDisableTiming));

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -84,7 +84,7 @@ public:
         Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE ||
         Type == UR_COMMAND_TIMESTAMP_RECORDING_EXP;
     if (RequiresTimings) {
-      Queue->createProfilingStream();
+      Queue->createHostSubmitTimeStream();
     }
     native_type EvEnd{nullptr}, EvQueued{nullptr}, EvStart{nullptr};
     UR_CHECK_ERROR(hipEventCreateWithFlags(

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -112,8 +112,9 @@ private:
   // This constructor is private to force programmers to use the makeNative /
   // make_user static members in order to create a ur_event_handle_t for HIP.
   ur_event_handle_t_(ur_command_t Type, ur_context_handle_t Context,
-                     ur_queue_handle_t Queue, hipStream_t Stream,
-                     uint32_t StreamToken);
+                     ur_queue_handle_t Queue, native_type EvEnd,
+                     native_type EvQueued, native_type EvStart,
+                     hipStream_t Stream, uint32_t StreamToken);
 
   // This constructor is private to force programmers to use the
   // makeWithNative for event interop

--- a/source/adapters/hip/platform.hpp
+++ b/source/adapters/hip/platform.hpp
@@ -20,6 +20,5 @@
 ///  when devices are used.
 ///
 struct ur_platform_handle_t_ {
-  static hipEvent_t EvBase; // HIP event used as base counter
   std::vector<std::unique_ptr<ur_device_handle_t_>> Devices;
 };

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -222,9 +222,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       UR_CHECK_ERROR(hipStreamDestroy(S));
     });
 
-    if (hQueue->IsProfStreamCreated) {
-      UR_CHECK_ERROR(hipStreamSynchronize(hQueue->getProfilingStream()));
-      UR_CHECK_ERROR(hipStreamDestroy(hQueue->getProfilingStream()));
+    if (hQueue->getHostSubmitTimeStream() != hipStream_t{0}) {
+      UR_CHECK_ERROR(hipStreamSynchronize(hQueue->getHostSubmitTimeStream()));
+      UR_CHECK_ERROR(hipStreamDestroy(hQueue->getHostSubmitTimeStream()));
     }
 
     return UR_RESULT_SUCCESS;

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -222,9 +222,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       UR_CHECK_ERROR(hipStreamDestroy(S));
     });
 
-    if (hQueue->ProfStreamCreated) {
-      UR_CHECK_ERROR(hipStreamSynchronize(ProfStream));
-      UR_CHECK_ERROR(hipStreamDestroy(ProfStream));
+    if (hQueue->IsProfStreamCreated) {
+      UR_CHECK_ERROR(hipStreamSynchronize(hQueue->getProfilingStream()));
+      UR_CHECK_ERROR(hipStreamDestroy(hQueue->getProfilingStream()));
     }
 
     return UR_RESULT_SUCCESS;

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -222,6 +222,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
       UR_CHECK_ERROR(hipStreamDestroy(S));
     });
 
+    if (hQueue->ProfStreamCreated) {
+      UR_CHECK_ERROR(hipStreamSynchronize(ProfStream));
+      UR_CHECK_ERROR(hipStreamDestroy(ProfStream));
+    }
+
     return UR_RESULT_SUCCESS;
   } catch (ur_result_t Err) {
     return Err;

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -117,12 +117,17 @@ urQueueCreate(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   try {
     std::unique_ptr<ur_queue_handle_t_> QueueImpl{nullptr};
 
-    unsigned int Flags = 0;
+    unsigned int Flags = hipStreamNonBlocking;
     ur_queue_flags_t URFlags = 0;
     int Priority = 0; // Not guaranteed, but, in ROCm 5.0-6.0, 0 is the default
-
     if (pProps && pProps->stype == UR_STRUCTURE_TYPE_QUEUE_PROPERTIES) {
       URFlags = pProps->flags;
+      if (URFlags == UR_QUEUE_FLAG_USE_DEFAULT_STREAM) {
+        Flags = hipStreamDefault;
+      } else if (URFlags == UR_QUEUE_FLAG_SYNC_WITH_DEFAULT_STREAM) {
+        Flags = 0;
+      }
+
       if (URFlags & UR_QUEUE_FLAG_PRIORITY_HIGH) {
         ScopedContext Active(hDevice);
         UR_CHECK_ERROR(hipDeviceGetStreamPriorityRange(nullptr, &Priority));
@@ -143,7 +148,7 @@ urQueueCreate(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 
     QueueImpl = std::unique_ptr<ur_queue_handle_t_>(new ur_queue_handle_t_{
         std::move(ComputeHipStreams), std::move(TransferHipStreams), hContext,
-        hDevice, Flags, pProps ? pProps->flags : 0, Priority});
+        hDevice, Flags, URFlags, Priority});
 
     *phQueue = QueueImpl.release();
 

--- a/source/adapters/hip/queue.hpp
+++ b/source/adapters/hip/queue.hpp
@@ -28,6 +28,7 @@ struct ur_queue_handle_t_ {
   // Stream used solely when profiling is enabled
   native_type ProfStream;
   bool IsProfStreamCreated{false};
+  std::once_flag ProfStreamFlag;
   // DelayCompute keeps track of which streams have been recently reused and
   // their next use should be delayed. If a stream has been recently reused it
   // will be skipped the next time it would be selected round-robin style. When
@@ -104,7 +105,6 @@ struct ur_queue_handle_t_ {
   // Function which creates the profiling stream. Called only if profiling is
   // enabled.
   void createProfilingStream() {
-    static std::once_flag ProfStreamFlag;
     std::call_once(ProfStreamFlag, [&]() {
       UR_CHECK_ERROR(
           hipStreamCreateWithFlags(&ProfStream, hipStreamNonBlocking));

--- a/source/adapters/hip/queue.hpp
+++ b/source/adapters/hip/queue.hpp
@@ -65,8 +65,8 @@ struct ur_queue_handle_t_ {
                      ur_context_handle_t Context, ur_device_handle_t Device,
                      unsigned int Flags, ur_queue_flags_t URFlags, int Priority,
                      bool BackendOwns = true)
-      : ComputeStreams{std::move(ComputeStreams)},
-        TransferStreams{std::move(TransferStreams)},
+      : ComputeStreams{std::move(ComputeStreams)}, TransferStreams{std::move(
+                                                       TransferStreams)},
         DelayCompute(this->ComputeStreams.size(), false),
         ComputeAppliedBarrier(this->ComputeStreams.size()),
         TransferAppliedBarrier(this->TransferStreams.size()), Context{Context},

--- a/source/adapters/hip/queue.hpp
+++ b/source/adapters/hip/queue.hpp
@@ -101,9 +101,9 @@ struct ur_queue_handle_t_ {
   native_type getNextTransferStream();
   native_type get() { return getNextComputeStream(); };
 
-  // Function which creates the profiling stream. Called only if profiling is
-  // enabled.
-  void createProfilingStream() {
+  // Function which creates the profiling stream. Called only from makeNative
+  // event when profiling is required.
+  void createHostSubmitTimeStream() {
     static std::once_flag HostSubmitTimeStreamFlag;
     std::call_once(HostSubmitTimeStreamFlag, [&]() {
       UR_CHECK_ERROR(hipStreamCreateWithFlags(&HostSubmitTimeStream,

--- a/source/adapters/hip/queue.hpp
+++ b/source/adapters/hip/queue.hpp
@@ -25,8 +25,9 @@ struct ur_queue_handle_t_ {
 
   std::vector<native_type> ComputeStreams;
   std::vector<native_type> TransferStreams;
-  // Stream used for recording EvQueue. It is created only if profiling is
-  // enabled - either for the queue or per event.
+  // Stream used for recording EvQueue, which holds information about when the
+  // command in question is enqueued on host, as opposed to started. It is
+  // created only if profiling is enabled - either for queue or per event.
   native_type HostSubmitTimeStream{0};
   // DelayCompute keeps track of which streams have been recently reused and
   // their next use should be delayed. If a stream has been recently reused it


### PR DESCRIPTION
HIP changes:
- To match with the current behaviour of CUDA adapter, `EvBase` in HIP was moved to `device` and                                                      `getElapsedTime` function now handles the profiling events' synchronization. Also, we were using `hipStreamDefault` flag as default, but in CUDA, we use `CU_STREAM_NON_BLOCKING`, this was also changed to match with cuda, **commits 1-3**
- Added an extra profiling stream to `Queue` which is only created when profiling is enabled and it is used to record `EvQueued`. This was necessary because before we were recording it on the `NULL` stream and this might not be the best solution for HIP, see https://github.com/intel/llvm/issues/12904, **commit 4**

CUDA changes:
- Also added the extra profiling stream for consistency, **commit 5**

**intel/llvm** CI: https://github.com/intel/llvm/pull/13861