### PR TITLE
[CUDA][HIP] Fix build info log reporting

### DIFF
--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -345,16 +345,24 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
   switch (propName) {
-  case UR_PROGRAM_BUILD_INFO_STATUS: {
+  case UR_PROGRAM_BUILD_INFO_STATUS:
     return ReturnValue(hProgram->BuildStatus);
-  }
   case UR_PROGRAM_BUILD_INFO_OPTIONS:
     return ReturnValue(hProgram->BuildOptions.c_str());
-  case UR_PROGRAM_BUILD_INFO_LOG:
-    return ReturnValue(hProgram->InfoLog, hProgram->MaxLogSize);
-  case UR_PROGRAM_BUILD_INFO_BINARY_TYPE: {
-    return ReturnValue(hProgram->BinaryType);
+  case UR_PROGRAM_BUILD_INFO_LOG: {
+    // We only know the maximum log length, which CUDA guarantees will include
+    // the null terminator.
+    // To determine the actual length of the log, search for the first
+    // null terminator, not searching past the known maximum. If that does find
+    // one, it will return the length excluding the null terminator, so remember
+    // to include that.
+    auto LogLen =
+        std::min(hProgram->MaxLogSize,
+                 strnlen(hProgram->InfoLog, hProgram->MaxLogSize) + 1);
+    return ReturnValue(hProgram->InfoLog, LogLen);
   }
+  case UR_PROGRAM_BUILD_INFO_BINARY_TYPE:
+    return ReturnValue(hProgram->BinaryType);
   default:
     break;
   }

--- a/test/conformance/program/program_adapter_cuda.match
+++ b/test/conformance/program/program_adapter_cuda.match
@@ -2,7 +2,6 @@ urProgramBuildTest.BuildFailure/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urProgramCreateWithILTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramCreateWithILTest.SuccessWithProperties/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramCreateWithILTest.BuildInvalidProgram/NVIDIA_CUDA_BACKEND___{{.*}}
-{{OPT}}urProgramGetBuildInfoSingleTest.LogIsNullTerminated/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramGetInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}

--- a/test/conformance/program/program_adapter_hip.match
+++ b/test/conformance/program/program_adapter_hip.match
@@ -1,8 +1,6 @@
 urProgramBuildTest.BuildFailure/AMD_HIP_BACKEND___{{.*}}_
 # HIP hasn't implemented urProgramCreateWithNativeHandleTest
 {{OPT}}urProgramCreateWithNativeHandleTest.Success/AMD_HIP_BACKEND___{{.*}}_
-# This test flakily fails
-{{OPT}}urProgramGetBuildInfoSingleTest.LogIsNullTerminated/AMD_HIP_BACKEND___{{.*}}_
 # HIP doesn't expose kernel numbers or names
 urProgramGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_NUM_KERNELS
 urProgramGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROGRAM_INFO_KERNEL_NAMES

--- a/test/conformance/program/urProgramGetBuildInfo.cpp
+++ b/test/conformance/program/urProgramGetBuildInfo.cpp
@@ -75,6 +75,8 @@ TEST_P(urProgramGetBuildInfoSingleTest, LogIsNullTerminated) {
 
     ASSERT_SUCCESS(urProgramGetBuildInfo(
         program, device, UR_PROGRAM_BUILD_INFO_LOG, 0, nullptr, &logSize));
+    // The size should always include the null terminator.
+    ASSERT_GT(logSize, 0);
     log.resize(logSize);
     log[logSize - 1] = 'x';
     ASSERT_SUCCESS(urProgramGetBuildInfo(program, device,


### PR DESCRIPTION
We were always returning the maximum log size (of 8192) even when the actual log was much shorter. Strictly speaking, we should be returning the log only up to the first null terminator. Doing otherwise could cause strange behaviour, and may account for the flaky fails we've seen in this test on both adapters.