### PR TITLE
[CI] Run E2E on PR

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -161,14 +161,12 @@ jobs:
       run: ctest -C ${{matrix.build_type}} --output-on-failure -L "fuzz-short" --verbose
 
   level-zero:
-    if: github.repository == 'oneapi-src/unified-runtime'
     name: Level Zero
     uses: ./.github/workflows/build-hw-reusable.yml
     with:
       name: L0
 
   opencl:
-    if: github.repository == 'oneapi-src/unified-runtime'
     name: OpenCL
     uses: ./.github/workflows/build-hw-reusable.yml
     with:
@@ -176,25 +174,46 @@ jobs:
       platform: "Intel(R) OpenCL"
 
   cuda:
-    if: github.repository == 'oneapi-src/unified-runtime'
     name: CUDA
     uses: ./.github/workflows/build-hw-reusable.yml
     with:
       name: CUDA
 
   hip:
-    if: github.repository == 'oneapi-src/unified-runtime'
     name: HIP
     uses: ./.github/workflows/build-hw-reusable.yml
     with:
       name: HIP
 
   native-cpu:
-    if: github.repository == 'oneapi-src/unified-runtime'
     name: Native CPU
     uses: ./.github/workflows/build-hw-reusable.yml
     with:
       name: NATIVE_CPU
+
+  e2e-level-zero:
+    name: E2E L0
+    permissions:
+      contents: read
+      pull-requests: write
+    needs: [ubuntu-build, level-zero]
+    uses: ./.github/workflows/e2e_level_zero.yml
+
+  e2e-opencl:
+    name: E2E OpenCL
+    permissions:
+      contents: read
+      pull-requests: write
+    needs: [ubuntu-build, opencl]
+    uses: ./.github/workflows/e2e_opencl.yml
+
+  e2e-cuda:
+    name: E2E CUDA
+    permissions:
+      contents: read
+      pull-requests: write
+    needs: [ubuntu-build, cuda]
+    uses: ./.github/workflows/e2e_cuda.yml
 
   windows-build:
     name: Build - Windows
@@ -261,7 +280,6 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{matrix.build_type}} --output-on-failure -L "umf|loader|validation|tracing|unit|urtrace"
-
 
   macos-build:
     name: Build - MacOS

--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -30,10 +30,6 @@ on:
         description: Tag defifned for the runner
         type: string
         required: true
-      trigger:
-        description: Type of workflow trigger
-        type: string
-        required: true
       xfail:
         description: Allow test failures
         type: string
@@ -53,12 +49,33 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
+  changed-files:
+    name: Check for changed files
+    runs-on: ubuntu-22.04
+    outputs:
+      any_changed: ${{ steps.get-changed.outputs.any_changed }}
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Get changed files
+      id: get-changed
+      uses: tj-actions/changed-files@d6babd6899969df1a11d14c368283ea4436bca78 # v44.5.2
+      with:
+        files: |
+          source/adapters/${{inputs.str_name}}/**
+
   e2e-build-hw:
-    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
+    # We want to run the job only if there are changes in the specific adapter
+    if: needs.changed-files.outputs.any_changed == 'true'
     name: Build SYCL, UR, run E2E
+    needs: changed-files
+    permissions:
+      contents: read
+      pull-requests: write
+
+    # Allow failures, since SYCL tests and API may be not stable
+    continue-on-error: true
     strategy:
       matrix:
         adapter: [
@@ -83,38 +100,10 @@ jobs:
         ls -la ./
         rm -rf ./* || true
 
-    - name: Add comment to PR
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      if: ${{ always() && inputs.trigger != 'schedule' }}
-      with:
-        script: |
-          const adapter = '${{ matrix.adapter.name }}';
-          const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-          const body = `E2E ${adapter} build: \n${url}`;
-
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: body
-          })
-
     - name: Checkout UR
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ur-repo
-
-    # On issue_comment trigger (for PRs) we need to fetch special ref for
-    # proper PR's merge commit. Note, this ref may be absent if the PR is already merged.
-    - name: Fetch PR's merge commit
-      if: ${{ inputs.trigger != 'schedule' }}
-      working-directory: ${{github.workspace}}/ur-repo
-      env:
-        PR_NO: ${{github.event.issue.number}}
-      run: |
-        git fetch -- https://github.com/${{github.repository}} +refs/pull/${PR_NO}/*:refs/remotes/origin/pr/${PR_NO}/*
-        git checkout origin/pr/${PR_NO}/merge
-        git rev-parse origin/pr/${PR_NO}/merge
 
     - name: Checkout SYCL
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -190,7 +179,7 @@ jobs:
 
     - name: Add comment to PR
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-      if: ${{ always() && inputs.trigger != 'schedule' }}
+      if: ${{ always() }}
       with:
         script: |
           const adapter = '${{ matrix.adapter.name }}';

--- a/.github/workflows/e2e_cuda.yml
+++ b/.github/workflows/e2e_cuda.yml
@@ -1,11 +1,7 @@
 name: E2E Cuda
 
 on:
-  schedule:
-    # Run every day at 23:00 UTC
-    - cron: '0 23 * * *'
-  issue_comment:
-    types: [created, edited]
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,12 +9,10 @@ permissions:
 
 jobs:
   e2e-build-hw:
-    # trigger only if PR comment contains "e2e-cuda"
-    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/e2e-cuda')) || (github.event_name == 'schedule') }}
+    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
     name: Start e2e job
     # use core flow, run it with cuda specific parameters
     uses: ./.github/workflows/e2e_core.yml
-    # parameters that we pass to the core flow
     with:
       name: "CUDA"
       runner_tag: "CUDA_E2E"
@@ -26,4 +20,3 @@ jobs:
       prefix: "ext_oneapi_"
       config: "--cuda"
       unit: "gpu"
-      trigger: "${{github.event_name}}"

--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -1,11 +1,7 @@
 name: E2E Level Zero
 
 on:
-  schedule:
-    # Run every day at 23:00 UTC
-    - cron: '0 23 * * *'
-  issue_comment:
-    types: [created, edited]
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,12 +9,10 @@ permissions:
 
 jobs:
   e2e-build-hw:
-    # trigger only if PR comment contains "e2e-level-zero"
-    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/e2e-level-zero')) || (github.event_name == 'schedule') }}
+    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
     name: Start e2e job
     # use core flow, run it with L0 specific parameters
     uses: ./.github/workflows/e2e_core.yml
-    # parameters that we pass to the core flow
     with:
       name: "L0"
       runner_tag: "L0_E2E"
@@ -26,7 +20,6 @@ jobs:
       prefix: "ext_oneapi_"
       config: ""
       unit: "gpu"
-      trigger: "${{github.event_name}}"
       # Failing tests
       xfail: "ESIMD/preemption.cpp;syclcompat/atomic/atomic_class.cpp;ProgramManager/uneven_kernel_split.cpp;Plugin/level_zero_ext_intel_queue_index.cpp;Plugin/level_zero_ext_intel_cslice.cpp;Matrix/joint_matrix_rowmajorA_rowmajorB.cpp;Matrix/element_wise_ops.cpp;Matrix/element_wise_all_ops.cpp;Matrix/SG32/element_wise_all_ops.cpp"
       # Flaky tests

--- a/.github/workflows/e2e_opencl.yml
+++ b/.github/workflows/e2e_opencl.yml
@@ -1,11 +1,7 @@
 name: E2E OpenCL
 
 on:
-  schedule:
-    # Run every day at 23:00 UTC
-    - cron: '0 23 * * *'
-  issue_comment:
-    types: [created, edited]
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,12 +9,10 @@ permissions:
 
 jobs:
   e2e-build-hw:
-    # trigger only if PR comment contains "e2e-opencl"
-    if: ${{ (github.event.issue.pull_request && contains(github.event.comment.body, '/e2e-opencl')) || (github.event_name == 'schedule') }}
+    if: github.repository == 'oneapi-src/unified-runtime'  # run only on upstream; forks will not have the HW
     name: Start e2e job
     # use core flow, run it with OpenCL specific parameters
     uses: ./.github/workflows/e2e_core.yml
-    # parameters that we pass to the core flow
     with:
       name: "OPENCL"
       runner_tag: "OPENCL"
@@ -26,4 +20,3 @@ jobs:
       prefix: ""
       config: ""
       unit: "cpu"
-      trigger: "${{github.event_name}}"


### PR DESCRIPTION
We don't want to treat these workflows as blockers though, so we enable continue-on-error for step with tests.
Add comment with actual test status to the PR.

// I've tested the flow on my fork: https://github.com/lukaszstolarczuk/unified-runtime/pull/7
// comment is added; flow only works if prev. (dependent) jobs are done (e.g. "cuda" required for "e2e_cuda")