### PR TITLE
[L0] Phase 2 of Counter-Based Event Implementation

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -589,7 +589,7 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
     Device = Event->UrQueue->Device;
   }
 
-  if (!Event->CounterBasedEventsEnabled) {
+  if (Event->CounterBasedEventsEnabled) {
     auto Cache = getCounterBasedEventCache(
         !Event->UrQueue || Event->UrQueue->UsingImmCmdLists, Device);
     Cache->emplace_back(Event);

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -576,8 +576,7 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   }
   Cache->erase(It);
   // We have to reset event before using it.
-  if (!CounterBasedEventEnabled)
-    Event->reset();
+  Event->reset();
   return Event;
 }
 

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -564,7 +564,7 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   std::scoped_lock<ur_mutex> Lock(EventCacheMutex);
   auto Cache = getEventCache(HostVisible, WithProfiling, Device);
   if (CounterBasedEventEnabled) {
-    Cache = getCounterBasedEventCache(UsingImmCmdList, Device);
+    Cache = getCounterBasedEventCache(WithProfiling, UsingImmCmdList, Device);
   }
   if (Cache->empty())
     return nullptr;
@@ -576,6 +576,7 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   }
   Cache->erase(It);
   // We have to reset event before using it.
+  // if(!CounterBasedEventEnabled)
   Event->reset();
   return Event;
 }
@@ -590,6 +591,7 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
 
   if (Event->CounterBasedEventsEnabled) {
     auto Cache = getCounterBasedEventCache(
+        Event->isProfilingEnabled(),
         !(Event->UrQueue) || (Event->UrQueue)->UsingImmCmdLists, Device);
     Cache->emplace_back(Event);
   } else {

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -590,8 +590,7 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
 
   if (Event->CounterBasedEventsEnabled) {
     auto Cache = getCounterBasedEventCache(
-        !Legacy(Event->UrQueue) || Legacy(Event->UrQueue)->UsingImmCmdLists,
-        Device);
+        !(Event->UrQueue) || (Event->UrQueue)->UsingImmCmdLists, Device);
     Cache->emplace_back(Event);
   } else {
     auto Cache = getEventCache(Event->isHostVisible(),

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -591,7 +591,8 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
 
   if (Event->CounterBasedEventsEnabled) {
     auto Cache = getCounterBasedEventCache(
-        !Event->UrQueue || Event->UrQueue->UsingImmCmdLists, Device);
+        !Legacy(Event->UrQueue) || Legacy(Event->UrQueue)->UsingImmCmdLists,
+        Device);
     Cache->emplace_back(Event);
   } else {
     auto Cache = getEventCache(Event->isHostVisible(),

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -576,7 +576,6 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   }
   Cache->erase(It);
   // We have to reset event before using it.
-  // if(!CounterBasedEventEnabled)
   Event->reset();
   return Event;
 }

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -217,6 +217,15 @@ struct ur_context_handle_t_ : _ur_object {
   // Add ur_event_handle_t to cache.
   void addEventToContextCache(ur_event_handle_t);
 
+  enum EventCacheType {
+    HostVisibleProfilingCacheType,
+    HostVisibleRegularCacheType,
+    HostInvisibleProfilingCacheType,
+    HostInvisibleRegularCacheType,
+    CounterBasedImmediateCacheType,
+    CounterBasedRegularCacheType
+  };
+
   enum ZeEventPoolCacheType {
     HostVisibleCacheType,
     HostInvisibleCacheType,
@@ -226,14 +235,6 @@ struct ur_context_handle_t_ : _ur_object {
     HostInvisibleCounterBasedImmediateCacheType
   };
 
-  enum EventCacheType {
-    HostVisibleProfilingCacheType,
-    HostVisibleRegularCacheType,
-    HostInvisibleProfilingCacheType,
-    HostInvisibleRegularCacheType,
-    CounterBasedImmediateCacheType,
-    CounterBasedRegularCacheType
-  };
 
   std::list<ze_event_pool_handle_t> *
   getZeEventPoolCache(bool HostVisible, bool WithProfiling,

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -217,15 +217,6 @@ struct ur_context_handle_t_ : _ur_object {
   // Add ur_event_handle_t to cache.
   void addEventToContextCache(ur_event_handle_t);
 
-  enum EventCacheType {
-    HostVisibleProfilingCacheType,
-    HostVisibleRegularCacheType,
-    HostInvisibleProfilingCacheType,
-    HostInvisibleRegularCacheType,
-    CounterBasedImmediateCacheType,
-    CounterBasedRegularCacheType
-  };
-
   enum ZeEventPoolCacheType {
     HostVisibleCacheType,
     HostInvisibleCacheType,
@@ -235,6 +226,14 @@ struct ur_context_handle_t_ : _ur_object {
     HostInvisibleCounterBasedImmediateCacheType
   };
 
+  enum EventCacheType {
+    HostVisibleProfilingCacheType,
+    HostVisibleRegularCacheType,
+    HostInvisibleProfilingCacheType,
+    HostInvisibleRegularCacheType,
+    CounterBasedImmediateCacheType,
+    CounterBasedRegularCacheType
+  };
 
   std::list<ze_event_pool_handle_t> *
   getZeEventPoolCache(bool HostVisible, bool WithProfiling,

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -39,6 +39,13 @@ struct ur_context_handle_t_ : _ur_object {
       : ZeContext{ZeContext}, Devices{Devs, Devs + NumDevices},
         NumDevices{NumDevices} {
     OwnNativeHandle = OwnZeContext;
+    for (const auto &Device : Devices) {
+      for (int i = 0; i < EventCacheTypeCount; i++) {
+        EventCaches.emplace_back();
+        EventCachesDeviceMap[i].insert(
+            std::make_pair(Device, EventCaches.size() - 1));
+      }
+    }
   }
 
   ur_context_handle_t_(ze_context_handle_t ZeContext) : ZeContext{ZeContext} {}
@@ -333,11 +340,6 @@ private:
         auto EventCachesMap =
             WithProfiling ? &EventCachesDeviceMap[HostVisibleProfilingCacheType]
                           : &EventCachesDeviceMap[HostVisibleRegularCacheType];
-        if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
-        }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
         return WithProfiling ? &EventCaches[HostVisibleProfilingCacheType]
@@ -349,11 +351,6 @@ private:
             WithProfiling
                 ? &EventCachesDeviceMap[HostInvisibleProfilingCacheType]
                 : &EventCachesDeviceMap[HostInvisibleRegularCacheType];
-        if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
-        }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
         return WithProfiling ? &EventCaches[HostInvisibleProfilingCacheType]
@@ -369,11 +366,6 @@ private:
             WithProfiling
                 ? &EventCachesDeviceMap[CounterBasedImmediateProfilingCacheType]
                 : &EventCachesDeviceMap[CounterBasedImmediateCacheType];
-        if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
-        }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
         return WithProfiling
@@ -386,11 +378,6 @@ private:
             WithProfiling
                 ? &EventCachesDeviceMap[CounterBasedRegularProfilingCacheType]
                 : &EventCachesDeviceMap[CounterBasedRegularCacheType];
-        if (EventCachesMap->find(Device) == EventCachesMap->end()) {
-          EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
-        }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
         return WithProfiling

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -208,10 +208,11 @@ struct ur_context_handle_t_ : _ur_object {
                                              bool UsingImmCmdList);
 
   // Get ur_event_handle_t from cache.
-  ur_event_handle_t
-  getEventFromContextCache(bool HostVisible, bool WithProfiling,
-                           ur_device_handle_t Device,
-                           bool CounterBasedEventEnabled bool UsingImmCmdList);
+  ur_event_handle_t getEventFromContextCache(bool HostVisible,
+                                             bool WithProfiling,
+                                             ur_device_handle_t Device,
+                                             bool CounterBasedEventEnabled,
+                                             bool UsingImmCmdList);
 
   // Add ur_event_handle_t to cache.
   void addEventToContextCache(ur_event_handle_t);
@@ -340,7 +341,7 @@ private:
         return WithProfiling ? &EventCaches[2] : &EventCaches[3];
       }
     }
-  }
+  };
   auto getCounterBasedEventCache(bool UsingImmediateCmdList,
                                  ur_device_handle_t Device) {
     if (UsingImmediateCmdList) {
@@ -368,9 +369,10 @@ private:
         return &EventCaches[5];
       }
     }
-  };
+  }
+};
 
-  // Helper function to release the context, a caller must lock the
-  // platform-level mutex guarding the container with contexts because the
-  // context can be removed from the list of tracked contexts.
-  ur_result_t ContextReleaseHelper(ur_context_handle_t Context);
+// Helper function to release the context, a caller must lock the
+// platform-level mutex guarding the container with contexts because the
+// context can be removed from the list of tracked contexts.
+ur_result_t ContextReleaseHelper(ur_context_handle_t Context);

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -311,34 +311,45 @@ struct ur_context_handle_t_ : _ur_object {
   ze_context_handle_t getZeHandle() const;
 
 private:
+  enum EventCacheType {
+    HostVisibleProfilingCacheType,
+    HostVisibleRegularCacheType,
+    HostInvisibleProfilingCacheType,
+    HostInvisibleRegularCacheType,
+    CounterBasedRegularCacheType,
+    CounterBasedImmediateCacheType
+  };
   // Get the cache of events for a provided scope and profiling mode.
   auto getEventCache(bool HostVisible, bool WithProfiling,
                      ur_device_handle_t Device) {
     if (HostVisible) {
       if (Device) {
         auto EventCachesMap =
-            WithProfiling ? &EventCachesDeviceMap[0] : &EventCachesDeviceMap[1];
+            WithProfiling ? &EventCachesDeviceMap[HostVisibleProfilingCacheType]
+                          : &EventCachesDeviceMap[HostVisibleRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
+          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return WithProfiling ? &EventCaches[0] : &EventCaches[1];
+        return WithProfiling ? &EventCaches[HostVisibleProfilingCacheType]
+                             : &EventCaches[HostVisibleRegularCacheType];
       }
     } else {
       if (Device) {
         auto EventCachesMap =
-            WithProfiling ? &EventCachesDeviceMap[2] : &EventCachesDeviceMap[3];
+            WithProfiling
+                ? &EventCachesDeviceMap[HostInvisibleProfilingCacheType]
+                : &EventCachesDeviceMap[HostInvisibleRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
+          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return WithProfiling ? &EventCaches[2] : &EventCaches[3];
+        return WithProfiling ? &EventCaches[HostInvisibleProfilingCacheType]
+                             : &EventCaches[HostInvisibleRegularCacheType];
       }
     }
   };
@@ -346,27 +357,27 @@ private:
                                  ur_device_handle_t Device) {
     if (UsingImmediateCmdList) {
       if (Device) {
-        auto EventCachesMap = &EventCachesDeviceMap[4];
+        auto EventCachesMap =
+            &EventCachesDeviceMap[CounterBasedImmediateCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
+          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return &EventCaches[4];
+        return &EventCaches[CounterBasedImmediateCacheType];
       }
     } else {
       if (Device) {
-        auto EventCachesMap = &EventCachesDeviceMap[5];
+        auto EventCachesMap =
+            &EventCachesDeviceMap[CounterBasedRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCachesMap->insert(
-              std::make_pair(Device, EventCaches.size() - 1));
+          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return &EventCaches[5];
+        return &EventCaches[CounterBasedRegularCacheType];
       }
     }
   }

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -217,7 +217,7 @@ struct ur_context_handle_t_ : _ur_object {
   // Add ur_event_handle_t to cache.
   void addEventToContextCache(ur_event_handle_t);
 
-  enum EventPoolCacheType {
+  enum ZeEventPoolCacheType {
     HostVisibleCacheType,
     HostInvisibleCacheType,
     HostVisibleCounterBasedRegularCacheType,
@@ -226,11 +226,20 @@ struct ur_context_handle_t_ : _ur_object {
     HostInvisibleCounterBasedImmediateCacheType
   };
 
+  enum EventCacheType {
+    HostVisibleProfilingCacheType,
+    HostVisibleRegularCacheType,
+    HostInvisibleProfilingCacheType,
+    HostInvisibleRegularCacheType,
+    CounterBasedImmediateCacheType,
+    CounterBasedRegularCacheType
+  };
+
   std::list<ze_event_pool_handle_t> *
   getZeEventPoolCache(bool HostVisible, bool WithProfiling,
                       bool CounterBasedEventEnabled, bool UsingImmediateCmdList,
                       ze_device_handle_t ZeDevice) {
-    EventPoolCacheType CacheType;
+    ZeEventPoolCacheType CacheType;
 
     calculateCacheIndex(HostVisible, CounterBasedEventEnabled,
                         UsingImmediateCmdList, CacheType);
@@ -253,7 +262,7 @@ struct ur_context_handle_t_ : _ur_object {
   ur_result_t calculateCacheIndex(bool HostVisible,
                                   bool CounterBasedEventEnabled,
                                   bool UsingImmediateCmdList,
-                                  EventPoolCacheType &CacheType) {
+                                  ZeEventPoolCacheType &CacheType) {
     if (CounterBasedEventEnabled && HostVisible && !UsingImmediateCmdList) {
       CacheType = HostVisibleCounterBasedRegularCacheType;
     } else if (CounterBasedEventEnabled && !HostVisible &&
@@ -311,14 +320,6 @@ struct ur_context_handle_t_ : _ur_object {
   ze_context_handle_t getZeHandle() const;
 
 private:
-  enum EventCacheType {
-    HostVisibleProfilingCacheType,
-    HostVisibleRegularCacheType,
-    HostInvisibleProfilingCacheType,
-    HostInvisibleRegularCacheType,
-    CounterBasedRegularCacheType,
-    CounterBasedImmediateCacheType
-  };
   // Get the cache of events for a provided scope and profiling mode.
   auto getEventCache(bool HostVisible, bool WithProfiling,
                      ur_device_handle_t Device) {

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -235,6 +235,8 @@ struct ur_context_handle_t_ : _ur_object {
     HostInvisibleRegularCacheType,
     CounterBasedImmediateCacheType,
     CounterBasedRegularCacheType,
+    CounterBasedImmediateProfilingCacheType,
+    CounterBasedRegularProfilingCacheType,
     EventCacheTypeCount
   };
 
@@ -359,12 +361,14 @@ private:
       }
     }
   };
-  auto getCounterBasedEventCache(bool UsingImmediateCmdList,
+  auto getCounterBasedEventCache(bool WithProfiling, bool UsingImmediateCmdList,
                                  ur_device_handle_t Device) {
     if (UsingImmediateCmdList) {
       if (Device) {
         auto EventCachesMap =
-            &EventCachesDeviceMap[CounterBasedImmediateCacheType];
+            WithProfiling
+                ? &EventCachesDeviceMap[CounterBasedImmediateProfilingCacheType]
+                : &EventCachesDeviceMap[CounterBasedImmediateCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
           EventCachesMap->insert(
@@ -372,12 +376,16 @@ private:
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return &EventCaches[CounterBasedImmediateCacheType];
+        return WithProfiling
+                   ? &EventCaches[CounterBasedImmediateProfilingCacheType]
+                   : &EventCaches[CounterBasedImmediateCacheType];
       }
     } else {
       if (Device) {
         auto EventCachesMap =
-            &EventCachesDeviceMap[CounterBasedRegularCacheType];
+            WithProfiling
+                ? &EventCachesDeviceMap[CounterBasedRegularProfilingCacheType]
+                : &EventCachesDeviceMap[CounterBasedRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
           EventCachesMap->insert(
@@ -385,7 +393,9 @@ private:
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
-        return &EventCaches[CounterBasedRegularCacheType];
+        return WithProfiling
+                   ? &EventCaches[CounterBasedRegularProfilingCacheType]
+                   : &EventCaches[CounterBasedRegularCacheType];
       }
     }
   }

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -329,7 +329,8 @@ private:
                           : &EventCachesDeviceMap[HostVisibleRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
+          EventCachesMap->insert(
+              std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
@@ -344,7 +345,8 @@ private:
                 : &EventCachesDeviceMap[HostInvisibleRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
+          EventCachesMap->insert(
+              std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
@@ -361,7 +363,8 @@ private:
             &EventCachesDeviceMap[CounterBasedImmediateCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
+          EventCachesMap->insert(
+              std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {
@@ -373,7 +376,8 @@ private:
             &EventCachesDeviceMap[CounterBasedRegularCacheType];
         if (EventCachesMap->find(Device) == EventCachesMap->end()) {
           EventCaches.emplace_back();
-          EventCaches.insert(std::make_pair(Device, EventCaches.size() - 1));
+          EventCachesMap->insert(
+              std::make_pair(Device, EventCaches.size() - 1));
         }
         return &EventCaches[(*EventCachesMap)[Device]];
       } else {

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -147,9 +147,10 @@ struct ur_context_handle_t_ : _ur_object {
   // head.
   //
   // Cache of event pools to which host-visible events are added to.
-  std::vector<std::list<ze_event_pool_handle_t>> ZeEventPoolCache{12};
+  std::vector<std::list<ze_event_pool_handle_t>> ZeEventPoolCache{
+      ZeEventPoolCacheTypeCount * 2};
   std::vector<std::unordered_map<ze_device_handle_t, size_t>>
-      ZeEventPoolCacheDeviceMap{12};
+      ZeEventPoolCacheDeviceMap{ZeEventPoolCacheTypeCount * 2};
 
   // This map will be used to determine if a pool is full or not
   // by storing number of empty slots available in the pool.
@@ -171,9 +172,9 @@ struct ur_context_handle_t_ : _ur_object {
 
   // Caches for events.
   using EventCache = std::vector<std::list<ur_event_handle_t>>;
-  EventCache EventCaches{6};
+  EventCache EventCaches{EventCacheTypeCount};
   std::vector<std::unordered_map<ur_device_handle_t, size_t>>
-      EventCachesDeviceMap{6};
+      EventCachesDeviceMap{EventCacheTypeCount};
 
   // Initialize the PI context.
   ur_result_t initialize();
@@ -223,7 +224,8 @@ struct ur_context_handle_t_ : _ur_object {
     HostVisibleCounterBasedRegularCacheType,
     HostInvisibleCounterBasedRegularCacheType,
     HostVisibleCounterBasedImmediateCacheType,
-    HostInvisibleCounterBasedImmediateCacheType
+    HostInvisibleCounterBasedImmediateCacheType,
+    ZeEventPoolCacheTypeCount
   };
 
   enum EventCacheType {
@@ -232,7 +234,8 @@ struct ur_context_handle_t_ : _ur_object {
     HostInvisibleProfilingCacheType,
     HostInvisibleRegularCacheType,
     CounterBasedImmediateCacheType,
-    CounterBasedRegularCacheType
+    CounterBasedRegularCacheType,
+    EventCacheTypeCount
   };
 
   std::list<ze_event_pool_handle_t> *

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -833,7 +833,7 @@ urEventRetain(ur_event_handle_t Event ///< [in] handle of the event object
 ur_result_t
 urEventRelease(ur_event_handle_t Event ///< [in] handle of the event object
 ) {
-  if (Event->CounterBasedEventsEnabled && --Event->RefCountExternal == 0) {
+  if (--Event->RefCountExternal == 0 && Event->CounterBasedEventsEnabled) {
     Event->Context->addEventToContextCache(Event);
   } else {
     UR_CALL(urEventReleaseInternal(Event));

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -998,7 +998,7 @@ ur_result_t ur_event_handle_t_::getOrCreateHostVisibleEvent(
 }
 
 ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
-  if (!Event->CounterBasedEventsEnabled && !Event->RefCount.decrementAndTest())
+  if (!Event->RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   if (Event->CommandType == UR_COMMAND_MEM_UNMAP && Event->CommandData) {

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -833,8 +833,7 @@ urEventRetain(ur_event_handle_t Event ///< [in] handle of the event object
 ur_result_t
 urEventRelease(ur_event_handle_t Event ///< [in] handle of the event object
 ) {
-  Event->RefCountExternal--;
-  if (Event->CounterBasedEventsEnabled && Event->RefCountExternal == 0) {
+  if (Event->CounterBasedEventsEnabled && --Event->RefCountExternal == 0) {
     Event->Context->addEventToContextCache(Event);
   } else {
     UR_CALL(urEventReleaseInternal(Event));

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1054,8 +1054,7 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
   // When we add an event to the cache we need to check whether profiling is
   // enabled or not, so we access properties of the queue and that's why queue
   // must released later.
-  if ((Event->RefCountExternal > 0 && !Event->CounterBasedEventsEnabled) &&
-      (DisableEventsCaching || !Event->OwnNativeHandle)) {
+  if (DisableEventsCaching || !Event->OwnNativeHandle) {
     delete Event;
   } else {
     Event->Context->addEventToContextCache(Event);

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1187,7 +1187,7 @@ ur_queue_handle_t_::ur_queue_handle_t_(
     return std::atoi(UrRet) != 0;
   }();
   this->CounterBasedEventsEnabled =
-      UsingImmCmdLists && isInOrderQueue() && Device->useDriverInOrderLists() &&
+      isInOrderQueue() && Device->useDriverInOrderLists() &&
       useDriverCounterBasedEvents &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }


### PR DESCRIPTION
-enable counter-based events for regular commandlist 
-counter-based events may be reused even though they are not done 
-when ref count goes to not used by external clients value it means that event may be reused by subsequent calls -move events that are no longer externally visible to re-usable pool and reuse those more aggressively

intel/llvm PR: https://github.com/intel/llvm/pull/14754