### PR TITLE
[DRAFT][Prototype] Add implementation for counter-based events in command-buffers

### DIFF
--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -30,7 +30,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ze_command_list_handle_t CommandList,
       ze_command_list_handle_t CommandListResetEvents,
       ZeStruct<ze_command_list_desc_t> ZeDesc,
-      const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
+      const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList,
+      const bool UseCounterBasedEvents);
 
   ~ur_exp_command_buffer_handle_t_();
 
@@ -54,10 +55,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ze_command_list_handle_t ZeCommandListResetEvents;
   // Level Zero command list descriptor
   ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
-  // List of Level Zero fences created when submitting a graph.
-  // This list is needed to release all fences retained by the
-  // command_buffer.
-  std::vector<ze_fence_handle_t> ZeFencesList;
   // Queue properties from command-buffer descriptor
   // TODO: Do we need these?
   ur_queue_properties_t QueueProperties;
@@ -86,6 +83,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   bool IsProfilingEnabled = false;
   // Command-buffer can be submitted to an in-order command-list.
   bool IsInOrderCmdList = false;
+  // Command-buffer will use counter based events when using in-order
+  // command-lists
+  bool UseCounterBasedEvents = false;
   // This list is needed to release all kernels retained by the
   // command_buffer.
   std::vector<ur_kernel_handle_t> KernelsList;

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -522,7 +522,8 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
                   ZeEventPoolDesc.flags);
     if (CounterBasedEventEnabled) {
       if (UsingImmCmdList) {
-        counterBasedExt.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
+        //FIXME DEBUG
+        counterBasedExt.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE | ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE;
       } else {
         counterBasedExt.flags =
             ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE;

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1089,6 +1089,24 @@ bool ur_device_handle_t_::useDriverInOrderLists() {
   return UseDriverInOrderLists;
 }
 
+bool ur_device_handle_t_::useDriverCounterBasedEvents() {
+  static const bool UseDriverCounterBasedEvents = [this] {
+    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_COUNTER_BASED_EVENTS");
+    if (!UrRet) {
+      if (this->isPVC())
+        return true;
+      return false;
+    }
+    return std::atoi(UrRet) != 0;
+  }();
+
+  // FIXME
+  //  std::cerr << "useDriverCounterBasedEvents: " << UseDriverCounterBasedEvent
+  //  << std::endl;
+
+  return UseDriverCounterBasedEvents;
+}
+
 ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
                                             int SubSubDeviceIndex) {
   // Maintain various device properties cache.

--- a/source/adapters/level_zero/device.hpp
+++ b/source/adapters/level_zero/device.hpp
@@ -146,6 +146,10 @@ struct ur_device_handle_t_ : _ur_object {
   // Whether Adapter uses driver's implementation of in-order lists or not
   bool useDriverInOrderLists();
 
+  // Whether the Adapter uses counter based events for in-order command-lists
+  // FIXME Is this true for every scenario
+  bool useDriverCounterBasedEvents();
+
   // Returns whether immediate command lists are used on this device.
   ImmCmdlistMode ImmCommandListUsed{};
 

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1168,19 +1168,18 @@ ur_queue_handle_t_::ur_queue_handle_t_(
       ZeCommandListBatchComputeConfig.startSize();
   CopyCommandBatch.QueueBatchSize = ZeCommandListBatchCopyConfig.startSize();
 
-  static const bool useDriverCounterBasedEvents = [Device] {
-    const char *UrRet = std::getenv("UR_L0_USE_DRIVER_COUNTER_BASED_EVENTS");
-    if (!UrRet) {
-      if (Device->isPVC())
-        return true;
-      return false;
-    }
-    return std::atoi(UrRet) != 0;
-  }();
   this->CounterBasedEventsEnabled =
       UsingImmCmdLists && isInOrderQueue() && Device->useDriverInOrderLists() &&
-      useDriverCounterBasedEvents &&
+      Device->useDriverCounterBasedEvents() &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
+  //  std::cerr << "CounterBasedEventsEnabled: " <<
+  //  this->CounterBasedEventsEnabled << std::endl; std::cerr <<
+  //  "UsingImmCmdLists: " << UsingImmCmdLists << std::endl; std::cerr <<
+  //  "isInOrderQueue() " << isInOrderQueue() << std::endl; std::cerr <<
+  //  "Device->useDriverInOrderLists() " << Device->useDriverInOrderLists() <<
+  //  std::endl; std::cerr << "ZeDriverEventPoolCountingEventsExtensionFound: "
+  //  << Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound <<
+  //  std::endl;
 }
 
 void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {


### PR DESCRIPTION
- Replaces the signalEvent and the user output event in the command-buffer implementation with counter-based events.
- Removes the reset-all command-list when the graph is linear

TODO:

- The waitEvent is still a regular event. Might need to use mutable-command lists to replace it with a counter-based event.
- Counter-based events are only enabled when the queue associated with the graph is in-order. This is to interact nicely with existing level-zero code that enables counter-based events only for in-order queues (see the function createEventAndAssociateQueue()). This limitation should probably be removed. However, we should check what happens when 2 graphs are submitted simultaneously to an out-of-order queue?
- Extra testing on intel-llvm might be needed. Probably add UR_L0_USE_DRIVER_COUNTER_BASED_EVENTS=1 to existing tests.
- Benchmarking to see if this optimizations provides a tangible benefit.

Intel/llvm tests: https://github.com/intel/llvm/pull/14038