### PR TITLE
[GHA] Temporarily disable testing on windows-2022

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -230,6 +230,9 @@ jobs:
            adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
          - adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON'}
            compiler: {c: clang-cl, cxx: clang-cl}
+         # TODO: testing is flaky on windows-2022 in Release mode
+         - os: 'windows-2022'
+           build_type: Release
 
         build_type: [Debug, Release]
         compiler: [{c: cl, cxx: cl}, {c: clang-cl, cxx: clang-cl}]


### PR DESCRIPTION
As noted in #1715 testing on Windows Server 2022 in Release mode has become flaky in the last couple of days. The root cause of this has so far been elusive and the issue is not reproducible on a local Windows 11 machine. This patch temporarily disables this axis from the job matrix while investigation continues.
