### PR TITLE
add DEPENDENTLOADFLAG linker flag on Windows

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -131,6 +131,11 @@ function(add_ur_library name)
     add_library(${name} ${ARGN})
     add_ur_target_compile_options(${name})
     add_ur_target_link_options(${name})
+    if(MSVC)
+        target_link_options(${name} PRIVATE
+            $<$<STREQUAL:$<TARGET_LINKER_FILE_NAME:${name}>,link.exe>:/DEPENDENTLOADFLAG:0x2000>
+        )
+    endif()
 endfunction()
 
 include(FetchContent)


### PR DESCRIPTION
This is to address potential DLL planting security issue, see: https://msrc.microsoft.com/blog/2018/04/triaging-a-dll-planting-vulnerability/#current-working-directory-cwd-dll-planting