### PR TITLE
[Bindless][Exp] Add const-qualifier to Src param in urBindlessImagesImageCopyExp

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7773,7 +7773,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue,                 ///< [in] handle of the queue object
     void *pDst,                               ///< [in] location the data will be copied to
-    void *pSrc,                               ///< [in] location the data will be copied from
+    const void *pSrc,                         ///< [in] location the data will be copied from
     const ur_image_format_t *pImageFormat,    ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc,        ///< [in] pointer to image description
     ur_exp_image_copy_flags_t imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
@@ -11139,7 +11139,7 @@ typedef struct ur_bindless_images_sampled_image_create_exp_params_t {
 typedef struct ur_bindless_images_image_copy_exp_params_t {
     ur_queue_handle_t *phQueue;
     void **ppDst;
-    void **ppSrc;
+    const void **ppSrc;
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
     ur_exp_image_copy_flags_t *pimageCopyFlags;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1582,7 +1582,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageCreateExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageCopyExp_t)(
     ur_queue_handle_t,
     void *,
-    void *,
+    const void *,
     const ur_image_format_t *,
     const ur_image_desc_t *,
     ur_exp_image_copy_flags_t,

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -527,7 +527,7 @@ params:
     - type: void*
       name: pDst
       desc: "[in] location the data will be copied to"
-    - type: void*
+    - type: const void*
       name: pSrc
       desc: "[in] location the data will be copied from"
     - type: "const $x_image_format_t*"

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -634,7 +634,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    ur_queue_handle_t hQueue, void *pDst, void *pSrc,
+    ur_queue_handle_t hQueue, void *pDst, const void *pSrc,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
     ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
@@ -676,18 +676,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                                   (CUdeviceptr)pDst) != CUDA_SUCCESS;
 
         size_t CopyExtentBytes = PixelSizeBytes * copyExtent.width;
-        char *SrcWithOffset = (char *)pSrc + (srcOffset.x * PixelSizeBytes);
+        const char *SrcWithOffset =
+            static_cast<const char *>(pSrc) + (srcOffset.x * PixelSizeBytes);
 
         if (isCudaArray) {
-          UR_CHECK_ERROR(cuMemcpyHtoAAsync(
-              (CUarray)pDst, dstOffset.x * PixelSizeBytes,
-              (void *)SrcWithOffset, CopyExtentBytes, Stream));
+          UR_CHECK_ERROR(
+              cuMemcpyHtoAAsync((CUarray)pDst, dstOffset.x * PixelSizeBytes,
+                                static_cast<const void *>(SrcWithOffset),
+                                CopyExtentBytes, Stream));
         } else if (memType == CU_MEMORYTYPE_DEVICE) {
-          void *DstWithOffset =
-              (void *)((char *)pDst + (PixelSizeBytes * dstOffset.x));
-          UR_CHECK_ERROR(cuMemcpyHtoDAsync((CUdeviceptr)DstWithOffset,
-                                           (void *)SrcWithOffset,
-                                           CopyExtentBytes, Stream));
+          void *DstWithOffset = static_cast<void *>(
+              static_cast<char *>(pDst) + (PixelSizeBytes * dstOffset.x));
+          UR_CHECK_ERROR(
+              cuMemcpyHtoDAsync((CUdeviceptr)DstWithOffset,
+                                static_cast<const void *>(SrcWithOffset),
+                                CopyExtentBytes, Stream));
         } else {
           // This should be unreachable.
           return UR_RESULT_ERROR_INVALID_VALUE;
@@ -763,15 +766,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                                   (CUdeviceptr)pSrc) != CUDA_SUCCESS;
 
         size_t CopyExtentBytes = PixelSizeBytes * copyExtent.width;
-        void *DstWithOffset =
-            (void *)((char *)pDst + (PixelSizeBytes * dstOffset.x));
+        void *DstWithOffset = static_cast<void *>(
+            static_cast<char *>(pDst) + (PixelSizeBytes * dstOffset.x));
 
         if (isCudaArray) {
           UR_CHECK_ERROR(cuMemcpyAtoHAsync(DstWithOffset, (CUarray)pSrc,
                                            PixelSizeBytes * srcOffset.x,
                                            CopyExtentBytes, Stream));
         } else if (memType == CU_MEMORYTYPE_DEVICE) {
-          char *SrcWithOffset = (char *)pSrc + (srcOffset.x * PixelSizeBytes);
+          const char *SrcWithOffset =
+              static_cast<const char *>(pSrc) + (srcOffset.x * PixelSizeBytes);
           UR_CHECK_ERROR(cuMemcpyDtoHAsync(DstWithOffset,
                                            (CUdeviceptr)SrcWithOffset,
                                            CopyExtentBytes, Stream));

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -76,7 +76,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] void *pSrc,
+    [[maybe_unused]] const void *pSrc,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -751,7 +751,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
-    void *pDst, void *pSrc, const ur_image_format_t *pImageFormat,
+    void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
     const ur_image_desc_t *pImageDesc, ur_exp_image_copy_flags_t imageCopyFlags,
     ur_rect_offset_t srcOffset, ur_rect_offset_t dstOffset,
     ur_rect_region_t copyExtent, ur_rect_region_t hostExtent,
@@ -813,8 +813,9 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
       UR_CALL(getImageRegionHelper(ZeImageDesc, &dstOffset, &copyExtent,
                                    DstRegion));
       auto *UrImage = static_cast<_ur_image *>(pDst);
-      char *SrcPtr = static_cast<char *>(pSrc) + srcOffset.z * SrcSlicePitch +
-                     srcOffset.y * SrcRowPitch + srcOffset.x * PixelSizeInBytes;
+      const char *SrcPtr =
+          static_cast<const char *>(pSrc) + srcOffset.z * SrcSlicePitch +
+          srcOffset.y * SrcRowPitch + srcOffset.x * PixelSizeInBytes;
       ZE2UR_CALL(zeCommandListAppendImageCopyFromMemoryExt,
                  (ZeCommandList, UrImage->ZeImage, SrcPtr, &DstRegion,
                   SrcRowPitch, SrcSlicePitch, ZeEvent, WaitList.Length,
@@ -844,7 +845,7 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
       ze_image_region_t SrcRegion;
       UR_CALL(getImageRegionHelper(ZeImageDesc, &srcOffset, &copyExtent,
                                    SrcRegion));
-      auto *UrImage = static_cast<_ur_image *>(pSrc);
+      auto *UrImage = static_cast<const _ur_image *>(pSrc);
       char *DstPtr = static_cast<char *>(pDst) + dstOffset.z * DstSlicePitch +
                      dstOffset.y * DstRowPitch + dstOffset.x * PixelSizeInBytes;
       ZE2UR_CALL(zeCommandListAppendImageCopyToMemoryExt,
@@ -876,7 +877,7 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
     UR_CALL(
         getImageRegionHelper(ZeImageDesc, &srcOffset, &copyExtent, SrcRegion));
     auto *UrImageDst = static_cast<_ur_image *>(pDst);
-    auto *UrImageSrc = static_cast<_ur_image *>(pSrc);
+    auto *UrImageSrc = static_cast<const _ur_image *>(pSrc);
     ZE2UR_CALL(zeCommandListAppendImageCopyRegion,
                (ZeCommandList, UrImageDst->ZeImage, UrImageSrc->ZeImage,
                 &DstRegion, &SrcRegion, ZeEvent, WaitList.Length,

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -381,7 +381,7 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
                                    const ur_event_handle_t *phEventWaitList,
                                    ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesImageCopyExp(
-      void *pDst, void *pSrc, const ur_image_format_t *pImageFormat,
+      void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
       const ur_image_desc_t *pImageDesc,
       ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
       ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,

--- a/source/adapters/level_zero/queue_api.cpp
+++ b/source/adapters/level_zero/queue_api.cpp
@@ -255,7 +255,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
                                       phEventWaitList, phEvent);
 }
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    ur_queue_handle_t hQueue, void *pDst, void *pSrc,
+    ur_queue_handle_t hQueue, void *pDst, const void *pSrc,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
     ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,

--- a/source/adapters/level_zero/queue_api.hpp
+++ b/source/adapters/level_zero/queue_api.hpp
@@ -123,7 +123,7 @@ struct ur_queue_handle_t_ {
                                            const ur_event_handle_t *,
                                            ur_event_handle_t *) = 0;
   virtual ur_result_t bindlessImagesImageCopyExp(
-      void *, void *, const ur_image_format_t *, const ur_image_desc_t *,
+      void *, const void *, const ur_image_format_t *, const ur_image_desc_t *,
       ur_exp_image_copy_flags_t, ur_rect_offset_t, ur_rect_offset_t,
       ur_rect_region_t, ur_rect_region_t, uint32_t, const ur_event_handle_t *,
       ur_event_handle_t *) = 0;

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -435,7 +435,7 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueWriteHostPipe(
 }
 
 ur_result_t ur_queue_immediate_in_order_t::bindlessImagesImageCopyExp(
-    void *pDst, void *pSrc, const ur_image_format_t *pImageFormat,
+    void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
     const ur_image_desc_t *pImageDesc, ur_exp_image_copy_flags_t imageCopyFlags,
     ur_rect_offset_t srcOffset, ur_rect_offset_t dstOffset,
     ur_rect_region_t copyExtent, ur_rect_region_t hostExtent,

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -162,7 +162,7 @@ struct ur_queue_immediate_in_order_t : _ur_object, public ur_queue_handle_t_ {
                                    const ur_event_handle_t *phEventWaitList,
                                    ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesImageCopyExp(
-      void *pDst, void *pSrc, const ur_image_format_t *pImageFormat,
+      void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
       const ur_image_desc_t *pImageDesc,
       ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
       ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -7454,7 +7454,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -76,7 +76,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] void *pSrc,
+    [[maybe_unused]] const void *pSrc,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -76,7 +76,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] void *pSrc,
+    [[maybe_unused]] const void *pSrc,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5770,7 +5770,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7194,7 +7194,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6364,7 +6364,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6856,7 +6856,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5847,7 +5847,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pDst,               ///< [in] location the data will be copied to
-    void *pSrc,               ///< [in] location the data will be copied from
+    const void *pSrc,         ///< [in] location the data will be copied from
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description


### PR DESCRIPTION
Add const-qualifier to `Src` parameter in `urBindlessImagesImageCopyExp`.

Corresponding DPC++ PR: https://github.com/intel/llvm/pull/14140