### PR TITLE
fix passing LLVM LIT arguments in workflows

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -147,7 +147,8 @@ jobs:
       run: cmake --build ${{github.workspace}}/sycl_build -j
 
     - name: Set extra llvm-lit options
-      run: echo "LIT_OPTS=\"-sv ${{matrix.adapter.extra_lit_flags}}\"" >> $GITHUB_ENV
+      if: matrix.adapter.extra_lit_flags != ''
+      run: echo "LIT_OPTS=${{matrix.adapter.extra_lit_flags}}" >> $GITHUB_ENV
 
     - name: Run check-sycl
       # Remove after fixing SYCL test :: abi/layout_handler.cpp

--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -33,4 +33,4 @@ jobs:
       filter_out: "GroupAlgorithm/root_group.cpp|Basic/exceptions-SYCL-2020.cpp|Graph/UnsupportedDevice/device_query.cpp|Graph/RecordReplay/exception_inconsistent_contexts.cpp"
       # These runners by default spawn upwards of 260 workers. That's too much for the GPU.
       # We also add a time out just in case some test hangs
-      extra_lit_flags: "-j 50 --max-time 600"
+      extra_lit_flags: "-sv -j 50 --max-time 600"


### PR DESCRIPTION
This time I tested the change :)