### PR TITLE
Logger callback function sink

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -381,54 +381,58 @@ typedef enum ur_function_t {
   UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP = 221,
   /// Enumerator for ::urEnqueueTimestampRecordingExp
   UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP = 223,
-  /// Enumerator for ::urEnqueueKernelLaunchCustomExp
-  UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP = 224,
-  /// Enumerator for ::urKernelGetSuggestedLocalWorkSize
-  UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE = 225,
-  /// Enumerator for ::urBindlessImagesImportExternalMemoryExp
-  UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP = 226,
-  /// Enumerator for ::urBindlessImagesImportExternalSemaphoreExp
-  UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP = 227,
-  /// Enumerator for ::urEnqueueNativeCommandExp
-  UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP = 228,
   /// Enumerator for ::urLoaderConfigSetMockingEnabled
-  UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED = 229,
+  UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED = 224,
+  /// Enumerator for ::urAdapterSetLoggerCallback
+  UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK = 225,
+  /// Enumerator for ::urAdapterSetLoggerCallbackLevel
+  UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL = 226,
+  /// Enumerator for ::urKernelGetSuggestedLocalWorkSize
+  UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE = 227,
+  /// Enumerator for ::urBindlessImagesImportExternalMemoryExp
+  UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP = 228,
+  /// Enumerator for ::urBindlessImagesMapExternalLinearMemoryExp
+  UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP = 229,
   /// Enumerator for ::urBindlessImagesReleaseExternalMemoryExp
   UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP = 230,
+  /// Enumerator for ::urBindlessImagesImportExternalSemaphoreExp
+  UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP = 231,
   /// Enumerator for ::urCommandBufferAppendUSMMemcpyExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP = 231,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP = 232,
   /// Enumerator for ::urCommandBufferAppendUSMFillExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP = 232,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP = 233,
   /// Enumerator for ::urCommandBufferAppendMemBufferCopyExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP = 233,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP = 234,
   /// Enumerator for ::urCommandBufferAppendMemBufferWriteExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP = 234,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP = 235,
   /// Enumerator for ::urCommandBufferAppendMemBufferReadExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP = 235,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP = 236,
   /// Enumerator for ::urCommandBufferAppendMemBufferCopyRectExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP = 236,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP = 237,
   /// Enumerator for ::urCommandBufferAppendMemBufferWriteRectExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP = 237,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP = 238,
   /// Enumerator for ::urCommandBufferAppendMemBufferReadRectExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP = 238,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP = 239,
   /// Enumerator for ::urCommandBufferAppendMemBufferFillExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP = 239,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP = 240,
   /// Enumerator for ::urCommandBufferAppendUSMPrefetchExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 240,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP = 241,
   /// Enumerator for ::urCommandBufferAppendUSMAdviseExp
-  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 241,
+  UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP = 242,
   /// Enumerator for ::urCommandBufferEnqueueExp
-  UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 242,
+  UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP = 243,
   /// Enumerator for ::urCommandBufferUpdateSignalEventExp
-  UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP = 243,
+  UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP = 244,
   /// Enumerator for ::urCommandBufferUpdateWaitEventsExp
-  UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP = 244,
-  /// Enumerator for ::urBindlessImagesMapExternalLinearMemoryExp
-  UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP = 245,
-  /// Enumerator for ::urEnqueueEventsWaitWithBarrierExt
-  UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT = 246,
+  UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP = 245,
+  /// Enumerator for ::urEnqueueKernelLaunchCustomExp
+  UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP = 246,
+  /// Enumerator for ::urEnqueueNativeCommandExp
+  UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP = 247,
   /// Enumerator for ::urPhysicalMemGetInfo
-  UR_FUNCTION_PHYSICAL_MEM_GET_INFO = 249,
+  UR_FUNCTION_PHYSICAL_MEM_GET_INFO = 248,
+  /// Enumerator for ::urEnqueueEventsWaitWithBarrierExt
+  UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT = 249,
   /// @cond
   UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -1389,6 +1393,80 @@ typedef enum ur_adapter_backend_t {
   /// @endcond
 
 } ur_adapter_backend_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Minimum level of messages to be processed by the logger.
+typedef enum ur_logger_level_t {
+  /// Debugging messages used for development purposes.
+  UR_LOGGER_LEVEL_DEBUG = 0,
+  /// General messages not related to debugging, warnings or errors.
+  UR_LOGGER_LEVEL_INFO = 1,
+  /// Used to warn users about potential problems.
+  UR_LOGGER_LEVEL_WARN = 2,
+  /// Used when an error has occurred.
+  UR_LOGGER_LEVEL_ERROR = 3,
+  /// Restrict logger processing any messages.
+  UR_LOGGER_LEVEL_QUIET = 4,
+  /// @cond
+  UR_LOGGER_LEVEL_FORCE_UINT32 = 0x7fffffff
+  /// @endcond
+
+} ur_logger_level_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Callback function to retrieve output from the logger.
+typedef void (*ur_logger_callback_t)(
+    /// [out] Minimum level of messages to be processed by the logger.
+    ur_logger_level_t level,
+    /// [in][out] pointer to data to be passed to callback
+    const char *pLoggerMsg,
+    /// [in][out] pointer to data to be passed to callback
+    void *pUserData);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level);
 
 #if !defined(__GNUC__)
 #pragma endregion
@@ -12135,6 +12213,26 @@ typedef struct ur_loader_config_set_mocking_enabled_params_t {
   ur_loader_config_handle_t *phLoaderConfig;
   ur_bool_t *penable;
 } ur_loader_config_set_mocking_enabled_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterSetLoggerCallback
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_set_logger_callback_params_t {
+  ur_adapter_handle_t *phAdapter;
+  ur_logger_callback_t *ppfnLoggerCallback;
+  void **ppUserData;
+  ur_logger_level_t *plevel;
+} ur_adapter_set_logger_callback_params_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function parameters for urAdapterSetLoggerCallbackLevel
+/// @details Each entry is a pointer to the parameter passed to the function;
+///     allowing the callback the ability to modify the parameter's value
+typedef struct ur_adapter_set_logger_callback_level_params_t {
+  ur_adapter_handle_t *phAdapter;
+  ur_logger_level_t *plevel;
+} ur_adapter_set_logger_callback_level_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urPlatformGet

--- a/include/ur_api_funcs.def
+++ b/include/ur_api_funcs.def
@@ -17,6 +17,8 @@
 
  // Auto-generated file, do not edit.
 
+_UR_API(urAdapterSetLoggerCallback)
+_UR_API(urAdapterSetLoggerCallbackLevel)
 _UR_API(urPlatformGet)
 _UR_API(urPlatformGetInfo)
 _UR_API(urPlatformGetNativeHandle)

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -24,6 +24,43 @@ extern "C" {
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterSetLoggerCallback
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallback_t)(
+    ur_adapter_handle_t, ur_logger_callback_t, void *, ur_logger_level_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urAdapterSetLoggerCallbackLevel
+typedef ur_result_t(UR_APICALL *ur_pfnAdapterSetLoggerCallbackLevel_t)(
+    ur_adapter_handle_t, ur_logger_level_t);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Table of Adapter functions pointers
+typedef struct ur_adapter_dditable_t {
+  ur_pfnAdapterSetLoggerCallback_t pfnSetLoggerCallback;
+  ur_pfnAdapterSetLoggerCallbackLevel_t pfnSetLoggerCallbackLevel;
+} ur_adapter_dditable_t;
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Function-pointer for urGetAdapterProcAddrTable
+typedef ur_result_t(UR_APICALL *ur_pfnGetAdapterProcAddrTable_t)(
+    ur_api_version_t, ur_adapter_dditable_t *);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urPlatformGet
 typedef ur_result_t(UR_APICALL *ur_pfnPlatformGet_t)(ur_adapter_handle_t *,
                                                      uint32_t, uint32_t,
@@ -1866,6 +1903,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetDeviceProcAddrTable_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Container for all DDI tables
 typedef struct ur_dditable_t {
+  ur_adapter_dditable_t Adapter;
   ur_platform_dditable_t Platform;
   ur_context_dditable_t Context;
   ur_event_dditable_t Event;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -143,6 +143,16 @@ urPrintAdapterBackend(enum ur_adapter_backend_t value, char *buffer,
                       const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_logger_level_t enum
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL
+urPrintLoggerLevel(enum ur_logger_level_t value, char *buffer,
+                   const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_platform_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -1463,6 +1473,26 @@ urPrintLoaderConfigSetCodeLocationCallbackParams(
 ///         - `buff_size < out_size`
 UR_APIEXPORT ur_result_t UR_APICALL urPrintLoaderConfigSetMockingEnabledParams(
     const struct ur_loader_config_set_mocking_enabled_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_set_logger_callback_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterSetLoggerCallbackParams(
+    const struct ur_adapter_set_logger_callback_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_adapter_set_logger_callback_level_params_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintAdapterSetLoggerCallbackLevelParams(
+    const struct ur_adapter_set_logger_callback_level_params_t *params,
     char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -287,6 +287,7 @@ operator<<(std::ostream &os,
 inline std::ostream &operator<<(std::ostream &os, enum ur_adapter_info_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_adapter_backend_t value);
+inline std::ostream &operator<<(std::ostream &os, enum ur_logger_level_t value);
 inline std::ostream &operator<<(std::ostream &os,
                                 enum ur_platform_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_api_version_t value);
@@ -1105,8 +1106,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
   case UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP:
     os << "UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP";
     break;
-  case UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP:
-    os << "UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP";
+  case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED:
+    os << "UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED";
+    break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK:
+    os << "UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK";
+    break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL:
+    os << "UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL";
     break;
   case UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE:
     os << "UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE";
@@ -1114,17 +1121,14 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
   case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP:
     os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP";
     break;
-  case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP:
-    os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP";
-    break;
-  case UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP:
-    os << "UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP";
-    break;
-  case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED:
-    os << "UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED";
+  case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP:
+    os << "UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP";
     break;
   case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP:
     os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP";
+    break;
+  case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP:
+    os << "UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP";
     break;
   case UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP:
     os << "UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP";
@@ -1168,14 +1172,17 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
   case UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP:
     os << "UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP";
     break;
-  case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP:
-    os << "UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP";
+  case UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP:
+    os << "UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP";
     break;
-  case UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT:
-    os << "UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT";
+  case UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP:
+    os << "UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP";
     break;
   case UR_FUNCTION_PHYSICAL_MEM_GET_INFO:
     os << "UR_FUNCTION_PHYSICAL_MEM_GET_INFO";
+    break;
+  case UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT:
+    os << "UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT";
     break;
   default:
     os << "unknown enumerator";
@@ -2270,6 +2277,34 @@ inline std::ostream &operator<<(std::ostream &os,
     break;
   case UR_ADAPTER_BACKEND_NATIVE_CPU:
     os << "UR_ADAPTER_BACKEND_NATIVE_CPU";
+    break;
+  default:
+    os << "unknown enumerator";
+    break;
+  }
+  return os;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_logger_level_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os,
+                                enum ur_logger_level_t value) {
+  switch (value) {
+  case UR_LOGGER_LEVEL_DEBUG:
+    os << "UR_LOGGER_LEVEL_DEBUG";
+    break;
+  case UR_LOGGER_LEVEL_INFO:
+    os << "UR_LOGGER_LEVEL_INFO";
+    break;
+  case UR_LOGGER_LEVEL_WARN:
+    os << "UR_LOGGER_LEVEL_WARN";
+    break;
+  case UR_LOGGER_LEVEL_ERROR:
+    os << "UR_LOGGER_LEVEL_ERROR";
+    break;
+  case UR_LOGGER_LEVEL_QUIET:
+    os << "UR_LOGGER_LEVEL_QUIET";
     break;
   default:
     os << "unknown enumerator";
@@ -11780,6 +11815,59 @@ inline std::ostream &operator<<(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_set_logger_callback_params_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &
+operator<<(std::ostream &os,
+           [[maybe_unused]] const struct ur_adapter_set_logger_callback_params_t
+               *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".pfnLoggerCallback = ";
+
+  os << reinterpret_cast<void *>(*(params->ppfnLoggerCallback));
+
+  os << ", ";
+  os << ".pUserData = ";
+
+  ur::details::printPtr(os, *(params->ppUserData));
+
+  os << ", ";
+  os << ".level = ";
+
+  os << *(params->plevel);
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_adapter_set_logger_callback_level_params_t
+/// type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(
+    std::ostream &os,
+    [[maybe_unused]] const struct ur_adapter_set_logger_callback_level_params_t
+        *params) {
+
+  os << ".hAdapter = ";
+
+  ur::details::printPtr(os, *(params->phAdapter));
+
+  os << ", ";
+  os << ".level = ";
+
+  os << *(params->plevel);
+
+  return os;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_platform_get_params_t type
 /// @returns
 ///     std::ostream &
@@ -19534,6 +19622,12 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os,
   } break;
   case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED: {
     os << (const struct ur_loader_config_set_mocking_enabled_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK: {
+    os << (const struct ur_adapter_set_logger_callback_params_t *)params;
+  } break;
+  case UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL: {
+    os << (const struct ur_adapter_set_logger_callback_level_params_t *)params;
   } break;
   case UR_FUNCTION_PLATFORM_GET: {
     os << (const struct ur_platform_get_params_t *)params;

--- a/scripts/core/INTRO.rst
+++ b/scripts/core/INTRO.rst
@@ -202,9 +202,9 @@ By default, no messages are printed.
 
 By default, there is a guarantee that *error* messages are flushed immediately. One can change this behavior to flush on lower-level messages.
 
-Loggers redirect messages to *stdout*, *stderr*, or a file (default: *stderr*).
+Loggers redirect messages to *stdout*, *stderr*, a file or a user configurable callback function (default: *stderr*).
 
-All of these logging options can be set with **UR_LOG_LOADER** and **UR_LOG_NULL** environment variables described in the **Environment Variables** section below.
+All of these logging options (except the callback) can be set with **UR_LOG_LOADER** and **UR_LOG_NULL** environment variables described in the **Environment Variables** section below.
 Both of these environment variables have the same syntax for setting logger options:
 
   "[level:debug|info|warning|error];[flush:<debug|info|warning|error>];[output:stdout|stderr|file,<path>]"
@@ -231,6 +231,10 @@ the ``out.log`` file::
 An example of an environment variable for setting up the null adapter library with logging level set to *warning* and output set to stdout::
 
   UR_LOG_NULL="level:warning;output:stdout"
+
+Logging callback
+^^^^^^^^^^^^^^^^^^^^^
+An API is available to configure the logging callback function :ref:`urAdapterSetLoggerCallback`. Additionally, the logging level can be set using :ref:`urAdapterSetLoggerCallbackLevel`.
 
 Adapter Discovery
 ---------------------

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -206,3 +206,76 @@ etors:
     - name: NATIVE_CPU
       value: "5"
       desc: "The backend is Native CPU"
+--- #--------------------------------------------------------------------------
+type: enum
+desc: "Minimum level of messages to be processed by the logger."
+class: $xAdapter
+name: $x_logger_level_t
+etors:
+    - name: DEBUG
+      value: "0"
+      desc: "Debugging messages used for development purposes."
+    - name: INFO
+      value: "1"
+      desc: "General messages not related to debugging, warnings or errors."
+    - name: WARN
+      value: "2"
+      desc: "Used to warn users about potential problems."
+    - name: ERROR
+      value: "3"
+      desc: "Used when an error has occurred."
+    - name: QUIET
+      value: "4"
+      desc: "Restrict logger processing any messages."
+--- #--------------------------------------------------------------------------
+type: fptr_typedef
+desc: "Callback function to retrieve output from the logger."
+name: $x_logger_callback_t
+return: "void"
+params:
+    - type: $x_logger_level_t
+      name: level
+      desc: "[out] Minimum level of messages to be processed by the logger."
+      init: DEBUG
+    - type: const char*
+      name: pLoggerMsg
+      desc: "[in][out] pointer to data to be passed to callback"
+    - type: void*
+      name: pUserData
+      desc: "[in][out] pointer to data to be passed to callback"
+--- #--------------------------------------------------------------------------
+type: function
+desc: |
+      Set a callback function for use by the logger to retrieve logging output.
+      It is a requirement that the callback function is thread safe and the
+      creator of the function will be responsible for this.
+class: $xAdapter
+name: SetLoggerCallback
+decl: static
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter"
+    - type: $x_logger_callback_t
+      name: pfnLoggerCallback
+      desc: "[in] Function pointer to callback from the logger."
+    - type: void*
+      name: pUserData
+      desc: "[in][out][optional] pointer to data to be passed to callback"
+    - type: $x_logger_level_t
+      name: level
+      desc: "[in] logging level"
+      init: 0
+--- #--------------------------------------------------------------------------
+type: function
+desc: "Set the minimum logging level for the logger Callback function."
+class: $xAdapter
+name: SetLoggerCallbackLevel
+decl: static
+params:
+    - type: $x_adapter_handle_t
+      name: hAdapter
+      desc: "[in] handle of the adapter"
+    - type: $x_logger_level_t
+      name: level
+      desc: "[in] logging level"

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -529,77 +529,83 @@ etors:
 - name: ENQUEUE_TIMESTAMP_RECORDING_EXP
   desc: Enumerator for $xEnqueueTimestampRecordingExp
   value: '223'
-- name: ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP
-  desc: Enumerator for $xEnqueueKernelLaunchCustomExp
-  value: '224'
-- name: KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE
-  desc: Enumerator for $xKernelGetSuggestedLocalWorkSize
-  value: '225'
-- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP
-  desc: Enumerator for $xBindlessImagesImportExternalMemoryExp
-  value: '226'
-- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
-  desc: Enumerator for $xBindlessImagesImportExternalSemaphoreExp
-  value: '227'
-- name: ENQUEUE_NATIVE_COMMAND_EXP
-  desc: Enumerator for $xEnqueueNativeCommandExp
-  value: '228'
 - name: LOADER_CONFIG_SET_MOCKING_ENABLED
   desc: Enumerator for $xLoaderConfigSetMockingEnabled
+  value: '224'
+- name: ADAPTER_SET_LOGGER_CALLBACK
+  desc: Enumerator for $xAdapterSetLoggerCallback
+  value: '225'
+- name: ADAPTER_SET_LOGGER_CALLBACK_LEVEL
+  desc: Enumerator for $xAdapterSetLoggerCallbackLevel
+  value: '226'
+- name: KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE
+  desc: Enumerator for $xKernelGetSuggestedLocalWorkSize
+  value: '227'
+- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP
+  desc: Enumerator for $xBindlessImagesImportExternalMemoryExp
+  value: '228'
+- name: BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP
+  desc: Enumerator for $xBindlessImagesMapExternalLinearMemoryExp
   value: '229'
 - name: BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP
   desc: Enumerator for $xBindlessImagesReleaseExternalMemoryExp
   value: '230'
+- name: BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesImportExternalSemaphoreExp
+  value: '231'
 - name: COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP
   desc: Enumerator for $xCommandBufferAppendUSMMemcpyExp
-  value: '231'
+  value: '232'
 - name: COMMAND_BUFFER_APPEND_USM_FILL_EXP
   desc: Enumerator for $xCommandBufferAppendUSMFillExp
-  value: '232'
+  value: '233'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferCopyExp
-  value: '233'
+  value: '234'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferWriteExp
-  value: '234'
+  value: '235'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferReadExp
-  value: '235'
+  value: '236'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferCopyRectExp
-  value: '236'
+  value: '237'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferWriteRectExp
-  value: '237'
+  value: '238'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferReadRectExp
-  value: '238'
+  value: '239'
 - name: COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP
   desc: Enumerator for $xCommandBufferAppendMemBufferFillExp
-  value: '239'
+  value: '240'
 - name: COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP
   desc: Enumerator for $xCommandBufferAppendUSMPrefetchExp
-  value: '240'
+  value: '241'
 - name: COMMAND_BUFFER_APPEND_USM_ADVISE_EXP
   desc: Enumerator for $xCommandBufferAppendUSMAdviseExp
-  value: '241'
+  value: '242'
 - name: COMMAND_BUFFER_ENQUEUE_EXP
   desc: Enumerator for $xCommandBufferEnqueueExp
-  value: '242'
+  value: '243'
 - name: COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP
   desc: Enumerator for $xCommandBufferUpdateSignalEventExp
-  value: '243'
+  value: '244'
 - name: COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP
   desc: Enumerator for $xCommandBufferUpdateWaitEventsExp
-  value: '244'
-- name: BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP
-  desc: Enumerator for $xBindlessImagesMapExternalLinearMemoryExp
   value: '245'
-- name: ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT
-  desc: Enumerator for $xEnqueueEventsWaitWithBarrierExt
+- name: ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP
+  desc: Enumerator for $xEnqueueKernelLaunchCustomExp
   value: '246'
+- name: ENQUEUE_NATIVE_COMMAND_EXP
+  desc: Enumerator for $xEnqueueNativeCommandExp
+  value: '247'
 - name: PHYSICAL_MEM_GET_INFO
   desc: Enumerator for $xPhysicalMemGetInfo
+  value: '248'
+- name: ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT
+  desc: Enumerator for $xEnqueueEventsWaitWithBarrierExt
   value: '249'
 ---
 type: enum

--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -54,7 +54,7 @@ namespace ur_tracing_layer
 
         getContext()->notify_end(${th.make_func_etor(n, tags, obj)}, "${th.make_func_name(n, tags, obj)}", &params, &result, instance);
 
-        if (logger.getLevel() <= logger::Level::INFO) {
+        if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
             std::ostringstream args_str;
             ur::extras::printFunctionParams(args_str, ${th.make_func_etor(n, tags, obj)}, &params);
             logger.info("   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);

--- a/source/adapters/adapter.def.in
+++ b/source/adapters/adapter.def.in
@@ -1,6 +1,7 @@
 LIBRARY @TARGET_LIBNAME@
 EXPORTS
 	urGetGlobalProcAddrTable
+	urGetAdapterProcAddrTable
 	urGetBindlessImagesExpProcAddrTable
 	urGetCommandBufferExpProcAddrTable
 	urGetContextProcAddrTable

--- a/source/adapters/adapter.map.in
+++ b/source/adapters/adapter.map.in
@@ -1,6 +1,7 @@
 @TARGET_LIBNAME@ {
 	global:
 		urGetGlobalProcAddrTable;
+		urGetAdapterProcAddrTable;
 		urGetBindlessImagesExpProcAddrTable;
 		urGetCommandBufferExpProcAddrTable;
 		urGetContextProcAddrTable;

--- a/source/adapters/cuda/adapter.cpp
+++ b/source/adapters/cuda/adapter.cpp
@@ -29,7 +29,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     std::cerr << msg << std::endl;
   }
@@ -42,7 +42,7 @@ public:
 // https://github.com/oneapi-src/unified-runtime/issues/1330
 ur_adapter_handle_t_::ur_adapter_handle_t_()
     : logger(logger::get_logger("cuda",
-                                /*default_log_level*/ logger::Level::ERR)) {
+                                /*default_log_level*/ UR_LOGGER_LEVEL_ERROR)) {
 
   if (std::getenv("UR_LOG_CUDA") != nullptr)
     return;
@@ -114,6 +114,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  adapter.logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    ur_adapter_handle_t, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  adapter.logger.setCallbackLevel(level);
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -446,6 +446,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/source/adapters/hip/adapter.cpp
+++ b/source/adapters/hip/adapter.cpp
@@ -28,7 +28,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     std::cerr << msg << std::endl;
   }
@@ -40,8 +40,8 @@ public:
 // through UR entry points.
 // https://github.com/oneapi-src/unified-runtime/issues/1330
 ur_adapter_handle_t_::ur_adapter_handle_t_()
-    : logger(
-          logger::get_logger("hip", /*default_log_level*/ logger::Level::ERR)) {
+    : logger(logger::get_logger("hip",
+                                /*default_log_level*/ UR_LOGGER_LEVEL_ERROR)) {
 
   if (std::getenv("UR_LOG_HIP") != nullptr)
     return;
@@ -102,6 +102,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   default:
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  adapter.logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  adapter.logger.setCallbackLevel(level);
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/hip/ur_interface_loader.cpp
+++ b/source/adapters/hip/ur_interface_loader.cpp
@@ -443,6 +443,18 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
   return UR_RESULT_SUCCESS;
 }
 
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -41,7 +41,7 @@ public:
     this->ostream = &std::cerr;
   }
 
-  virtual void print([[maybe_unused]] logger::Level level,
+  virtual void print([[maybe_unused]] ur_logger_level_t level,
                      const std::string &msg) override {
     fprintf(stderr, "%s", msg.c_str());
   }
@@ -723,4 +723,26 @@ ur_result_t urAdapterGetInfo(ur_adapter_handle_t, ur_adapter_info_t PropName,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  if (GlobalAdapter) {
+    GlobalAdapter->logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  if (GlobalAdapter) {
+    GlobalAdapter->logger.setCallbackLevel(level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
 } // namespace ur::level_zero

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -48,6 +48,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   return result;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+
+  pDdiTable->pfnSetLoggerCallback = ur::level_zero::urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur::level_zero::urAdapterSetLoggerCallbackLevel;
+
+  return result;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     ur_api_version_t version, ur_bindless_images_exp_dditable_t *pDdiTable) {
   auto result = validateProcInputs(version, pDdiTable);
@@ -528,6 +542,10 @@ ur_result_t urAdapterGetDdiTables(ur_dditable_t *ddi) {
 
   result = ur::level_zero::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
                                                     &ddi->Global);
+  if (result != UR_RESULT_SUCCESS)
+    return result;
+  result = ur::level_zero::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,
+                                                     &ddi->Adapter);
   if (result != UR_RESULT_SUCCESS)
     return result;
   result = ur::level_zero::urGetBindlessImagesExpProcAddrTable(

--- a/source/adapters/level_zero/ur_interface_loader.hpp
+++ b/source/adapters/level_zero/ur_interface_loader.hpp
@@ -21,6 +21,12 @@ ur_result_t urAdapterGetLastError(ur_adapter_handle_t hAdapter,
 ur_result_t urAdapterGetInfo(ur_adapter_handle_t hAdapter,
                              ur_adapter_info_t propName, size_t propSize,
                              void *pPropValue, size_t *pPropSizeRet);
+ur_result_t urAdapterSetLoggerCallback(ur_adapter_handle_t hAdapter,
+                                       ur_logger_callback_t pfnLoggerCallback,
+                                       void *pUserData,
+                                       ur_logger_level_t level);
+ur_result_t urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter,
+                                            ur_logger_level_t level);
 ur_result_t urPlatformGet(ur_adapter_handle_t *phAdapters, uint32_t NumAdapters,
                           uint32_t NumEntries,
                           ur_platform_handle_t *phPlatforms,

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -261,6 +261,102 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  ur_adapter_set_logger_callback_params_t params = {
+      &hAdapter, &pfnLoggerCallback, &pUserData, &level};
+
+  auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_before_callback("urAdapterSetLoggerCallback"));
+  if (beforeCallback) {
+    result = beforeCallback(&params);
+    if (result != UR_RESULT_SUCCESS) {
+      return result;
+    }
+  }
+
+  auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_replace_callback("urAdapterSetLoggerCallback"));
+  if (replaceCallback) {
+    result = replaceCallback(&params);
+  } else {
+
+    result = UR_RESULT_SUCCESS;
+  }
+
+  if (result != UR_RESULT_SUCCESS) {
+    return result;
+  }
+
+  auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_after_callback("urAdapterSetLoggerCallback"));
+  if (afterCallback) {
+    return afterCallback(&params);
+  }
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  ur_adapter_set_logger_callback_level_params_t params = {&hAdapter, &level};
+
+  auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_before_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (beforeCallback) {
+    result = beforeCallback(&params);
+    if (result != UR_RESULT_SUCCESS) {
+      return result;
+    }
+  }
+
+  auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_replace_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (replaceCallback) {
+    result = replaceCallback(&params);
+  } else {
+
+    result = UR_RESULT_SUCCESS;
+  }
+
+  if (result != UR_RESULT_SUCCESS) {
+    return result;
+  }
+
+  auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
+      mock::getCallbacks().get_after_callback(
+          "urAdapterSetLoggerCallbackLevel"));
+  if (afterCallback) {
+    return afterCallback(&params);
+  }
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     /// [in][range(0, NumAdapters)] array of adapters to query for platforms.
@@ -10904,6 +11000,37 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   pDdiTable->pfnAdapterGetLastError = driver::urAdapterGetLastError;
 
   pDdiTable->pfnAdapterGetInfo = driver::urAdapterGetInfo;
+
+  return result;
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) try {
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (driver::d_context.version < version)
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  pDdiTable->pfnSetLoggerCallback = driver::urAdapterSetLoggerCallback;
+
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      driver::urAdapterSetLoggerCallbackLevel;
 
   return result;
 } catch (...) {

--- a/source/adapters/native_cpu/adapter.cpp
+++ b/source/adapters/native_cpu/adapter.cpp
@@ -66,3 +66,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  Adapter.logger.setCallbackSink(pfnLoggerCallback, pUserData, level);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  Adapter.logger.setCallbackLevel(level);
+
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -430,4 +430,17 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 } // extern "C"

--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -137,3 +137,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    ur_adapter_handle_t, ur_logger_callback_t pfnLoggerCallback,
+    void *pUserData, ur_logger_level_t level = UR_LOGGER_LEVEL_QUIET) {
+
+  if (adapter) {
+    adapter->log.setCallbackSink(pfnLoggerCallback, pUserData, level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urAdapterSetLoggerCallbackLevel(ur_adapter_handle_t, ur_logger_level_t level) {
+
+  if (adapter) {
+    adapter->log.setCallbackLevel(level);
+  }
+
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -438,6 +438,19 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    ur_api_version_t version, ur_adapter_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnSetLoggerCallback = urAdapterSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallbackLevel = urAdapterSetLoggerCallbackLevel;
+
+  return UR_RESULT_SUCCESS;
+}
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/source/common/logger/ur_level.hpp
+++ b/source/common/logger/ur_level.hpp
@@ -8,22 +8,21 @@
 
 #include <stdexcept>
 #include <string>
+#include <ur_api.h>
 
 namespace logger {
 
-enum class Level { DEBUG, INFO, WARN, ERR, QUIET };
-
-inline constexpr auto level_to_str(Level level) {
+inline constexpr auto level_to_str(ur_logger_level_t level) {
   switch (level) {
-  case Level::DEBUG:
+  case UR_LOGGER_LEVEL_DEBUG:
     return "DEBUG";
-  case Level::INFO:
+  case UR_LOGGER_LEVEL_INFO:
     return "INFO";
-  case Level::WARN:
+  case UR_LOGGER_LEVEL_WARN:
     return "WARNING";
-  case Level::ERR:
+  case UR_LOGGER_LEVEL_ERROR:
     return "ERROR";
-  case Level::QUIET:
+  case UR_LOGGER_LEVEL_QUIET:
     return "QUIET";
   default:
     return "";
@@ -31,26 +30,26 @@ inline constexpr auto level_to_str(Level level) {
 }
 
 inline auto str_to_level(std::string name) {
-  struct lvl_name {
+  struct level_name {
     std::string name;
-    Level lvl;
+    ur_logger_level_t level;
   };
 
-  const lvl_name lvl_names[] = {{"debug", Level::DEBUG},
-                                {"info", Level::INFO},
-                                {"warning", Level::WARN},
-                                {"error", Level::ERR},
-                                {"quiet", Level::QUIET}};
+  const level_name level_names[] = {{"debug", UR_LOGGER_LEVEL_DEBUG},
+                                    {"info", UR_LOGGER_LEVEL_INFO},
+                                    {"warning", UR_LOGGER_LEVEL_WARN},
+                                    {"error", UR_LOGGER_LEVEL_ERROR},
+                                    {"quiet", UR_LOGGER_LEVEL_QUIET}};
 
-  for (auto const &item : lvl_names) {
+  for (auto const &item : level_names) {
     if (item.name.compare(name) == 0) {
-      return item.lvl;
+      return item.level;
     }
   }
   throw std::invalid_argument(
       std::string("Parsing error: no valid log level for string '") + name +
       std::string("'.") +
-      std::string("\nValid log level names are: debug, info, warning, error, "
+      std::string("\nValid log level names are: debug, info, warning, error "
                   "and quiet"));
 }
 

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -14,13 +14,14 @@
 
 namespace logger {
 
-Logger create_logger(std::string logger_name, bool skip_prefix = false,
-                     bool skip_linebreak = false,
-                     logger::Level default_log_level = logger::Level::QUIET);
+Logger
+create_logger(std::string logger_name, bool skip_prefix = false,
+              bool skip_linebreak = false,
+              ur_logger_level_t default_log_level = UR_LOGGER_LEVEL_QUIET);
 
 inline Logger &
 get_logger(std::string name = "common",
-           logger::Level default_log_level = logger::Level::QUIET) {
+           ur_logger_level_t default_log_level = UR_LOGGER_LEVEL_QUIET) {
   static Logger logger =
       create_logger(std::move(name), /*skip_prefix*/ false,
                     /*slip_linebreak*/ false, default_log_level);
@@ -31,22 +32,22 @@ inline void init(const std::string &name) { get_logger(name.c_str()); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::DEBUG, format, std::forward<Args>(args)...);
+  get_logger().log(UR_LOGGER_LEVEL_DEBUG, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::INFO, format, std::forward<Args>(args)...);
+  get_logger().log(UR_LOGGER_LEVEL_INFO, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warning(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::WARN, format, std::forward<Args>(args)...);
+  get_logger().log(UR_LOGGER_LEVEL_WARN, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::ERR, format, std::forward<Args>(args)...);
+  get_logger().log(UR_LOGGER_LEVEL_ERROR, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
@@ -57,29 +58,32 @@ inline void always(const char *format, Args &&...args) {
 template <typename... Args>
 inline void debug(const logger::LegacyMessage &p, const char *format,
                   Args &&...args) {
-  get_logger().log(p, logger::Level::DEBUG, format,
+  get_logger().log(p, UR_LOGGER_LEVEL_DEBUG, format,
                    std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(logger::LegacyMessage p, const char *format, Args &&...args) {
-  get_logger().log(p, logger::Level::INFO, format, std::forward<Args>(args)...);
+  get_logger().log(p, UR_LOGGER_LEVEL_INFO, format,
+                   std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warning(logger::LegacyMessage p, const char *format,
                     Args &&...args) {
-  get_logger().log(p, logger::Level::WARN, format, std::forward<Args>(args)...);
+  get_logger().log(p, UR_LOGGER_LEVEL_WARN, format,
+                   std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(logger::LegacyMessage p, const char *format, Args &&...args) {
-  get_logger().log(p, logger::Level::ERR, format, std::forward<Args>(args)...);
+  get_logger().log(p, UR_LOGGER_LEVEL_ERROR, format,
+                   std::forward<Args>(args)...);
 }
 
-inline void setLevel(logger::Level level) { get_logger().setLevel(level); }
+inline void setLevel(ur_logger_level_t level) { get_logger().setLevel(level); }
 
-inline void setFlushLevel(logger::Level level) {
+inline void setFlushLevel(ur_logger_level_t level) {
   get_logger().setFlushLevel(level);
 }
 
@@ -115,21 +119,20 @@ template <typename T> inline std::string toHex(T t) {
 ///                            to be printed immediately as they occur
 ///             - output: stderr
 inline Logger create_logger(std::string logger_name, bool skip_prefix,
-                            bool skip_linebreak,
-                            logger::Level default_log_level) {
+                            bool skip_linebreak, ur_logger_level_t level) {
   std::transform(logger_name.begin(), logger_name.end(), logger_name.begin(),
                  ::toupper);
-  const auto default_flush_level = logger::Level::ERR;
+  std::stringstream env_var_name;
+  const auto default_flush_level = UR_LOGGER_LEVEL_ERROR;
   const std::string default_output = "stderr";
-  auto level = default_log_level;
   auto flush_level = default_flush_level;
   std::unique_ptr<logger::Sink> sink;
 
-  auto env_var_name = "UR_LOG_" + logger_name;
+  env_var_name << "UR_LOG_" << logger_name;
   try {
-    auto map = getenv_to_map(env_var_name.c_str());
+    auto map = getenv_to_map(env_var_name.str().c_str());
     if (!map.has_value()) {
-      return Logger(default_log_level,
+      return Logger(level,
                     std::make_unique<logger::StderrSink>(
                         std::move(logger_name), skip_prefix, skip_linebreak));
     }
@@ -148,7 +151,7 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix,
       map->erase(kv);
     }
 
-    std::vector<std::string> values = {std::move(default_output)};
+    std::vector<std::string> values = {default_output};
     kv = map->find("output");
     if (kv != map->end()) {
       values = kv->second;
@@ -158,7 +161,7 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix,
     if (!map->empty()) {
       std::cerr << "Wrong logger environment variable parameter: '"
                 << map->begin()->first << "'. Default logger options are set.";
-      return Logger(default_log_level,
+      return Logger(level,
                     std::make_unique<logger::StderrSink>(
                         std::move(logger_name), skip_prefix, skip_linebreak));
     }
@@ -169,12 +172,13 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix,
                                               skip_prefix, skip_linebreak);
   } catch (const std::invalid_argument &e) {
     std::cerr << "Error when creating a logger instance from the '"
-              << env_var_name << "' environment variable:\n"
+              << env_var_name.str() << "' environment variable:\n"
               << e.what() << std::endl;
-    return Logger(default_log_level,
+    return Logger(level,
                   std::make_unique<logger::StderrSink>(
                       std::move(logger_name), skip_prefix, skip_linebreak));
   }
+
   sink->setFlushLevel(flush_level);
 
   return Logger(level, std::move(sink));

--- a/source/common/logger/ur_sinks.hpp
+++ b/source/common/logger/ur_sinks.hpp
@@ -8,10 +8,12 @@
 #define UR_SINKS_HPP 1
 
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 
+#include "ur_api.h"
 #include "ur_filesystem_resolved.hpp"
 #include "ur_level.hpp"
 #include "ur_print.hpp"
@@ -25,9 +27,9 @@ inline bool isTearDowned = false;
 class Sink {
 public:
   template <typename... Args>
-  void log(logger::Level level, const char *fmt, Args &&...args) {
+  void log(ur_logger_level_t level, const char *fmt, Args &&...args) {
     std::ostringstream buffer;
-    if (!skip_prefix && level != logger::Level::QUIET) {
+    if (!skip_prefix && level != UR_LOGGER_LEVEL_QUIET) {
       buffer << "<" << logger_name << ">"
              << "[" << level_to_str(level) << "]: ";
     }
@@ -50,23 +52,23 @@ public:
 #endif
   }
 
-  void setFlushLevel(logger::Level level) { this->flush_level = level; }
+  void setFlushLevel(ur_logger_level_t level) { this->flush_level = level; }
 
   virtual ~Sink() = default;
 
 protected:
   std::ostream *ostream;
-  logger::Level flush_level;
+  ur_logger_level_t flush_level;
 
   Sink(std::string logger_name, bool skip_prefix = false,
        bool skip_linebreak = false)
       : logger_name(std::move(logger_name)), skip_prefix(skip_prefix),
         skip_linebreak(skip_linebreak) {
     ostream = nullptr;
-    flush_level = logger::Level::ERR;
+    flush_level = UR_LOGGER_LEVEL_ERROR;
   }
 
-  virtual void print(logger::Level level, const std::string &msg) {
+  virtual void print(ur_logger_level_t level, const std::string &msg) {
     std::scoped_lock<std::mutex> lock(output_mutex);
     *ostream << msg;
     if (level >= flush_level) {
@@ -157,8 +159,8 @@ public:
     this->ostream = &std::cout;
   }
 
-  StdoutSink(std::string logger_name, Level flush_lvl, bool skip_prefix = false,
-             bool skip_linebreak = false)
+  StdoutSink(std::string logger_name, ur_logger_level_t flush_lvl,
+             bool skip_prefix = false, bool skip_linebreak = false)
       : StdoutSink(std::move(logger_name), skip_prefix, skip_linebreak) {
     this->flush_level = flush_lvl;
   }
@@ -174,8 +176,8 @@ public:
     this->ostream = &std::cerr;
   }
 
-  StderrSink(std::string logger_name, Level flush_lvl, bool skip_prefix,
-             bool skip_linebreak)
+  StderrSink(std::string logger_name, ur_logger_level_t flush_lvl,
+             bool skip_prefix, bool skip_linebreak)
       : StderrSink(std::move(logger_name), skip_prefix, skip_linebreak) {
     this->flush_level = flush_lvl;
   }
@@ -198,8 +200,9 @@ public:
     this->ostream = &ofstream;
   }
 
-  FileSink(std::string logger_name, filesystem::path file_path, Level flush_lvl,
-           bool skip_prefix = false, bool skip_linebreak = false)
+  FileSink(std::string logger_name, filesystem::path file_path,
+           ur_logger_level_t flush_lvl, bool skip_prefix = false,
+           bool skip_linebreak = false)
       : FileSink(std::move(logger_name), std::move(file_path), skip_prefix,
                  skip_linebreak) {
     this->flush_level = flush_lvl;
@@ -209,6 +212,34 @@ public:
 
 private:
   std::ofstream ofstream;
+};
+
+class CallbackSink : public Sink {
+public:
+  CallbackSink(std::string logger_name, bool skip_prefix = false,
+               bool skip_linebreak = false)
+      : Sink(std::move(logger_name), skip_prefix, skip_linebreak) {}
+
+  CallbackSink(std::string logger_name, ur_logger_level_t flush_lvl,
+               bool skip_prefix, bool skip_linebreak)
+      : CallbackSink(std::move(logger_name), skip_prefix, skip_linebreak) {
+    this->flush_level = flush_lvl;
+  }
+
+  ~CallbackSink() = default;
+
+  void setCallback(ur_logger_callback_t cb, void *pUserData) {
+    callback = cb;
+    userData = pUserData;
+  }
+
+private:
+  ur_logger_callback_t callback;
+  void *userData;
+
+  virtual void print(ur_logger_level_t level, const std::string &msg) override {
+    callback(level, msg.c_str(), userData);
+  }
 };
 
 inline std::unique_ptr<Sink> sink_from_str(std::string logger_name,

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -21,7 +21,7 @@ context_t *getContext() { return context_t::get_direct(); }
 ///////////////////////////////////////////////////////////////////////////////
 context_t::context_t()
     : logger(logger::create_logger("sanitizer", false, false,
-                                   logger::Level::WARN)) {}
+                                   UR_LOGGER_LEVEL_WARN)) {}
 
 ur_result_t context_t::tearDown() {
   switch (enabledType) {

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -48,7 +48,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET, "urAdapterGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET, &params);
     logger.info("   <--- urAdapterGet({}) -> {};\n", args_str.str(), result);
@@ -79,7 +79,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RELEASE, "urAdapterRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RELEASE,
                                     &params);
@@ -112,7 +112,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_RETAIN, "urAdapterRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RETAIN,
                                     &params);
@@ -151,7 +151,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_LAST_ERROR,
                            "urAdapterGetLastError", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ADAPTER_GET_LAST_ERROR, &params);
@@ -199,12 +199,94 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
   getContext()->notify_end(UR_FUNCTION_ADAPTER_GET_INFO, "urAdapterGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET_INFO,
                                     &params);
     logger.info("   <--- urAdapterGetInfo({}) -> {};\n", args_str.str(),
                 result);
+  }
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallback =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+
+  if (nullptr == pfnSetLoggerCallback)
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  ur_adapter_set_logger_callback_params_t params = {
+      &hAdapter, &pfnLoggerCallback, &pUserData, &level};
+  uint64_t instance =
+      getContext()->notify_begin(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK,
+                                 "urAdapterSetLoggerCallback", &params);
+
+  auto &logger = getContext()->logger;
+  logger.info("   ---> urAdapterSetLoggerCallback\n");
+
+  ur_result_t result =
+      pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+
+  getContext()->notify_end(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK,
+                           "urAdapterSetLoggerCallback", &params, &result,
+                           instance);
+
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
+    std::ostringstream args_str;
+    ur::extras::printFunctionParams(
+        args_str, UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK, &params);
+    logger.info("   <--- urAdapterSetLoggerCallback({}) -> {};\n",
+                args_str.str(), result);
+  }
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallbackLevel =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+
+  if (nullptr == pfnSetLoggerCallbackLevel)
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+
+  ur_adapter_set_logger_callback_level_params_t params = {&hAdapter, &level};
+  uint64_t instance =
+      getContext()->notify_begin(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL,
+                                 "urAdapterSetLoggerCallbackLevel", &params);
+
+  auto &logger = getContext()->logger;
+  logger.info("   ---> urAdapterSetLoggerCallbackLevel\n");
+
+  ur_result_t result = pfnSetLoggerCallbackLevel(hAdapter, level);
+
+  getContext()->notify_end(UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL,
+                           "urAdapterSetLoggerCallbackLevel", &params, &result,
+                           instance);
+
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
+    std::ostringstream args_str;
+    ur::extras::printFunctionParams(
+        args_str, UR_FUNCTION_ADAPTER_SET_LOGGER_CALLBACK_LEVEL, &params);
+    logger.info("   <--- urAdapterSetLoggerCallbackLevel({}) -> {};\n",
+                args_str.str(), result);
   }
 
   return result;
@@ -247,7 +329,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
   getContext()->notify_end(UR_FUNCTION_PLATFORM_GET, "urPlatformGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET,
                                     &params);
@@ -294,7 +376,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
   getContext()->notify_end(UR_FUNCTION_PLATFORM_GET_INFO, "urPlatformGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET_INFO,
                                     &params);
@@ -330,7 +412,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
                            "urPlatformGetApiVersion", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_API_VERSION, &params);
@@ -369,7 +451,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
                            "urPlatformGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, &params);
@@ -413,7 +495,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
                            "urPlatformCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -456,7 +538,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
                            "urPlatformGetBackendOption", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION, &params);
@@ -505,7 +587,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
   getContext()->notify_end(UR_FUNCTION_DEVICE_GET, "urDeviceGet", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET, &params);
     logger.info("   <--- urDeviceGet({}) -> {};\n", args_str.str(), result);
@@ -552,7 +634,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
   getContext()->notify_end(UR_FUNCTION_DEVICE_GET_INFO, "urDeviceGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET_INFO,
                                     &params);
@@ -584,7 +666,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
   getContext()->notify_end(UR_FUNCTION_DEVICE_RETAIN, "urDeviceRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RETAIN,
                                     &params);
@@ -616,7 +698,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
   getContext()->notify_end(UR_FUNCTION_DEVICE_RELEASE, "urDeviceRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RELEASE,
                                     &params);
@@ -661,7 +743,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
   getContext()->notify_end(UR_FUNCTION_DEVICE_PARTITION, "urDevicePartition",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_PARTITION,
                                     &params);
@@ -706,7 +788,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
   getContext()->notify_end(UR_FUNCTION_DEVICE_SELECT_BINARY,
                            "urDeviceSelectBinary", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_SELECT_BINARY,
                                     &params);
@@ -742,7 +824,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
                            "urDeviceGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, &params);
@@ -786,7 +868,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
                            "urDeviceCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -830,7 +912,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
                            "urDeviceGetGlobalTimestamps", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, &params);
@@ -871,7 +953,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_CREATE, "urContextCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_CREATE,
                                     &params);
@@ -903,7 +985,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_RETAIN, "urContextRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RETAIN,
                                     &params);
@@ -935,7 +1017,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_RELEASE, "urContextRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RELEASE,
                                     &params);
@@ -984,7 +1066,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
   getContext()->notify_end(UR_FUNCTION_CONTEXT_GET_INFO, "urContextGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_GET_INFO,
                                     &params);
@@ -1021,7 +1103,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
                            "urContextGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, &params);
@@ -1071,7 +1153,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
                            "urContextCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1112,7 +1194,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
                            "urContextSetExtendedDeleter", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, &params);
@@ -1157,7 +1239,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
   getContext()->notify_end(UR_FUNCTION_MEM_IMAGE_CREATE, "urMemImageCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_CREATE,
                                     &params);
@@ -1200,7 +1282,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
   getContext()->notify_end(UR_FUNCTION_MEM_BUFFER_CREATE, "urMemBufferCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_CREATE,
                                     &params);
@@ -1233,7 +1315,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
   getContext()->notify_end(UR_FUNCTION_MEM_RETAIN, "urMemRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RETAIN, &params);
     logger.info("   <--- urMemRetain({}) -> {};\n", args_str.str(), result);
@@ -1264,7 +1346,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
   getContext()->notify_end(UR_FUNCTION_MEM_RELEASE, "urMemRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RELEASE, &params);
     logger.info("   <--- urMemRelease({}) -> {};\n", args_str.str(), result);
@@ -1305,7 +1387,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
   getContext()->notify_end(UR_FUNCTION_MEM_BUFFER_PARTITION,
                            "urMemBufferPartition", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_PARTITION,
                                     &params);
@@ -1343,7 +1425,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
   getContext()->notify_end(UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                            "urMemGetNativeHandle", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                                     &params);
@@ -1387,7 +1469,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
                            "urMemBufferCreateWithNativeHandle", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1435,7 +1517,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
                            "urMemImageCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1483,7 +1565,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_MEM_GET_INFO, "urMemGetInfo", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_INFO,
                                     &params);
@@ -1530,7 +1612,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
   getContext()->notify_end(UR_FUNCTION_MEM_IMAGE_GET_INFO, "urMemImageGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_GET_INFO,
                                     &params);
@@ -1567,7 +1649,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_CREATE, "urSamplerCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_CREATE,
                                     &params);
@@ -1599,7 +1681,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_RETAIN, "urSamplerRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RETAIN,
                                     &params);
@@ -1631,7 +1713,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_RELEASE, "urSamplerRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RELEASE,
                                     &params);
@@ -1675,7 +1757,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
   getContext()->notify_end(UR_FUNCTION_SAMPLER_GET_INFO, "urSamplerGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_GET_INFO,
                                     &params);
@@ -1712,7 +1794,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
                            "urSamplerGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, &params);
@@ -1756,7 +1838,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
                            "urSamplerCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -1798,7 +1880,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_HOST_ALLOC, "urUSMHostAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_HOST_ALLOC,
                                     &params);
@@ -1842,7 +1924,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_DEVICE_ALLOC, "urUSMDeviceAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_DEVICE_ALLOC,
                                     &params);
@@ -1887,7 +1969,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
   getContext()->notify_end(UR_FUNCTION_USM_SHARED_ALLOC, "urUSMSharedAlloc",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_SHARED_ALLOC,
                                     &params);
@@ -1922,7 +2004,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
   getContext()->notify_end(UR_FUNCTION_USM_FREE, "urUSMFree", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_FREE, &params);
     logger.info("   <--- urUSMFree({}) -> {};\n", args_str.str(), result);
@@ -1966,7 +2048,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
   getContext()->notify_end(UR_FUNCTION_USM_GET_MEM_ALLOC_INFO,
                            "urUSMGetMemAllocInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, &params);
@@ -2004,7 +2086,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_CREATE, "urUSMPoolCreate",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_CREATE,
                                     &params);
@@ -2036,7 +2118,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_RETAIN, "urUSMPoolRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RETAIN,
                                     &params);
@@ -2068,7 +2150,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_RELEASE, "urUSMPoolRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RELEASE,
                                     &params);
@@ -2112,7 +2194,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
   getContext()->notify_end(UR_FUNCTION_USM_POOL_GET_INFO, "urUSMPoolGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_GET_INFO,
                                     &params);
@@ -2166,7 +2248,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
                            "urVirtualMemGranularityGetInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO, &params);
@@ -2209,7 +2291,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                            "urVirtualMemReserve", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                                     &params);
@@ -2246,7 +2328,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_FREE, "urVirtualMemFree",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_FREE,
                                     &params);
@@ -2291,7 +2373,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_MAP, "urVirtualMemMap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_MAP,
                                     &params);
@@ -2327,7 +2409,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_UNMAP, "urVirtualMemUnmap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_UNMAP,
                                     &params);
@@ -2367,7 +2449,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS,
                            "urVirtualMemSetAccess", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS, &params);
@@ -2419,7 +2501,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                            "urVirtualMemGetInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                                     &params);
@@ -2463,7 +2545,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_CREATE,
                            "urPhysicalMemCreate", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_CREATE,
                                     &params);
@@ -2496,7 +2578,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                            "urPhysicalMemRetain", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                                     &params);
@@ -2529,7 +2611,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                            "urPhysicalMemRelease", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                                     &params);
@@ -2576,7 +2658,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
   getContext()->notify_end(UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                            "urPhysicalMemGetInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                                     &params);
@@ -2619,7 +2701,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_CREATE_WITH_IL,
                            "urProgramCreateWithIL", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_IL, &params);
@@ -2674,7 +2756,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
                            "urProgramCreateWithBinary", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, &params);
@@ -2711,7 +2793,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_BUILD, "urProgramBuild", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD,
                                     &params);
@@ -2747,7 +2829,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_COMPILE, "urProgramCompile",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE,
                                     &params);
@@ -2793,7 +2875,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_LINK, "urProgramLink", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK,
                                     &params);
@@ -2825,7 +2907,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_RETAIN, "urProgramRetain",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RETAIN,
                                     &params);
@@ -2857,7 +2939,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_RELEASE, "urProgramRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RELEASE,
                                     &params);
@@ -2903,7 +2985,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
                            "urProgramGetFunctionPointer", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, &params);
@@ -2953,7 +3035,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
                            "urProgramGetGlobalVariablePointer", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER, &params);
@@ -3002,7 +3084,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_GET_INFO, "urProgramGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_GET_INFO,
                                     &params);
@@ -3052,7 +3134,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_GET_BUILD_INFO,
                            "urProgramGetBuildInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_BUILD_INFO, &params);
@@ -3095,7 +3177,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
                            "urProgramSetSpecializationConstants", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, &params);
@@ -3132,7 +3214,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
                            "urProgramGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, &params);
@@ -3176,7 +3258,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
                            "urProgramCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -3213,7 +3295,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
   getContext()->notify_end(UR_FUNCTION_KERNEL_CREATE, "urKernelCreate", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_CREATE,
                                     &params);
@@ -3257,7 +3339,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                            "urKernelSetArgValue", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                                     &params);
@@ -3297,7 +3379,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                            "urKernelSetArgLocal", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                                     &params);
@@ -3346,7 +3428,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_GET_INFO, "urKernelGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_INFO,
                                     &params);
@@ -3392,7 +3474,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                            "urKernelGetGroupInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                                     &params);
@@ -3441,7 +3523,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
                            "urKernelGetSubGroupInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, &params);
@@ -3474,7 +3556,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
   getContext()->notify_end(UR_FUNCTION_KERNEL_RETAIN, "urKernelRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RETAIN,
                                     &params);
@@ -3506,7 +3588,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
   getContext()->notify_end(UR_FUNCTION_KERNEL_RELEASE, "urKernelRelease",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RELEASE,
                                     &params);
@@ -3547,7 +3629,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_POINTER,
                            "urKernelSetArgPointer", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_POINTER, &params);
@@ -3591,7 +3673,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                            "urKernelSetExecInfo", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                                     &params);
@@ -3632,7 +3714,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_SAMPLER,
                            "urKernelSetArgSampler", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, &params);
@@ -3673,7 +3755,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
   getContext()->notify_end(UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ,
                            "urKernelSetArgMemObj", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, &params);
@@ -3715,7 +3797,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
                            "urKernelSetSpecializationConstants", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, &params);
@@ -3751,7 +3833,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
                            "urKernelGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, &params);
@@ -3797,7 +3879,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
                            "urKernelCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -3852,7 +3934,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
                            "urKernelGetSuggestedLocalWorkSize", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE, &params);
@@ -3896,7 +3978,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
   getContext()->notify_end(UR_FUNCTION_QUEUE_GET_INFO, "urQueueGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_GET_INFO,
                                     &params);
@@ -3935,7 +4017,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
   getContext()->notify_end(UR_FUNCTION_QUEUE_CREATE, "urQueueCreate", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_CREATE,
                                     &params);
@@ -3967,7 +4049,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
   getContext()->notify_end(UR_FUNCTION_QUEUE_RETAIN, "urQueueRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RETAIN,
                                     &params);
@@ -3999,7 +4081,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
   getContext()->notify_end(UR_FUNCTION_QUEUE_RELEASE, "urQueueRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RELEASE,
                                     &params);
@@ -4037,7 +4119,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
                            "urQueueGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, &params);
@@ -4083,7 +4165,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                            "urQueueCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -4116,7 +4198,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
   getContext()->notify_end(UR_FUNCTION_QUEUE_FINISH, "urQueueFinish", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FINISH,
                                     &params);
@@ -4148,7 +4230,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
   getContext()->notify_end(UR_FUNCTION_QUEUE_FLUSH, "urQueueFlush", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FLUSH, &params);
     logger.info("   <--- urQueueFlush({}) -> {};\n", args_str.str(), result);
@@ -4190,7 +4272,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
   getContext()->notify_end(UR_FUNCTION_EVENT_GET_INFO, "urEventGetInfo",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_GET_INFO,
                                     &params);
@@ -4235,7 +4317,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
                            "urEventGetProfilingInfo", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_PROFILING_INFO, &params);
@@ -4271,7 +4353,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
   getContext()->notify_end(UR_FUNCTION_EVENT_WAIT, "urEventWait", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_WAIT, &params);
     logger.info("   <--- urEventWait({}) -> {};\n", args_str.str(), result);
@@ -4302,7 +4384,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
   getContext()->notify_end(UR_FUNCTION_EVENT_RETAIN, "urEventRetain", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RETAIN,
                                     &params);
@@ -4334,7 +4416,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
   getContext()->notify_end(UR_FUNCTION_EVENT_RELEASE, "urEventRelease", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RELEASE,
                                     &params);
@@ -4369,7 +4451,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
                            "urEventGetNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, &params);
@@ -4413,7 +4495,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
                            "urEventCreateWithNativeHandle", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, &params);
@@ -4453,7 +4535,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
   getContext()->notify_end(UR_FUNCTION_EVENT_SET_CALLBACK, "urEventSetCallback",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_SET_CALLBACK,
                                     &params);
@@ -4524,7 +4606,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                            "urEnqueueKernelLaunch", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                                     &params);
@@ -4571,7 +4653,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                            "urEnqueueEventsWait", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                                     &params);
@@ -4621,7 +4703,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
                            "urEnqueueEventsWaitWithBarrier", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, &params);
@@ -4681,7 +4763,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
                            "urEnqueueMemBufferRead", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, &params);
@@ -4741,7 +4823,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
                            "urEnqueueMemBufferWrite", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, &params);
@@ -4817,7 +4899,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                            "urEnqueueMemBufferReadRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, &params);
@@ -4894,7 +4976,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                            "urEnqueueMemBufferWriteRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, &params);
@@ -4953,7 +5035,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
                            "urEnqueueMemBufferCopy", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, &params);
@@ -5025,7 +5107,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                            "urEnqueueMemBufferCopyRect", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, &params);
@@ -5090,7 +5172,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
                            "urEnqueueMemBufferFill", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, &params);
@@ -5155,7 +5237,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ,
                            "urEnqueueMemImageRead", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, &params);
@@ -5221,7 +5303,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
                            "urEnqueueMemImageWrite", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, &params);
@@ -5282,7 +5364,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY,
                            "urEnqueueMemImageCopy", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, &params);
@@ -5344,7 +5426,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP,
                            "urEnqueueMemBufferMap", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, &params);
@@ -5395,7 +5477,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_MEM_UNMAP, "urEnqueueMemUnmap",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_MEM_UNMAP,
                                     &params);
@@ -5453,7 +5535,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_FILL, "urEnqueueUSMFill",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL,
                                     &params);
@@ -5509,7 +5591,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY, "urEnqueueUSMMemcpy",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY,
                                     &params);
@@ -5562,7 +5644,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                            "urEnqueueUSMPrefetch", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                                     &params);
@@ -5605,7 +5687,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_ADVISE, "urEnqueueUSMAdvise",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_ADVISE,
                                     &params);
@@ -5668,7 +5750,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                            "urEnqueueUSMFill2D", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                                     &params);
@@ -5733,7 +5815,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                            "urEnqueueUSMMemcpy2D", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                                     &params);
@@ -5797,7 +5879,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
                            "urEnqueueDeviceGlobalVariableWrite", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, &params);
@@ -5861,7 +5943,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
                            "urEnqueueDeviceGlobalVariableRead", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, &params);
@@ -5924,7 +6006,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
   getContext()->notify_end(UR_FUNCTION_ENQUEUE_READ_HOST_PIPE,
                            "urEnqueueReadHostPipe", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_READ_HOST_PIPE, &params);
@@ -5989,7 +6071,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
                            "urEnqueueWriteHostPipe", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE, &params);
@@ -6042,7 +6124,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
   getContext()->notify_end(UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                            "urUSMPitchedAllocExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                                     &params);
@@ -6087,7 +6169,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
       "urBindlessImagesUnsampledImageHandleDestroyExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str,
@@ -6135,7 +6217,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
       "urBindlessImagesSampledImageHandleDestroyExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
@@ -6183,7 +6265,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
                            "urBindlessImagesImageAllocateExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP, &params);
@@ -6224,7 +6306,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
                            "urBindlessImagesImageFreeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP, &params);
@@ -6272,7 +6354,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
       UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
       "urBindlessImagesUnsampledImageCreateExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
@@ -6325,7 +6407,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
                            "urBindlessImagesSampledImageCreateExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
@@ -6405,7 +6487,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                            "urBindlessImagesImageCopyExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP, &params);
@@ -6451,7 +6533,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
                            "urBindlessImagesImageGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP, &params);
@@ -6497,7 +6579,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
                            "urBindlessImagesMipmapGetLevelExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP, &params);
@@ -6538,7 +6620,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
                            "urBindlessImagesMipmapFreeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP, &params);
@@ -6587,7 +6669,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
       "urBindlessImagesImportExternalMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
@@ -6637,7 +6719,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
                            "urBindlessImagesMapExternalArrayExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP, &params);
@@ -6685,7 +6767,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
       "urBindlessImagesMapExternalLinearMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
@@ -6729,7 +6811,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
       UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
       "urBindlessImagesReleaseExternalMemoryExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
@@ -6778,7 +6860,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesImportExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
@@ -6823,7 +6905,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
       "urBindlessImagesReleaseExternalSemaphoreExp", &params, &result,
       instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
@@ -6887,7 +6969,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesWaitExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
@@ -6950,7 +7032,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
       UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
       "urBindlessImagesSignalExternalSemaphoreExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
@@ -6995,7 +7077,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
                            "urCommandBufferCreateExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP, &params);
@@ -7030,7 +7112,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
                            "urCommandBufferRetainExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP, &params);
@@ -7065,7 +7147,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
                            "urCommandBufferReleaseExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP, &params);
@@ -7101,7 +7183,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
                            "urCommandBufferFinalizeExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP, &params);
@@ -7197,7 +7279,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
                            "urCommandBufferAppendKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP, &params);
@@ -7272,7 +7354,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
                            "urCommandBufferAppendUSMMemcpyExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP, &params);
@@ -7350,7 +7432,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
                            "urCommandBufferAppendUSMFillExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP, &params);
@@ -7431,7 +7513,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
       "urCommandBufferAppendMemBufferCopyExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
@@ -7510,7 +7592,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
       "urCommandBufferAppendMemBufferWriteExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
@@ -7589,7 +7671,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
       "urCommandBufferAppendMemBufferReadExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
@@ -7684,7 +7766,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
       "urCommandBufferAppendMemBufferCopyRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
@@ -7783,7 +7865,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
       "urCommandBufferAppendMemBufferWriteRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
@@ -7881,7 +7963,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
       "urCommandBufferAppendMemBufferReadRectExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
@@ -7964,7 +8046,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
       UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
       "urCommandBufferAppendMemBufferFillExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
@@ -8040,7 +8122,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
                            "urCommandBufferAppendUSMPrefetchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP, &params);
@@ -8115,7 +8197,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
                            "urCommandBufferAppendUSMAdviseExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP, &params);
@@ -8167,7 +8249,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
                            "urCommandBufferEnqueueExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP, &params);
@@ -8207,7 +8289,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
                            "urCommandBufferUpdateKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP, &params);
@@ -8246,7 +8328,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
                            "urCommandBufferUpdateSignalEventExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP, &params);
@@ -8290,7 +8372,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
                            "urCommandBufferUpdateWaitEventsExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP, &params);
@@ -8336,7 +8418,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
                            "urCommandBufferGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP, &params);
@@ -8411,7 +8493,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
                            "urEnqueueCooperativeKernelLaunchExp", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP, &params);
@@ -8469,7 +8551,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
       UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
       "urKernelSuggestMaxCooperativeGroupCountExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
@@ -8531,7 +8613,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                            "urEnqueueTimestampRecordingExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP, &params);
@@ -8614,7 +8696,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
                            "urEnqueueKernelLaunchCustomExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP, &params);
@@ -8654,7 +8736,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_BUILD_EXP, "urProgramBuildExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD_EXP,
                                     &params);
@@ -8694,7 +8776,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_COMPILE_EXP,
                            "urProgramCompileExp", &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE_EXP,
                                     &params);
@@ -8745,7 +8827,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
   getContext()->notify_end(UR_FUNCTION_PROGRAM_LINK_EXP, "urProgramLinkExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK_EXP,
                                     &params);
@@ -8782,7 +8864,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
   getContext()->notify_end(UR_FUNCTION_USM_IMPORT_EXP, "urUSMImportExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_IMPORT_EXP,
                                     &params);
@@ -8816,7 +8898,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
   getContext()->notify_end(UR_FUNCTION_USM_RELEASE_EXP, "urUSMReleaseExp",
                            &params, &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_RELEASE_EXP,
                                     &params);
@@ -8854,7 +8936,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
                            "urUsmP2PEnablePeerAccessExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP, &params);
@@ -8893,7 +8975,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
                            "urUsmP2PDisablePeerAccessExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP, &params);
@@ -8948,7 +9030,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
                            "urUsmP2PPeerAccessGetInfoExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP, &params);
@@ -9000,7 +9082,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
                            "urEnqueueEventsWaitWithBarrierExt", &params,
                            &result, instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT, &params);
@@ -9072,7 +9154,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
                            "urEnqueueNativeCommandExp", &params, &result,
                            instance);
 
-  if (logger.getLevel() <= logger::Level::INFO) {
+  if (logger.getLevel() <= UR_LOGGER_LEVEL_INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP, &params);
@@ -9123,6 +9205,42 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 
   dditable.pfnAdapterGetInfo = pDdiTable->pfnAdapterGetInfo;
   pDdiTable->pfnAdapterGetInfo = ur_tracing_layer::urAdapterGetInfo;
+
+  return result;
+}
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+__urdlllocal ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) {
+  auto &dditable = ur_tracing_layer::getContext()->urDdiTable.Adapter;
+
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (UR_MAJOR_VERSION(ur_tracing_layer::getContext()->version) !=
+          UR_MAJOR_VERSION(version) ||
+      UR_MINOR_VERSION(ur_tracing_layer::getContext()->version) >
+          UR_MINOR_VERSION(version))
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallback =
+      ur_tracing_layer::urAdapterSetLoggerCallback;
+
+  dditable.pfnSetLoggerCallbackLevel = pDdiTable->pfnSetLoggerCallbackLevel;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur_tracing_layer::urAdapterSetLoggerCallbackLevel;
 
   return result;
 }
@@ -10333,6 +10451,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   if (UR_RESULT_SUCCESS == result) {
     result = ur_tracing_layer::urGetGlobalProcAddrTable(UR_API_VERSION_CURRENT,
                                                         &dditable->Global);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    result = ur_tracing_layer::urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT,
+                                                         &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -196,6 +196,78 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallback =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+
+  if (nullptr == pfnSetLoggerCallback) {
+    return UR_RESULT_ERROR_UNINITIALIZED;
+  }
+
+  if (getContext()->enableParameterValidation) {
+    if (NULL == hAdapter)
+      return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+    if (NULL == pfnLoggerCallback)
+      return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+    if (UR_LOGGER_LEVEL_QUIET < level)
+      return UR_RESULT_ERROR_INVALID_ENUMERATION;
+  }
+
+  if (getContext()->enableLifetimeValidation &&
+      !getContext()->refCountContext->isReferenceValid(hAdapter)) {
+    getContext()->refCountContext->logInvalidReference(hAdapter);
+  }
+
+  ur_result_t result =
+      pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  auto pfnSetLoggerCallbackLevel =
+      getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+
+  if (nullptr == pfnSetLoggerCallbackLevel) {
+    return UR_RESULT_ERROR_UNINITIALIZED;
+  }
+
+  if (getContext()->enableParameterValidation) {
+    if (NULL == hAdapter)
+      return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
+
+    if (UR_LOGGER_LEVEL_QUIET < level)
+      return UR_RESULT_ERROR_INVALID_ENUMERATION;
+  }
+
+  if (getContext()->enableLifetimeValidation &&
+      !getContext()->refCountContext->isReferenceValid(hAdapter)) {
+    getContext()->refCountContext->logInvalidReference(hAdapter);
+  }
+
+  ur_result_t result = pfnSetLoggerCallbackLevel(hAdapter, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     /// [in][range(0, NumAdapters)] array of adapters to query for platforms.
@@ -9774,6 +9846,43 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) {
+  auto &dditable = ur_validation_layer::getContext()->urDdiTable.Adapter;
+
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (UR_MAJOR_VERSION(ur_validation_layer::getContext()->version) !=
+          UR_MAJOR_VERSION(version) ||
+      UR_MINOR_VERSION(ur_validation_layer::getContext()->version) >
+          UR_MINOR_VERSION(version))
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  dditable.pfnSetLoggerCallback = pDdiTable->pfnSetLoggerCallback;
+  pDdiTable->pfnSetLoggerCallback =
+      ur_validation_layer::urAdapterSetLoggerCallback;
+
+  dditable.pfnSetLoggerCallbackLevel = pDdiTable->pfnSetLoggerCallbackLevel;
+  pDdiTable->pfnSetLoggerCallbackLevel =
+      ur_validation_layer::urAdapterSetLoggerCallbackLevel;
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Exported function for filling application's BindlessImagesExp table
 ///        with current process' addresses
 ///
@@ -11025,6 +11134,11 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   if (UR_RESULT_SUCCESS == result) {
     result = ur_validation_layer::urGetGlobalProcAddrTable(
         UR_API_VERSION_CURRENT, &dditable->Global);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    result = ur_validation_layer::urGetAdapterProcAddrTable(
+        UR_API_VERSION_CURRENT, &dditable->Adapter);
   }
 
   if (UR_RESULT_SUCCESS == result) {

--- a/source/loader/loader.def.in
+++ b/source/loader/loader.def.in
@@ -5,6 +5,8 @@ EXPORTS
 	urAdapterGetLastError
 	urAdapterRelease
 	urAdapterRetain
+	urAdapterSetLoggerCallback
+	urAdapterSetLoggerCallbackLevel
 	urBindlessImagesImageAllocateExp
 	urBindlessImagesImageCopyExp
 	urBindlessImagesImageFreeExp
@@ -99,6 +101,7 @@ EXPORTS
 	urEventRetain
 	urEventSetCallback
 	urEventWait
+	urGetAdapterProcAddrTable
 	urGetBindlessImagesExpProcAddrTable
 	urGetCommandBufferExpProcAddrTable
 	urGetContextProcAddrTable
@@ -173,6 +176,8 @@ EXPORTS
 	urPrintAdapterInfo
 	urPrintAdapterReleaseParams
 	urPrintAdapterRetainParams
+	urPrintAdapterSetLoggerCallbackLevelParams
+	urPrintAdapterSetLoggerCallbackParams
 	urPrintApiVersion
 	urPrintBaseDesc
 	urPrintBaseProperties
@@ -373,6 +378,7 @@ EXPORTS
 	urPrintLoaderConfigSetMockingEnabledParams
 	urPrintLoaderInitParams
 	urPrintLoaderTearDownParams
+	urPrintLoggerLevel
 	urPrintMapFlags
 	urPrintMemBufferCreateParams
 	urPrintMemBufferCreateWithNativeHandleParams

--- a/source/loader/loader.map.in
+++ b/source/loader/loader.map.in
@@ -5,6 +5,8 @@
 		urAdapterGetLastError;
 		urAdapterRelease;
 		urAdapterRetain;
+		urAdapterSetLoggerCallback;
+		urAdapterSetLoggerCallbackLevel;
 		urBindlessImagesImageAllocateExp;
 		urBindlessImagesImageCopyExp;
 		urBindlessImagesImageFreeExp;
@@ -99,6 +101,7 @@
 		urEventRetain;
 		urEventSetCallback;
 		urEventWait;
+		urGetAdapterProcAddrTable;
 		urGetBindlessImagesExpProcAddrTable;
 		urGetCommandBufferExpProcAddrTable;
 		urGetContextProcAddrTable;
@@ -173,6 +176,8 @@
 		urPrintAdapterInfo;
 		urPrintAdapterReleaseParams;
 		urPrintAdapterRetainParams;
+		urPrintAdapterSetLoggerCallbackLevelParams;
+		urPrintAdapterSetLoggerCallbackParams;
 		urPrintApiVersion;
 		urPrintBaseDesc;
 		urPrintBaseProperties;
@@ -373,6 +378,7 @@
 		urPrintLoaderConfigSetMockingEnabledParams;
 		urPrintLoaderInitParams;
 		urPrintLoaderTearDownParams;
+		urPrintLoggerLevel;
 		urPrintMapFlags;
 		urPrintMemBufferCreateParams;
 		urPrintMemBufferCreateWithNativeHandleParams;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -186,6 +186,63 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallback
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  [[maybe_unused]] auto context = getContext();
+
+  // extract platform's function pointer table
+  auto dditable = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->dditable;
+  auto pfnSetLoggerCallback = dditable->ur.Adapter.pfnSetLoggerCallback;
+  if (nullptr == pfnSetLoggerCallback)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  // convert loader handle to platform handle
+  hAdapter = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->handle;
+
+  // forward to device-platform
+  result = pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urAdapterSetLoggerCallbackLevel
+__urdlllocal ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  [[maybe_unused]] auto context = getContext();
+
+  // extract platform's function pointer table
+  auto dditable = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->dditable;
+  auto pfnSetLoggerCallbackLevel =
+      dditable->ur.Adapter.pfnSetLoggerCallbackLevel;
+  if (nullptr == pfnSetLoggerCallbackLevel)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  // convert loader handle to platform handle
+  hAdapter = reinterpret_cast<ur_adapter_object_t *>(hAdapter)->handle;
+
+  // forward to device-platform
+  result = pfnSetLoggerCallbackLevel(hAdapter, level);
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
 __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     /// [in][range(0, NumAdapters)] array of adapters to query for platforms.
@@ -9318,6 +9375,61 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
       // return pointers directly to platform's DDIs
       *pDdiTable =
           ur_loader::getContext()->platforms.front().dditable.ur.Global;
+    }
+  }
+
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Exported function for filling application's Adapter table
+///        with current process' addresses
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
+UR_DLLEXPORT ur_result_t UR_APICALL urGetAdapterProcAddrTable(
+    /// [in] API version requested
+    ur_api_version_t version,
+    /// [in,out] pointer to table of DDI function pointers
+    ur_adapter_dditable_t *pDdiTable) {
+  if (nullptr == pDdiTable)
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+
+  if (ur_loader::getContext()->version < version)
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+
+  ur_result_t result = UR_RESULT_SUCCESS;
+
+  // Load the device-platform DDI tables
+  for (auto &platform : ur_loader::getContext()->platforms) {
+    // statically linked adapter inside of the loader
+    if (platform.handle == nullptr)
+      continue;
+
+    if (platform.initStatus != UR_RESULT_SUCCESS)
+      continue;
+    auto getTable = reinterpret_cast<ur_pfnGetAdapterProcAddrTable_t>(
+        ur_loader::LibLoader::getFunctionPtr(platform.handle.get(),
+                                             "urGetAdapterProcAddrTable"));
+    if (!getTable)
+      continue;
+    platform.initStatus = getTable(version, &platform.dditable.ur.Adapter);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
+    if (ur_loader::getContext()->platforms.size() != 1 ||
+        ur_loader::getContext()->forceIntercept) {
+      // return pointers to loader's DDIs
+      pDdiTable->pfnSetLoggerCallback = ur_loader::urAdapterSetLoggerCallback;
+      pDdiTable->pfnSetLoggerCallbackLevel =
+          ur_loader::urAdapterSetLoggerCallbackLevel;
+    } else {
+      // return pointers directly to platform's DDIs
+      *pDdiTable =
+          ur_loader::getContext()->platforms.front().dditable.ur.Adapter;
     }
   }
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -484,6 +484,69 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  auto pfnSetLoggerCallback =
+      ur_lib::getContext()->urDdiTable.Adapter.pfnSetLoggerCallback;
+  if (nullptr == pfnSetLoggerCallback)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  return pfnSetLoggerCallback(hAdapter, pfnLoggerCallback, pUserData, level);
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) try {
+  auto pfnSetLoggerCallbackLevel =
+      ur_lib::getContext()->urDdiTable.Adapter.pfnSetLoggerCallbackLevel;
+  if (nullptr == pfnSetLoggerCallbackLevel)
+    return UR_RESULT_ERROR_UNINITIALIZED;
+
+  return pfnSetLoggerCallbackLevel(hAdapter, level);
+} catch (...) {
+  return exceptionToResult(std::current_exception());
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -28,6 +28,11 @@ __urdlllocal ur_result_t context_t::ddiInit() {
   }
 
   if (UR_RESULT_SUCCESS == result) {
+    result =
+        urGetAdapterProcAddrTable(UR_API_VERSION_CURRENT, &urDdiTable.Adapter);
+  }
+
+  if (UR_RESULT_SUCCESS == result) {
     result = urGetBindlessImagesExpProcAddrTable(UR_API_VERSION_CURRENT,
                                                  &urDdiTable.BindlessImagesExp);
   }

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -130,6 +130,13 @@ ur_result_t urPrintAdapterBackend(enum ur_adapter_backend_t value, char *buffer,
   return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t urPrintLoggerLevel(enum ur_logger_level_t value, char *buffer,
+                               const size_t buff_size, size_t *out_size) {
+  std::stringstream ss;
+  ss << value;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t urPrintPlatformInfo(enum ur_platform_info_t value, char *buffer,
                                 const size_t buff_size, size_t *out_size) {
   std::stringstream ss;
@@ -1158,6 +1165,22 @@ ur_result_t
 urPrintAdapterGetInfoParams(const struct ur_adapter_get_info_params_t *params,
                             char *buffer, const size_t buff_size,
                             size_t *out_size) {
+  std::stringstream ss;
+  ss << params;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintAdapterSetLoggerCallbackParams(
+    const struct ur_adapter_set_logger_callback_params_t *params, char *buffer,
+    const size_t buff_size, size_t *out_size) {
+  std::stringstream ss;
+  ss << params;
+  return str_copy(&ss, buffer, buff_size, out_size);
+}
+
+ur_result_t urPrintAdapterSetLoggerCallbackLevelParams(
+    const struct ur_adapter_set_logger_callback_level_params_t *params,
+    char *buffer, const size_t buff_size, size_t *out_size) {
   std::stringstream ss;
   ss << params;
   return str_copy(&ss, buffer, buff_size, out_size);

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -441,6 +441,57 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Set a callback function for use by the logger to retrieve logging
+/// output.
+///        It is a requirement that the callback function is thread safe and the
+///        creator of the function will be responsible for this.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
+///         + `NULL == pfnLoggerCallback`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallback(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] Function pointer to callback from the logger.
+    ur_logger_callback_t pfnLoggerCallback,
+    /// [in][out][optional] pointer to data to be passed to callback
+    void *pUserData,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+/// @brief Set the minimum logging level for the logger Callback function.
+///
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_UNINITIALIZED
+///     - ::UR_RESULT_ERROR_DEVICE_LOST
+///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
+///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
+///         + `NULL == hAdapter`
+///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
+///         + `::UR_LOGGER_LEVEL_QUIET < level`
+ur_result_t UR_APICALL urAdapterSetLoggerCallbackLevel(
+    /// [in] handle of the adapter
+    ur_adapter_handle_t hAdapter,
+    /// [in] logging level
+    ur_logger_level_t level) {
+  ur_result_t result = UR_RESULT_SUCCESS;
+  return result;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Retrieves all available platforms for the given adapters
 ///
 /// @details

--- a/test/unit/logger/fixtures.hpp
+++ b/test/unit/logger/fixtures.hpp
@@ -92,8 +92,19 @@ class DefaultLoggerWithFileSink : public UniquePtrLoggerWithFilesink {
 protected:
   void SetUp() override {
     logger = std::make_unique<logger::Logger>(
-        logger::Level::WARN,
+        UR_LOGGER_LEVEL_WARN,
         std::make_unique<logger::FileSink>(logger_name, file_path));
+  }
+};
+
+class LoggerWithCallbackSink : public ::testing::Test {
+protected:
+  std::unique_ptr<logger::Logger> logger;
+
+  void SetUp() override {
+    logger = std::make_unique<logger::Logger>(
+        UR_LOGGER_LEVEL_QUIET, nullptr, UR_LOGGER_LEVEL_WARN,
+        std::make_unique<logger::CallbackSink>("UR_LOG_CALLBACK"));
   }
 };
 


### PR DESCRIPTION
This PR implements https://github.com/oneapi-src/unified-runtime/issues/1330 through a new logger sink: a user configurable callback. It introduces some spec additions:

- `typedef void (*ur_logger_output_callback_t)(ur_logger_level_t level, const char *pLoggerMsg, void *pUserData)`
- `urSetLoggerCallback(ur_adapter_handle_t hAdapter, ur_logger_output_callback_t pfnLoggerCallback, void *pUserData, ur_logger_level_t level`
)`
- `urSetLoggerCallbackLevel(ur_adapter_handle_t hAdapter, ur_logger_level_t level)`
- `typedef enum ur_logger_level_t` (moved the logger::level enum into the spec)

This new logger sink will only be constructed once a user makes a call to `urSetLoggerCallback`, supplying their own callback function. They can set the minimum logging level through `urSetLoggerCallbackLevel`. Any subsequent logging calls will additionally make a call to the supplied callback where the log level, message and user data will be sent.

A new test suite `LoggerWithCallbackSink` has been added to test this new functionality.

intel/llvm PR: https://github.com/intel/llvm/pull/14422