### PR TITLE
Add hAdapter parameter to urPlatformCreateWithNativeHandle

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1188,6 +1188,8 @@ typedef struct ur_platform_native_properties_t {
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
@@ -1195,6 +1197,7 @@ typedef struct ur_platform_native_properties_t {
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformCreateWithNativeHandle(
     ur_native_handle_t hNativePlatform,                 ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t hAdapter,                       ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *phPlatform                    ///< [out] pointer to the handle of the platform object created.
 );
@@ -9552,6 +9555,7 @@ typedef struct ur_platform_get_native_handle_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_platform_create_with_native_handle_params_t {
     ur_native_handle_t *phNativePlatform;
+    ur_adapter_handle_t *phAdapter;
     const ur_platform_native_properties_t **ppProperties;
     ur_platform_handle_t **pphPlatform;
 } ur_platform_create_with_native_handle_params_t;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -49,6 +49,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnPlatformGetNativeHandle_t)(
 /// @brief Function-pointer for urPlatformCreateWithNativeHandle
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformCreateWithNativeHandle_t)(
     ur_native_handle_t,
+    ur_adapter_handle_t,
     const ur_platform_native_properties_t *,
     ur_platform_handle_t *);
 

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -10215,6 +10215,12 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->phNativePlatform));
 
     os << ", ";
+    os << ".hAdapter = ";
+
+    ur::details::printPtr(os,
+                          *(params->phAdapter));
+
+    os << ", ";
     os << ".pProperties = ";
 
     ur::details::printPtr(os,

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -211,6 +211,9 @@ params:
     - type: $x_native_handle_t
       name: hNativePlatform
       desc: "[in][nocheck] the native handle of the platform."
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter associated with the native backend."
     - type: const $x_platform_native_properties_t*
       name: pProperties
       desc: "[in][optional] pointer to native platform properties struct."

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -653,7 +653,7 @@ def get_adapter_handles(specs):
     objs = []
     for s in specs:
         for obj in s['objects']:
-            if obj_traits.is_handle(obj) and not obj_traits.is_loader_only(obj):
+            if obj_traits.is_handle(obj) and not (obj_traits.is_loader_only(obj) or 'native' in obj['name']):
                 objs.append(obj)
 
     return objs

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -132,7 +132,7 @@ namespace ur_loader
         %else:
         <%param_replacements={}%>
         %for i, item in enumerate(th.get_loader_prologue(n, tags, obj, meta)):
-        %if not '_native_object_' in item['obj'] or th.make_func_name(n, tags, obj) == 'urPlatformCreateWithNativeHandle':
+        %if not '_native_object_' in item['obj']:
         // extract platform's function pointer table
         auto dditable = reinterpret_cast<${item['obj']}*>( ${item['pointer']}${item['name']} )->dditable;
         auto ${th.make_pfn_name(n, tags, obj)} = dditable->${n}.${th.get_table_name(n, tags, obj)}.${th.make_pfn_name(n, tags, obj)};
@@ -151,7 +151,7 @@ namespace ur_loader
         for( size_t i = ${item['range'][0]}; i < ${item['range'][1]}; ++i )
             ${item['name']}Local[ i ] = reinterpret_cast<${item['obj']}*>( ${item['name']}[ i ] )->handle;
         %else:
-        %if not '_native_object_' in item['obj'] or th.make_func_name(n, tags, obj) == 'urPlatformCreateWithNativeHandle':
+        %if not '_native_object_' in item['obj']:
         // convert loader handle to platform handle
         %if item['optional']:
         ${item['name']} = ( ${item['name']} ) ? reinterpret_cast<${item['obj']}*>( ${item['name']} )->handle : nullptr;
@@ -279,7 +279,7 @@ namespace ur_loader
         %if item['release']:
         // release loader handle
         ${item['factory']}.release( ${item['name']} );
-        %elif not '_native_object_' in item['obj'] or th.make_func_name(n, tags, obj) == 'urPlatformCreateWithNativeHandle':
+        %elif not '_native_object_' in item['obj']:
         try
         {
             %if 'typename' in item:

--- a/source/adapters/cuda/platform.cpp
+++ b/source/adapters/cuda/platform.cpp
@@ -141,12 +141,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform,
-    const ur_platform_native_properties_t *pProperties,
-    ur_platform_handle_t *phPlatform) {
-  std::ignore = hNativePlatform;
-  std::ignore = pProperties;
-  std::ignore = phPlatform;
+    ur_native_handle_t, ur_adapter_handle_t,
+    const ur_platform_native_properties_t *, ur_platform_handle_t *) {
+  // There is no CUDA equivalent to ur_platform_handle_t
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/hip/platform.cpp
+++ b/source/adapters/hip/platform.cpp
@@ -135,12 +135,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform,
-    const ur_platform_native_properties_t *pProperties,
-    ur_platform_handle_t *phPlatform) {
-  std::ignore = hNativePlatform;
-  std::ignore = pProperties;
-  std::ignore = phPlatform;
+    ur_native_handle_t, ur_adapter_handle_t,
+    const ur_platform_native_properties_t *, ur_platform_handle_t *) {
+  // There is no HIP equivalent to ur_platform_handle_t
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -123,6 +123,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         NativePlatform, ///< [in] the native handle of the platform.
+    ur_adapter_handle_t,
     const ur_platform_native_properties_t
         *Properties, ///< [in][optional] pointer to native platform properties
                      ///< struct.

--- a/source/adapters/native_cpu/platform.cpp
+++ b/source/adapters/native_cpu/platform.cpp
@@ -96,13 +96,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform,
-    const ur_platform_native_properties_t *pProperties,
-    ur_platform_handle_t *phPlatform) {
-  std::ignore = hNativePlatform;
-  std::ignore = pProperties;
-  std::ignore = phPlatform;
-
+    ur_native_handle_t, ur_adapter_handle_t,
+    const ur_platform_native_properties_t *, ur_platform_handle_t *) {
   DIE_NO_IMPLEMENTATION;
 }
 

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -263,6 +263,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
@@ -274,8 +276,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     auto pfnCreateWithNativeHandle =
         d_context.urDdiTable.Platform.pfnCreateWithNativeHandle;
     if (nullptr != pfnCreateWithNativeHandle) {
-        result =
-            pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
+        result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter,
+                                           pProperties, phPlatform);
     } else {
         // generic implementation
         *phPlatform = reinterpret_cast<ur_platform_handle_t>(d_context.get());

--- a/source/adapters/opencl/platform.cpp
+++ b/source/adapters/opencl/platform.cpp
@@ -106,8 +106,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
-    ur_native_handle_t hNativePlatform, const ur_platform_native_properties_t *,
-    ur_platform_handle_t *phPlatform) {
+    ur_native_handle_t hNativePlatform, ur_adapter_handle_t,
+    const ur_platform_native_properties_t *, ur_platform_handle_t *phPlatform) {
   *phPlatform = reinterpret_cast<ur_platform_handle_t>(hNativePlatform);
   return UR_RESULT_SUCCESS;
 }

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -352,6 +352,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
@@ -365,15 +367,15 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     }
 
     ur_platform_create_with_native_handle_params_t params = {
-        &hNativePlatform, &pProperties, &phPlatform};
+        &hNativePlatform, &hAdapter, &pProperties, &phPlatform};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
                              "urPlatformCreateWithNativeHandle", &params);
 
     context.logger.info("---> urPlatformCreateWithNativeHandle");
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
+    ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter,
+                                                   pProperties, phPlatform);
 
     context.notify_end(UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE,
                        "urPlatformCreateWithNativeHandle", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -347,6 +347,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
@@ -360,13 +362,22 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     }
 
     if (context.enableParameterValidation) {
+        if (NULL == hAdapter) {
+            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+        }
+
         if (NULL == phPlatform) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
     }
 
-    ur_result_t result =
-        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
+    if (context.enableLifetimeValidation &&
+        !refCountContext.isReferenceValid(hAdapter)) {
+        refCountContext.logInvalidReference(hAdapter);
+    }
+
+    ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter,
+                                                   pProperties, phPlatform);
 
     return result;
 }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -364,6 +364,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
@@ -372,8 +374,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->dditable;
+    auto dditable = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->dditable;
     auto pfnCreateWithNativeHandle =
         dditable->ur.Platform.pfnCreateWithNativeHandle;
     if (nullptr == pfnCreateWithNativeHandle) {
@@ -381,12 +382,11 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     }
 
     // convert loader handle to platform handle
-    hNativePlatform =
-        reinterpret_cast<ur_native_object_t *>(hNativePlatform)->handle;
+    hAdapter = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->handle;
 
     // forward to device-platform
-    result =
-        pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
+    result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter, pProperties,
+                                       phPlatform);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -22,7 +22,6 @@ ur_event_factory_t ur_event_factory;
 ur_program_factory_t ur_program_factory;
 ur_kernel_factory_t ur_kernel_factory;
 ur_queue_factory_t ur_queue_factory;
-ur_native_factory_t ur_native_factory;
 ur_sampler_factory_t ur_sampler_factory;
 ur_mem_factory_t ur_mem_factory;
 ur_physical_mem_factory_t ur_physical_mem_factory;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -49,10 +49,6 @@ using ur_queue_object_t = object_t<ur_queue_handle_t>;
 using ur_queue_factory_t =
     singleton_factory_t<ur_queue_object_t, ur_queue_handle_t>;
 
-using ur_native_object_t = object_t<ur_native_handle_t>;
-using ur_native_factory_t =
-    singleton_factory_t<ur_native_object_t, ur_native_handle_t>;
-
 using ur_sampler_object_t = object_t<ur_sampler_handle_t>;
 using ur_sampler_factory_t =
     singleton_factory_t<ur_sampler_object_t, ur_sampler_handle_t>;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -653,6 +653,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
@@ -660,6 +662,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *
@@ -671,7 +675,8 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnCreateWithNativeHandle(hNativePlatform, pProperties, phPlatform);
+    return pfnCreateWithNativeHandle(hNativePlatform, hAdapter, pProperties,
+                                     phPlatform);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -569,6 +569,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phPlatform`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
@@ -576,6 +578,8 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
+    ur_adapter_handle_t
+        hAdapter, ///< [in] handle of the adapter associated with the native backend.
     const ur_platform_native_properties_t *
         pProperties, ///< [in][optional] pointer to native platform properties struct.
     ur_platform_handle_t *

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -20,8 +20,8 @@ TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
         // We can however convert the native_handle back into a unified-runtime
         // handle and perform some query on it to verify that it works.
         ur_platform_handle_t plat = nullptr;
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urPlatformCreateWithNativeHandle(native_handle, nullptr, &plat));
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urPlatformCreateWithNativeHandle(
+            native_handle, adapters[0], nullptr, &plat));
         ASSERT_NE(plat, nullptr);
 
         std::string input_platform_name = uur::GetPlatformName(platform);
@@ -45,8 +45,8 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
         ur_platform_native_properties_t props = {
             UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES, nullptr, true};
         ur_platform_handle_t plat = nullptr;
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urPlatformCreateWithNativeHandle(native_handle, &props, &plat));
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urPlatformCreateWithNativeHandle(
+            native_handle, adapters[0], &props, &plat));
         ASSERT_NE(plat, nullptr);
 
         std::string input_platform_name = uur::GetPlatformName(platform);
@@ -70,8 +70,8 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
         ur_platform_native_properties_t props = {
             UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES, nullptr, false};
         ur_platform_handle_t plat = nullptr;
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urPlatformCreateWithNativeHandle(native_handle, &props, &plat));
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urPlatformCreateWithNativeHandle(
+            native_handle, adapters[0], &props, &plat));
         ASSERT_NE(plat, nullptr);
 
         std::string input_platform_name = uur::GetPlatformName(platform);
@@ -84,8 +84,8 @@ TEST_F(urPlatformCreateWithNativeHandleTest, InvalidNullPointerPlatform) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = nullptr;
         ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
-        ASSERT_EQ_RESULT(
-            UR_RESULT_ERROR_INVALID_NULL_POINTER,
-            urPlatformCreateWithNativeHandle(native_handle, nullptr, nullptr));
+        ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
+                         urPlatformCreateWithNativeHandle(
+                             native_handle, adapters[0], nullptr, nullptr));
     }
 }


### PR DESCRIPTION
Other CreateWithNative entry points need a UR handle primarily so the loader has something to obtain a ddi table from. This new adapter parameter fulfils that purpose for PlatformCreateWithNative, allowing us to remove a weird hack that saw the loader getting (apparently succesfully somehow??) a loader object out of the native handle itself.

fixes https://github.com/oneapi-src/unified-runtime/issues/1068