### PR TITLE
[L0] Fix immediate command list use in Command Queues

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -733,6 +733,10 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
           !(ZeCommandListIt->second.InOrderList)) {
         continue;
       }
+      // Only allow to reuse Regular Command Lists
+      if (ZeCommandListIt->second.IsImmediate) {
+        continue;
+      }
       auto &ZeCommandList = ZeCommandListIt->first;
       auto it = Queue->CommandListMap.find(ZeCommandList);
       if (it != Queue->CommandListMap.end()) {

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -30,6 +30,7 @@
 struct l0_command_list_cache_info {
   ZeStruct<ze_command_queue_desc_t> ZeQueueDesc;
   bool InOrderList = false;
+  bool IsImmediate = false;
 };
 
 struct ur_context_handle_t_ : _ur_object {

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -665,6 +665,7 @@ ur_result_t ur_queue_handle_legacy_t_::queueRelease() {
           struct l0_command_list_cache_info ListInfo;
           ListInfo.ZeQueueDesc = it->second.ZeQueueDesc;
           ListInfo.InOrderList = it->second.IsInOrderList;
+          ListInfo.IsImmediate = it->second.IsImmediate;
           ZeCommandListCache.push_back({it->first, ListInfo});
         } else {
           // A non-reusable comamnd list that came from a make_queue call is
@@ -745,7 +746,8 @@ void ur_queue_handle_legacy_t_::ur_queue_group_t::setImmCmdList(
           .insert(std::pair<ze_command_list_handle_t, ur_command_list_info_t>{
               ZeCommandList,
               ur_command_list_info_t(nullptr, true, false, nullptr, ZeQueueDesc,
-                                     queue->useCompletionBatching(), false)})
+                                     queue->useCompletionBatching(), false,
+                                     false, true)})
           .first);
 }
 
@@ -2080,6 +2082,7 @@ ur_result_t ur_queue_handle_legacy_t_::resetCommandList(
     struct l0_command_list_cache_info ListInfo;
     ListInfo.ZeQueueDesc = CommandList->second.ZeQueueDesc;
     ListInfo.InOrderList = CommandList->second.IsInOrderList;
+    ListInfo.IsImmediate = CommandList->second.IsImmediate;
     ZeCommandListCache.push_back({CommandList->first, ListInfo});
   }
 
@@ -2430,9 +2433,9 @@ ur_queue_handle_legacy_t_::ur_queue_group_t::getImmCmdList() {
       Queue->CommandListMap
           .insert(std::pair<ze_command_list_handle_t, ur_command_list_info_t>{
               ZeCommandList,
-              ur_command_list_info_t(nullptr, true, false, nullptr,
-                                     ZeCommandQueueDesc,
-                                     Queue->useCompletionBatching())})
+              ur_command_list_info_t(
+                  nullptr, true, false, nullptr, ZeCommandQueueDesc,
+                  Queue->useCompletionBatching(), true, false, true)})
           .first;
 
   return ImmCmdLists[Index];

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -168,10 +168,11 @@ struct ur_command_list_info_t {
                          bool IsClosed, ze_command_queue_handle_t ZeQueue,
                          ZeStruct<ze_command_queue_desc_t> ZeQueueDesc,
                          bool UseCompletionBatching, bool CanReuse = true,
-                         bool IsInOrderList = false)
+                         bool IsInOrderList = false, bool IsImmediate = false)
       : ZeFence(ZeFence), ZeFenceInUse(ZeFenceInUse), IsClosed(IsClosed),
         ZeQueue(ZeQueue), ZeQueueDesc(ZeQueueDesc),
-        IsInOrderList(IsInOrderList), CanReuse(CanReuse) {
+        IsInOrderList(IsInOrderList), CanReuse(CanReuse),
+        IsImmediate(IsImmediate) {
     if (UseCompletionBatching) {
       completions = ur_completion_batches();
     }
@@ -204,6 +205,7 @@ struct ur_command_list_info_t {
   // Indicates if this is an inorder list
   bool IsInOrderList;
   bool CanReuse;
+  bool IsImmediate;
 
   // Helper functions to tell if this is a copy command-list.
   bool isCopy(ur_queue_handle_legacy_t Queue) const;


### PR DESCRIPTION
- Keep track of all immediate command lists ensuring that they are not used in regular queues after they are placed back into the command list map.