### PR TITLE
Add support for comments in match files

### DIFF
--- a/cmake/match.py
+++ b/cmake/match.py
@@ -63,6 +63,7 @@ def check_status(input_lines, match_lines):
 class Tag(Enum):
     OPT = "{{OPT}}"         # makes the line optional
     IGNORE = "{{IGNORE}}"   # ignores all input until next match or end of input file
+    COMMENT = "#"           # comment - line ignored
 
 
 ## @brief main function for the match file processing script
@@ -76,7 +77,15 @@ def main():
 
     with open(input_file, 'r') as input, open(match_file, 'r') as match:
         input_lines = input.readlines()
-        match_lines = match.readlines()
+        # Filter out empty lines and comments (lines beginning with the comment
+        # character, ignoring leading whitespace)
+        match_lines = list(
+            filter(
+                lambda line: line.strip()
+                and not line.lstrip().startswith(Tag.COMMENT.value),
+                match.readlines(),
+            )
+        )
 
     ignored_lines = []
 

--- a/test/conformance/enqueue/enqueue_adapter_hip.match
+++ b/test/conformance/enqueue/enqueue_adapter_hip.match
@@ -1,3 +1,4 @@
+# HIP can't check kernel arguments
 urEnqueueKernelLaunchTest.InvalidKernelArgs/AMD_HIP_BACKEND___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.NonMatchingLocalSize/AMD_HIP_BACKEND___{{.*}}_
 urEnqueueKernelLaunchKernelSubGroupTest.Success/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/program/program_adapter_hip.match
+++ b/test/conformance/program/program_adapter_hip.match
@@ -13,7 +13,10 @@ urProgramBuildTest.BuildFailure/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramGetBuildInfoTest.InvalidNullHandleDevice/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_BUILD_INFO_BINARY_TYPE
 {{OPT}}urProgramGetBuildInfoSingleTest.LogIsNullTerminated/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_KERNELS
+
+# HIP doesn't expose kernel names
 {{OPT}}urProgramGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES
+
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_REFERENCE_COUNT
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_CONTEXT
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_DEVICES
@@ -23,7 +26,10 @@ urProgramBuildTest.BuildFailure/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_BINARIES
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_KERNELS
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES
+
+# HIP hasn't implemented urProgramLink
 {{OPT}}urProgramLinkTest.Success/AMD_HIP_BACKEND___{{.*}}_
+
 {{OPT}}urProgramSetSpecializationConstantsTest.Success/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramSetSpecializationConstantsTest.UseDefaultValue/AMD_HIP_BACKEND___{{.*}}_
 {{OPT}}urProgramSetMultipleSpecializationConstantsTest.MultipleCalls/AMD_HIP_BACKEND___{{.*}}_


### PR DESCRIPTION
These have a variety of uses. For example, by documenting the reasons for known failures inside the match files themselves, we can keep all relevant information in one place and help direct developers towards known reproducers, areas of code to investigate, etc.

The comment character is '#' which is fairly common and intuitive, especially in conf-style file types. Also no GTest tests should ever be named with that character.