### PR TITLE
Set minimum L0 device support to support UR kernel update

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1295,7 +1295,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     MutableGroupCountDesc->pNext = NextDesc;
     DEBUG_LOG(MutableGroupCountDesc->pNext);
     MutableGroupCountDesc->pGroupCount = &ZeThreadGroupDimensions;
-    DEBUG_LOG(MutableGroupCountDesc->pGroupCount);
+    DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountX);
+    DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountY);
+    DEBUG_LOG(MutableGroupCountDesc->pGroupCount->groupCountZ);
     NextDesc = MutableGroupCountDesc.get();
     GroupCountDescs.push_back(std::move(MutableGroupCountDesc));
 

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -947,18 +947,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
     return ReturnValue(true);
   case UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP: {
-    // TODO: Level Zero API allows to check support for all sub-features:
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS,
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT,
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE,
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET,
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_SIGNAL_EVENT,
-    // ZE_MUTABLE_COMMAND_EXP_FLAG_WAIT_EVENTS
-    // but UR has only one property to check the mutable command lists feature
-    // support. For now return true if kernel arguments can be updated.
-    auto KernelArgUpdateSupport =
-        Device->ZeDeviceMutableCmdListsProperties->mutableCommandFlags &
-        ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS;
+    // Update support requires being able to update kernel arguments and all
+    // aspects of the kernel NDRange.
+    const ze_mutable_command_exp_flags_t UpdateMask =
+        ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS |
+        ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT |
+        ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE |
+        ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET;
+
+    const bool KernelArgUpdateSupport =
+        (Device->ZeDeviceMutableCmdListsProperties->mutableCommandFlags &
+         UpdateMask) == UpdateMask;
     return ReturnValue(KernelArgUpdateSupport &&
                        Device->Platform->ZeMutableCmdListExt.Supported);
   }


### PR DESCRIPTION
In order to support all the ways a kernel command in a command-buffer can be updated in Unified Runtime, the following capabilities need to be available from the device:
* `ZE_MUTABLE_COMMAND_EXP_FLAG_KERNEL_ARGUMENTS`
* `ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_COUNT`
* `ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE`
* `ZE_MUTABLE_COMMAND_EXP_FLAG_GLOBAL_OFFSET`

Only supporting kernel argument update is not sufficient, as is currently the case. There is also no way in the UR API currently to take advantage of the `ZE_MUTABLE_COMMAND_EXP_FLAG_SIGNAL_EVENT` and `ZE_MUTABLE_COMMAND_EXP_FLAG_WAIT_EVENTS` capabilities, so these can be omitted.

Also fix debug printing of `pGroupCount` in command update, as we want to show the values it contains rather than pointer value.

DPC++ PR https://github.com/intel/llvm/pull/13987