### PR TITLE
[CUDA] wire up cooperative kernel launch

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -535,9 +535,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     const size_t *pLocalWorkSize, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  return urEnqueueKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                               pGlobalWorkSize, pLocalWorkSize,
-                               numEventsInWaitList, phEventWaitList, phEvent);
+  if (pGlobalWorkOffset == nullptr) {
+    ur_exp_launch_property_t coop_prop;
+    coop_prop.id = UR_EXP_LAUNCH_PROPERTY_ID_COOPERATIVE;
+    coop_prop.value.cooperative = 1;
+    return urEnqueueKernelLaunchCustomExp(
+        hQueue, hKernel, workDim, pGlobalWorkSize, pLocalWorkSize, 1,
+        &coop_prop, numEventsInWaitList, phEventWaitList, phEvent);
+  } else {
+    return urEnqueueKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                                 pGlobalWorkSize, pLocalWorkSize,
+                                 numEventsInWaitList, phEventWaitList, phEvent);
+  }
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -542,11 +542,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     return urEnqueueKernelLaunchCustomExp(
         hQueue, hKernel, workDim, pGlobalWorkSize, pLocalWorkSize, 1,
         &coop_prop, numEventsInWaitList, phEventWaitList, phEvent);
-  } else {
-    return urEnqueueKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
-                                 pGlobalWorkSize, pLocalWorkSize,
-                                 numEventsInWaitList, phEventWaitList, phEvent);
   }
+  return urEnqueueKernelLaunch(hQueue, hKernel, workDim, pGlobalWorkOffset,
+                               pGlobalWorkSize, pLocalWorkSize,
+                               numEventsInWaitList, phEventWaitList, phEvent);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(

--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -535,7 +535,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     const size_t *pLocalWorkSize, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  if (pGlobalWorkOffset == nullptr) {
+  if (*pGlobalWorkOffset == 0 || pGlobalWorkOffset == nullptr) {
     ur_exp_launch_property_t coop_prop;
     coop_prop.id = UR_EXP_LAUNCH_PROPERTY_ID_COOPERATIVE;
     coop_prop.value.cooperative = 1;


### PR DESCRIPTION
The DPC++ `root_group` test already passes (and still does with this patch), but it doesn't actually enable `root_group` sync in reality. However I think the only thing missing is this small patch. With this patch the the custom kernel launch is called with the cooperative attribute. 

I've tested this locally, but will link up a dpc++ ci test for completeness.