### PR TITLE
[CUDA][HIP] Make calls to `new` failsafe

### DIFF
--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -71,7 +71,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     MemObj = URMemObj.release();
   } catch (ur_result_t Err) {
     return Err;
-  } catch (std::bad_alloc &Err) {
+  } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
@@ -98,10 +98,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
 
     // Do nothing if there are other references
     if (hMem->decrementReferenceCount() > 0) {
-      return UR_RESULT_SUCCESS;
-    }
-
-    if (hMem->isSubBuffer()) {
       return UR_RESULT_SUCCESS;
     }
 
@@ -247,7 +243,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     *phMem = URMemObj.release();
   } catch (ur_result_t Err) {
     return Err;
-  } catch (std::bad_alloc &Err) {
+  } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -56,9 +56,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 
     auto URMemObj = std::unique_ptr<ur_mem_handle_t_>(
         new ur_mem_handle_t_{hContext, flags, AllocMode, HostPtr, size});
-    if (URMemObj == nullptr) {
-      return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
 
     // First allocation will be made at urMemBufferCreate if context only
     // has one device
@@ -74,6 +71,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     MemObj = URMemObj.release();
   } catch (ur_result_t Err) {
     return Err;
+  } catch (std::bad_alloc &Err) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }
@@ -243,10 +242,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
                                                             Device, Stream));
         UR_CHECK_ERROR(cuStreamSynchronize(Stream));
       }
-    }
-
-    if (URMemObj == nullptr) {
-      return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     *phMem = URMemObj.release();

--- a/source/adapters/cuda/memory.hpp
+++ b/source/adapters/cuda/memory.hpp
@@ -394,6 +394,7 @@ struct ur_mem_handle_t_ {
   }
 
   ~ur_mem_handle_t_() {
+    clear();
     if (isBuffer() && isSubBuffer()) {
       urMemRelease(std::get<BufferMem>(Mem).Parent);
       return;

--- a/source/adapters/cuda/physical_mem.cpp
+++ b/source/adapters/cuda/physical_mem.cpp
@@ -32,8 +32,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
   default:
     UR_CHECK_ERROR(Result);
   }
-  *phPhysicalMem = new ur_physical_mem_handle_t_(ResHandle, hContext, hDevice);
-
+  try {
+    *phPhysicalMem =
+        new ur_physical_mem_handle_t_(ResHandle, hContext, hDevice);
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
   return UR_RESULT_SUCCESS;
 }
 
@@ -53,10 +59,10 @@ urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
 
     ScopedContext Active(hPhysicalMem->getDevice());
     UR_CHECK_ERROR(cuMemRelease(hPhysicalMem->get()));
-    return UR_RESULT_SUCCESS;
   } catch (ur_result_t err) {
     return err;
   } catch (...) {
     return UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }
+  return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -187,23 +187,30 @@ ur_result_t createProgram(ur_context_handle_t hContext,
             UR_RESULT_ERROR_INVALID_CONTEXT);
   UR_ASSERT(size, UR_RESULT_ERROR_INVALID_SIZE);
 
-  std::unique_ptr<ur_program_handle_t_> RetProgram{
-      new ur_program_handle_t_{hContext, hDevice}};
+  try {
+    std::unique_ptr<ur_program_handle_t_> RetProgram{
+        new ur_program_handle_t_{hContext, hDevice}};
 
-  if (pProperties) {
-    if (pProperties->count > 0 && pProperties->pMetadatas == nullptr) {
-      return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-    } else if (pProperties->count == 0 && pProperties->pMetadatas != nullptr) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
+    if (pProperties) {
+      if (pProperties->count > 0 && pProperties->pMetadatas == nullptr) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+      } else if (pProperties->count == 0 &&
+                 pProperties->pMetadatas != nullptr) {
+        return UR_RESULT_ERROR_INVALID_SIZE;
+      }
+      UR_CHECK_ERROR(
+          RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count));
     }
-    UR_CHECK_ERROR(
-        RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count));
+
+    auto pBinary_string = reinterpret_cast<const char *>(pBinary);
+
+    UR_CHECK_ERROR(RetProgram->setBinary(pBinary_string, size));
+    *phProgram = RetProgram.release();
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
   }
-
-  auto pBinary_string = reinterpret_cast<const char *>(pBinary);
-
-  UR_CHECK_ERROR(RetProgram->setBinary(pBinary_string, size));
-  *phProgram = RetProgram.release();
 
   return UR_RESULT_SUCCESS;
 }
@@ -317,6 +324,8 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
 
   } catch (ur_result_t Err) {
     Result = Err;
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
   return Result;
 }

--- a/source/adapters/cuda/queue.cpp
+++ b/source/adapters/cuda/queue.cpp
@@ -167,12 +167,11 @@ urQueueCreate(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 
     return UR_RESULT_SUCCESS;
   } catch (ur_result_t Err) {
-
     return Err;
-
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
-
-    return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+    return UR_RESULT_ERROR_UNKNOWN;
   }
 }
 

--- a/source/adapters/cuda/sampler.cpp
+++ b/source/adapters/cuda/sampler.cpp
@@ -14,46 +14,55 @@
 UR_APIEXPORT ur_result_t UR_APICALL
 urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
                 ur_sampler_handle_t *phSampler) {
-  std::unique_ptr<ur_sampler_handle_t_> Sampler{
-      new ur_sampler_handle_t_(hContext)};
+  try {
+    std::unique_ptr<ur_sampler_handle_t_> Sampler{
+        new ur_sampler_handle_t_(hContext)};
 
-  if (pDesc->stype == UR_STRUCTURE_TYPE_SAMPLER_DESC) {
-    Sampler->Props |= static_cast<uint32_t>(pDesc->normalizedCoords);
-    Sampler->Props |= pDesc->filterMode << 1;
-    Sampler->Props |= pDesc->addressingMode << 2;
-  } else {
-    // Set default values
-    Sampler->Props |= true; // Normalized Coords
-    Sampler->Props |= UR_SAMPLER_ADDRESSING_MODE_CLAMP << 2;
-  }
-
-  void *pNext = const_cast<void *>(pDesc->pNext);
-  while (pNext != nullptr) {
-    const ur_base_desc_t *BaseDesc =
-        reinterpret_cast<const ur_base_desc_t *>(pNext);
-    if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES) {
-      const ur_exp_sampler_mip_properties_t *SamplerMipProperties =
-          reinterpret_cast<const ur_exp_sampler_mip_properties_t *>(pNext);
-      Sampler->MaxMipmapLevelClamp = SamplerMipProperties->maxMipmapLevelClamp;
-      Sampler->MinMipmapLevelClamp = SamplerMipProperties->minMipmapLevelClamp;
-      Sampler->MaxAnisotropy = SamplerMipProperties->maxAnisotropy;
-      Sampler->Props |= SamplerMipProperties->mipFilterMode << 11;
-    } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES) {
-      const ur_exp_sampler_addr_modes_t *SamplerAddrModes =
-          reinterpret_cast<const ur_exp_sampler_addr_modes_t *>(pNext);
-      Sampler->Props |= SamplerAddrModes->addrModes[0] << 2;
-      Sampler->Props |= SamplerAddrModes->addrModes[1] << 5;
-      Sampler->Props |= SamplerAddrModes->addrModes[2] << 8;
-    } else if (BaseDesc->stype ==
-               UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES) {
-      const ur_exp_sampler_cubemap_properties_t *SamplerCubemapProperties =
-          reinterpret_cast<const ur_exp_sampler_cubemap_properties_t *>(pNext);
-      Sampler->Props |= SamplerCubemapProperties->cubemapFilterMode << 12;
+    if (pDesc->stype == UR_STRUCTURE_TYPE_SAMPLER_DESC) {
+      Sampler->Props |= static_cast<uint32_t>(pDesc->normalizedCoords);
+      Sampler->Props |= pDesc->filterMode << 1;
+      Sampler->Props |= pDesc->addressingMode << 2;
+    } else {
+      // Set default values
+      Sampler->Props |= true; // Normalized Coords
+      Sampler->Props |= UR_SAMPLER_ADDRESSING_MODE_CLAMP << 2;
     }
-    pNext = const_cast<void *>(BaseDesc->pNext);
-  }
 
-  *phSampler = Sampler.release();
+    void *pNext = const_cast<void *>(pDesc->pNext);
+    while (pNext != nullptr) {
+      const ur_base_desc_t *BaseDesc =
+          reinterpret_cast<const ur_base_desc_t *>(pNext);
+      if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES) {
+        const ur_exp_sampler_mip_properties_t *SamplerMipProperties =
+            reinterpret_cast<const ur_exp_sampler_mip_properties_t *>(pNext);
+        Sampler->MaxMipmapLevelClamp =
+            SamplerMipProperties->maxMipmapLevelClamp;
+        Sampler->MinMipmapLevelClamp =
+            SamplerMipProperties->minMipmapLevelClamp;
+        Sampler->MaxAnisotropy = SamplerMipProperties->maxAnisotropy;
+        Sampler->Props |= SamplerMipProperties->mipFilterMode << 11;
+      } else if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES) {
+        const ur_exp_sampler_addr_modes_t *SamplerAddrModes =
+            reinterpret_cast<const ur_exp_sampler_addr_modes_t *>(pNext);
+        Sampler->Props |= SamplerAddrModes->addrModes[0] << 2;
+        Sampler->Props |= SamplerAddrModes->addrModes[1] << 5;
+        Sampler->Props |= SamplerAddrModes->addrModes[2] << 8;
+      } else if (BaseDesc->stype ==
+                 UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES) {
+        const ur_exp_sampler_cubemap_properties_t *SamplerCubemapProperties =
+            reinterpret_cast<const ur_exp_sampler_cubemap_properties_t *>(
+                pNext);
+        Sampler->Props |= SamplerCubemapProperties->cubemapFilterMode << 12;
+      }
+      pNext = const_cast<void *>(BaseDesc->pNext);
+    }
+
+    *phSampler = Sampler.release();
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/hip/context.cpp
+++ b/source/adapters/hip/context.cpp
@@ -50,8 +50,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
     *phContext = ContextPtr.release();
   } catch (ur_result_t Err) {
     RetErr = Err;
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
-    RetErr = UR_RESULT_ERROR_OUT_OF_RESOURCES;
+    return UR_RESULT_ERROR_UNKNOWN;
   }
   return RetErr;
 }

--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -46,8 +46,10 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
                                 hProgram, hProgram->getContext()});
   } catch (ur_result_t Err) {
     Result = Err;
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
-    Result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+    return UR_RESULT_ERROR_UNKNOWN;
   }
 
   *phKernel = RetKernel.release();

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -68,10 +68,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
       return UR_RESULT_SUCCESS;
     }
 
-    if (hMem->isSubBuffer()) {
-      return UR_RESULT_SUCCESS;
-    }
-
     // Call destructor
     std::unique_ptr<ur_mem_handle_t_> uniqueMemObj(hMem);
 

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -133,9 +133,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
 
     auto URMemObj = std::unique_ptr<ur_mem_handle_t_>(
         new ur_mem_handle_t_{hContext, flags, AllocMode, HostPtr, size});
-    if (URMemObj == nullptr) {
-      throw UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
 
     // First allocation will be made at urMemBufferCreate if context only
     // has one device
@@ -157,6 +154,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     RetMemObj = URMemObj.release();
   } catch (ur_result_t Err) {
     Result = Err;
+  } catch (std::bad_alloc &Err) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
   }
@@ -383,10 +382,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
 
     auto URMemObj = std::unique_ptr<ur_mem_handle_t_>(new ur_mem_handle_t_{
         hContext, flags, *pImageFormat, *pImageDesc, pHost});
-
-    if (URMemObj == nullptr) {
-      return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
 
     if (PerformInitialCopy) {
       for (const auto &Dev : hContext->getDevices()) {

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -150,7 +150,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     RetMemObj = URMemObj.release();
   } catch (ur_result_t Err) {
     Result = Err;
-  } catch (std::bad_alloc &Err) {
+  } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
@@ -213,9 +213,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   } catch (ur_result_t Err) {
     *phMem = nullptr;
     return Err;
-  } catch (...) {
+  } catch (std::bad_alloc &) {
     *phMem = nullptr;
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    *phMem = nullptr;
+    return UR_RESULT_ERROR_UNKNOWN;
   }
 
   ReleaseGuard.dismiss();
@@ -391,7 +394,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     *phMem = URMemObj.release();
   } catch (ur_result_t Err) {
     return Err;
-  } catch (std::bad_alloc &Err) {
+  } catch (std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;

--- a/source/adapters/hip/memory.hpp
+++ b/source/adapters/hip/memory.hpp
@@ -390,6 +390,7 @@ struct ur_mem_handle_t_ {
   }
 
   ~ur_mem_handle_t_() noexcept(false) {
+    clear();
     if (isBuffer() && isSubBuffer()) {
       urMemRelease(std::get<BufferMem>(Mem).Parent);
       return;

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -467,35 +467,37 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
                       hDevice) != hContext->getDevices().end(),
             UR_RESULT_ERROR_INVALID_CONTEXT);
 
-  ur_result_t Result = UR_RESULT_SUCCESS;
+  try {
+    std::unique_ptr<ur_program_handle_t_> RetProgram{
+        new ur_program_handle_t_{hContext, hDevice}};
 
-  std::unique_ptr<ur_program_handle_t_> RetProgram{
-      new ur_program_handle_t_{hContext, hDevice}};
-
-  if (pProperties) {
-    if (pProperties->count > 0 && pProperties->pMetadatas == nullptr) {
-      return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-    } else if (pProperties->count == 0 && pProperties->pMetadatas != nullptr) {
-      return UR_RESULT_ERROR_INVALID_SIZE;
+    if (pProperties) {
+      if (pProperties->count > 0 && pProperties->pMetadatas == nullptr) {
+        return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+      } else if (pProperties->count == 0 &&
+                 pProperties->pMetadatas != nullptr) {
+        return UR_RESULT_ERROR_INVALID_SIZE;
+      }
+      UR_CHECK_ERROR(
+          RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count));
     }
-    Result =
-        RetProgram->setMetadata(pProperties->pMetadatas, pProperties->count);
-    UR_ASSERT(Result == UR_RESULT_SUCCESS, Result);
+
+    auto pBinary_string = reinterpret_cast<const char *>(pBinary);
+    if (size == 0) {
+      size = strlen(pBinary_string) + 1;
+    }
+
+    UR_ASSERT(size, UR_RESULT_ERROR_INVALID_SIZE);
+
+    UR_CHECK_ERROR(RetProgram->setBinary(pBinary_string, size));
+
+    *phProgram = RetProgram.release();
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
   }
-
-  auto pBinary_string = reinterpret_cast<const char *>(pBinary);
-  if (size == 0) {
-    size = strlen(pBinary_string) + 1;
-  }
-
-  UR_ASSERT(size, UR_RESULT_ERROR_INVALID_SIZE);
-
-  Result = RetProgram->setBinary(pBinary_string, size);
-  UR_ASSERT(Result == UR_RESULT_SUCCESS, Result);
-
-  *phProgram = RetProgram.release();
-
-  return Result;
+  return UR_RESULT_SUCCESS;
 }
 
 // This entry point is only used for native specialization constants (SPIR-V),

--- a/source/adapters/hip/queue.cpp
+++ b/source/adapters/hip/queue.cpp
@@ -155,8 +155,10 @@ urQueueCreate(ur_context_handle_t hContext, ur_device_handle_t hDevice,
     return UR_RESULT_SUCCESS;
   } catch (ur_result_t Err) {
     return Err;
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
-    return UR_RESULT_ERROR_OUT_OF_RESOURCES;
+    return UR_RESULT_ERROR_UNKNOWN;
   }
 }
 

--- a/source/adapters/hip/sampler.cpp
+++ b/source/adapters/hip/sampler.cpp
@@ -14,20 +14,26 @@
 ur_result_t urSamplerCreate(ur_context_handle_t hContext,
                             const ur_sampler_desc_t *pDesc,
                             ur_sampler_handle_t *phSampler) {
-  std::unique_ptr<ur_sampler_handle_t_> RetImplSampl{
-      new ur_sampler_handle_t_(hContext)};
+  try {
+    std::unique_ptr<ur_sampler_handle_t_> RetImplSampl{
+        new ur_sampler_handle_t_(hContext)};
 
-  if (pDesc && pDesc->stype == UR_STRUCTURE_TYPE_SAMPLER_DESC) {
-    RetImplSampl->Props |= pDesc->normalizedCoords;
-    RetImplSampl->Props |= pDesc->filterMode << 1;
-    RetImplSampl->Props |= pDesc->addressingMode << 2;
-  } else {
-    // Set default values
-    RetImplSampl->Props |= true; // Normalized Coords
-    RetImplSampl->Props |= UR_SAMPLER_ADDRESSING_MODE_CLAMP << 2;
+    if (pDesc && pDesc->stype == UR_STRUCTURE_TYPE_SAMPLER_DESC) {
+      RetImplSampl->Props |= pDesc->normalizedCoords;
+      RetImplSampl->Props |= pDesc->filterMode << 1;
+      RetImplSampl->Props |= pDesc->addressingMode << 2;
+    } else {
+      // Set default values
+      RetImplSampl->Props |= true; // Normalized Coords
+      RetImplSampl->Props |= UR_SAMPLER_ADDRESSING_MODE_CLAMP << 2;
+    }
+
+    *phSampler = RetImplSampl.release();
+  } catch (std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
   }
-
-  *phSampler = RetImplSampl.release();
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
Use unique ptrs, and have the destructor call clear(), instead of calling it manually. Also add a case for a std::bad_alloc.