### PR TITLE
[EXP][CUDA] Add `UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP`

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1599,6 +1599,7 @@ typedef enum ur_device_info_t {
                                                                      ///< command-buffers.
     UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP = 0x1001,       ///< [::ur_bool_t] Returns true if the device supports updating the kernel
                                                                      ///< commands in a command-buffer.
+    UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP = 0x1111,                      ///< [::ur_bool_t] return true if enqueue Cluster Launch is supported
     UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP = 0x2000,             ///< [::ur_bool_t] returns true if the device supports the creation of
                                                                      ///< bindless images
     UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP = 0x2001,  ///< [::ur_bool_t] returns true if the device supports the creation of

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2514,6 +2514,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     case UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP";
         break;
+    case UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP:
+        os << "UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP";
+        break;
     case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP";
         break;
@@ -3999,6 +4002,18 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
         os << ")";
     } break;
     case UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP: {
+        const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+        if (sizeof(ur_bool_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    case UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP: {
         const ur_bool_t *tptr = (const ur_bool_t *)ptr;
         if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";

--- a/scripts/core/exp-launch-properties.yml
+++ b/scripts/core/exp-launch-properties.yml
@@ -128,4 +128,14 @@ returns:
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+--- #--------------------------------------------------------------------------
+type: enum
+extend: true
+typed_etors: true
+desc: "Extension enums to $x_device_info_t to support arch specific launch properties."
+name: $x_device_info_t
+etors:
+    - name: CLUSTER_LAUNCH_EXP
+      value: "0x1111"
+      desc: "[$x_bool_t] return true if enqueue Cluster Launch is supported"
 

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -1085,6 +1085,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
   case UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP:
     return ReturnValue(true);
+  case UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP: {
+    int Value = getAttribute(hDevice,
+                             CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR) >= 9;
+    return ReturnValue(static_cast<bool>(Value));
+  }
 
   default:
     break;

--- a/test/conformance/exp_launch_properties/launch_properties.cpp
+++ b/test/conformance/exp_launch_properties/launch_properties.cpp
@@ -76,9 +76,9 @@ TEST_P(urEnqueueKernelLaunchCustomTest, Success) {
         }
 
         ur_bool_t cluster_launch_supported = false;
-        ASSERT_SUCCESS(
-            urDeviceGetInfo(device, UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP,
-                            sizeof(ur_bool_t), &cluster_launch_supported, nullptr));
+        ASSERT_SUCCESS(urDeviceGetInfo(
+            device, UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP, sizeof(ur_bool_t),
+            &cluster_launch_supported, nullptr));
 
         if (cluster_launch_supported) {
             ur_exp_launch_property_t cluster_dims_prop;

--- a/test/conformance/exp_launch_properties/launch_properties.cpp
+++ b/test/conformance/exp_launch_properties/launch_properties.cpp
@@ -75,7 +75,12 @@ TEST_P(urEnqueueKernelLaunchCustomTest, Success) {
             props.push_back(coop_prop);
         }
 
-        if (compute_capability >= 9.0) {
+        ur_bool_t cluster_launch_supported = false;
+        ASSERT_SUCCESS(
+            urDeviceGetInfo(device, UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP,
+                            sizeof(ur_bool_t), &cluster_launch_supported, nullptr));
+
+        if (cluster_launch_supported) {
             ur_exp_launch_property_t cluster_dims_prop;
             cluster_dims_prop.id = UR_EXP_LAUNCH_PROPERTY_ID_CLUSTER_DIMENSION;
             cluster_dims_prop.value.clusterDim[0] = 1;

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -335,6 +335,8 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
     printDeviceInfo<ur_bool_t>(
         hDevice, UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_SUPPORT_EXP);
     std::cout << prefix;
+    printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP);
+    std::cout << prefix;
     printDeviceInfo<ur_bool_t>(hDevice,
                                UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP);
     std::cout << prefix;


### PR DESCRIPTION
Add UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP to the launch property extension.

One of the launch properties is not supported on all devices so requires an aspect.
This aspect returns true only for sm_90 cuda gpus.

This will be tested via a intel/llvm PR shortly.