### PR TITLE
[UR] Update L0 loader to v1.17.6

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -42,7 +42,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG v1.17.0)
+        set(UR_LEVEL_ZERO_LOADER_TAG v1.17.6)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104


### PR DESCRIPTION
In v1.17.0 L0 loader started to fetch spdlog repo to get the headers and this causes issues in some scenarios. v1.17.6 removes that dependency from third party repo.