### PR TITLE
Refactor Level Zero Command-Buffer implementation

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -330,7 +330,6 @@ ur_result_t enqueueCommandBufferMemCopyHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryCopy()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopy,
              (ZeCommandList, Dst, Src, Size, ZeLaunchEvent, ZeEventList.size(),
               getPointerFromVector(ZeEventList)));
@@ -389,7 +388,6 @@ ur_result_t enqueueCommandBufferMemCopyRectHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
   ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
              (ZeCommandList, Dst, &ZeDstRegion, DstPitch, DstSlicePitch, Src,
               &ZeSrcRegion, SrcPitch, SrcSlicePitch, ZeLaunchEvent,
@@ -422,7 +420,6 @@ ur_result_t enqueueCommandBufferFillHelper(
   ze_command_list_handle_t ZeCommandList =
       CommandBuffer->chooseCommandList(PreferCopyEngine);
 
-  logger::debug("calling zeCommandListAppendMemoryFill()");
   ZE2UR_CALL(zeCommandListAppendMemoryFill,
              (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeLaunchEvent,
               ZeEventList.size(), getPointerFromVector(ZeEventList)));
@@ -933,7 +930,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
       UR_COMMAND_KERNEL_LAUNCH, CommandBuffer, NumSyncPointsInWaitList,
       SyncPointWaitList, false, RetSyncPoint, ZeEventList, ZeLaunchEvent));
 
-  logger::debug("calling zeCommandListAppendLaunchKernel()");
   ZE2UR_CALL(zeCommandListAppendLaunchKernel,
              (CommandBuffer->ZeComputeCommandList, Kernel->ZeKernel,
               &ZeThreadGroupDimensions, ZeLaunchEvent, ZeEventList.size(),

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -620,9 +620,6 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
 
   ZeStruct<ze_mutable_command_list_exp_desc_t> ZeMutableCommandListDesc;
   if (IsUpdatable) {
-    auto Platform = Context->getPlatform();
-    UR_ASSERT(Platform->ZeMutableCmdListExt.Supported,
-              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
     ZeMutableCommandListDesc.flags = 0;
     ZeCommandListDesc.pNext = &ZeMutableCommandListDesc;
   }
@@ -659,6 +656,11 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   bool EnableProfiling =
       CommandBufferDesc && CommandBufferDesc->enableProfiling;
   bool IsUpdatable = CommandBufferDesc && CommandBufferDesc->isUpdatable;
+
+  if (IsUpdatable) {
+    UR_ASSERT(Context->getPlatform()->ZeMutableCmdListExt.Supported,
+              UR_RESULT_ERROR_UNSUPPORTED_FEATURE);
+  }
 
   ur_event_handle_t SignalEvent;
   ur_event_handle_t WaitEvent;

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1254,7 +1254,8 @@ namespace {
  * @param[out] ZeCommandQueue The L0 command queue.
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
-ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
+ur_result_t getZeCommandQueue(ur_queue_handle_legacy_t Queue,
+                              bool UseCopyEngine,
                               ze_command_queue_handle_t &ZeCommandQueue) {
   auto &QGroup = Queue->getQueueGroup(UseCopyEngine);
   uint32_t QueueGroupOrdinal;
@@ -1271,7 +1272,7 @@ ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
-                                ur_queue_handle_t Queue,
+                                ur_queue_handle_legacy_t Queue,
                                 uint32_t NumEventsInWaitList,
                                 const ur_event_handle_t *EventWaitList) {
   const bool UseCopyEngine = false;
@@ -1322,7 +1323,7 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
  * @return UR_RESULT_SUCCESS or an error code on failure
  */
 ur_result_t createUserEvent(ur_exp_command_buffer_handle_t CommandBuffer,
-                            ur_queue_handle_t Queue,
+                            ur_queue_handle_legacy_t Queue,
                             ur_command_list_ptr_t SignalCommandList,
                             ur_event_handle_t &Event) {
   // Execution event for this enqueue of the UR command-buffer

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -69,7 +69,7 @@ preferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
   assert(PatternSize > 0);
 
   PreferCopyEngine = false;
-  if (!CommandBuffer->UseCopyEngine()) {
+  if (!CommandBuffer->useCopyEngine()) {
     return UR_RESULT_SUCCESS;
   }
 
@@ -301,8 +301,8 @@ ur_result_t createSyncPointAndGetZeEvents(
 
   // Get sync point and register the event with it.
   ur_exp_command_buffer_sync_point_t SyncPoint =
-      CommandBuffer->GetNextSyncPoint();
-  CommandBuffer->RegisterSyncPoint(SyncPoint, LaunchEvent);
+      CommandBuffer->getNextSyncPoint();
+  CommandBuffer->registerSyncPoint(SyncPoint, LaunchEvent);
 
   if (RetSyncPoint) {
     *RetSyncPoint = SyncPoint;
@@ -463,7 +463,7 @@ ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   if (ZeComputeCommandList) {
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeComputeCommandList));
   }
-  if (UseCopyEngine() && ZeCopyCommandList) {
+  if (useCopyEngine() && ZeCopyCommandList) {
     ZE_CALL_NOCHECK(zeCommandListDestroy, (ZeCopyCommandList));
   }
 
@@ -549,7 +549,7 @@ ur_exp_command_buffer_command_handle_t_::
     urKernelRelease(Kernel);
 }
 
-void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
+void ur_exp_command_buffer_handle_t_::registerSyncPoint(
     ur_exp_command_buffer_sync_point_t SyncPoint, ur_event_handle_t Event) {
   SyncPoints[SyncPoint] = Event;
   NextSyncPoint++;
@@ -558,7 +558,7 @@ void ur_exp_command_buffer_handle_t_::RegisterSyncPoint(
 
 ze_command_list_handle_t
 ur_exp_command_buffer_handle_t_::chooseCommandList(bool PreferCopyEngine) {
-  if (PreferCopyEngine && this->UseCopyEngine() && !this->IsInOrderCmdList) {
+  if (PreferCopyEngine && this->useCopyEngine() && !this->IsInOrderCmdList) {
     // We indicate that ZeCopyCommandList contains commands to be submitted.
     this->MCopyCommandListEmpty = false;
     return this->ZeCopyCommandList;
@@ -766,7 +766,7 @@ urCommandBufferFinalizeExp(ur_exp_command_buffer_handle_t CommandBuffer) {
   ZE2UR_CALL(zeCommandListClose, (CommandBuffer->ZeComputeCommandList));
   ZE2UR_CALL(zeCommandListClose, (CommandBuffer->ZeCommandListResetEvents));
 
-  if (CommandBuffer->UseCopyEngine()) {
+  if (CommandBuffer->useCopyEngine()) {
     ZE2UR_CALL(zeCommandListClose, (CommandBuffer->ZeCopyCommandList));
   }
 

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -726,8 +726,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_exp_command_buffer_sync_point_t *SyncPointWaitList,
     ur_exp_command_buffer_sync_point_t *RetSyncPoint,
     ur_exp_command_buffer_command_handle_t *Command) {
-  UR_ASSERT(CommandBuffer && Kernel && Kernel->Program,
-            UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(Kernel->Program, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Lock(
       Kernel->Mutex, Kernel->Program->Mutex, CommandBuffer->Mutex);
@@ -1340,9 +1339,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t Command,
     const ur_exp_command_buffer_update_kernel_launch_desc_t *CommandDesc) {
-  UR_ASSERT(Command, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(Command->Kernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT(CommandDesc, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(CommandDesc->newWorkDim <= 3,
             UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -31,8 +31,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ze_command_list_handle_t CommandListTranslated,
       ze_command_list_handle_t CommandListResetEvents,
       ze_command_list_handle_t CopyCommandList,
-      ZeStruct<ze_command_list_desc_t> ZeDesc,
-      ZeStruct<ze_command_list_desc_t> ZeCopyDesc,
+      ur_event_handle_t SignalEvent,
+      ur_event_handle_t WaitEvent,
+      ur_event_handle_t AllResetEvent,
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
   ~ur_exp_command_buffer_handle_t_();
@@ -70,12 +71,17 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ze_command_list_handle_t ZeComputeCommandListTranslated;
   // Level Zero command list handle
   ze_command_list_handle_t ZeCommandListResetEvents;
-  // Level Zero command list descriptor
-  ZeStruct<ze_command_list_desc_t> ZeCommandListDesc;
   // Level Zero Copy command list handle
   ze_command_list_handle_t ZeCopyCommandList;
-  // Level Zero Copy command list descriptor
-  ZeStruct<ze_command_list_desc_t> ZeCopyCommandListDesc;
+  // Event which will signals the most recent execution of the command-buffer
+  // has finished
+  ur_event_handle_t SignalEvent = nullptr;
+  // Event which a command-buffer waits on until the wait-list dependencies
+  // passed to a command-buffer enqueue have been satisfied.
+  ur_event_handle_t WaitEvent = nullptr;
+  // Event which a command-buffer waits on until the main command-list event
+  // have been reset.
+  ur_event_handle_t AllResetEvent = nullptr;
   // This flag is must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
@@ -94,15 +100,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ur_exp_command_buffer_sync_point_t NextSyncPoint;
   // List of Level Zero events associated to submitted commands.
   std::vector<ze_event_handle_t> ZeEventsList;
-  // Event which will signals the most recent execution of the command-buffer
-  // has finished
-  ur_event_handle_t SignalEvent = nullptr;
-  // Event which a command-buffer waits on until the wait-list dependencies
-  // passed to a command-buffer enqueue have been satisfied.
-  ur_event_handle_t WaitEvent = nullptr;
-  // Event which a command-buffer waits on until the main command-list event
-  // have been reset.
-  ur_event_handle_t AllResetEvent = nullptr;
+
   // Indicates if command-buffer commands can be updated after it is closed.
   bool IsUpdatable = false;
   // Indicates if command buffer was finalized.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -36,12 +36,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_();
 
-//  void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
-//                         ur_event_handle_t Event) {
-//    SyncPoints[SyncPoint] = Event;
-//    NextSyncPoint++;
-//  }
-
   void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
                          ur_event_handle_t Event);
 
@@ -52,16 +46,26 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
-  // FIXME Refactor Documentation
-  ur_result_t getFence(ze_command_queue_handle_t &ZeCommandQueue,
-                       ze_fence_handle_t &ZeFence);
-  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
-                                ze_command_queue_handle_t &ZeCommandQueue);
+  /**
+   * Obtains a fence for a specific L0 queue. If there is already an available
+   * fence for this queue, it will be reused.
+   * @param[in] ZeCommandQueue The L0 queue associated with the fence.
+   * @param[out] ZeFence The fence.
+   * @return UR_RESULT_SUCCESS or an error code on failure
+   */
+  ur_result_t getFenceForQueue(ze_command_queue_handle_t &ZeCommandQueue,
+                               ze_fence_handle_t &ZeFence);
+
+  /**
+   * Chooses which command list to use when appending a command to this command
+   * buffer.
+   * @param[in] PreferCopyEngine If true, will try to choose a copy engine
+   * command-list. Will choose a compute command-list otherwise.
+   * @param[out] ZeCommandList The chosen command list.
+   * @return UR_RESULT_SUCCESS or an error code on failure
+   */
   ur_result_t chooseCommandList(bool PreferCopyEngine,
                                 ze_command_list_handle_t *ZeCommandList);
-  ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t *ZeCommandList,
-                                size_t PatternSize);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -50,6 +50,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
+  //FIXME Refactor Documentation
+  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
+
   // UR context associated with this command-buffer
   ur_context_handle_t Context;
   // Device associated with this command buffer

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -30,19 +30,20 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ze_command_list_handle_t CommandList,
       ze_command_list_handle_t CommandListTranslated,
       ze_command_list_handle_t CommandListResetEvents,
-      ze_command_list_handle_t CopyCommandList,
-      ur_event_handle_t SignalEvent,
-      ur_event_handle_t WaitEvent,
-      ur_event_handle_t AllResetEvent,
+      ze_command_list_handle_t CopyCommandList, ur_event_handle_t SignalEvent,
+      ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
   ~ur_exp_command_buffer_handle_t_();
 
+//  void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
+//                         ur_event_handle_t Event) {
+//    SyncPoints[SyncPoint] = Event;
+//    NextSyncPoint++;
+//  }
+
   void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
-                         ur_event_handle_t Event) {
-    SyncPoints[SyncPoint] = Event;
-    NextSyncPoint++;
-  }
+                         ur_event_handle_t Event);
 
   ur_exp_command_buffer_sync_point_t GetNextSyncPoint() const {
     return NextSyncPoint;
@@ -52,8 +53,10 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
   // FIXME Refactor Documentation
-  ur_result_t getFence(ze_command_queue_handle_t & ZeCommandQueue, ze_fence_handle_t &ZeFence);
-  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine, ze_command_queue_handle_t& ZeCommandQueue);
+  ur_result_t getFence(ze_command_queue_handle_t &ZeCommandQueue,
+                       ze_fence_handle_t &ZeFence);
+  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine,
+                                ze_command_queue_handle_t &ZeCommandQueue);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
                                 ze_command_list_handle_t *ZeCommandList);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
@@ -98,7 +101,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Next sync_point value (may need to consider ways to reuse values if 32-bits
   // is not enough)
   ur_exp_command_buffer_sync_point_t NextSyncPoint;
-  // List of Level Zero events associated to submitted commands.
+  // List of Level Zero events associated with submitted commands.
   std::vector<ze_event_handle_t> ZeEventsList;
 
   // Indicates if command-buffer commands can be updated after it is closed.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -50,8 +50,12 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Indicates if a copy engine is available for use
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
-  //FIXME Refactor Documentation
-  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
+  // FIXME Refactor Documentation
+  ur_result_t chooseCommandList(bool PreferCopyEngine,
+                                ze_command_list_handle_t &ZeCommandList);
+  ur_result_t chooseCommandList(bool PreferCopyEngine,
+                                ze_command_list_handle_t &ZeCommandList,
+                                size_t PatternSize);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -51,10 +51,12 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
   // FIXME Refactor Documentation
+  ur_result_t getFence(ze_command_queue_handle_t & ZeCommandQueue, ze_fence_handle_t &ZeFence);
+  ur_result_t getZeCommandQueue(ur_queue_handle_t Queue, bool UseCopyEngine, ze_command_queue_handle_t& ZeCommandQueue);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t &ZeCommandList);
+                                ze_command_list_handle_t *ZeCommandList);
   ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t &ZeCommandList,
+                                ze_command_list_handle_t *ZeCommandList,
                                 size_t PatternSize);
 
   // UR context associated with this command-buffer
@@ -84,9 +86,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // Must be an element in ZeFencesMap, so is not required to be destroyed
   // itself.
   ze_fence_handle_t ZeActiveFence;
-  // Queue properties from command-buffer descriptor
-  // TODO: Do we need these?
-  ur_queue_properties_t QueueProperties;
   // Map of sync_points to ur_events
   std::unordered_map<ur_exp_command_buffer_sync_point_t, ur_event_handle_t>
       SyncPoints;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -61,11 +61,9 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
    * buffer.
    * @param[in] PreferCopyEngine If true, will try to choose a copy engine
    * command-list. Will choose a compute command-list otherwise.
-   * @param[out] ZeCommandList The chosen command list.
-   * @return UR_RESULT_SUCCESS or an error code on failure
+   * @return The chosen command list.
    */
-  ur_result_t chooseCommandList(bool PreferCopyEngine,
-                                ze_command_list_handle_t *ZeCommandList);
+  ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -36,15 +36,15 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ~ur_exp_command_buffer_handle_t_();
 
-  void RegisterSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
+  void registerSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
                          ur_event_handle_t Event);
 
-  ur_exp_command_buffer_sync_point_t GetNextSyncPoint() const {
+  ur_exp_command_buffer_sync_point_t getNextSyncPoint() const {
     return NextSyncPoint;
   }
 
   // Indicates if a copy engine is available for use
-  bool UseCopyEngine() const { return ZeCopyCommandList != nullptr; }
+  bool useCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
   /**
    * Obtains a fence for a specific L0 queue. If there is already an available


### PR DESCRIPTION
intel/llvm PR: https://github.com/intel/llvm/pull/14240

General:
  - The idea is to make the code more readable and avoid code duplication when possible.
  - There was a lot of branching in some entrypoints. Some of that functionality was moved into separate functions.
  - The checks for InOrder/OutOfOrder and ComputeEngine/CopyEngine were also moved to separate common functions where possible.

`enqueueCommandBufferMemCopyHelper()`:
`enqueueCommandBufferMemCopyRectHelper()`:
`enqueueCommandBufferFillHelper()`:
  - Use common function to create the sync point: `createSyncPointIfNeeded()`
  - Use common function to choose the command-list: `ur_exp_command_buffer_handle_t_::chooseCommandList()`
  - Move conditions to check if the queue is in order or not to the common functions: `createSyncPointIfNeeded()` and `chooseCommandList()`
  - For enqueueCommandBufferFillHelper() only, move the pattern checks into `PreferCopyEngineForFill()`

`ur_exp_command_buffer_handle_t`:
  - Removed `ZeCopyCommandListDesc`, `ZeCommandListDesc` and `QueueProperties` variables. They were not being used.

`ur_exp_command_buffer_handle_t_::RegisterSyncPoint()`:
  - Moved definition to the .cpp file and moved the functionality to insert the event into `ZeEventsList` to this function (it was in `urCommandBufferFinalizeExp()`)

`ur_exp_command_buffer_handle_t_::chooseCommandList()`:
  - New member function that chooses which command list to use (i.e. compute engine or copy engine). This is used in the memcpy helpers.

`ur_exp_command_buffer_handle_t_::getFenceForQueue()`:
   - New member function that returns a fence for a specific L0 queue. This is used in `urCommandBufferEnqueueExp()`.

`urCommandBufferCreateExp()`:
  - Moved code that checks whether the commandbuffer can be created in-order into a separate function: `canBeInOrder()`
  - Moved common code for creation of command-lists into a separate function: `createMainCommandList()`
  - Moved the creation of the `ur_exp_command_buffer_handle_t_` object to the end of the function.

`urCommandBufferFinalizeExp()`:
  - Simplified code that appends sync point events to the command-list
  - Moved code that sets `ZeEventsList` to `ur_exp_command_buffer_handle_t_::RegisterSyncPoint()`

`urCommandBufferAppendKernelLaunchExp()`:
  - Remove `UR_ASSERT` that was duplicated in the UR validation layers.
  - Moved code that sets the kernel global offset to a separate function: `setKernelGlobalOffset()`
  - Moved code that sets the kernel pending arguments to a separate function: `setKernelPendingArguments()`
  - Moved code that creates a command handle when the command buffer is updatable to a separate function: `createCommandHandle()`
  - Use common function to create the sync point: `createSyncPointIfNeeded()`

`urCommandBufferAppendUSMPrefetchExp()`:
`urCommandBufferAppendUSMAdviseExp()`:
  - Use common function to create the sync point: `createSyncPointIfNeeded()`

`urCommandBufferAppendMemBufferFillExp()`
`urCommandBufferAppendUSMFillExp()`
  - Moved check for `CopyEngine` to the helper function.

`urCommandBufferEnqueueExp()`:
  - Create function that returns an L0 queue based on the engine being used - `getZeCommandQueue()`
  - Moved code that waits for the command buffer dependencies to a separate function - `waitForDependencies()`
  - Moved code that creates the return event and handles profiling to a separate function - `createUserEvent()`

`urCommandBufferUpdateKernelLaunchExp()`:
 - Remove `UR_ASSERTS` that are duplicate in the UR validation layers.
 - Moved `CommandDesc` asserts into a separate function - `validateCommandDesc()`
 - Moved creation of `MutableCommandDesc` and submission to `zexCommandListUpdateMutableCommandsExp()` to a separate function - `updateKernelCommand()`
 - Use a vector of `std::variant` to hold the descriptions instead of having 4 separate vectors.