### PR TITLE
[L0] Maintain Lock of Queue while syncing the Last Command Event and update Last Command Event only if matching

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1696,6 +1696,7 @@ ur_result_t ur_queue_handle_t_::synchronize() {
     // If event is discarded then it can be in reset state or underlying level
     // zero handle can have device scope, so we can't synchronize the last
     // event.
+    auto savedLastCommandEvent = LastCommandEvent;
     if (isInOrderQueue() && !LastCommandEvent->IsDiscarded) {
       ZE2UR_CALL(zeHostSynchronize, (LastCommandEvent->ZeEvent));
 
@@ -1737,7 +1738,12 @@ ur_result_t ur_queue_handle_t_::synchronize() {
         }
       }
     }
-    LastCommandEvent = nullptr;
+    // If the current version of the LastCommandEvent == savedLastCommandEvent,
+    // then LastCommandEvent = nullptr; Otherwise, if LastCommandEvent !=
+    // savedLastCommandEvent, then LastCommandEvent is unchanged.
+    if (LastCommandEvent == savedLastCommandEvent) {
+      LastCommandEvent = nullptr;
+    }
   }
 
   // Since all timestamp recordings should have finished with the

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1697,14 +1697,7 @@ ur_result_t ur_queue_handle_t_::synchronize() {
     // zero handle can have device scope, so we can't synchronize the last
     // event.
     if (isInOrderQueue() && !LastCommandEvent->IsDiscarded) {
-      if (UrL0QueueSyncNonBlocking) {
-        auto SyncZeEvent = LastCommandEvent->ZeEvent;
-        this->Mutex.unlock();
-        ZE2UR_CALL(zeHostSynchronize, (SyncZeEvent));
-        this->Mutex.lock();
-      } else {
-        ZE2UR_CALL(zeHostSynchronize, (LastCommandEvent->ZeEvent));
-      }
+      ZE2UR_CALL(zeHostSynchronize, (LastCommandEvent->ZeEvent));
 
       // clean up all events known to have been completed as well,
       // so they can be reused later


### PR DESCRIPTION
- To avoid usecases where the LastcommandEvent could be updated in another thread and a thread can be expecting the Queue Wait to include this event, then hold the queue lock such that the last command event remains unchanged during synchronization.