### PR TITLE
[Bindless][Exp] Windows & DX12 interop. Semaphore ops can take values.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -31,200 +31,200 @@ extern "C" {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Defines unique stable identifiers for all functions
 typedef enum ur_function_t {
-    UR_FUNCTION_CONTEXT_CREATE = 1,                                            ///< Enumerator for ::urContextCreate
-    UR_FUNCTION_CONTEXT_RETAIN = 2,                                            ///< Enumerator for ::urContextRetain
-    UR_FUNCTION_CONTEXT_RELEASE = 3,                                           ///< Enumerator for ::urContextRelease
-    UR_FUNCTION_CONTEXT_GET_INFO = 4,                                          ///< Enumerator for ::urContextGetInfo
-    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                                 ///< Enumerator for ::urContextGetNativeHandle
-    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,                         ///< Enumerator for ::urContextCreateWithNativeHandle
-    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,                              ///< Enumerator for ::urContextSetExtendedDeleter
-    UR_FUNCTION_DEVICE_GET = 8,                                                ///< Enumerator for ::urDeviceGet
-    UR_FUNCTION_DEVICE_GET_INFO = 9,                                           ///< Enumerator for ::urDeviceGetInfo
-    UR_FUNCTION_DEVICE_RETAIN = 10,                                            ///< Enumerator for ::urDeviceRetain
-    UR_FUNCTION_DEVICE_RELEASE = 11,                                           ///< Enumerator for ::urDeviceRelease
-    UR_FUNCTION_DEVICE_PARTITION = 12,                                         ///< Enumerator for ::urDevicePartition
-    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                                     ///< Enumerator for ::urDeviceSelectBinary
-    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                                 ///< Enumerator for ::urDeviceGetNativeHandle
-    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,                         ///< Enumerator for ::urDeviceCreateWithNativeHandle
-    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,                             ///< Enumerator for ::urDeviceGetGlobalTimestamps
-    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                                    ///< Enumerator for ::urEnqueueKernelLaunch
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                                      ///< Enumerator for ::urEnqueueEventsWait
-    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,                         ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                                  ///< Enumerator for ::urEnqueueMemBufferRead
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                                 ///< Enumerator for ::urEnqueueMemBufferWrite
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,                             ///< Enumerator for ::urEnqueueMemBufferReadRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,                            ///< Enumerator for ::urEnqueueMemBufferWriteRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                                  ///< Enumerator for ::urEnqueueMemBufferCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,                             ///< Enumerator for ::urEnqueueMemBufferCopyRect
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                                  ///< Enumerator for ::urEnqueueMemBufferFill
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                                   ///< Enumerator for ::urEnqueueMemImageRead
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                                  ///< Enumerator for ::urEnqueueMemImageWrite
-    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                                   ///< Enumerator for ::urEnqueueMemImageCopy
-    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                                   ///< Enumerator for ::urEnqueueMemBufferMap
-    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                                        ///< Enumerator for ::urEnqueueMemUnmap
-    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                                         ///< Enumerator for ::urEnqueueUSMFill
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                                       ///< Enumerator for ::urEnqueueUSMMemcpy
-    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                                     ///< Enumerator for ::urEnqueueUSMPrefetch
-    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                                       ///< Enumerator for ::urEnqueueUSMAdvise
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,                     ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
-    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,                      ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
-    UR_FUNCTION_EVENT_GET_INFO = 40,                                           ///< Enumerator for ::urEventGetInfo
-    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                                 ///< Enumerator for ::urEventGetProfilingInfo
-    UR_FUNCTION_EVENT_WAIT = 42,                                               ///< Enumerator for ::urEventWait
-    UR_FUNCTION_EVENT_RETAIN = 43,                                             ///< Enumerator for ::urEventRetain
-    UR_FUNCTION_EVENT_RELEASE = 44,                                            ///< Enumerator for ::urEventRelease
-    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                                  ///< Enumerator for ::urEventGetNativeHandle
-    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,                          ///< Enumerator for ::urEventCreateWithNativeHandle
-    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                                       ///< Enumerator for ::urEventSetCallback
-    UR_FUNCTION_KERNEL_CREATE = 48,                                            ///< Enumerator for ::urKernelCreate
-    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                                     ///< Enumerator for ::urKernelSetArgValue
-    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                                     ///< Enumerator for ::urKernelSetArgLocal
-    UR_FUNCTION_KERNEL_GET_INFO = 51,                                          ///< Enumerator for ::urKernelGetInfo
-    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                                    ///< Enumerator for ::urKernelGetGroupInfo
-    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,                                ///< Enumerator for ::urKernelGetSubGroupInfo
-    UR_FUNCTION_KERNEL_RETAIN = 54,                                            ///< Enumerator for ::urKernelRetain
-    UR_FUNCTION_KERNEL_RELEASE = 55,                                           ///< Enumerator for ::urKernelRelease
-    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                                   ///< Enumerator for ::urKernelSetArgPointer
-    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                                     ///< Enumerator for ::urKernelSetExecInfo
-    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                                   ///< Enumerator for ::urKernelSetArgSampler
-    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                                   ///< Enumerator for ::urKernelSetArgMemObj
-    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,                      ///< Enumerator for ::urKernelSetSpecializationConstants
-    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                                 ///< Enumerator for ::urKernelGetNativeHandle
-    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,                         ///< Enumerator for ::urKernelCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                                         ///< Enumerator for ::urMemImageCreate
-    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                                        ///< Enumerator for ::urMemBufferCreate
-    UR_FUNCTION_MEM_RETAIN = 65,                                               ///< Enumerator for ::urMemRetain
-    UR_FUNCTION_MEM_RELEASE = 66,                                              ///< Enumerator for ::urMemRelease
-    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                                     ///< Enumerator for ::urMemBufferPartition
-    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                                    ///< Enumerator for ::urMemGetNativeHandle
-    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                                   ///< Enumerator for ::urEnqueueReadHostPipe
-    UR_FUNCTION_MEM_GET_INFO = 70,                                             ///< Enumerator for ::urMemGetInfo
-    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                                       ///< Enumerator for ::urMemImageGetInfo
-    UR_FUNCTION_PLATFORM_GET = 72,                                             ///< Enumerator for ::urPlatformGet
-    UR_FUNCTION_PLATFORM_GET_INFO = 73,                                        ///< Enumerator for ::urPlatformGetInfo
-    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                                 ///< Enumerator for ::urPlatformGetApiVersion
-    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                               ///< Enumerator for ::urPlatformGetNativeHandle
-    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,                       ///< Enumerator for ::urPlatformCreateWithNativeHandle
-    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                                   ///< Enumerator for ::urProgramCreateWithIL
-    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                               ///< Enumerator for ::urProgramCreateWithBinary
-    UR_FUNCTION_PROGRAM_BUILD = 80,                                            ///< Enumerator for ::urProgramBuild
-    UR_FUNCTION_PROGRAM_COMPILE = 81,                                          ///< Enumerator for ::urProgramCompile
-    UR_FUNCTION_PROGRAM_LINK = 82,                                             ///< Enumerator for ::urProgramLink
-    UR_FUNCTION_PROGRAM_RETAIN = 83,                                           ///< Enumerator for ::urProgramRetain
-    UR_FUNCTION_PROGRAM_RELEASE = 84,                                          ///< Enumerator for ::urProgramRelease
-    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,                             ///< Enumerator for ::urProgramGetFunctionPointer
-    UR_FUNCTION_PROGRAM_GET_INFO = 86,                                         ///< Enumerator for ::urProgramGetInfo
-    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                                   ///< Enumerator for ::urProgramGetBuildInfo
-    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,                     ///< Enumerator for ::urProgramSetSpecializationConstants
-    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,                                ///< Enumerator for ::urProgramGetNativeHandle
-    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,                        ///< Enumerator for ::urProgramCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_GET_INFO = 91,                                           ///< Enumerator for ::urQueueGetInfo
-    UR_FUNCTION_QUEUE_CREATE = 92,                                             ///< Enumerator for ::urQueueCreate
-    UR_FUNCTION_QUEUE_RETAIN = 93,                                             ///< Enumerator for ::urQueueRetain
-    UR_FUNCTION_QUEUE_RELEASE = 94,                                            ///< Enumerator for ::urQueueRelease
-    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                                  ///< Enumerator for ::urQueueGetNativeHandle
-    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,                          ///< Enumerator for ::urQueueCreateWithNativeHandle
-    UR_FUNCTION_QUEUE_FINISH = 97,                                             ///< Enumerator for ::urQueueFinish
-    UR_FUNCTION_QUEUE_FLUSH = 98,                                              ///< Enumerator for ::urQueueFlush
-    UR_FUNCTION_SAMPLER_CREATE = 101,                                          ///< Enumerator for ::urSamplerCreate
-    UR_FUNCTION_SAMPLER_RETAIN = 102,                                          ///< Enumerator for ::urSamplerRetain
-    UR_FUNCTION_SAMPLER_RELEASE = 103,                                         ///< Enumerator for ::urSamplerRelease
-    UR_FUNCTION_SAMPLER_GET_INFO = 104,                                        ///< Enumerator for ::urSamplerGetInfo
-    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,                               ///< Enumerator for ::urSamplerGetNativeHandle
-    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,                       ///< Enumerator for ::urSamplerCreateWithNativeHandle
-    UR_FUNCTION_USM_HOST_ALLOC = 107,                                          ///< Enumerator for ::urUSMHostAlloc
-    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                                        ///< Enumerator for ::urUSMDeviceAlloc
-    UR_FUNCTION_USM_SHARED_ALLOC = 109,                                        ///< Enumerator for ::urUSMSharedAlloc
-    UR_FUNCTION_USM_FREE = 110,                                                ///< Enumerator for ::urUSMFree
-    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                                  ///< Enumerator for ::urUSMGetMemAllocInfo
-    UR_FUNCTION_USM_POOL_CREATE = 112,                                         ///< Enumerator for ::urUSMPoolCreate
-    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,                               ///< Enumerator for ::urCommandBufferCreateExp
-    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,                             ///< Enumerator for ::urPlatformGetBackendOption
-    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,                    ///< Enumerator for ::urMemBufferCreateWithNativeHandle
-    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,                     ///< Enumerator for ::urMemImageCreateWithNativeHandle
-    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                                 ///< Enumerator for ::urEnqueueWriteHostPipe
-    UR_FUNCTION_USM_POOL_RETAIN = 118,                                         ///< Enumerator for ::urUSMPoolRetain
-    UR_FUNCTION_USM_POOL_RELEASE = 119,                                        ///< Enumerator for ::urUSMPoolRelease
-    UR_FUNCTION_USM_POOL_GET_INFO = 120,                                       ///< Enumerator for ::urUSMPoolGetInfo
-    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                               ///< Enumerator for ::urCommandBufferRetainExp
-    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                              ///< Enumerator for ::urCommandBufferReleaseExp
-    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                             ///< Enumerator for ::urCommandBufferFinalizeExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125,                 ///< Enumerator for ::urCommandBufferAppendKernelLaunchExp
-    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                              ///< Enumerator for ::urCommandBufferEnqueueExp
-    UR_FUNCTION_USM_PITCHED_ALLOC_EXP = 132,                                   ///< Enumerator for ::urUSMPitchedAllocExp
-    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP = 133,      ///< Enumerator for ::urBindlessImagesUnsampledImageHandleDestroyExp
-    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP = 134,        ///< Enumerator for ::urBindlessImagesSampledImageHandleDestroyExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP = 135,                      ///< Enumerator for ::urBindlessImagesImageAllocateExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP = 136,                          ///< Enumerator for ::urBindlessImagesImageFreeExp
-    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP = 137,              ///< Enumerator for ::urBindlessImagesUnsampledImageCreateExp
-    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP = 138,                ///< Enumerator for ::urBindlessImagesSampledImageCreateExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP = 139,                          ///< Enumerator for ::urBindlessImagesImageCopyExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP = 140,                      ///< Enumerator for ::urBindlessImagesImageGetInfoExp
-    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP = 141,                    ///< Enumerator for ::urBindlessImagesMipmapGetLevelExp
-    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142,                         ///< Enumerator for ::urBindlessImagesMipmapFreeExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP = 143,                    ///< Enumerator for ::urBindlessImagesImportOpaqueFDExp
-    UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144,                  ///< Enumerator for ::urBindlessImagesMapExternalArrayExp
-    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145,                     ///< Enumerator for ::urBindlessImagesReleaseInteropExp
-    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP = 146, ///< Enumerator for ::urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-    UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147,          ///< Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
-    UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,             ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
-    UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,           ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
-    UR_FUNCTION_ENQUEUE_USM_FILL_2D = 151,                                     ///< Enumerator for ::urEnqueueUSMFill2D
-    UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D = 152,                                   ///< Enumerator for ::urEnqueueUSMMemcpy2D
-    UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO = 153,                        ///< Enumerator for ::urVirtualMemGranularityGetInfo
-    UR_FUNCTION_VIRTUAL_MEM_RESERVE = 154,                                     ///< Enumerator for ::urVirtualMemReserve
-    UR_FUNCTION_VIRTUAL_MEM_FREE = 155,                                        ///< Enumerator for ::urVirtualMemFree
-    UR_FUNCTION_VIRTUAL_MEM_MAP = 156,                                         ///< Enumerator for ::urVirtualMemMap
-    UR_FUNCTION_VIRTUAL_MEM_UNMAP = 157,                                       ///< Enumerator for ::urVirtualMemUnmap
-    UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS = 158,                                  ///< Enumerator for ::urVirtualMemSetAccess
-    UR_FUNCTION_VIRTUAL_MEM_GET_INFO = 159,                                    ///< Enumerator for ::urVirtualMemGetInfo
-    UR_FUNCTION_PHYSICAL_MEM_CREATE = 160,                                     ///< Enumerator for ::urPhysicalMemCreate
-    UR_FUNCTION_PHYSICAL_MEM_RETAIN = 161,                                     ///< Enumerator for ::urPhysicalMemRetain
-    UR_FUNCTION_PHYSICAL_MEM_RELEASE = 162,                                    ///< Enumerator for ::urPhysicalMemRelease
-    UR_FUNCTION_USM_IMPORT_EXP = 163,                                          ///< Enumerator for ::urUSMImportExp
-    UR_FUNCTION_USM_RELEASE_EXP = 164,                                         ///< Enumerator for ::urUSMReleaseExp
-    UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP = 165,                          ///< Enumerator for ::urUsmP2PEnablePeerAccessExp
-    UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP = 166,                         ///< Enumerator for ::urUsmP2PDisablePeerAccessExp
-    UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP = 167,                        ///< Enumerator for ::urUsmP2PPeerAccessGetInfoExp
-    UR_FUNCTION_LOADER_CONFIG_CREATE = 172,                                    ///< Enumerator for ::urLoaderConfigCreate
-    UR_FUNCTION_LOADER_CONFIG_RELEASE = 173,                                   ///< Enumerator for ::urLoaderConfigRelease
-    UR_FUNCTION_LOADER_CONFIG_RETAIN = 174,                                    ///< Enumerator for ::urLoaderConfigRetain
-    UR_FUNCTION_LOADER_CONFIG_GET_INFO = 175,                                  ///< Enumerator for ::urLoaderConfigGetInfo
-    UR_FUNCTION_LOADER_CONFIG_ENABLE_LAYER = 176,                              ///< Enumerator for ::urLoaderConfigEnableLayer
-    UR_FUNCTION_ADAPTER_RELEASE = 177,                                         ///< Enumerator for ::urAdapterRelease
-    UR_FUNCTION_ADAPTER_GET = 178,                                             ///< Enumerator for ::urAdapterGet
-    UR_FUNCTION_ADAPTER_RETAIN = 179,                                          ///< Enumerator for ::urAdapterRetain
-    UR_FUNCTION_ADAPTER_GET_LAST_ERROR = 180,                                  ///< Enumerator for ::urAdapterGetLastError
-    UR_FUNCTION_ADAPTER_GET_INFO = 181,                                        ///< Enumerator for ::urAdapterGetInfo
-    UR_FUNCTION_PROGRAM_BUILD_EXP = 197,                                       ///< Enumerator for ::urProgramBuildExp
-    UR_FUNCTION_PROGRAM_COMPILE_EXP = 198,                                     ///< Enumerator for ::urProgramCompileExp
-    UR_FUNCTION_PROGRAM_LINK_EXP = 199,                                        ///< Enumerator for ::urProgramLinkExp
-    UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK = 200,                ///< Enumerator for ::urLoaderConfigSetCodeLocationCallback
-    UR_FUNCTION_LOADER_INIT = 201,                                             ///< Enumerator for ::urLoaderInit
-    UR_FUNCTION_LOADER_TEAR_DOWN = 202,                                        ///< Enumerator for ::urLoaderTearDown
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP = 203,                    ///< Enumerator for ::urCommandBufferAppendUSMMemcpyExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP = 204,                      ///< Enumerator for ::urCommandBufferAppendUSMFillExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP = 205,               ///< Enumerator for ::urCommandBufferAppendMemBufferCopyExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP = 206,              ///< Enumerator for ::urCommandBufferAppendMemBufferWriteExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP = 207,               ///< Enumerator for ::urCommandBufferAppendMemBufferReadExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP = 208,          ///< Enumerator for ::urCommandBufferAppendMemBufferCopyRectExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP = 209,         ///< Enumerator for ::urCommandBufferAppendMemBufferWriteRectExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP = 210,          ///< Enumerator for ::urCommandBufferAppendMemBufferReadRectExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP = 211,               ///< Enumerator for ::urCommandBufferAppendMemBufferFillExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 212,                  ///< Enumerator for ::urCommandBufferAppendUSMPrefetchExp
-    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 213,                    ///< Enumerator for ::urCommandBufferAppendUSMAdviseExp
-    UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP = 214,                   ///< Enumerator for ::urEnqueueCooperativeKernelLaunchExp
-    UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 215,          ///< Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
-    UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER = 216,                     ///< Enumerator for ::urProgramGetGlobalVariablePointer
-    UR_FUNCTION_DEVICE_GET_SELECTED = 217,                                     ///< Enumerator for ::urDeviceGetSelected
-    UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP = 218,                       ///< Enumerator for ::urCommandBufferRetainCommandExp
-    UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP = 219,                      ///< Enumerator for ::urCommandBufferReleaseCommandExp
-    UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP = 220,                 ///< Enumerator for ::urCommandBufferUpdateKernelLaunchExp
-    UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 221,                             ///< Enumerator for ::urCommandBufferGetInfoExp
-    UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP = 222,                     ///< Enumerator for ::urCommandBufferCommandGetInfoExp
-    UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP = 223,                         ///< Enumerator for ::urEnqueueTimestampRecordingExp
-    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP = 224,                        ///< Enumerator for ::urEnqueueKernelLaunchCustomExp
-    UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE = 225,                    ///< Enumerator for ::urKernelGetSuggestedLocalWorkSize
+    UR_FUNCTION_CONTEXT_CREATE = 1,                                       ///< Enumerator for ::urContextCreate
+    UR_FUNCTION_CONTEXT_RETAIN = 2,                                       ///< Enumerator for ::urContextRetain
+    UR_FUNCTION_CONTEXT_RELEASE = 3,                                      ///< Enumerator for ::urContextRelease
+    UR_FUNCTION_CONTEXT_GET_INFO = 4,                                     ///< Enumerator for ::urContextGetInfo
+    UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE = 5,                            ///< Enumerator for ::urContextGetNativeHandle
+    UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE = 6,                    ///< Enumerator for ::urContextCreateWithNativeHandle
+    UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER = 7,                         ///< Enumerator for ::urContextSetExtendedDeleter
+    UR_FUNCTION_DEVICE_GET = 8,                                           ///< Enumerator for ::urDeviceGet
+    UR_FUNCTION_DEVICE_GET_INFO = 9,                                      ///< Enumerator for ::urDeviceGetInfo
+    UR_FUNCTION_DEVICE_RETAIN = 10,                                       ///< Enumerator for ::urDeviceRetain
+    UR_FUNCTION_DEVICE_RELEASE = 11,                                      ///< Enumerator for ::urDeviceRelease
+    UR_FUNCTION_DEVICE_PARTITION = 12,                                    ///< Enumerator for ::urDevicePartition
+    UR_FUNCTION_DEVICE_SELECT_BINARY = 13,                                ///< Enumerator for ::urDeviceSelectBinary
+    UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE = 14,                            ///< Enumerator for ::urDeviceGetNativeHandle
+    UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE = 15,                    ///< Enumerator for ::urDeviceCreateWithNativeHandle
+    UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS = 16,                        ///< Enumerator for ::urDeviceGetGlobalTimestamps
+    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH = 17,                               ///< Enumerator for ::urEnqueueKernelLaunch
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT = 18,                                 ///< Enumerator for ::urEnqueueEventsWait
+    UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER = 19,                    ///< Enumerator for ::urEnqueueEventsWaitWithBarrier
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ = 20,                             ///< Enumerator for ::urEnqueueMemBufferRead
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE = 21,                            ///< Enumerator for ::urEnqueueMemBufferWrite
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT = 22,                        ///< Enumerator for ::urEnqueueMemBufferReadRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT = 23,                       ///< Enumerator for ::urEnqueueMemBufferWriteRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY = 24,                             ///< Enumerator for ::urEnqueueMemBufferCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT = 25,                        ///< Enumerator for ::urEnqueueMemBufferCopyRect
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL = 26,                             ///< Enumerator for ::urEnqueueMemBufferFill
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ = 27,                              ///< Enumerator for ::urEnqueueMemImageRead
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE = 28,                             ///< Enumerator for ::urEnqueueMemImageWrite
+    UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY = 29,                              ///< Enumerator for ::urEnqueueMemImageCopy
+    UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP = 30,                              ///< Enumerator for ::urEnqueueMemBufferMap
+    UR_FUNCTION_ENQUEUE_MEM_UNMAP = 31,                                   ///< Enumerator for ::urEnqueueMemUnmap
+    UR_FUNCTION_ENQUEUE_USM_FILL = 32,                                    ///< Enumerator for ::urEnqueueUSMFill
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY = 33,                                  ///< Enumerator for ::urEnqueueUSMMemcpy
+    UR_FUNCTION_ENQUEUE_USM_PREFETCH = 34,                                ///< Enumerator for ::urEnqueueUSMPrefetch
+    UR_FUNCTION_ENQUEUE_USM_ADVISE = 35,                                  ///< Enumerator for ::urEnqueueUSMAdvise
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE = 38,                ///< Enumerator for ::urEnqueueDeviceGlobalVariableWrite
+    UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ = 39,                 ///< Enumerator for ::urEnqueueDeviceGlobalVariableRead
+    UR_FUNCTION_EVENT_GET_INFO = 40,                                      ///< Enumerator for ::urEventGetInfo
+    UR_FUNCTION_EVENT_GET_PROFILING_INFO = 41,                            ///< Enumerator for ::urEventGetProfilingInfo
+    UR_FUNCTION_EVENT_WAIT = 42,                                          ///< Enumerator for ::urEventWait
+    UR_FUNCTION_EVENT_RETAIN = 43,                                        ///< Enumerator for ::urEventRetain
+    UR_FUNCTION_EVENT_RELEASE = 44,                                       ///< Enumerator for ::urEventRelease
+    UR_FUNCTION_EVENT_GET_NATIVE_HANDLE = 45,                             ///< Enumerator for ::urEventGetNativeHandle
+    UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE = 46,                     ///< Enumerator for ::urEventCreateWithNativeHandle
+    UR_FUNCTION_EVENT_SET_CALLBACK = 47,                                  ///< Enumerator for ::urEventSetCallback
+    UR_FUNCTION_KERNEL_CREATE = 48,                                       ///< Enumerator for ::urKernelCreate
+    UR_FUNCTION_KERNEL_SET_ARG_VALUE = 49,                                ///< Enumerator for ::urKernelSetArgValue
+    UR_FUNCTION_KERNEL_SET_ARG_LOCAL = 50,                                ///< Enumerator for ::urKernelSetArgLocal
+    UR_FUNCTION_KERNEL_GET_INFO = 51,                                     ///< Enumerator for ::urKernelGetInfo
+    UR_FUNCTION_KERNEL_GET_GROUP_INFO = 52,                               ///< Enumerator for ::urKernelGetGroupInfo
+    UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO = 53,                           ///< Enumerator for ::urKernelGetSubGroupInfo
+    UR_FUNCTION_KERNEL_RETAIN = 54,                                       ///< Enumerator for ::urKernelRetain
+    UR_FUNCTION_KERNEL_RELEASE = 55,                                      ///< Enumerator for ::urKernelRelease
+    UR_FUNCTION_KERNEL_SET_ARG_POINTER = 56,                              ///< Enumerator for ::urKernelSetArgPointer
+    UR_FUNCTION_KERNEL_SET_EXEC_INFO = 57,                                ///< Enumerator for ::urKernelSetExecInfo
+    UR_FUNCTION_KERNEL_SET_ARG_SAMPLER = 58,                              ///< Enumerator for ::urKernelSetArgSampler
+    UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ = 59,                              ///< Enumerator for ::urKernelSetArgMemObj
+    UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS = 60,                 ///< Enumerator for ::urKernelSetSpecializationConstants
+    UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE = 61,                            ///< Enumerator for ::urKernelGetNativeHandle
+    UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE = 62,                    ///< Enumerator for ::urKernelCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE = 63,                                    ///< Enumerator for ::urMemImageCreate
+    UR_FUNCTION_MEM_BUFFER_CREATE = 64,                                   ///< Enumerator for ::urMemBufferCreate
+    UR_FUNCTION_MEM_RETAIN = 65,                                          ///< Enumerator for ::urMemRetain
+    UR_FUNCTION_MEM_RELEASE = 66,                                         ///< Enumerator for ::urMemRelease
+    UR_FUNCTION_MEM_BUFFER_PARTITION = 67,                                ///< Enumerator for ::urMemBufferPartition
+    UR_FUNCTION_MEM_GET_NATIVE_HANDLE = 68,                               ///< Enumerator for ::urMemGetNativeHandle
+    UR_FUNCTION_ENQUEUE_READ_HOST_PIPE = 69,                              ///< Enumerator for ::urEnqueueReadHostPipe
+    UR_FUNCTION_MEM_GET_INFO = 70,                                        ///< Enumerator for ::urMemGetInfo
+    UR_FUNCTION_MEM_IMAGE_GET_INFO = 71,                                  ///< Enumerator for ::urMemImageGetInfo
+    UR_FUNCTION_PLATFORM_GET = 72,                                        ///< Enumerator for ::urPlatformGet
+    UR_FUNCTION_PLATFORM_GET_INFO = 73,                                   ///< Enumerator for ::urPlatformGetInfo
+    UR_FUNCTION_PLATFORM_GET_API_VERSION = 74,                            ///< Enumerator for ::urPlatformGetApiVersion
+    UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE = 75,                          ///< Enumerator for ::urPlatformGetNativeHandle
+    UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE = 76,                  ///< Enumerator for ::urPlatformCreateWithNativeHandle
+    UR_FUNCTION_PROGRAM_CREATE_WITH_IL = 78,                              ///< Enumerator for ::urProgramCreateWithIL
+    UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY = 79,                          ///< Enumerator for ::urProgramCreateWithBinary
+    UR_FUNCTION_PROGRAM_BUILD = 80,                                       ///< Enumerator for ::urProgramBuild
+    UR_FUNCTION_PROGRAM_COMPILE = 81,                                     ///< Enumerator for ::urProgramCompile
+    UR_FUNCTION_PROGRAM_LINK = 82,                                        ///< Enumerator for ::urProgramLink
+    UR_FUNCTION_PROGRAM_RETAIN = 83,                                      ///< Enumerator for ::urProgramRetain
+    UR_FUNCTION_PROGRAM_RELEASE = 84,                                     ///< Enumerator for ::urProgramRelease
+    UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER = 85,                        ///< Enumerator for ::urProgramGetFunctionPointer
+    UR_FUNCTION_PROGRAM_GET_INFO = 86,                                    ///< Enumerator for ::urProgramGetInfo
+    UR_FUNCTION_PROGRAM_GET_BUILD_INFO = 87,                              ///< Enumerator for ::urProgramGetBuildInfo
+    UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 88,                ///< Enumerator for ::urProgramSetSpecializationConstants
+    UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE = 89,                           ///< Enumerator for ::urProgramGetNativeHandle
+    UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE = 90,                   ///< Enumerator for ::urProgramCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_GET_INFO = 91,                                      ///< Enumerator for ::urQueueGetInfo
+    UR_FUNCTION_QUEUE_CREATE = 92,                                        ///< Enumerator for ::urQueueCreate
+    UR_FUNCTION_QUEUE_RETAIN = 93,                                        ///< Enumerator for ::urQueueRetain
+    UR_FUNCTION_QUEUE_RELEASE = 94,                                       ///< Enumerator for ::urQueueRelease
+    UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE = 95,                             ///< Enumerator for ::urQueueGetNativeHandle
+    UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE = 96,                     ///< Enumerator for ::urQueueCreateWithNativeHandle
+    UR_FUNCTION_QUEUE_FINISH = 97,                                        ///< Enumerator for ::urQueueFinish
+    UR_FUNCTION_QUEUE_FLUSH = 98,                                         ///< Enumerator for ::urQueueFlush
+    UR_FUNCTION_SAMPLER_CREATE = 101,                                     ///< Enumerator for ::urSamplerCreate
+    UR_FUNCTION_SAMPLER_RETAIN = 102,                                     ///< Enumerator for ::urSamplerRetain
+    UR_FUNCTION_SAMPLER_RELEASE = 103,                                    ///< Enumerator for ::urSamplerRelease
+    UR_FUNCTION_SAMPLER_GET_INFO = 104,                                   ///< Enumerator for ::urSamplerGetInfo
+    UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE = 105,                          ///< Enumerator for ::urSamplerGetNativeHandle
+    UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE = 106,                  ///< Enumerator for ::urSamplerCreateWithNativeHandle
+    UR_FUNCTION_USM_HOST_ALLOC = 107,                                     ///< Enumerator for ::urUSMHostAlloc
+    UR_FUNCTION_USM_DEVICE_ALLOC = 108,                                   ///< Enumerator for ::urUSMDeviceAlloc
+    UR_FUNCTION_USM_SHARED_ALLOC = 109,                                   ///< Enumerator for ::urUSMSharedAlloc
+    UR_FUNCTION_USM_FREE = 110,                                           ///< Enumerator for ::urUSMFree
+    UR_FUNCTION_USM_GET_MEM_ALLOC_INFO = 111,                             ///< Enumerator for ::urUSMGetMemAllocInfo
+    UR_FUNCTION_USM_POOL_CREATE = 112,                                    ///< Enumerator for ::urUSMPoolCreate
+    UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP = 113,                          ///< Enumerator for ::urCommandBufferCreateExp
+    UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION = 114,                        ///< Enumerator for ::urPlatformGetBackendOption
+    UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE = 115,               ///< Enumerator for ::urMemBufferCreateWithNativeHandle
+    UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE = 116,                ///< Enumerator for ::urMemImageCreateWithNativeHandle
+    UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE = 117,                            ///< Enumerator for ::urEnqueueWriteHostPipe
+    UR_FUNCTION_USM_POOL_RETAIN = 118,                                    ///< Enumerator for ::urUSMPoolRetain
+    UR_FUNCTION_USM_POOL_RELEASE = 119,                                   ///< Enumerator for ::urUSMPoolRelease
+    UR_FUNCTION_USM_POOL_GET_INFO = 120,                                  ///< Enumerator for ::urUSMPoolGetInfo
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP = 121,                          ///< Enumerator for ::urCommandBufferRetainExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP = 122,                         ///< Enumerator for ::urCommandBufferReleaseExp
+    UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP = 123,                        ///< Enumerator for ::urCommandBufferFinalizeExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP = 125,            ///< Enumerator for ::urCommandBufferAppendKernelLaunchExp
+    UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 128,                         ///< Enumerator for ::urCommandBufferEnqueueExp
+    UR_FUNCTION_USM_PITCHED_ALLOC_EXP = 132,                              ///< Enumerator for ::urUSMPitchedAllocExp
+    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP = 133, ///< Enumerator for ::urBindlessImagesUnsampledImageHandleDestroyExp
+    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP = 134,   ///< Enumerator for ::urBindlessImagesSampledImageHandleDestroyExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP = 135,                 ///< Enumerator for ::urBindlessImagesImageAllocateExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP = 136,                     ///< Enumerator for ::urBindlessImagesImageFreeExp
+    UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP = 137,         ///< Enumerator for ::urBindlessImagesUnsampledImageCreateExp
+    UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP = 138,           ///< Enumerator for ::urBindlessImagesSampledImageCreateExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP = 139,                     ///< Enumerator for ::urBindlessImagesImageCopyExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP = 140,                 ///< Enumerator for ::urBindlessImagesImageGetInfoExp
+    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP = 141,               ///< Enumerator for ::urBindlessImagesMipmapGetLevelExp
+    UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142,                    ///< Enumerator for ::urBindlessImagesMipmapFreeExp
+    UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144,             ///< Enumerator for ::urBindlessImagesMapExternalArrayExp
+    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145,                ///< Enumerator for ::urBindlessImagesReleaseInteropExp
+    UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147,     ///< Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
+    UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,        ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
+    UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,      ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
+    UR_FUNCTION_ENQUEUE_USM_FILL_2D = 151,                                ///< Enumerator for ::urEnqueueUSMFill2D
+    UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D = 152,                              ///< Enumerator for ::urEnqueueUSMMemcpy2D
+    UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO = 153,                   ///< Enumerator for ::urVirtualMemGranularityGetInfo
+    UR_FUNCTION_VIRTUAL_MEM_RESERVE = 154,                                ///< Enumerator for ::urVirtualMemReserve
+    UR_FUNCTION_VIRTUAL_MEM_FREE = 155,                                   ///< Enumerator for ::urVirtualMemFree
+    UR_FUNCTION_VIRTUAL_MEM_MAP = 156,                                    ///< Enumerator for ::urVirtualMemMap
+    UR_FUNCTION_VIRTUAL_MEM_UNMAP = 157,                                  ///< Enumerator for ::urVirtualMemUnmap
+    UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS = 158,                             ///< Enumerator for ::urVirtualMemSetAccess
+    UR_FUNCTION_VIRTUAL_MEM_GET_INFO = 159,                               ///< Enumerator for ::urVirtualMemGetInfo
+    UR_FUNCTION_PHYSICAL_MEM_CREATE = 160,                                ///< Enumerator for ::urPhysicalMemCreate
+    UR_FUNCTION_PHYSICAL_MEM_RETAIN = 161,                                ///< Enumerator for ::urPhysicalMemRetain
+    UR_FUNCTION_PHYSICAL_MEM_RELEASE = 162,                               ///< Enumerator for ::urPhysicalMemRelease
+    UR_FUNCTION_USM_IMPORT_EXP = 163,                                     ///< Enumerator for ::urUSMImportExp
+    UR_FUNCTION_USM_RELEASE_EXP = 164,                                    ///< Enumerator for ::urUSMReleaseExp
+    UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP = 165,                     ///< Enumerator for ::urUsmP2PEnablePeerAccessExp
+    UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP = 166,                    ///< Enumerator for ::urUsmP2PDisablePeerAccessExp
+    UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP = 167,                   ///< Enumerator for ::urUsmP2PPeerAccessGetInfoExp
+    UR_FUNCTION_LOADER_CONFIG_CREATE = 172,                               ///< Enumerator for ::urLoaderConfigCreate
+    UR_FUNCTION_LOADER_CONFIG_RELEASE = 173,                              ///< Enumerator for ::urLoaderConfigRelease
+    UR_FUNCTION_LOADER_CONFIG_RETAIN = 174,                               ///< Enumerator for ::urLoaderConfigRetain
+    UR_FUNCTION_LOADER_CONFIG_GET_INFO = 175,                             ///< Enumerator for ::urLoaderConfigGetInfo
+    UR_FUNCTION_LOADER_CONFIG_ENABLE_LAYER = 176,                         ///< Enumerator for ::urLoaderConfigEnableLayer
+    UR_FUNCTION_ADAPTER_RELEASE = 177,                                    ///< Enumerator for ::urAdapterRelease
+    UR_FUNCTION_ADAPTER_GET = 178,                                        ///< Enumerator for ::urAdapterGet
+    UR_FUNCTION_ADAPTER_RETAIN = 179,                                     ///< Enumerator for ::urAdapterRetain
+    UR_FUNCTION_ADAPTER_GET_LAST_ERROR = 180,                             ///< Enumerator for ::urAdapterGetLastError
+    UR_FUNCTION_ADAPTER_GET_INFO = 181,                                   ///< Enumerator for ::urAdapterGetInfo
+    UR_FUNCTION_PROGRAM_BUILD_EXP = 197,                                  ///< Enumerator for ::urProgramBuildExp
+    UR_FUNCTION_PROGRAM_COMPILE_EXP = 198,                                ///< Enumerator for ::urProgramCompileExp
+    UR_FUNCTION_PROGRAM_LINK_EXP = 199,                                   ///< Enumerator for ::urProgramLinkExp
+    UR_FUNCTION_LOADER_CONFIG_SET_CODE_LOCATION_CALLBACK = 200,           ///< Enumerator for ::urLoaderConfigSetCodeLocationCallback
+    UR_FUNCTION_LOADER_INIT = 201,                                        ///< Enumerator for ::urLoaderInit
+    UR_FUNCTION_LOADER_TEAR_DOWN = 202,                                   ///< Enumerator for ::urLoaderTearDown
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP = 203,               ///< Enumerator for ::urCommandBufferAppendUSMMemcpyExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP = 204,                 ///< Enumerator for ::urCommandBufferAppendUSMFillExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP = 205,          ///< Enumerator for ::urCommandBufferAppendMemBufferCopyExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP = 206,         ///< Enumerator for ::urCommandBufferAppendMemBufferWriteExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP = 207,          ///< Enumerator for ::urCommandBufferAppendMemBufferReadExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP = 208,     ///< Enumerator for ::urCommandBufferAppendMemBufferCopyRectExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP = 209,    ///< Enumerator for ::urCommandBufferAppendMemBufferWriteRectExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP = 210,     ///< Enumerator for ::urCommandBufferAppendMemBufferReadRectExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP = 211,          ///< Enumerator for ::urCommandBufferAppendMemBufferFillExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 212,             ///< Enumerator for ::urCommandBufferAppendUSMPrefetchExp
+    UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 213,               ///< Enumerator for ::urCommandBufferAppendUSMAdviseExp
+    UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP = 214,              ///< Enumerator for ::urEnqueueCooperativeKernelLaunchExp
+    UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP = 215,     ///< Enumerator for ::urKernelSuggestMaxCooperativeGroupCountExp
+    UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER = 216,                ///< Enumerator for ::urProgramGetGlobalVariablePointer
+    UR_FUNCTION_DEVICE_GET_SELECTED = 217,                                ///< Enumerator for ::urDeviceGetSelected
+    UR_FUNCTION_COMMAND_BUFFER_RETAIN_COMMAND_EXP = 218,                  ///< Enumerator for ::urCommandBufferRetainCommandExp
+    UR_FUNCTION_COMMAND_BUFFER_RELEASE_COMMAND_EXP = 219,                 ///< Enumerator for ::urCommandBufferReleaseCommandExp
+    UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP = 220,            ///< Enumerator for ::urCommandBufferUpdateKernelLaunchExp
+    UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 221,                        ///< Enumerator for ::urCommandBufferGetInfoExp
+    UR_FUNCTION_COMMAND_BUFFER_COMMAND_GET_INFO_EXP = 222,                ///< Enumerator for ::urCommandBufferCommandGetInfoExp
+    UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP = 223,                    ///< Enumerator for ::urEnqueueTimestampRecordingExp
+    UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP = 224,                   ///< Enumerator for ::urEnqueueKernelLaunchCustomExp
+    UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE = 225,               ///< Enumerator for ::urKernelGetSuggestedLocalWorkSize
+    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP = 226,         ///< Enumerator for ::urBindlessImagesImportExternalMemoryExp
+    UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP = 227,      ///< Enumerator for ::urBindlessImagesImportExternalSemaphoreExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7336,6 +7336,30 @@ typedef enum ur_exp_sampler_cubemap_filter_mode_t {
 } ur_exp_sampler_cubemap_filter_mode_t;
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Dictates the type of external memory handle.
+typedef enum ur_exp_external_mem_type_t {
+    UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD = 0,              ///< Opaque file descriptor
+    UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT = 1,               ///< Win32 NT handle
+    UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE = 2, ///< Win32 NT DirectX 12 resource handle
+    /// @cond
+    UR_EXP_EXTERNAL_MEM_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_external_mem_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Dictates the type of external semaphore handle.
+typedef enum ur_exp_external_semaphore_type_t {
+    UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD = 0,           ///< Opaque file descriptor
+    UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT = 1,            ///< Win32 NT handle
+    UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE = 2, ///< Win32 NT DirectX 12 fence handle
+    /// @cond
+    UR_EXP_EXTERNAL_SEMAPHORE_TYPE_FORCE_UINT32 = 0x7fffffff
+    /// @endcond
+
+} ur_exp_external_semaphore_type_t;
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief File descriptor
 typedef struct ur_exp_file_descriptor_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
@@ -7803,7 +7827,7 @@ urBindlessImagesMipmapFreeExp(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import external memory in the form of a file descriptor
+/// @brief Import external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -7817,6 +7841,8 @@ urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropMemDesc`
 ///         + `NULL == phInteropMem`
@@ -7824,10 +7850,11 @@ urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportOpaqueFDExp(
+urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext,               ///< [in] handle of the context object
     ur_device_handle_t hDevice,                 ///< [in] handle of the device object
     size_t size,                                ///< [in] size of the external memory
+    ur_exp_external_mem_type_t memHandleType,   ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t *phInteropMem   ///< [out] interop memory handle to the external memory
 );
@@ -7891,7 +7918,7 @@ urBindlessImagesReleaseInteropExp(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import an external semaphore in the form of a file descriptor
+/// @brief Import an external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -7905,15 +7932,18 @@ urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropSemaphoreDesc`
 ///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext,                           ///< [in] handle of the context object
     ur_device_handle_t hDevice,                             ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t semHandleType,         ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *phInteropSemaphore   ///< [out] interop semaphore handle to the external semaphore
 );
@@ -7964,6 +7994,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
+    bool hasWaitValue,                            ///< [in] indicates whether the samephore is capable and should wait on a
+                                                  ///< certain value.
+                                                  ///< Otherwise the semaphore is treated like a binary state, and
+                                                  ///< `waitValue` is ignored.
+    uint64_t waitValue,                           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                   ///< events that must be complete before this command can be executed.
@@ -7996,6 +8031,11 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
+    bool hasSignalValue,                          ///< [in] indicates whether the samephore is capable and should signal on a
+                                                  ///< certain value.
+                                                  ///< Otherwise the semaphore is treated like a binary state, and
+                                                  ///< `signalValue` is ignored.
+    uint64_t signalValue,                         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
     const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
                                                   ///< events that must be complete before this command can be executed.
@@ -10992,16 +11032,17 @@ typedef struct ur_bindless_images_mipmap_free_exp_params_t {
 } ur_bindless_images_mipmap_free_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urBindlessImagesImportOpaqueFDExp
+/// @brief Function parameters for urBindlessImagesImportExternalMemoryExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_bindless_images_import_opaque_fd_exp_params_t {
+typedef struct ur_bindless_images_import_external_memory_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
     size_t *psize;
+    ur_exp_external_mem_type_t *pmemHandleType;
     ur_exp_interop_mem_desc_t **ppInteropMemDesc;
     ur_exp_interop_mem_handle_t **pphInteropMem;
-} ur_bindless_images_import_opaque_fd_exp_params_t;
+} ur_bindless_images_import_external_memory_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesMapExternalArrayExp
@@ -11027,15 +11068,16 @@ typedef struct ur_bindless_images_release_interop_exp_params_t {
 } ur_bindless_images_release_interop_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
+/// @brief Function parameters for urBindlessImagesImportExternalSemaphoreExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t {
+typedef struct ur_bindless_images_import_external_semaphore_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
+    ur_exp_external_semaphore_type_t *psemHandleType;
     ur_exp_interop_semaphore_desc_t **ppInteropSemaphoreDesc;
     ur_exp_interop_semaphore_handle_t **pphInteropSemaphore;
-} ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t;
+} ur_bindless_images_import_external_semaphore_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesDestroyExternalSemaphoreExp
@@ -11054,6 +11096,8 @@ typedef struct ur_bindless_images_destroy_external_semaphore_exp_params_t {
 typedef struct ur_bindless_images_wait_external_semaphore_exp_params_t {
     ur_queue_handle_t *phQueue;
     ur_exp_interop_semaphore_handle_t *phSemaphore;
+    bool *phasWaitValue;
+    uint64_t *pwaitValue;
     uint32_t *pnumEventsInWaitList;
     const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;
@@ -11066,6 +11110,8 @@ typedef struct ur_bindless_images_wait_external_semaphore_exp_params_t {
 typedef struct ur_bindless_images_signal_external_semaphore_exp_params_t {
     ur_queue_handle_t *phQueue;
     ur_exp_interop_semaphore_handle_t *phSemaphore;
+    bool *phasSignalValue;
+    uint64_t *psignalValue;
     uint32_t *pnumEventsInWaitList;
     const ur_event_handle_t **pphEventWaitList;
     ur_event_handle_t **pphEvent;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1604,11 +1604,12 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMipmapFreeExp_t)(
     ur_exp_image_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urBindlessImagesImportOpaqueFDExp
-typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportOpaqueFDExp_t)(
+/// @brief Function-pointer for urBindlessImagesImportExternalMemoryExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalMemoryExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
     size_t,
+    ur_exp_external_mem_type_t,
     ur_exp_interop_mem_desc_t *,
     ur_exp_interop_mem_handle_t *);
 
@@ -1630,10 +1631,11 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseInteropExp_t)(
     ur_exp_interop_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t)(
+/// @brief Function-pointer for urBindlessImagesImportExternalSemaphoreExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
+    ur_exp_external_semaphore_type_t,
     ur_exp_interop_semaphore_desc_t *,
     ur_exp_interop_semaphore_handle_t *);
 
@@ -1649,6 +1651,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesDestroyExternalSemaphoreExp_
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesWaitExternalSemaphoreExp_t)(
     ur_queue_handle_t,
     ur_exp_interop_semaphore_handle_t,
+    bool,
+    uint64_t,
     uint32_t,
     const ur_event_handle_t *,
     ur_event_handle_t *);
@@ -1658,6 +1662,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesWaitExternalSemaphoreExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSignalExternalSemaphoreExp_t)(
     ur_queue_handle_t,
     ur_exp_interop_semaphore_handle_t,
+    bool,
+    uint64_t,
     uint32_t,
     const ur_event_handle_t *,
     ur_event_handle_t *);
@@ -1675,10 +1681,10 @@ typedef struct ur_bindless_images_exp_dditable_t {
     ur_pfnBindlessImagesImageGetInfoExp_t pfnImageGetInfoExp;
     ur_pfnBindlessImagesMipmapGetLevelExp_t pfnMipmapGetLevelExp;
     ur_pfnBindlessImagesMipmapFreeExp_t pfnMipmapFreeExp;
-    ur_pfnBindlessImagesImportOpaqueFDExp_t pfnImportOpaqueFDExp;
+    ur_pfnBindlessImagesImportExternalMemoryExp_t pfnImportExternalMemoryExp;
     ur_pfnBindlessImagesMapExternalArrayExp_t pfnMapExternalArrayExp;
     ur_pfnBindlessImagesReleaseInteropExp_t pfnReleaseInteropExp;
-    ur_pfnBindlessImagesImportExternalSemaphoreOpaqueFDExp_t pfnImportExternalSemaphoreOpaqueFDExp;
+    ur_pfnBindlessImagesImportExternalSemaphoreExp_t pfnImportExternalSemaphoreExp;
     ur_pfnBindlessImagesDestroyExternalSemaphoreExp_t pfnDestroyExternalSemaphoreExp;
     ur_pfnBindlessImagesWaitExternalSemaphoreExp_t pfnWaitExternalSemaphoreExp;
     ur_pfnBindlessImagesSignalExternalSemaphoreExp_t pfnSignalExternalSemaphoreExp;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -891,6 +891,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpImageCopyFlags(enum ur_exp_image_c
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerCubemapFilterMode(enum ur_exp_sampler_cubemap_filter_mode_t value, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_exp_external_mem_type_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpExternalMemType(enum ur_exp_external_mem_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_exp_external_semaphore_type_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpExternalSemaphoreType(enum ur_exp_external_semaphore_type_t value, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_exp_file_descriptor_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -2075,12 +2091,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMipmapGetLevelExpParams
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMipmapFreeExpParams(const struct ur_bindless_images_mipmap_free_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_import_opaque_fd_exp_params_t struct
+/// @brief Print ur_bindless_images_import_external_memory_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportOpaqueFdExpParams(const struct ur_bindless_images_import_opaque_fd_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalMemoryExpParams(const struct ur_bindless_images_import_external_memory_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_map_external_array_exp_params_t struct
@@ -2099,12 +2115,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMapExternalArrayExpPara
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseInteropExpParams(const struct ur_bindless_images_release_interop_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t struct
+/// @brief Print ur_bindless_images_import_external_semaphore_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalSemaphoreOpaqueFdExpParams(const struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalSemaphoreExpParams(const struct ur_bindless_images_import_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_destroy_external_semaphore_exp_params_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -326,6 +326,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_map_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_usm_migration_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_image_copy_flag_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_filter_mode_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_external_mem_type_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_external_semaphore_type_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_file_descriptor_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_win32_handle_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_mip_properties_t params);
@@ -743,17 +745,11 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP";
         break;
-    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP:
-        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP";
-        break;
     case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP";
         break;
     case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP";
-        break;
-    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP:
-        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP";
         break;
     case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP";
@@ -931,6 +927,12 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
         break;
     case UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE:
         os << "UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE";
+        break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP";
+        break;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP";
         break;
     default:
         os << "unknown enumerator";
@@ -9313,6 +9315,48 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_exp_sampler_cubemap_fi
     return os;
 }
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_exp_external_mem_type_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_external_mem_type_t value) {
+    switch (value) {
+    case UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD:
+        os << "UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD";
+        break;
+    case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT:
+        os << "UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT";
+        break;
+    case UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE:
+        os << "UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_exp_external_semaphore_type_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, enum ur_exp_external_semaphore_type_t value) {
+    switch (value) {
+    case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD:
+        os << "UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD";
+        break;
+    case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT:
+        os << "UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT";
+        break;
+    case UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE:
+        os << "UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE";
+        break;
+    default:
+        os << "unknown enumerator";
+        break;
+    }
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_exp_file_descriptor_t type
 /// @returns
 ///     std::ostream &
@@ -14760,10 +14804,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_bindless_images_import_opaque_fd_exp_params_t type
+/// @brief Print operator for the ur_bindless_images_import_external_memory_exp_params_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_import_opaque_fd_exp_params_t *params) {
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_import_external_memory_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14780,6 +14824,11 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ".size = ";
 
     os << *(params->psize);
+
+    os << ", ";
+    os << ".memHandleType = ";
+
+    os << *(params->pmemHandleType);
 
     os << ", ";
     os << ".pInteropMemDesc = ";
@@ -14867,10 +14916,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t type
+/// @brief Print operator for the ur_bindless_images_import_external_semaphore_exp_params_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t *params) {
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_import_external_semaphore_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -14882,6 +14931,11 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     ur::details::printPtr(os,
                           *(params->phDevice));
+
+    os << ", ";
+    os << ".semHandleType = ";
+
+    os << *(params->psemHandleType);
 
     os << ", ";
     os << ".pInteropSemaphoreDesc = ";
@@ -14942,6 +14996,16 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->phSemaphore));
 
     os << ", ";
+    os << ".hasWaitValue = ";
+
+    os << *(params->phasWaitValue);
+
+    os << ", ";
+    os << ".waitValue = ";
+
+    os << *(params->pwaitValue);
+
+    os << ", ";
     os << ".numEventsInWaitList = ";
 
     os << *(params->pnumEventsInWaitList);
@@ -14983,6 +15047,16 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 
     ur::details::printPtr(os,
                           *(params->phSemaphore));
+
+    os << ", ";
+    os << ".hasSignalValue = ";
+
+    os << *(params->phasSignalValue);
+
+    os << ", ";
+    os << ".signalValue = ";
+
+    os << *(params->psignalValue);
 
     os << ", ";
     os << ".numEventsInWaitList = ";
@@ -17417,8 +17491,8 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     case UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP: {
         os << (const struct ur_bindless_images_mipmap_free_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP: {
-        os << (const struct ur_bindless_images_import_opaque_fd_exp_params_t *)params;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP: {
+        os << (const struct ur_bindless_images_import_external_memory_exp_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP: {
         os << (const struct ur_bindless_images_map_external_array_exp_params_t *)params;
@@ -17426,8 +17500,8 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP: {
         os << (const struct ur_bindless_images_release_interop_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP: {
-        os << (const struct ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t *)params;
+    case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP: {
+        os << (const struct ur_bindless_images_import_external_semaphore_exp_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP: {
         os << (const struct ur_bindless_images_destroy_external_semaphore_exp_params_t *)params;

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -112,6 +112,16 @@ Enums
     * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_SEAMLESS
     * ${X}_EXP_SAMPLER_CUBEMAP_FILTER_MODE_DISJOINTED
 
+* ${x}_exp_external_mem_type_t
+    * ${X}_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD
+    * ${X}_EXP_EXTERNAL_MEM_TYPE_WIN32_NT
+    * ${X}_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE
+
+* ${x}_exp_external_semaphore_type_t
+    * ${X}_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD
+    * ${X}_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT
+    * ${X}_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE
+
 * ${x}_function_t
     * ${X}_FUNCTION_USM_PITCHED_ALLOC_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP
@@ -124,10 +134,10 @@ Enums
     * ${X}_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP
-    * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP
+    * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP
-    * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP
+    * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
@@ -167,10 +177,10 @@ Functions
    * ${x}BindlessImagesMipmapFreeExp
 
 * Interop
-   * ${x}BindlessImagesImportOpaqueFDExp
+   * ${x}BindlessImagesImportExternalMemoryExp
    * ${x}BindlessImagesMapExternalArrayExp
    * ${x}BindlessImagesReleaseInteropExp
-   * ${x}BindlessImagesImportExternalSemaphoreOpaqueFDExp
+   * ${x}BindlessImagesImportExternalSemaphoreExp
    * ${x}BindlessImagesDestroyExternalSemaphoreExp
    * ${x}BindlessImagesWaitExternalSemaphoreExp
    * ${x}BindlessImagesSignalExternalSemaphoreExp
@@ -210,6 +220,23 @@ Changelog
 +----------+-------------------------------------------------------------+
 | 12.0     | Added image arrays to list of supported bindless images     |
 +----------+-------------------------------------------------------------+
+| 13.0     || Interop import API has been adapted to cater to multiple   |
+|          ||  external memory and semaphore handle types                |
+|          || Removed the following APIs:                                |
+|          ||  - ImportExternalOpaqueFDExp                               |
+|          ||  - ImportExternalSemaphoreOpaqueFDExp                      |
+|          || Added the following APIs:                                  |
+|          ||  - ImportExternalMemoryExp                                 |
+|          ||  - ImportExternalSemaphoreExp                              |
+|          || Added the following enums:                                 |
+|          ||  - exp_external_mem_type_t                                 |
+|          ||  - exp_external_semaphore_type_t                           |
+|          || Semaphore oparations now take value parameters which set   |
+|          || the state the semaphore should wait on or signal.          |
+|          || Introduced resource enums for DX12 interop:                |
+|          ||  - ${X}_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE       |
+|          ||  - ${X}_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE    |
++------------------------------------------------------------------------+
 
 Contributors
 --------------------------------------------------------------------------------

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -181,6 +181,30 @@ etors:
   - name: SEAMLESS
     desc: "Enable Seamless filtering"
 --- #--------------------------------------------------------------------------
+type: enum
+desc: "Dictates the type of external memory handle."
+class: $xBindlessImages
+name: $x_exp_external_mem_type_t
+etors:
+  - name: OPAQUE_FD
+    desc: "Opaque file descriptor"
+  - name: WIN32_NT
+    desc: "Win32 NT handle"
+  - name: WIN32_NT_DX12_RESOURCE
+    desc: "Win32 NT DirectX 12 resource handle"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Dictates the type of external semaphore handle."
+class: $xBindlessImages
+name: $x_exp_external_semaphore_type_t
+etors:
+  - name: OPAQUE_FD
+    desc: "Opaque file descriptor"
+  - name: WIN32_NT
+    desc: "Win32 NT handle"
+  - name: WIN32_NT_DX12_FENCE
+    desc: "Win32 NT DirectX 12 fence handle"
+--- #--------------------------------------------------------------------------
 type: struct
 desc: "File descriptor"
 name: $x_exp_file_descriptor_t
@@ -624,9 +648,9 @@ returns:
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Import external memory in the form of a file descriptor"
+desc: "Import external memory"
 class: $xBindlessImages
-name: ImportOpaqueFDExp
+name: ImportExternalMemoryExp
 ordinal: "0"
 analogue:
     - "**cuImportExternalMemory**"
@@ -640,6 +664,9 @@ params:
     - type: size_t
       name: size
       desc: "[in] size of the external memory"
+    - type: $x_exp_external_mem_type_t
+      name: memHandleType
+      desc: "[in] type of external memory handle"
     - type: $x_exp_interop_mem_desc_t*
       name: pInteropMemDesc
       desc: "[in] the interop memory descriptor"
@@ -706,9 +733,9 @@ returns:
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Import an external semaphore in the form of a file descriptor"
+desc: "Import an external semaphore"
 class: $xBindlessImages
-name: ImportExternalSemaphoreOpaqueFDExp
+name: ImportExternalSemaphoreExp
 ordinal: "0"
 analogue:
     - "**cuImportExternalSemaphore**"
@@ -719,6 +746,9 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
+    - type: $x_exp_external_semaphore_type_t
+      name: semHandleType
+      desc: "[in] type of external memory handle"
     - type: $x_exp_interop_semaphore_desc_t*
       name: pInteropSemaphoreDesc
       desc: "[in] the interop semaphore descriptor"
@@ -764,6 +794,14 @@ params:
     - type: $x_exp_interop_semaphore_handle_t
       name: hSemaphore
       desc: "[in] interop semaphore handle"
+    - type: bool
+      name: hasWaitValue
+      desc: |
+            [in] indicates whether the samephore is capable and should wait on a certain value.
+            Otherwise the semaphore is treated like a binary state, and `waitValue` is ignored.
+    - type: uint64_t
+      name: waitValue
+      desc: "[in] the value to be waited on"
     - type: uint32_t
       name: numEventsInWaitList
       desc: "[in] size of the event wait list"
@@ -795,6 +833,14 @@ params:
     - type: $x_exp_interop_semaphore_handle_t
       name: hSemaphore
       desc: "[in] interop semaphore handle"
+    - type: bool
+      name: hasSignalValue
+      desc: | 
+            [in] indicates whether the samephore is capable and should signal on a certain value.
+            Otherwise the semaphore is treated like a binary state, and `signalValue` is ignored.
+    - type: uint64_t
+      name: signalValue
+      desc: "[in] the value to be signalled"
     - type: uint32_t
       name: numEventsInWaitList
       desc: "[in] size of the event wait list"

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -400,18 +400,12 @@ etors:
 - name: BINDLESS_IMAGES_MIPMAP_FREE_EXP
   desc: Enumerator for $xBindlessImagesMipmapFreeExp
   value: '142'
-- name: BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP
-  desc: Enumerator for $xBindlessImagesImportOpaqueFDExp
-  value: '143'
 - name: BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
   desc: Enumerator for $xBindlessImagesMapExternalArrayExp
   value: '144'
 - name: BINDLESS_IMAGES_RELEASE_INTEROP_EXP
   desc: Enumerator for $xBindlessImagesReleaseInteropExp
   value: '145'
-- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP
-  desc: Enumerator for $xBindlessImagesImportExternalSemaphoreOpaqueFDExp
-  value: '146'
 - name: BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP
   desc: Enumerator for $xBindlessImagesDestroyExternalSemaphoreExp
   value: '147'
@@ -589,6 +583,12 @@ etors:
 - name: KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE
   desc: Enumerator for $xKernelGetSuggestedLocalWorkSize
   value: '225'
+- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP
+  desc: Enumerator for $xBindlessImagesImportExternalMemoryExp
+  value: '226'
+- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesImportExternalSemaphoreExp
+  value: '227'
 ---
 type: enum
 desc: Defines structure types

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -337,11 +337,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImageGetInfoExp = urBindlessImagesImageGetInfoExp;
   pDdiTable->pfnMipmapGetLevelExp = urBindlessImagesMipmapGetLevelExp;
   pDdiTable->pfnMipmapFreeExp = urBindlessImagesMipmapFreeExp;
-  pDdiTable->pfnImportOpaqueFDExp = urBindlessImagesImportOpaqueFDExp;
+  pDdiTable->pfnImportExternalMemoryExp =
+      urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
-  pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-      urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+  pDdiTable->pfnImportExternalSemaphoreExp =
+      urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnDestroyExternalSemaphoreExp =
       urBindlessImagesDestroyExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -113,9 +113,10 @@ urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
+    [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
     [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -138,10 +139,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
     [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -157,6 +158,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {
@@ -166,6 +168,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -941,13 +941,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
   return urBindlessImagesImageFreeExp(hContext, hDevice, hMem);
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, size_t size,
+    ur_exp_external_mem_type_t memHandleType,
     ur_exp_interop_mem_desc_t *pInteropMemDesc,
     ur_exp_interop_mem_handle_t *phInteropMem) {
   std::ignore = hContext;
   std::ignore = hDevice;
   std::ignore = size;
+  std::ignore = memHandleType;
   std::ignore = pInteropMemDesc;
   std::ignore = phInteropMem;
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
@@ -982,13 +984,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    ur_exp_external_semaphore_type_t semHandleType,
     ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
     ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle) {
   std::ignore = hContext;
   std::ignore = hDevice;
+  std::ignore = semHandleType;
   std::ignore = pInteropSemaphoreDesc;
   std::ignore = phInteropSemaphoreHandle;
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
@@ -1009,10 +1012,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+    bool hasValue, uint64_t waitValue, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hQueue;
   std::ignore = hSemaphore;
+  std::ignore = hasValue;
+  std::ignore = waitValue;
   std::ignore = numEventsInWaitList;
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
@@ -1023,10 +1028,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+    bool hasValue, uint64_t signalValue, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hQueue;
   std::ignore = hSemaphore;
+  std::ignore = hasValue;
+  std::ignore = signalValue;
   std::ignore = numEventsInWaitList;
   std::ignore = phEventWaitList;
   std::ignore = phEvent;

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -384,11 +384,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImageGetInfoExp = urBindlessImagesImageGetInfoExp;
   pDdiTable->pfnMipmapGetLevelExp = urBindlessImagesMipmapGetLevelExp;
   pDdiTable->pfnMipmapFreeExp = urBindlessImagesMipmapFreeExp;
-  pDdiTable->pfnImportOpaqueFDExp = urBindlessImagesImportOpaqueFDExp;
+  pDdiTable->pfnImportExternalMemoryExp =
+      urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
-  pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-      urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+  pDdiTable->pfnImportExternalSemaphoreExp =
+      urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnDestroyExternalSemaphoreExp =
       urBindlessImagesDestroyExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -113,9 +113,10 @@ urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
+    [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
     [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -138,10 +139,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
     [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -157,6 +158,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {
@@ -166,6 +168,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -326,11 +326,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImageGetInfoExp = urBindlessImagesImageGetInfoExp;
   pDdiTable->pfnMipmapGetLevelExp = urBindlessImagesMipmapGetLevelExp;
   pDdiTable->pfnMipmapFreeExp = urBindlessImagesMipmapFreeExp;
-  pDdiTable->pfnImportOpaqueFDExp = urBindlessImagesImportOpaqueFDExp;
+  pDdiTable->pfnImportExternalMemoryExp =
+      urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
-  pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-      urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+  pDdiTable->pfnImportExternalSemaphoreExp =
+      urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnDestroyExternalSemaphoreExp =
       urBindlessImagesDestroyExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -4518,11 +4518,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
@@ -4531,11 +4533,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnImportOpaqueFDExp =
-        d_context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
-    if (nullptr != pfnImportOpaqueFDExp) {
-        result = pfnImportOpaqueFDExp(hContext, hDevice, size, pInteropMemDesc,
-                                      phInteropMem);
+    auto pfnImportExternalMemoryExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
+    if (nullptr != pfnImportExternalMemoryExp) {
+        result =
+            pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
+                                       pInteropMemDesc, phInteropMem);
     } else {
         // generic implementation
         *phInteropMem =
@@ -4604,11 +4607,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
@@ -4617,12 +4621,12 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // if the driver has created a custom function, then call it instead of using the generic path
-    auto pfnImportExternalSemaphoreOpaqueFDExp =
-        d_context.urDdiTable.BindlessImagesExp
-            .pfnImportExternalSemaphoreOpaqueFDExp;
-    if (nullptr != pfnImportExternalSemaphoreOpaqueFDExp) {
-        result = pfnImportExternalSemaphoreOpaqueFDExp(
-            hContext, hDevice, pInteropSemaphoreDesc, phInteropSemaphore);
+    auto pfnImportExternalSemaphoreExp =
+        d_context.urDdiTable.BindlessImagesExp.pfnImportExternalSemaphoreExp;
+    if (nullptr != pfnImportExternalSemaphoreExp) {
+        result = pfnImportExternalSemaphoreExp(hContext, hDevice, semHandleType,
+                                               pInteropSemaphoreDesc,
+                                               phInteropSemaphore);
     } else {
         // generic implementation
         *phInteropSemaphore =
@@ -4665,7 +4669,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -4683,8 +4693,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     auto pfnWaitExternalSemaphoreExp =
         d_context.urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
     if (nullptr != pfnWaitExternalSemaphoreExp) {
-        result = pfnWaitExternalSemaphoreExp(
-            hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+        result = pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, hasWaitValue,
+                                             waitValue, numEventsInWaitList,
+                                             phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -4702,7 +4713,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -4721,7 +4738,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
         d_context.urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
     if (nullptr != pfnSignalExternalSemaphoreExp) {
         result = pfnSignalExternalSemaphoreExp(
-            hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+            hQueue, hSemaphore, hasSignalValue, signalValue,
+            numEventsInWaitList, phEventWaitList, phEvent);
     } else {
         // generic implementation
         if (nullptr != phEvent) {
@@ -5931,15 +5949,16 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
 
     pDdiTable->pfnMipmapFreeExp = driver::urBindlessImagesMipmapFreeExp;
 
-    pDdiTable->pfnImportOpaqueFDExp = driver::urBindlessImagesImportOpaqueFDExp;
+    pDdiTable->pfnImportExternalMemoryExp =
+        driver::urBindlessImagesImportExternalMemoryExp;
 
     pDdiTable->pfnMapExternalArrayExp =
         driver::urBindlessImagesMapExternalArrayExp;
 
     pDdiTable->pfnReleaseInteropExp = driver::urBindlessImagesReleaseInteropExp;
 
-    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-        driver::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+    pDdiTable->pfnImportExternalSemaphoreExp =
+        driver::urBindlessImagesImportExternalSemaphoreExp;
 
     pDdiTable->pfnDestroyExternalSemaphoreExp =
         driver::urBindlessImagesDestroyExternalSemaphoreExp;

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -113,9 +113,10 @@ urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
+    [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
     [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -138,13 +139,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
     [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t
-        *phInteropSemaphoreHandle) {
+    [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -158,6 +158,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {
@@ -167,6 +168,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -344,11 +344,12 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImageGetInfoExp = urBindlessImagesImageGetInfoExp;
   pDdiTable->pfnMipmapGetLevelExp = urBindlessImagesMipmapGetLevelExp;
   pDdiTable->pfnMipmapFreeExp = urBindlessImagesMipmapFreeExp;
-  pDdiTable->pfnImportOpaqueFDExp = urBindlessImagesImportOpaqueFDExp;
+  pDdiTable->pfnImportExternalMemoryExp =
+      urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
-  pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-      urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+  pDdiTable->pfnImportExternalSemaphoreExp =
+      urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnDestroyExternalSemaphoreExp =
       urBindlessImagesDestroyExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5885,41 +5885,45 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
-    auto pfnImportOpaqueFDExp =
-        context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+    auto pfnImportExternalMemoryExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
 
-    if (nullptr == pfnImportOpaqueFDExp) {
+    if (nullptr == pfnImportExternalMemoryExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_bindless_images_import_opaque_fd_exp_params_t params = {
-        &hContext, &hDevice, &size, &pInteropMemDesc, &phInteropMem};
-    uint64_t instance =
-        context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
-                             "urBindlessImagesImportOpaqueFDExp", &params);
+    ur_bindless_images_import_external_memory_exp_params_t params = {
+        &hContext,      &hDevice,         &size,
+        &memHandleType, &pInteropMemDesc, &phInteropMem};
+    uint64_t instance = context.notify_begin(
+        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
+        "urBindlessImagesImportExternalMemoryExp", &params);
 
-    context.logger.info("---> urBindlessImagesImportOpaqueFDExp");
+    context.logger.info("---> urBindlessImagesImportExternalMemoryExp");
 
-    ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              pInteropMemDesc, phInteropMem);
+    ur_result_t result = pfnImportExternalMemoryExp(
+        hContext, hDevice, size, memHandleType, pInteropMemDesc, phInteropMem);
 
-    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP,
-                       "urBindlessImagesImportOpaqueFDExp", &params, &result,
-                       instance);
+    context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
+                       "urBindlessImagesImportExternalMemoryExp", &params,
+                       &result, instance);
 
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
-        args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_OPAQUE_FD_EXP, &params);
+        args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
+        &params);
     context.logger.info("({}) -> {};\n", args_str.str(), result);
 
     return result;
@@ -6007,45 +6011,45 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
-    auto pfnImportExternalSemaphoreOpaqueFDExp =
-        context.urDdiTable.BindlessImagesExp
-            .pfnImportExternalSemaphoreOpaqueFDExp;
+    auto pfnImportExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportExternalSemaphoreExp;
 
-    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+    if (nullptr == pfnImportExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t params =
-        {&hContext, &hDevice, &pInteropSemaphoreDesc, &phInteropSemaphore};
+    ur_bindless_images_import_external_semaphore_exp_params_t params = {
+        &hContext, &hDevice, &semHandleType, &pInteropSemaphoreDesc,
+        &phInteropSemaphore};
     uint64_t instance = context.notify_begin(
-        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
-        "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params);
+        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesImportExternalSemaphoreExp", &params);
 
-    context.logger.info(
-        "---> urBindlessImagesImportExternalSemaphoreOpaqueFDExp");
+    context.logger.info("---> urBindlessImagesImportExternalSemaphoreExp");
 
-    ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, pInteropSemaphoreDesc, phInteropSemaphore);
+    ur_result_t result = pfnImportExternalSemaphoreExp(
+        hContext, hDevice, semHandleType, pInteropSemaphoreDesc,
+        phInteropSemaphore);
 
     context.notify_end(
-        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
-        "urBindlessImagesImportExternalSemaphoreOpaqueFDExp", &params, &result,
+        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesImportExternalSemaphoreExp", &params, &result,
         instance);
 
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
-        args_str,
-        UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_OPAQUE_FD_EXP,
+        args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
         &params);
     context.logger.info("({}) -> {};\n", args_str.str(), result);
 
@@ -6097,7 +6101,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6117,7 +6127,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     }
 
     ur_bindless_images_wait_external_semaphore_exp_params_t params = {
-        &hQueue, &hSemaphore, &numEventsInWaitList, &phEventWaitList, &phEvent};
+        &hQueue,    &hSemaphore,          &hasWaitValue,
+        &waitValue, &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
     uint64_t instance = context.notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
         "urBindlessImagesWaitExternalSemaphoreExp", &params);
@@ -6125,7 +6137,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     context.logger.info("---> urBindlessImagesWaitExternalSemaphoreExp");
 
     ur_result_t result = pfnWaitExternalSemaphoreExp(
-        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+        hQueue, hSemaphore, hasWaitValue, waitValue, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
                        "urBindlessImagesWaitExternalSemaphoreExp", &params,
@@ -6145,7 +6158,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6165,7 +6184,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     }
 
     ur_bindless_images_signal_external_semaphore_exp_params_t params = {
-        &hQueue, &hSemaphore, &numEventsInWaitList, &phEventWaitList, &phEvent};
+        &hQueue,      &hSemaphore,          &hasSignalValue,
+        &signalValue, &numEventsInWaitList, &phEventWaitList,
+        &phEvent};
     uint64_t instance = context.notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
         "urBindlessImagesSignalExternalSemaphoreExp", &params);
@@ -6173,7 +6194,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     context.logger.info("---> urBindlessImagesSignalExternalSemaphoreExp");
 
     ur_result_t result = pfnSignalExternalSemaphoreExp(
-        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+        hQueue, hSemaphore, hasSignalValue, signalValue, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     context.notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
@@ -7933,9 +7955,9 @@ __urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnMipmapFreeExp =
         ur_tracing_layer::urBindlessImagesMipmapFreeExp;
 
-    dditable.pfnImportOpaqueFDExp = pDdiTable->pfnImportOpaqueFDExp;
-    pDdiTable->pfnImportOpaqueFDExp =
-        ur_tracing_layer::urBindlessImagesImportOpaqueFDExp;
+    dditable.pfnImportExternalMemoryExp = pDdiTable->pfnImportExternalMemoryExp;
+    pDdiTable->pfnImportExternalMemoryExp =
+        ur_tracing_layer::urBindlessImagesImportExternalMemoryExp;
 
     dditable.pfnMapExternalArrayExp = pDdiTable->pfnMapExternalArrayExp;
     pDdiTable->pfnMapExternalArrayExp =
@@ -7945,10 +7967,10 @@ __urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnReleaseInteropExp =
         ur_tracing_layer::urBindlessImagesReleaseInteropExp;
 
-    dditable.pfnImportExternalSemaphoreOpaqueFDExp =
-        pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp;
-    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-        ur_tracing_layer::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+    dditable.pfnImportExternalSemaphoreExp =
+        pDdiTable->pfnImportExternalSemaphoreExp;
+    pDdiTable->pfnImportExternalSemaphoreExp =
+        ur_tracing_layer::urBindlessImagesImportExternalSemaphoreExp;
 
     dditable.pfnDestroyExternalSemaphoreExp =
         pDdiTable->pfnDestroyExternalSemaphoreExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7381,20 +7381,22 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
 ) {
-    auto pfnImportOpaqueFDExp =
-        context.urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
+    auto pfnImportExternalMemoryExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
 
-    if (nullptr == pfnImportOpaqueFDExp) {
+    if (nullptr == pfnImportExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -7414,6 +7416,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
         if (NULL == phInteropMem) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
     }
 
     if (context.enableLifetimeValidation &&
@@ -7426,8 +7432,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
         refCountContext.logInvalidReference(hDevice);
     }
 
-    ur_result_t result = pfnImportOpaqueFDExp(hContext, hDevice, size,
-                                              pInteropMemDesc, phInteropMem);
+    ur_result_t result = pfnImportExternalMemoryExp(
+        hContext, hDevice, size, memHandleType, pInteropMemDesc, phInteropMem);
 
     return result;
 }
@@ -7543,21 +7549,21 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
 ) {
-    auto pfnImportExternalSemaphoreOpaqueFDExp =
-        context.urDdiTable.BindlessImagesExp
-            .pfnImportExternalSemaphoreOpaqueFDExp;
+    auto pfnImportExternalSemaphoreExp =
+        context.urDdiTable.BindlessImagesExp.pfnImportExternalSemaphoreExp;
 
-    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+    if (nullptr == pfnImportExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -7577,6 +7583,11 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
         if (NULL == phInteropSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
+
+        if (UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE <
+            semHandleType) {
+            return UR_RESULT_ERROR_INVALID_ENUMERATION;
+        }
     }
 
     if (context.enableLifetimeValidation &&
@@ -7589,8 +7600,9 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
         refCountContext.logInvalidReference(hDevice);
     }
 
-    ur_result_t result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, pInteropSemaphoreDesc, phInteropSemaphore);
+    ur_result_t result = pfnImportExternalSemaphoreExp(
+        hContext, hDevice, semHandleType, pInteropSemaphoreDesc,
+        phInteropSemaphore);
 
     return result;
 }
@@ -7645,7 +7657,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7688,7 +7706,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     }
 
     ur_result_t result = pfnWaitExternalSemaphoreExp(
-        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+        hQueue, hSemaphore, hasWaitValue, waitValue, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     return result;
 }
@@ -7698,7 +7717,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7741,7 +7766,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     }
 
     ur_result_t result = pfnSignalExternalSemaphoreExp(
-        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+        hQueue, hSemaphore, hasSignalValue, signalValue, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     return result;
 }
@@ -9595,9 +9621,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnMipmapFreeExp =
         ur_validation_layer::urBindlessImagesMipmapFreeExp;
 
-    dditable.pfnImportOpaqueFDExp = pDdiTable->pfnImportOpaqueFDExp;
-    pDdiTable->pfnImportOpaqueFDExp =
-        ur_validation_layer::urBindlessImagesImportOpaqueFDExp;
+    dditable.pfnImportExternalMemoryExp = pDdiTable->pfnImportExternalMemoryExp;
+    pDdiTable->pfnImportExternalMemoryExp =
+        ur_validation_layer::urBindlessImagesImportExternalMemoryExp;
 
     dditable.pfnMapExternalArrayExp = pDdiTable->pfnMapExternalArrayExp;
     pDdiTable->pfnMapExternalArrayExp =
@@ -9607,10 +9633,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnReleaseInteropExp =
         ur_validation_layer::urBindlessImagesReleaseInteropExp;
 
-    dditable.pfnImportExternalSemaphoreOpaqueFDExp =
-        pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp;
-    pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-        ur_validation_layer::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+    dditable.pfnImportExternalSemaphoreExp =
+        pDdiTable->pfnImportExternalSemaphoreExp;
+    pDdiTable->pfnImportExternalSemaphoreExp =
+        ur_validation_layer::urBindlessImagesImportExternalSemaphoreExp;
 
     dditable.pfnDestroyExternalSemaphoreExp =
         pDdiTable->pfnDestroyExternalSemaphoreExp;

--- a/source/loader/loader.def.in
+++ b/source/loader/loader.def.in
@@ -10,8 +10,8 @@ EXPORTS
 	urBindlessImagesImageCopyExp
 	urBindlessImagesImageFreeExp
 	urBindlessImagesImageGetInfoExp
-	urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-	urBindlessImagesImportOpaqueFDExp
+	urBindlessImagesImportExternalMemoryExp
+	urBindlessImagesImportExternalSemaphoreExp
 	urBindlessImagesMapExternalArrayExp
 	urBindlessImagesMipmapFreeExp
 	urBindlessImagesMipmapGetLevelExp
@@ -177,8 +177,8 @@ EXPORTS
 	urPrintBindlessImagesImageCopyExpParams
 	urPrintBindlessImagesImageFreeExpParams
 	urPrintBindlessImagesImageGetInfoExpParams
-	urPrintBindlessImagesImportExternalSemaphoreOpaqueFdExpParams
-	urPrintBindlessImagesImportOpaqueFdExpParams
+	urPrintBindlessImagesImportExternalMemoryExpParams
+	urPrintBindlessImagesImportExternalSemaphoreExpParams
 	urPrintBindlessImagesMapExternalArrayExpParams
 	urPrintBindlessImagesMipmapFreeExpParams
 	urPrintBindlessImagesMipmapGetLevelExpParams
@@ -300,6 +300,8 @@ EXPORTS
 	urPrintExpCommandBufferUpdateMemobjArgDesc
 	urPrintExpCommandBufferUpdatePointerArgDesc
 	urPrintExpCommandBufferUpdateValueArgDesc
+	urPrintExpExternalMemType
+	urPrintExpExternalSemaphoreType
 	urPrintExpFileDescriptor
 	urPrintExpImageCopyFlags
 	urPrintExpInteropMemDesc

--- a/source/loader/loader.map.in
+++ b/source/loader/loader.map.in
@@ -10,8 +10,8 @@
 		urBindlessImagesImageCopyExp;
 		urBindlessImagesImageFreeExp;
 		urBindlessImagesImageGetInfoExp;
-		urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
-		urBindlessImagesImportOpaqueFDExp;
+		urBindlessImagesImportExternalMemoryExp;
+		urBindlessImagesImportExternalSemaphoreExp;
 		urBindlessImagesMapExternalArrayExp;
 		urBindlessImagesMipmapFreeExp;
 		urBindlessImagesMipmapGetLevelExp;
@@ -177,8 +177,8 @@
 		urPrintBindlessImagesImageCopyExpParams;
 		urPrintBindlessImagesImageFreeExpParams;
 		urPrintBindlessImagesImageGetInfoExpParams;
-		urPrintBindlessImagesImportExternalSemaphoreOpaqueFdExpParams;
-		urPrintBindlessImagesImportOpaqueFdExpParams;
+		urPrintBindlessImagesImportExternalMemoryExpParams;
+		urPrintBindlessImagesImportExternalSemaphoreExpParams;
 		urPrintBindlessImagesMapExternalArrayExpParams;
 		urPrintBindlessImagesMipmapFreeExpParams;
 		urPrintBindlessImagesMipmapGetLevelExpParams;
@@ -300,6 +300,8 @@
 		urPrintExpCommandBufferUpdateMemobjArgDesc;
 		urPrintExpCommandBufferUpdatePointerArgDesc;
 		urPrintExpCommandBufferUpdateValueArgDesc;
+		urPrintExpExternalMemType;
+		urPrintExpExternalSemaphoreType;
 		urPrintExpFileDescriptor;
 		urPrintExpImageCopyFlags;
 		urPrintExpInteropMemDesc;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6246,11 +6246,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
@@ -6260,9 +6262,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnImportOpaqueFDExp =
-        dditable->ur.BindlessImagesExp.pfnImportOpaqueFDExp;
-    if (nullptr == pfnImportOpaqueFDExp) {
+    auto pfnImportExternalMemoryExp =
+        dditable->ur.BindlessImagesExp.pfnImportExternalMemoryExp;
+    if (nullptr == pfnImportExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -6273,8 +6275,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnImportOpaqueFDExp(hContext, hDevice, size, pInteropMemDesc,
-                                  phInteropMem);
+    result = pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
+                                        pInteropMemDesc, phInteropMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6378,11 +6380,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreOpaqueFDExp
-__urdlllocal ur_result_t UR_APICALL
-urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+/// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
@@ -6392,9 +6395,9 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnImportExternalSemaphoreOpaqueFDExp =
-        dditable->ur.BindlessImagesExp.pfnImportExternalSemaphoreOpaqueFDExp;
-    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+    auto pfnImportExternalSemaphoreExp =
+        dditable->ur.BindlessImagesExp.pfnImportExternalSemaphoreExp;
+    if (nullptr == pfnImportExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -6405,8 +6408,9 @@ urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // forward to device-platform
-    result = pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, pInteropSemaphoreDesc, phInteropSemaphore);
+    result = pfnImportExternalSemaphoreExp(hContext, hDevice, semHandleType,
+                                           pInteropSemaphoreDesc,
+                                           phInteropSemaphore);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6466,7 +6470,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6505,9 +6515,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     }
 
     // forward to device-platform
-    result =
-        pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
-                                    phEventWaitListLocal.data(), phEvent);
+    result = pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, hasWaitValue,
+                                         waitValue, numEventsInWaitList,
+                                         phEventWaitListLocal.data(), phEvent);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6531,7 +6541,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6570,9 +6586,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     }
 
     // forward to device-platform
-    result =
-        pfnSignalExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
-                                      phEventWaitListLocal.data(), phEvent);
+    result = pfnSignalExternalSemaphoreExp(
+        hQueue, hSemaphore, hasSignalValue, signalValue, numEventsInWaitList,
+        phEventWaitListLocal.data(), phEvent);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -8210,14 +8226,14 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
                 ur_loader::urBindlessImagesMipmapGetLevelExp;
             pDdiTable->pfnMipmapFreeExp =
                 ur_loader::urBindlessImagesMipmapFreeExp;
-            pDdiTable->pfnImportOpaqueFDExp =
-                ur_loader::urBindlessImagesImportOpaqueFDExp;
+            pDdiTable->pfnImportExternalMemoryExp =
+                ur_loader::urBindlessImagesImportExternalMemoryExp;
             pDdiTable->pfnMapExternalArrayExp =
                 ur_loader::urBindlessImagesMapExternalArrayExp;
             pDdiTable->pfnReleaseInteropExp =
                 ur_loader::urBindlessImagesReleaseInteropExp;
-            pDdiTable->pfnImportExternalSemaphoreOpaqueFDExp =
-                ur_loader::urBindlessImagesImportExternalSemaphoreOpaqueFDExp;
+            pDdiTable->pfnImportExternalSemaphoreExp =
+                ur_loader::urBindlessImagesImportExternalSemaphoreExp;
             pDdiTable->pfnDestroyExternalSemaphoreExp =
                 ur_loader::urBindlessImagesDestroyExternalSemaphoreExp;
             pDdiTable->pfnWaitExternalSemaphoreExp =

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6945,7 +6945,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import external memory in the form of a file descriptor
+/// @brief Import external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -6959,29 +6959,34 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropMemDesc`
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
         *phInteropMem ///< [out] interop memory handle to the external memory
     ) try {
-    auto pfnImportOpaqueFDExp =
-        ur_lib::context->urDdiTable.BindlessImagesExp.pfnImportOpaqueFDExp;
-    if (nullptr == pfnImportOpaqueFDExp) {
+    auto pfnImportExternalMemoryExp =
+        ur_lib::context->urDdiTable.BindlessImagesExp
+            .pfnImportExternalMemoryExp;
+    if (nullptr == pfnImportExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImportOpaqueFDExp(hContext, hDevice, size, pInteropMemDesc,
-                                phInteropMem);
+    return pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
+                                      pInteropMemDesc, phInteropMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -7068,7 +7073,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import an external semaphore in the form of a file descriptor
+/// @brief Import an external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -7082,28 +7087,33 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropSemaphoreDesc`
 ///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
         phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
     ) try {
-    auto pfnImportExternalSemaphoreOpaqueFDExp =
+    auto pfnImportExternalSemaphoreExp =
         ur_lib::context->urDdiTable.BindlessImagesExp
-            .pfnImportExternalSemaphoreOpaqueFDExp;
-    if (nullptr == pfnImportExternalSemaphoreOpaqueFDExp) {
+            .pfnImportExternalSemaphoreExp;
+    if (nullptr == pfnImportExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImportExternalSemaphoreOpaqueFDExp(
-        hContext, hDevice, pInteropSemaphoreDesc, phInteropSemaphore);
+    return pfnImportExternalSemaphoreExp(hContext, hDevice, semHandleType,
+                                         pInteropSemaphoreDesc,
+                                         phInteropSemaphore);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -7164,7 +7174,13 @@ ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7183,7 +7199,8 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, numEventsInWaitList,
+    return pfnWaitExternalSemaphoreExp(hQueue, hSemaphore, hasWaitValue,
+                                       waitValue, numEventsInWaitList,
                                        phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
@@ -7210,7 +7227,13 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7229,8 +7252,9 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnSignalExternalSemaphoreExp(
-        hQueue, hSemaphore, numEventsInWaitList, phEventWaitList, phEvent);
+    return pfnSignalExternalSemaphoreExp(hQueue, hSemaphore, hasSignalValue,
+                                         signalValue, numEventsInWaitList,
+                                         phEventWaitList, phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -895,6 +895,23 @@ ur_result_t urPrintExpSamplerCubemapFilterMode(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintExpExternalMemType(enum ur_exp_external_mem_type_t value,
+                                      char *buffer, const size_t buff_size,
+                                      size_t *out_size) {
+    std::stringstream ss;
+    ss << value;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t
+urPrintExpExternalSemaphoreType(enum ur_exp_external_semaphore_type_t value,
+                                char *buffer, const size_t buff_size,
+                                size_t *out_size) {
+    std::stringstream ss;
+    ss << value;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t
 urPrintExpFileDescriptor(const struct ur_exp_file_descriptor_t params,
                          char *buffer, const size_t buff_size,
@@ -1161,8 +1178,8 @@ ur_result_t urPrintBindlessImagesMipmapFreeExpParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintBindlessImagesImportOpaqueFdExpParams(
-    const struct ur_bindless_images_import_opaque_fd_exp_params_t *params,
+ur_result_t urPrintBindlessImagesImportExternalMemoryExpParams(
+    const struct ur_bindless_images_import_external_memory_exp_params_t *params,
     char *buffer, const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;
@@ -1185,9 +1202,9 @@ ur_result_t urPrintBindlessImagesReleaseInteropExpParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintBindlessImagesImportExternalSemaphoreOpaqueFdExpParams(
-    const struct
-    ur_bindless_images_import_external_semaphore_opaque_fd_exp_params_t *params,
+ur_result_t urPrintBindlessImagesImportExternalSemaphoreExpParams(
+    const struct ur_bindless_images_import_external_semaphore_exp_params_t
+        *params,
     char *buffer, const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5919,7 +5919,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import external memory in the form of a file descriptor
+/// @brief Import external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -5933,16 +5933,20 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropMemDesc`
 ///         + `NULL == phInteropMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
-ur_result_t UR_APICALL urBindlessImagesImportOpaqueFDExp(
+ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t
+        memHandleType, ///< [in] type of external memory handle
     ur_exp_interop_mem_desc_t
         *pInteropMemDesc, ///< [in] the interop memory descriptor
     ur_exp_interop_mem_handle_t
@@ -6019,7 +6023,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Import an external semaphore in the form of a file descriptor
+/// @brief Import an external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -6033,14 +6037,18 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pInteropSemaphoreDesc`
 ///         + `NULL == phInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreOpaqueFDExp(
+ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t
+        semHandleType, ///< [in] type of external memory handle
     ur_exp_interop_semaphore_desc_t
         *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
     ur_exp_interop_semaphore_handle_t *
@@ -6098,7 +6106,13 @@ ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
+                      ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `waitValue` is ignored.
+    uint64_t waitValue,           ///< [in] the value to be waited on
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6135,7 +6149,13 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_interop_semaphore_handle_t
-        hSemaphore,               ///< [in] interop semaphore handle
+        hSemaphore, ///< [in] interop semaphore handle
+    bool
+        hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
+                        ///< certain value.
+    ///< Otherwise the semaphore is treated like a binary state, and
+    ///< `signalValue` is ignored.
+    uint64_t signalValue,         ///< [in] the value to be signalled
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of


### PR DESCRIPTION
The interop import API has been adapted to cater to multiple external memory and semaphore handle types.

This enables memory and semaphores to be imported by single functions irregardless of what the underlying handle type is.

The following APIs have been removed:
 - `ImportExternalOpaqueFDExp`
 - `ImportExternalSemaphoreOpaqueFDExp`

The following APIs have been added:
 - `ImportExternalMemoryExp`
 - `ImportExternalSemaphoreExp`

The following enums have been added:
 - `exp_external_mem_type_t`
 - `exp_external_semaphore_type_t`

Support has also been added to import DirectX 12 memory and fences.

Semaphore operations (wait/signal) can now take values which set the semaphore state to the value passed by the user.