### PR TITLE
[HIP] Fix return type for urKernelGetInfo UR_KERNEL_INFO_NUM_ARGS

### DIFF
--- a/source/adapters/hip/kernel.hpp
+++ b/source/adapters/hip/kernel.hpp
@@ -201,7 +201,7 @@ struct ur_kernel_handle_t_ {
   /// offset. Note this only returns the current known number of arguments,
   /// not the real one required by the kernel, since this cannot be queried
   /// from the HIP Driver API
-  uint32_t getNumArgs() const noexcept { return Args.Indices.size() - 1; }
+  size_t getNumArgs() const noexcept { return Args.Indices.size() - 1; }
 
   void setKernelArg(int Index, size_t Size, const void *Arg) {
     Args.addArg(Index, Size, Arg);

--- a/test/conformance/kernel/kernel_adapter_hip.match
+++ b/test/conformance/kernel/kernel_adapter_hip.match
@@ -1,12 +1,5 @@
 urKernelGetGroupInfoWgSizeTest.CompileWorkGroupSize/AMD_HIP_BACKEND___{{.*}}_
 urKernelGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_NUM_REGS
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_FUNCTION_NAME
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_NUM_ARGS
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_REFERENCE_COUNT
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_CONTEXT
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_PROGRAM
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_ATTRIBUTES
-urKernelGetInfoTest.InvalidSizeSmall/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_NUM_REGS
 urKernelSetArgLocalTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_
 urKernelSetArgMemObjTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_
 urKernelSetArgPointerNegativeTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_


### PR DESCRIPTION
The property should be of type size_t.

Note that we're removing a bunch of match lines for seemingly unrelated properties, but in fact the CTS tests do not make use of the parameter they claim, and in fact hard-code the UR_KERNEL_INFO_NUM_ARGS property.