### PR TITLE
[NFC] Use sycl/sycl.hpp instead of CL/sycl.hpp

### DIFF
--- a/test/conformance/device_code/cpy_and_mult.cpp
+++ b/test/conformance/device_code/cpy_and_mult.cpp
@@ -3,7 +3,7 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
     size_t array_size = 16;

--- a/test/conformance/device_code/cpy_and_mult_usm.cpp
+++ b/test/conformance/device_code/cpy_and_mult_usm.cpp
@@ -3,7 +3,7 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 int main() {
     size_t array_size = 16;


### PR DESCRIPTION
CL/sycl.hpp is deprecated.