### PR TITLE
[CUDA][HIP] Always wait on interop events

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -36,9 +36,9 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
                                        CUevent EventNative)
     : CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1}, HasOwnership{false},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
-      StreamToken{std::numeric_limits<uint32_t>::max()}, EventID{0},
-      EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr}, Queue{nullptr},
-      Stream{nullptr}, Context{Context} {
+      IsInterop{true}, StreamToken{std::numeric_limits<uint32_t>::max()},
+      EventID{0}, EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr},
+      Queue{nullptr}, Stream{nullptr}, Context{Context} {
   urContextRetain(Context);
 }
 

--- a/source/adapters/cuda/event.hpp
+++ b/source/adapters/cuda/event.hpp
@@ -45,6 +45,8 @@ public:
 
   bool isCompleted() const noexcept;
 
+  bool isInterop() const noexcept { return IsInterop; };
+
   uint32_t getExecutionStatus() const noexcept {
 
     if (!isRecorded()) {
@@ -141,6 +143,8 @@ private:
   bool IsStarted;  // Signifies wether the operation associated with the
                    // UR event has started or not
 
+  const bool IsInterop{false}; // Made with urEventCreateWithNativeHandle
+
   uint32_t StreamToken;
   uint32_t EventID; // Queue identifier of the event.
 
@@ -195,7 +199,8 @@ ur_result_t forLatestEvents(const ur_event_handle_t *EventWaitList,
   CUstream LastSeenStream = 0;
   for (size_t i = 0; i < Events.size(); i++) {
     auto Event = Events[i];
-    if (!Event || (i != 0 && Event->getStream() == LastSeenStream)) {
+    if (!Event || (i != 0 && !Event->isInterop() &&
+                   Event->getStream() == LastSeenStream)) {
       continue;
     }
 

--- a/source/adapters/hip/event.cpp
+++ b/source/adapters/hip/event.cpp
@@ -31,9 +31,9 @@ ur_event_handle_t_::ur_event_handle_t_(ur_context_handle_t Context,
                                        hipEvent_t EventNative)
     : CommandType{UR_COMMAND_EVENTS_WAIT}, RefCount{1}, HasOwnership{false},
       HasBeenWaitedOn{false}, IsRecorded{false}, IsStarted{false},
-      StreamToken{std::numeric_limits<uint32_t>::max()}, EventId{0},
-      EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr}, Queue{nullptr},
-      Stream{nullptr}, Context{Context} {
+      IsInterop{true}, StreamToken{std::numeric_limits<uint32_t>::max()},
+      EventId{0}, EvEnd{EventNative}, EvStart{nullptr}, EvQueued{nullptr},
+      Queue{nullptr}, Stream{nullptr}, Context{Context} {
   urContextRetain(Context);
 }
 

--- a/source/adapters/hip/event.hpp
+++ b/source/adapters/hip/event.hpp
@@ -42,6 +42,8 @@ public:
 
   bool isCompleted() const;
 
+  bool isInterop() const noexcept { return IsInterop; };
+
   uint32_t getExecutionStatus() const {
     if (!isRecorded()) {
       return UR_EVENT_STATUS_SUBMITTED;
@@ -134,7 +136,8 @@ private:
                    // yet.
   bool IsStarted;  // Signifies wether the operation associated with the
                    // UR event has started or not
-                   //
+
+  const bool IsInterop{false}; // Made with urEventCreateWithNativeHandle
 
   uint32_t StreamToken;
   uint32_t EventId; // Queue identifier of the event.
@@ -190,7 +193,8 @@ ur_result_t forLatestEvents(const ur_event_handle_t *EventWaitList,
   hipStream_t LastSeenStream = 0;
   for (size_t i = 0; i < Events.size(); i++) {
     auto Event = Events[i];
-    if (!Event || (i != 0 && Event->getStream() == LastSeenStream)) {
+    if (!Event || (i != 0 && !Event->isInterop() &&
+                   Event->getStream() == LastSeenStream)) {
       continue;
     }
 


### PR DESCRIPTION
We can't make assumptions about interop events being on the same stream as other interop events, since in UR we don't track the streams that native events are recorded on.