### PR TITLE
Add flexibility to change level zero repo

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -6,17 +6,17 @@
 
 set(TARGET_NAME ur_adapter_level_zero)
 
-# Copy L0 loader/headers locally to the build to avoid leaking their path.
+# Copy Level Zero loader/headers locally to the build to avoid leaking their path.
 set(LEVEL_ZERO_COPY_DIR ${CMAKE_CURRENT_BINARY_DIR}/level_zero_loader)
-if (DEFINED L0_LIBRARY)
-  get_filename_component(LEVEL_ZERO_LIB_NAME "${L0_LIBRARY}" NAME)
+if (DEFINED EXTERNAL_LEVEL_ZERO_LIBRARY)
+  get_filename_component(LEVEL_ZERO_LIB_NAME "${EXTERNAL_LEVEL_ZERO_LIBRARY}" NAME)
   set(LEVEL_ZERO_LIBRARY ${LEVEL_ZERO_COPY_DIR}/${LEVEL_ZERO_LIB_NAME})
   message(STATUS "Copying Level Zero loader and headers to local build tree")
-  file(COPY ${L0_LIBRARY} DESTINATION ${LEVEL_ZERO_COPY_DIR} FOLLOW_SYMLINK_CHAIN)
+  file(COPY ${EXTERNAL_LEVEL_ZERO_LIBRARY} DESTINATION ${LEVEL_ZERO_COPY_DIR} FOLLOW_SYMLINK_CHAIN)
 endif()
-if (DEFINED L0_INCLUDE_DIR)
+if (DEFINED EXTERNAL_LEVEL_ZERO_INCLUDE_DIR)
   set(LEVEL_ZERO_INCLUDE_DIR ${LEVEL_ZERO_COPY_DIR}/level_zero)
-  file(COPY ${L0_INCLUDE_DIR}/level_zero DESTINATION ${LEVEL_ZERO_COPY_DIR})
+  file(COPY ${EXTERNAL_LEVEL_ZERO_INCLUDE_DIR}/level_zero DESTINATION ${LEVEL_ZERO_COPY_DIR})
 endif()
 
 if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
@@ -33,8 +33,12 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
     endif()
 
-    set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-    set(LEVEL_ZERO_LOADER_TAG v1.16.1)
+    if (NOT DEFINED LEVEL_ZERO_LOADER_REPO)
+        set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
+    endif()
+    if (NOT DEFINED LEVEL_ZERO_LOADER_TAG)
+        set(LEVEL_ZERO_LOADER_TAG v1.16.1)
+    endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
     set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
Add flexibility to provide level-zero loader repo.
Also rename the variable which allows to provide external prebuilt level zero loader and headers.