### PR TITLE
Fix level zero specific test

### DIFF
--- a/test/adapters/level_zero/CMakeLists.txt
+++ b/test/adapters/level_zero/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT UR_DPCXX)
     # Tests that require kernels can't be used if we aren't generating
     # device binaries
     message(WARNING
-        "UR_DPCXX is not defined, skipping adapter tests for level_zero")
+        "UR_DPCXX is not defined, skipping some adapter tests for level_zero")
 else()
     add_adapter_test(level_zero
         FIXTURE KERNELS
@@ -26,14 +26,14 @@ else()
         generate_device_binaries kernel_names_header)
 endif()
 
-if(LINUX)
+if(NOT WIN32)
     # Make L0 use CallMap from a seprate shared lib so that we can access the map
     # from the tests. This only seems to work on linux
     add_library(zeCallMap SHARED zeCallMap.cpp)
     target_compile_definitions(ur_adapter_level_zero PRIVATE UR_L0_CALL_COUNT_IN_TESTS)
     target_link_libraries(ur_adapter_level_zero PRIVATE zeCallMap)
 
-    add_adapter_test(level_zero
+    add_adapter_test(level_zero_ze_calls
         FIXTURE DEVICES
         SOURCES
             event_cache_tests.cpp
@@ -42,5 +42,5 @@ if(LINUX)
             "UR_L0_LEAKS_DEBUG=1"
     )
 
-    target_link_libraries(test-adapter-level_zero PRIVATE zeCallMap)
+    target_link_libraries(test-adapter-level_zero_ze_calls PRIVATE zeCallMap)
 endif()


### PR DESCRIPTION
Replace if(LINUX) with if(NOT WIN32) as the former wasn't working on some distros.

Also, there was a rebase conflict which resulted with having two tests with the same name. Rename one of them.