### PR TITLE
[UR] Fix adapter search on Windows

### DIFF
--- a/source/loader/windows/adapter_search.cpp
+++ b/source/loader/windows/adapter_search.cpp
@@ -23,8 +23,14 @@ namespace fs = filesystem;
 namespace ur_loader {
 
 std::optional<fs::path> getLoaderLibPath() {
+    HMODULE hModule = NULL;
     char pathStr[MAX_PATH_LEN_WIN];
-    if (GetModuleFileNameA(nullptr, pathStr, MAX_PATH_LEN_WIN)) {
+
+    if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                              GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          reinterpret_cast<LPCSTR>(&getLoaderLibPath),
+                          &hModule) &&
+        GetModuleFileNameA(hModule, pathStr, MAX_PATH_LEN_WIN)) {
         auto libPath = fs::path(pathStr);
         if (fs::exists(libPath)) {
             return fs::absolute(libPath).parent_path();


### PR DESCRIPTION
The loader mistakenly searched for adapters in the directory of the executable that linked it, instead of its own directory.