### PR TITLE
Fix lifetime of pointer used in L0 update

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1278,8 +1278,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
   UR_ASSERT(!(NewGlobalWorkSize && !NewLocalWorkSize) ||
                 (SupportedFeatures & ZE_MUTABLE_COMMAND_EXP_FLAG_GROUP_SIZE),
             UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+
+  ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
   if (NewGlobalWorkSize && Dim > 0) {
-    ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
     uint32_t WG[3];
     // If new global work size is provided but new local work size is not
     // provided then we still need to update local work size based on size


### PR DESCRIPTION
When we initialize our `ze_mutable_group_count_exp_desc_t` struct that's used in a pointer chain passed to
`zexCommandListUpdateMutableCommandsExp` we set the `pGroupCount` member to `&ZeThreadGroupDimensions`.

However, `ZeThreadGroupDimensions` is declared on the stack in the scope of the if statement. Resulting in this pointer becoming invalid after the scope of the if statement, when the L0 update API is called.

Fixed by moving the `ZeThreadGroupDimensions` variable outside the scope of the if statement, into the scope of the function, so that the address is valid when `zexCommandListUpdateMutableCommandsExp` is called.

DPC++ PR https://github.com/intel/llvm/pull/14076