### PR TITLE
Remove L0 limitation from command-buffer update CTS tests

### DIFF
--- a/test/conformance/exp_command_buffer/fixtures.h
+++ b/test/conformance/exp_command_buffer/fixtures.h
@@ -112,11 +112,6 @@ struct urUpdatableCommandBufferExpExecutionTest
             GTEST_SKIP() << "Updating EXP command-buffers is not supported.";
         }
 
-        // Currently level zero driver doesn't support updating execution range.
-        if (backend == UR_PLATFORM_BACKEND_LEVEL_ZERO) {
-            updatable_execution_range_support = false;
-        }
-
         // Create a command-buffer with update enabled.
         ur_exp_command_buffer_desc_t desc{
             UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, nullptr, true};
@@ -154,7 +149,6 @@ struct urUpdatableCommandBufferExpExecutionTest
     }
 
     ur_exp_command_buffer_handle_t updatable_cmd_buf_handle = nullptr;
-    ur_bool_t updatable_execution_range_support = true;
     ur_queue_handle_t queue = nullptr;
 };
 

--- a/test/conformance/exp_command_buffer/ndrange_update.cpp
+++ b/test/conformance/exp_command_buffer/ndrange_update.cpp
@@ -15,10 +15,6 @@ struct NDRangeUpdateTest
         UUR_RETURN_ON_FATAL_FAILURE(
             urUpdatableCommandBufferExpExecutionTest::SetUp());
 
-        if (!updatable_execution_range_support) {
-            GTEST_SKIP() << "Execution range update is not supported.";
-        }
-
         ur_device_usm_access_capability_flags_t shared_usm_flags;
         ASSERT_SUCCESS(
             uur::GetDeviceUSMSingleSharedSupport(device, shared_usm_flags));

--- a/test/conformance/exp_command_buffer/usm_fill_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/usm_fill_kernel_update.cpp
@@ -88,8 +88,7 @@ TEST_P(USMFillCommandTest, UpdateParameters) {
     Validate((uint32_t *)shared_ptr, global_size, val);
 
     // Allocate a new USM pointer of larger size if feature is supported.
-    size_t new_global_size =
-        updatable_execution_range_support ? 64 : global_size;
+    size_t new_global_size = global_size * 2;
     const size_t new_allocation_size = sizeof(val) * new_global_size;
     ASSERT_SUCCESS(urUSMSharedAlloc(context, device, nullptr, nullptr,
                                     new_allocation_size, &new_shared_ptr));
@@ -116,20 +115,20 @@ TEST_P(USMFillCommandTest, UpdateParameters) {
         &new_val, // hArgValue
     };
 
+    size_t new_local_size = local_size;
     ur_exp_command_buffer_update_kernel_launch_desc_t update_desc = {
         UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_DESC, // stype
         nullptr,                                                        // pNext
-        0,                // numNewMemObjArgs
-        1,                // numNewPointerArgs
-        1,                // numNewValueArgs
-        0,                // newWorkDim
-        nullptr,          // pNewMemObjArgList
-        &new_output_desc, // pNewPointerArgList
-        &new_input_desc,  // pNewValueArgList
-        nullptr,          // pNewGlobalWorkOffset
-        updatable_execution_range_support ? &new_global_size
-                                          : nullptr, // pNewGlobalWorkSize
-        nullptr,                                     // pNewLocalWorkSize
+        0,                                   // numNewMemObjArgs
+        1,                                   // numNewPointerArgs
+        1,                                   // numNewValueArgs
+        static_cast<uint32_t>(n_dimensions), // newWorkDim
+        nullptr,                             // pNewMemObjArgList
+        &new_output_desc,                    // pNewPointerArgList
+        &new_input_desc,                     // pNewValueArgList
+        nullptr,                             // pNewGlobalWorkOffset
+        &new_global_size,                    // pNewGlobalWorkSize
+        &new_local_size,                     // pNewLocalWorkSize
     };
 
     // Update kernel and enqueue command-buffer again


### PR DESCRIPTION
The command-buffer kernel update CTS tests currently assume that L0 doesn't support updating the ND-Range configuration of kernels in a command-buffer.

This is no longer the case, and the skips in these situations can be removed. This patch also contains tweaks to the tests to address issues hidden while the tests were skipped on Level Zero.