### PR TITLE
[CUDA] Check for nullptr before dereference.

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -535,7 +535,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
     const size_t *pLocalWorkSize, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
-  if (*pGlobalWorkOffset == 0 || pGlobalWorkOffset == nullptr) {
+  if (pGlobalWorkOffset == nullptr || *pGlobalWorkOffset == 0) {
     ur_exp_launch_property_t coop_prop;
     coop_prop.id = UR_EXP_LAUNCH_PROPERTY_ID_COOPERATIVE;
     coop_prop.value.cooperative = 1;


### PR DESCRIPTION
In https://github.com/oneapi-src/unified-runtime/pull/1674/files I made a check for nullptr after already dereferencing the pointer. This swaps the order around.