### PR TITLE
Limit # of workers in E2E job through LIT_OPTS

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -146,11 +146,14 @@ jobs:
     - name: Build SYCL
       run: cmake --build ${{github.workspace}}/sycl_build -j
 
+    - name: Set extra llvm-lit options
+      run: echo "LIT_OPTS=\"-sv \${{matrix.adapter.extra_lit_flags}}\"" >> $GITHUB_ENV
+
     - name: Run check-sycl
       # Remove after fixing SYCL test :: abi/layout_handler.cpp
       # This issue does not affect further execution of e2e with UR.
       continue-on-error: true
-      run: cmake --build ${{github.workspace}}/sycl_build --target check-sycl -j6
+      run: cmake --build ${{github.workspace}}/sycl_build --target check-sycl
 
     - name: Set additional env. vars
       run: |
@@ -172,7 +175,6 @@ jobs:
         -DSYCL_TEST_E2E_TARGETS="${{matrix.adapter.prefix}}${{matrix.adapter.str_name}}:${{matrix.adapter.unit}}"
         -DCMAKE_CXX_COMPILER="$(which clang++)"
         -DLLVM_LIT="${{github.workspace}}/sycl-repo/llvm/utils/lit/lit.py"
-        -DSYCL_E2E_TESTS_LIT_FLAGS="-sv;${{matrix.adapter.extra_lit_flags}}"
 
     - name: Set test filters for L0
       if: matrix.adapter.name == 'L0'

--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -33,4 +33,4 @@ jobs:
       filter_out: "GroupAlgorithm/root_group.cpp|Basic/exceptions-SYCL-2020.cpp|Graph/UnsupportedDevice/device_query.cpp|Graph/RecordReplay/exception_inconsistent_contexts.cpp"
       # These runners by default spawn upwards of 260 workers. That's too much for the GPU.
       # We also add a time out just in case some test hangs
-      extra_lit_flags: "-j 50;--max-time 600"
+      extra_lit_flags: "-j 50 --max-time 600"


### PR DESCRIPTION
LIT_OPTS is more generic, and also covers cases where there is no direct way to modify what CMake passes to llvm-lit command.