### PR TITLE
[Test] Add UUID to device name

### DIFF
--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -189,9 +189,13 @@ inline std::string GetPlatformName(ur_platform_handle_t hPlatform) {
 }
 
 inline std::string GetDeviceName(ur_device_handle_t device) {
-    std::string device_name;
+    std::string device_name, device_uuid;
     GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_NAME, device_name);
-    return GTestSanitizeString(device_name);
+    GetDeviceInfo<std::string>(device, UR_DEVICE_INFO_UUID, device_uuid);
+    if (!device_uuid.empty()) {
+        device_uuid += "____";
+    }
+    return GTestSanitizeString(device_name + device_uuid);
 }
 
 inline std::string GetPlatformAndDeviceName(ur_device_handle_t device) {


### PR DESCRIPTION
Without having a device index or UUID added to the device name, tests were failing in multi GPU systems as tests would instantiate the same testnames for separate GPUs of the same model. This makes each GPU name unique, which in turn makes test names unique.