### PR TITLE
[L0] Fix local build without system install

### DIFF
--- a/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
+++ b/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
@@ -3,9 +3,9 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "level_zero/ze_api.h"
 #include "ur_api.h"
 #include "uur/checks.h"
+#include "ze_api.h"
 #include <uur/fixtures.h>
 
 using urLevelZeroKernelNativeHandleTest = uur::urContextTest;


### PR DESCRIPTION
Use the include path for `ze_api.h` which points to the Level Zero loader in the build dependencies, which does not have reside in the `level_zero` subdirectory, in Level Zero adapter test suite.

I believe this passed GHA because of the presence of a system install of Level Zero, rather than relying on the header acquired via fetch content.
