### PR TITLE
[CTS] Fix UR_CONFORMANCE_ENABLE_MATCH_FILES=OFF

### DIFF
--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -25,6 +25,7 @@ function(add_test_adapter name adapter)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
     else()
+        separate_arguments(TEST_COMMAND)
         add_test(NAME ${TEST_NAME}
             COMMAND ${TEST_COMMAND}
             DEPENDS ${TEST_TARGET_NAME}


### PR DESCRIPTION
When configured without match files, the CTS was trying to run a command and its arguments as a single command, as it was represented by a single string variable. It needs to be a single string in the default case - when building with UR_CONFORMANCE_ENABLE_MATCH_FILES=ON - as that command string is passed off to another command via a flag, so it must be seen by the shell as one item.

While definitely not *nice*, this is the simplest fix I could think of which preserves the behaviour of the (more important, tested) 'default' case.