### PR TITLE
Remove the check for MultiDeviceEvent->CounterBasedEventsEnabled

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1529,8 +1529,7 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
 
           ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
                      (ZeCommandList, 1u, &EventList[I]->ZeEvent));
-          if (!MultiDeviceEvent->CounterBasedEventsEnabled)
-            ZE2UR_CALL(zeEventHostSignal, (MultiDeviceZeEvent));
+          ZE2UR_CALL(zeEventHostSignal, (MultiDeviceZeEvent));
 
           UR_CALL(Queue->executeCommandList(CommandList, /* IsBlocking */ false,
                                             /* OkToBatchCommand */ true));


### PR DESCRIPTION
Remove the if check condition for `MultiDeviceEvent->CounterBasedEventsEnabled` in l0 events. This is based on this [comment](https://github.com/oneapi-src/unified-runtime/pull/1685#discussion_r1619135051)