### PR TITLE
[GHA] Update permissions for e2e workflow

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -49,6 +49,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   changed-files:


### PR DESCRIPTION
The e2e jobs comment step is causing errors like [this](https://github.com/oneapi-src/unified-runtime/actions/runs/9386850540/job/25852167825?pr=1458).

This patch adds the `pull-request: write` permission to the workflow.
