### PR TITLE
[cuda] Add cuda 11.8 #ifdef for `cuEnqueueKernelEx`.

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -553,7 +553,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
                           pLocalWorkSize, numEventsInWaitList, phEventWaitList,
                           phEvent);
   }
-
+#if CUDA_VERSION >= 11080
   // Preconditions
   UR_ASSERT(hQueue->getDevice() == hKernel->getProgram()->getDevice(),
             UR_RESULT_ERROR_INVALID_KERNEL);
@@ -722,6 +722,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     return Err;
   }
   return UR_RESULT_SUCCESS;
+#endif // CUDA_VERSION >= 11080
+  setErrorMessage("This feature requires cuda 11.8 or later.",
+                  UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+  return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
 }
 
 /// Set parameters for general 3D memory copy.


### PR DESCRIPTION
This was erroring out for cuda earlier than 11.8 due to `cuEnqueueKernelEx` and associated attributes not being introduced till cuda 11.8