### PR TITLE
[L0] Implement IPC ops for L0 adapter

### DIFF
--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -1,6 +1,6 @@
 //===--------- usm.cpp - Level Zero Adapter -------------------------------===//
 //
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2023-2024 Intel Corporation
 //
 // Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
 // Exceptions. See LICENSE.TXT

--- a/source/adapters/level_zero/usm.hpp
+++ b/source/adapters/level_zero/usm.hpp
@@ -126,6 +126,11 @@ public:
   umf_result_t get_min_page_size(void *, size_t *) override;
   // TODO: Different name for each provider (Host/Shared/SharedRO/Device)
   const char *get_name() override { return "L0"; };
+  umf_result_t get_ipc_handle_size(size_t *) override;
+  umf_result_t get_ipc_handle(const void *, size_t, void *) override;
+  umf_result_t put_ipc_handle(void *) override;
+  umf_result_t open_ipc_handle(void *, void **) override;
+  umf_result_t close_ipc_handle(void *, size_t) override;
 };
 
 // Allocation routines for shared memory type

--- a/source/adapters/level_zero/usm.hpp
+++ b/source/adapters/level_zero/usm.hpp
@@ -85,11 +85,26 @@ public:
   virtual umf_result_t purge_force(void *, size_t) {
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
   };
-  umf_result_t allocation_merge(void *, void *, size_t) {
-    return UMF_RESULT_ERROR_UNKNOWN;
+  virtual umf_result_t allocation_merge(void *, void *, size_t) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
   }
-  umf_result_t allocation_split(void *, size_t, size_t) {
-    return UMF_RESULT_ERROR_UNKNOWN;
+  virtual umf_result_t allocation_split(void *, size_t, size_t) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  }
+  virtual umf_result_t get_ipc_handle_size(size_t *) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  }
+  virtual umf_result_t get_ipc_handle(const void *, size_t, void *) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  }
+  virtual umf_result_t put_ipc_handle(void *) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  }
+  virtual umf_result_t open_ipc_handle(void *, void **) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  }
+  virtual umf_result_t close_ipc_handle(void *, size_t) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
   }
   virtual const char *get_name() { return ""; };
   virtual ~USMMemoryProviderBase() = default;

--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023 Intel Corporation
+ * Copyright (C) 2023-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT

--- a/source/common/ur_util.cpp
+++ b/source/common/ur_util.cpp
@@ -9,15 +9,63 @@
  */
 
 #include "ur_util.hpp"
+#include "logger/ur_logger.hpp"
 
 #ifdef _WIN32
 #include <windows.h>
 int ur_getpid(void) { return static_cast<int>(GetCurrentProcessId()); }
+
+int ur_close_fd(int fd) { return -1; }
+
+int ur_duplicate_fd(int pid, int fd_in) {
+    // TODO: find another way to obtain a duplicate of another process's file descriptor
+    (void)pid;   // unused
+    (void)fd_in; // unused
+    return -1;
+}
+
 #else
 
+#include <sys/syscall.h>
 #include <unistd.h>
 int ur_getpid(void) { return static_cast<int>(getpid()); }
-#endif
+
+int ur_close_fd(int fd) { return close(fd); }
+
+int ur_duplicate_fd(int pid, int fd_in) {
+// pidfd_getfd(2) is used to obtain a duplicate of another process's file descriptor.
+// Permission to duplicate another process's file descriptor
+// is governed by a ptrace access mode PTRACE_MODE_ATTACH_REALCREDS check (see ptrace(2))
+// that can be changed using the /proc/sys/kernel/yama/ptrace_scope interface.
+// pidfd_getfd(2) is supported since Linux 5.6
+// pidfd_open(2) is supported since Linux 5.3
+#if defined(__NR_pidfd_open) && defined(__NR_pidfd_getfd)
+    errno = 0;
+    int pid_fd = syscall(SYS_pidfd_open, pid, 0);
+    if (pid_fd == -1) {
+        logger::error("SYS_pidfd_open");
+        return -1;
+    }
+
+    int fd_dup = syscall(SYS_pidfd_getfd, pid_fd, fd_in, 0);
+    close(pid_fd);
+    if (fd_dup == -1) {
+        logger::error("SYS_pidfd_getfd");
+        return -1;
+    }
+
+    return fd_dup;
+#else
+    // TODO: find another way to obtain a duplicate of another process's file descriptor
+    (void)pid;       // unused
+    (void)fd_in;     // unused
+    errno = ENOTSUP; // unsupported
+    logger::error("__NR_pidfd_open or __NR_pidfd_getfd not available");
+    return -1;
+#endif /* defined(__NR_pidfd_open) && defined(__NR_pidfd_getfd) */
+}
+
+#endif /* _WIN32 */
 
 std::optional<std::string> ur_getenv(const char *name) {
 #if defined(_WIN32)

--- a/source/common/ur_util.cpp
+++ b/source/common/ur_util.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2022-2023 Intel Corporation
+ * Copyright (C) 2022-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -27,6 +27,8 @@
 #include <vector>
 
 int ur_getpid(void);
+int ur_close_fd(int fd);
+int ur_duplicate_fd(int pid, int fd_in);
 
 /* for compatibility with non-clang compilers */
 #if defined(__has_feature)

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2022-2023 Intel Corporation
+ * Copyright (C) 2022-2024 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
  * See LICENSE.TXT

--- a/test/adapters/level_zero/CMakeLists.txt
+++ b/test/adapters/level_zero/CMakeLists.txt
@@ -69,4 +69,16 @@ if(NOT WIN32)
     target_link_libraries(test-adapter-level_zero_multi_queue PRIVATE zeCallMap)
 endif()
 
+add_adapter_test(level_zero_ipc
+    FIXTURE DEVICES
+    SOURCES
+        ipc.cpp
+    ENVIRONMENT
+        "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_level_zero>\""
+)
+
+target_link_libraries(test-adapter-level_zero_ipc PRIVATE
+    ur_umf
+)
+
 add_subdirectory(v2)

--- a/test/adapters/level_zero/ipc.cpp
+++ b/test/adapters/level_zero/ipc.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <umf/memory_pool.h>
+#include <umf/memory_provider.h>
+#include <uur/fixtures.h>
+
+#ifndef ASSERT_UMF_SUCCESS
+#define ASSERT_UMF_SUCCESS(ACTUAL) ASSERT_EQ(ACTUAL, UMF_RESULT_SUCCESS)
+#endif
+
+using urL0IpcTest = uur::urContextTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urL0IpcTest);
+
+TEST_P(urL0IpcTest, SuccessHostL0Ipc) {
+    ur_device_usm_access_capability_flags_t hostUSMSupport = 0;
+    ASSERT_SUCCESS(uur::GetDeviceUSMHostSupport(device, hostUSMSupport));
+    if (!hostUSMSupport) {
+        GTEST_SKIP() << "Host USM is not supported.";
+    }
+
+    void *ptr = nullptr;
+    size_t allocSize = sizeof(int);
+    ASSERT_SUCCESS(urUSMHostAlloc(context, nullptr, nullptr, allocSize, &ptr));
+    ASSERT_NE(ptr, nullptr);
+
+    umf_memory_pool_handle_t umfPool = umfPoolByPtr(ptr);
+    ASSERT_NE(umfPool, nullptr);
+
+    umf_memory_provider_handle_t umfProvider = nullptr;
+    ASSERT_UMF_SUCCESS(umfPoolGetMemoryProvider(umfPool, &umfProvider));
+
+    size_t ipcHandleSize = 0;
+    ASSERT_UMF_SUCCESS(
+        umfMemoryProviderGetIPCHandleSize(umfProvider, &ipcHandleSize));
+
+    void *ipcHandle = nullptr;
+    ASSERT_UMF_SUCCESS(
+        umfMemoryProviderAlloc(umfProvider, ipcHandleSize, 0, &ipcHandle));
+    ASSERT_UMF_SUCCESS(
+        umfMemoryProviderGetIPCHandle(umfProvider, ptr, allocSize, ipcHandle));
+
+    ASSERT_UMF_SUCCESS(umfMemoryProviderPutIPCHandle(umfProvider, ipcHandle));
+
+    ASSERT_UMF_SUCCESS(
+        umfMemoryProviderFree(umfProvider, ipcHandle, ipcHandleSize));
+
+    ASSERT_SUCCESS(urUSMFree(context, ptr));
+}


### PR DESCRIPTION
Depends on: https://github.com/oneapi-src/unified-runtime/pull/1430.
Those changes are based on the changes in L0 provider on UMF repo https://github.com/oneapi-src/unified-memory-framework/pull/558.