### PR TITLE
Prefer value over reference for `isPowerOf2`

### DIFF
--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -337,7 +337,7 @@ roundToHighestFactorOfGlobalSize(size_t &ThreadsPerBlockInDim,
 
 // Returns whether or not Value is a power of 2
 template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
-bool isPowerOf2(const T &Value) {
+bool isPowerOf2(const T Value) {
   return Value && !(Value & (Value - 1));
 }
 


### PR DESCRIPTION
It's questionable whether we should ever have taken a reference instead of a value type here, but since 02bb6290 `isPowerOf2` is only available for integral types. Thus, take a value instead of a reference since we will never need reference semantics, and don't ever expect to be passing large arguments.