### PR TITLE
[UR] Fix Multi Device Event Cache for shared Root Device

### DIFF
--- a/test/adapters/level_zero/CMakeLists.txt
+++ b/test/adapters/level_zero/CMakeLists.txt
@@ -57,3 +57,22 @@ if(NOT WIN32)
 
     target_link_libraries(test-adapter-level_zero_ze_calls PRIVATE zeCallMap)
 endif()
+
+if(NOT WIN32)
+    # Make L0 use CallMap from a seprate shared lib so that we can access the map
+    # from the tests. This only seems to work on linux
+    add_library(zeCallMap SHARED zeCallMap.cpp)
+    target_compile_definitions(ur_adapter_level_zero PRIVATE UR_L0_CALL_COUNT_IN_TESTS)
+    target_link_libraries(ur_adapter_level_zero PRIVATE zeCallMap)
+
+    add_adapter_test(level_zero_multi_queue
+        FIXTURE DEVICES
+        SOURCES
+            multi_device_event_cache_tests.cpp
+        ENVIRONMENT
+            "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
+            "UR_L0_LEAKS_DEBUG=1"
+    )
+
+    target_link_libraries(test-adapter-level_zero_multi_queue PRIVATE zeCallMap)
+endif()

--- a/test/adapters/level_zero/CMakeLists.txt
+++ b/test/adapters/level_zero/CMakeLists.txt
@@ -56,14 +56,6 @@ if(NOT WIN32)
     )
 
     target_link_libraries(test-adapter-level_zero_ze_calls PRIVATE zeCallMap)
-endif()
-
-if(NOT WIN32)
-    # Make L0 use CallMap from a seprate shared lib so that we can access the map
-    # from the tests. This only seems to work on linux
-    add_library(zeCallMap SHARED zeCallMap.cpp)
-    target_compile_definitions(ur_adapter_level_zero PRIVATE UR_L0_CALL_COUNT_IN_TESTS)
-    target_link_libraries(ur_adapter_level_zero PRIVATE zeCallMap)
 
     add_adapter_test(level_zero_multi_queue
         FIXTURE DEVICES

--- a/test/adapters/level_zero/multi_device_event_cache_tests.cpp
+++ b/test/adapters/level_zero/multi_device_event_cache_tests.cpp
@@ -1,0 +1,107 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "ur_print.hpp"
+#include "uur/fixtures.h"
+#include "uur/raii.h"
+
+#include <map>
+#include <string>
+
+extern std::map<std::string, int> *ZeCallCount;
+
+using urMultiQueueMultiDeviceEventCacheTest = uur::urAllDevicesTest;
+TEST_F(urMultiQueueMultiDeviceEventCacheTest,
+       GivenMultiSubDeviceWithQueuePerSubDeviceThenEventIsSharedBetweenQueues) {
+    uint32_t max_sub_devices = 0;
+    ASSERT_SUCCESS(
+        uur::GetDevicePartitionMaxSubDevices(devices[0], max_sub_devices));
+    if (max_sub_devices < 2) {
+        GTEST_SKIP();
+    }
+    ur_device_partition_property_t prop;
+    prop.type = UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN;
+    prop.value.affinity_domain =
+        UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE;
+
+    ur_device_partition_properties_t properties{
+        UR_STRUCTURE_TYPE_DEVICE_PARTITION_PROPERTIES,
+        nullptr,
+        &prop,
+        1,
+    };
+    uint32_t numSubDevices = 0;
+    ASSERT_SUCCESS(
+        urDevicePartition(devices[0], &properties, 0, nullptr, &numSubDevices));
+    std::vector<ur_device_handle_t> sub_devices;
+    sub_devices.reserve(numSubDevices);
+    ASSERT_SUCCESS(urDevicePartition(devices[0], &properties, numSubDevices,
+                                     sub_devices.data(), nullptr));
+    uur::raii::Context context1 = nullptr;
+    ASSERT_SUCCESS(
+        urContextCreate(1, &sub_devices[0], nullptr, context1.ptr()));
+    ASSERT_NE(nullptr, context1);
+    uur::raii::Context context2 = nullptr;
+    ASSERT_SUCCESS(
+        urContextCreate(1, &sub_devices[1], nullptr, context2.ptr()));
+    ASSERT_NE(nullptr, context2);
+    ur_queue_handle_t queue1 = nullptr;
+    ASSERT_SUCCESS(urQueueCreate(context1, sub_devices[0], 0, &queue1));
+    ur_queue_handle_t queue2 = nullptr;
+    ASSERT_SUCCESS(urQueueCreate(context2, sub_devices[1], 0, &queue2));
+    uur::raii::Event event = nullptr;
+    uur::raii::Event eventWait = nullptr;
+    uur::raii::Event eventWaitDummy = nullptr;
+    (*ZeCallCount)["zeCommandListAppendWaitOnEvents"] = 0;
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context2, nullptr,
+                                                 eventWait.ptr()));
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context1, nullptr,
+                                                 eventWaitDummy.ptr()));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWait(queue1, 1, eventWaitDummy.ptr(), eventWait.ptr()));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWait(queue2, 1, eventWait.ptr(), event.ptr()));
+    EXPECT_EQ((*ZeCallCount)["zeCommandListAppendWaitOnEvents"], 2);
+    ASSERT_SUCCESS(urEventRelease(eventWaitDummy.get()));
+    ASSERT_SUCCESS(urEventRelease(eventWait.get()));
+    ASSERT_SUCCESS(urEventRelease(event.get()));
+    ASSERT_SUCCESS(urQueueRelease(queue2));
+    ASSERT_SUCCESS(urQueueRelease(queue1));
+}
+
+TEST_F(urMultiQueueMultiDeviceEventCacheTest,
+       GivenMultiDeviceWithQueuePerDeviceThenMultiDeviceEventIsCreated) {
+    if (devices.size() < 2) {
+        GTEST_SKIP();
+    }
+    uur::raii::Context context1 = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &devices[0], nullptr, context1.ptr()));
+    ASSERT_NE(nullptr, context1);
+    uur::raii::Context context2 = nullptr;
+    ASSERT_SUCCESS(urContextCreate(1, &devices[1], nullptr, context2.ptr()));
+    ASSERT_NE(nullptr, context2);
+    ur_queue_handle_t queue1 = nullptr;
+    ASSERT_SUCCESS(urQueueCreate(context1, devices[0], 0, &queue1));
+    ur_queue_handle_t queue2 = nullptr;
+    ASSERT_SUCCESS(urQueueCreate(context2, devices[1], 0, &queue2));
+    uur::raii::Event event = nullptr;
+    uur::raii::Event eventWait = nullptr;
+    uur::raii::Event eventWaitDummy = nullptr;
+    (*ZeCallCount)["zeCommandListAppendWaitOnEvents"] = 0;
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context2, nullptr,
+                                                 eventWait.ptr()));
+    EXPECT_SUCCESS(urEventCreateWithNativeHandle(nullptr, context1, nullptr,
+                                                 eventWaitDummy.ptr()));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWait(queue1, 1, eventWaitDummy.ptr(), eventWait.ptr()));
+    EXPECT_SUCCESS(
+        urEnqueueEventsWait(queue2, 1, eventWait.ptr(), event.ptr()));
+    EXPECT_EQ((*ZeCallCount)["zeCommandListAppendWaitOnEvents"], 3);
+    ASSERT_SUCCESS(urEventRelease(eventWaitDummy.get()));
+    ASSERT_SUCCESS(urEventRelease(eventWait.get()));
+    ASSERT_SUCCESS(urEventRelease(event.get()));
+    ASSERT_SUCCESS(urQueueRelease(queue2));
+    ASSERT_SUCCESS(urQueueRelease(queue1));
+}


### PR DESCRIPTION
- Fix the creation of the multi device event to occur only when the root devices of the event and the executing queue do not match.