### PR TITLE
Add option to control building XPTI libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(UR_BUILD_ADAPTER_ALL "Build all currently supported adapters" OFF)
 option(UR_BUILD_EXAMPLE_CODEGEN "Build the codegen example." OFF)
 option(VAL_USE_LIBBACKTRACE_BACKTRACE "enable libbacktrace validation backtrace for linux" OFF)
 option(UR_ENABLE_ASSERTIONS "Enable assertions for all build types" OFF)
+option(UR_BUILD_XPTI_LIBS "Build the XPTI libraries when tracing is enabled" ON)
 set(UR_DPCXX "" CACHE FILEPATH "Path of the DPC++ compiler executable")
 set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
     "Path of the SYCL runtime library directory")
@@ -107,31 +108,34 @@ endif()
 if(UR_ENABLE_TRACING)
     add_compile_definitions(UR_ENABLE_TRACING)
 
-    # fetch xpti proxy library for the tracing layer
-    FetchContentSparse_Declare(xpti https://github.com/intel/llvm.git "sycl-nightly/20230703" "xpti")
-    FetchContent_MakeAvailable(xpti)
+    if (UR_BUILD_XPTI_LIBS)
+        # fetch xpti proxy library for the tracing layer
+        FetchContentSparse_Declare(xpti https://github.com/intel/llvm.git "sycl-nightly/20230703" "xpti")
+        FetchContent_MakeAvailable(xpti)
 
-    # set -fPIC for xpti since we are linking it with a shared library
-    set_target_properties(xpti PROPERTIES POSITION_INDEPENDENT_CODE ON)
+        # set -fPIC for xpti since we are linking it with a shared library
+        set_target_properties(xpti PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-    # fetch the xptifw dispatcher, mostly used for testing
-    # these variables need to be set for xptifw to compile
-    set(XPTI_SOURCE_DIR ${xpti_SOURCE_DIR})
-    set(XPTI_DIR ${xpti_SOURCE_DIR})
-    set(XPTI_ENABLE_TESTS OFF CACHE INTERNAL "Turn off xptifw tests")
+        # fetch the xptifw dispatcher, mostly used for testing
+        # these variables need to be set for xptifw to compile
+        set(XPTI_SOURCE_DIR ${xpti_SOURCE_DIR})
+        set(XPTI_DIR ${xpti_SOURCE_DIR})
+        set(XPTI_ENABLE_TESTS OFF CACHE INTERNAL "Turn off xptifw tests")
 
-    FetchContentSparse_Declare(xptifw https://github.com/intel/llvm.git "sycl-nightly/20230703" "xptifw")
+        FetchContentSparse_Declare(xptifw https://github.com/intel/llvm.git "sycl-nightly/20230703" "xptifw")
 
-    FetchContent_MakeAvailable(xptifw)
+        FetchContent_MakeAvailable(xptifw)
 
-    check_cxx_compiler_flag("-Wno-error=maybe-uninitialized" HAS_MAYBE_UNINIT)
-    if (HAS_MAYBE_UNINIT)
-        target_compile_options(xptifw PRIVATE -Wno-error=maybe-uninitialized)
+        check_cxx_compiler_flag("-Wno-error=maybe-uninitialized" HAS_MAYBE_UNINIT)
+        if (HAS_MAYBE_UNINIT)
+            target_compile_options(xptifw PRIVATE -Wno-error=maybe-uninitialized)
+        endif()
+
+        set_target_properties(xptifw PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+        )
     endif()
 
-    set_target_properties(xptifw PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-    )
     if (MSVC)
         set(TARGET_XPTI $<IF:$<CONFIG:Release>,xpti,xptid>)
     else()


### PR DESCRIPTION
This allows tracing to be enabled when UR is built from intel-llvm which already builds the XPTI targets