### PR TITLE
[HIP] Remove use of -nogpulib flag

### DIFF
--- a/.github/workflows/build-hw-reusable.yml
+++ b/.github/workflows/build-hw-reusable.yml
@@ -70,7 +70,9 @@ jobs:
 
     - name: Build
       # This is so that device binaries can find the sycl runtime library
-      run: cmake --build ${{github.workspace}}/build -j $(nproc) -v
+      run: |
+        ${{ matrix.adapter.name == 'HIP' && 'ls /opt/rocm/amdgcn/bitcode' || '' }}
+        cmake --build ${{github.workspace}}/build -j $(nproc) -v
 
     - name: Test adapter specific
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-hw-reusable.yml
+++ b/.github/workflows/build-hw-reusable.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Build
       # This is so that device binaries can find the sycl runtime library
-      run: cmake --build ${{github.workspace}}/build -j $(nproc)
+      run: cmake -v --build ${{github.workspace}}/build -j $(nproc)
 
     - name: Test adapter specific
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-hw-reusable.yml
+++ b/.github/workflows/build-hw-reusable.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Build
       # This is so that device binaries can find the sycl runtime library
       run: |
-        ${{ matrix.adapter.name == 'HIP' && 'ls /opt/rocm/amdgcn/bitcode' || '' }}
+        ${{ matrix.adapter.name == 'HIP' && 'ls /opt/rocm/**' || '' }}
         cmake --build ${{github.workspace}}/build -j $(nproc) -v
 
     - name: Test adapter specific

--- a/.github/workflows/build-hw-reusable.yml
+++ b/.github/workflows/build-hw-reusable.yml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Build
       # This is so that device binaries can find the sycl runtime library
-      run: cmake -v --build ${{github.workspace}}/build -j $(nproc)
+      run: cmake --build ${{github.workspace}}/build -j $(nproc) -v
 
     - name: Test adapter specific
       working-directory: ${{github.workspace}}/build

--- a/test/conformance/device_code/CMakeLists.txt
+++ b/test/conformance/device_code/CMakeLists.txt
@@ -74,11 +74,11 @@ macro(add_device_binary SOURCE_FILE)
         if(${TRIPLE} MATCHES "amd")
             set(AMD_TARGET_BACKEND -Xsycl-target-backend=${TRIPLE})
             set(AMD_OFFLOAD_ARCH  --offload-arch=${AMD_ARCH})
-            set(AMD_NOGPULIB -nogpulib)
+            set(AMD_ROCM_PATH --rocm-path=${UR_HIP_ROCM_DIR})
         else()
             set(AMD_TARGET_BACKEND)
             set(AMD_OFFLOAD_ARCH)
-            set(AMD_NOGPULIB)
+            set(AMD_ROCM_PATH)
         endif()
         # images are not yet supported in sycl on AMD
         if(${TRIPLE} MATCHES "amd" AND ${KERNEL_NAME} MATCHES "image_copy")
@@ -93,16 +93,9 @@ macro(add_device_binary SOURCE_FILE)
             continue()
         endif()
 
-        # HIP doesn't seem to provide the symbol
-        # `_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E11FixedSgSize` which
-        # causes a build failure here
-        if(${TRIPLE} MATCHES "amd" AND ${KERNEL_NAME} MATCHES "subgroup")
-            continue()
-        endif()
-
         add_custom_command(OUTPUT "${BIN_PATH}"
             COMMAND ${UR_DPCXX} -fsycl -fsycl-targets=${TRIPLE} -fsycl-device-code-split=off 
-            ${AMD_TARGET_BACKEND} ${AMD_OFFLOAD_ARCH} ${AMD_NOGPULIB}
+            ${AMD_TARGET_BACKEND} ${AMD_OFFLOAD_ARCH} ${AMD_ROCM_PATH}
             ${DPCXX_BUILD_FLAGS_LIST} ${SOURCE_FILE} -o ${EXE_PATH}
 
             COMMAND ${CMAKE_COMMAND} -E env ${EXTRA_ENV} ${UR_DEVICE_CODE_EXTRACTOR} --stem="${TRIPLE}.bin" ${EXE_PATH}


### PR DESCRIPTION
We need this to successfully compile the subgroup device_code test.