### PR TITLE
[CTS][CUDA][HIP] Skip invalid kernel argument test

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_hip.match
+++ b/test/conformance/enqueue/enqueue_adapter_hip.match
@@ -1,3 +1,6 @@
+{{OPT}}urEnqueueKernelLaunchTest.InvalidKernelArgs/AMD_HIP_BACKEND___{{.*}}_
+{{OPT}}urEnqueueKernelLaunchKernelWgSizeTest.NonMatchingLocalSize/AMD_HIP_BACKEND___{{.*}}_
+{{OPT}}urEnqueueKernelLaunchKernelSubGroupTest.Success/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchUSMLinkedList.Success/AMD_HIP_BACKEND___{{.*}}___UsePoolEnabled
 {{OPT}}urEnqueueMemBufferCopyRectTestWithParam.Success/AMD_HIP_BACKEND___{{.*}}___copy_row_2D
 {{OPT}}urEnqueueMemBufferCopyRectTestWithParam.Success/AMD_HIP_BACKEND___{{.*}}___copy_3d_2d

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -132,6 +132,16 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidWorkGroupSize) {
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidKernelArgs) {
+    ur_platform_backend_t backend;
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
+                                     sizeof(ur_platform_backend_t), &backend,
+                                     nullptr));
+
+    if (backend == UR_PLATFORM_BACKEND_CUDA ||
+        backend == UR_PLATFORM_BACKEND_HIP) {
+        GTEST_FAIL() << "AMD and Nvidia can't check kernel arguments.";
+    }
+
     // Enqueue kernel without setting any args
     ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
                                            &global_offset, &global_size,


### PR DESCRIPTION
CUDA and HIP have limited introspection capabilities so we can't check kernel arguments.