### PR TITLE
Fix duplicate targets for `test-adapter-level-zero`

### DIFF
--- a/test/adapters/level_zero/CMakeLists.txt
+++ b/test/adapters/level_zero/CMakeLists.txt
@@ -9,51 +9,50 @@ if(NOT UR_DPCXX)
     message(WARNING
         "UR_DPCXX is not defined, skipping adapter tests for level_zero")
 else()
+
+    set(EXTRA_ENV "")
+    if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+        set(EXTRA_SOURCES event_cache_tests.cpp)
+        set(EXTRA_ENV "UR_L0_LEAKS_DEBUG=1")
+    endif()
+
     add_adapter_test(level_zero
         FIXTURE KERNELS
         SOURCES
             urProgramLink.cpp
-            urKernelCreateWithNativeHandle.cpp
+            ${EXTRA_SOURCES}
         ENVIRONMENT
             "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
-    )
-    # TODO: valgrind tests require very new environment.
-    # Enable once all L0 runners are updated.
-    # add_adapter_memcheck_test(level_zero
-    #    ENVIRONMENT
-    #         "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
-    # )
-
-    target_link_libraries(test-adapter-level_zero PRIVATE
-        LevelZeroLoader
-        LevelZeroLoader-Headers
+            ${EXTRA_ENV}
     )
 
     target_include_directories(test-adapter-level_zero PRIVATE
         ${PROJECT_SOURCE_DIR}/source
         ${PROJECT_SOURCE_DIR}/source/adapters/level_zero
-        LevelZeroLoader-Headers
     )
 
     add_dependencies(test-adapter-level_zero
         generate_device_binaries kernel_names_header)
 endif()
 
-if(LINUX)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # Make L0 use CallMap from a seprate shared lib so that we can access the map
     # from the tests. This only seems to work on linux
     add_library(zeCallMap SHARED zeCallMap.cpp)
     target_compile_definitions(ur_adapter_level_zero PRIVATE UR_L0_CALL_COUNT_IN_TESTS)
     target_link_libraries(ur_adapter_level_zero PRIVATE zeCallMap)
-
-    add_adapter_test(level_zero
-        FIXTURE DEVICES
-        SOURCES
-            event_cache_tests.cpp
-        ENVIRONMENT
-            "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
-            "UR_L0_LEAKS_DEBUG=1"
-    )
+    # If UR_DPCXX is defined then the test-adapter-level-zero was added already taking into 
+    # consideration the needed extra sources and envs.
+    if(NOT UR_DPCXX)
+        add_adapter_test(level_zero
+            FIXTURE DEVICES
+            SOURCES
+                event_cache_tests.cpp
+            ENVIRONMENT
+                "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
+                "UR_L0_LEAKS_DEBUG=1"
+        )
+    endif()
 
     target_link_libraries(test-adapter-level_zero PRIVATE zeCallMap)
 endif()


### PR DESCRIPTION
If we configured our build with `UR_DPCXX` specified and on `LINUX` platform, we will have a duplicate target for `test-adapter-level-zero` which will fail with an error of multiple targets with the same name. This PR should fix that.

This also changes `if(LINUX)` to `if(CMAKE_SYSTEM_NAME STREQUAL Linux)`.