### PR TITLE
[CUDA][L0][Bindless] update design of urBindlessImagesImageCopyExp

### DIFF
--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1581,15 +1581,14 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageCreateExp_t)(
 /// @brief Function-pointer for urBindlessImagesImageCopyExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageCopyExp_t)(
     ur_queue_handle_t,
-    void *,
     const void *,
-    const ur_image_format_t *,
+    void *,
     const ur_image_desc_t *,
+    const ur_image_desc_t *,
+    const ur_image_format_t *,
+    const ur_image_format_t *,
+    ur_exp_image_copy_region_t *,
     ur_exp_image_copy_flags_t,
-    ur_rect_offset_t,
-    ur_rect_offset_t,
-    ur_rect_region_t,
-    ur_rect_region_t,
     uint32_t,
     const ur_event_handle_t *,
     ur_event_handle_t *);

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -963,6 +963,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropMemDesc(const struct ur_exp
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropSemaphoreDesc(const struct ur_exp_interop_semaphore_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print ur_exp_image_copy_region_t struct
+/// @returns
+///     - ::UR_RESULT_SUCCESS
+///     - ::UR_RESULT_ERROR_INVALID_SIZE
+///         - `buff_size < out_size`
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpImageCopyRegion(const struct ur_exp_image_copy_region_t params, char *buffer, const size_t buff_size, size_t *out_size);
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_exp_command_buffer_info_t enum
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -334,6 +334,7 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_cubemap_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_mem_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_semaphore_desc_t params);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_image_copy_region_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_command_info_t value);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_command_buffer_desc_t params);
@@ -1094,6 +1095,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_structure_type_t value
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES";
         break;
+    case UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION:
+        os << "UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION";
+        break;
     case UR_STRUCTURE_TYPE_EXP_ENQUEUE_NATIVE_COMMAND_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_EXP_ENQUEUE_NATIVE_COMMAND_PROPERTIES";
         break;
@@ -1346,6 +1350,11 @@ inline ur_result_t printStruct(std::ostream &os, const void *ptr) {
 
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES: {
         const ur_exp_sampler_cubemap_properties_t *pstruct = (const ur_exp_sampler_cubemap_properties_t *)ptr;
+        printPtr(os, pstruct);
+    } break;
+
+    case UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION: {
+        const ur_exp_image_copy_region_t *pstruct = (const ur_exp_image_copy_region_t *)ptr;
         printPtr(os, pstruct);
     } break;
 
@@ -9607,6 +9616,41 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_interop_se
     return os;
 }
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Print operator for the ur_exp_image_copy_region_t type
+/// @returns
+///     std::ostream &
+inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_image_copy_region_t params) {
+    os << "(struct ur_exp_image_copy_region_t){";
+
+    os << ".stype = ";
+
+    os << (params.stype);
+
+    os << ", ";
+    os << ".pNext = ";
+
+    ur::details::printStruct(os,
+                             (params.pNext));
+
+    os << ", ";
+    os << ".srcOffset = ";
+
+    os << (params.srcOffset);
+
+    os << ", ";
+    os << ".dstOffset = ";
+
+    os << (params.dstOffset);
+
+    os << ", ";
+    os << ".copyExtent = ";
+
+    os << (params.copyExtent);
+
+    os << "}";
+    return os;
+}
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Print operator for the ur_exp_command_buffer_info_t type
 /// @returns
 ///     std::ostream &
@@ -14866,54 +14910,52 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->phQueue));
 
     os << ", ";
-    os << ".pDst = ";
-
-    ur::details::printPtr(os,
-                          *(params->ppDst));
-
-    os << ", ";
     os << ".pSrc = ";
 
     ur::details::printPtr(os,
                           *(params->ppSrc));
 
     os << ", ";
-    os << ".pImageFormat = ";
+    os << ".pDst = ";
 
     ur::details::printPtr(os,
-                          *(params->ppImageFormat));
+                          *(params->ppDst));
 
     os << ", ";
-    os << ".pImageDesc = ";
+    os << ".pSrcImageDesc = ";
 
     ur::details::printPtr(os,
-                          *(params->ppImageDesc));
+                          *(params->ppSrcImageDesc));
+
+    os << ", ";
+    os << ".pDstImageDesc = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppDstImageDesc));
+
+    os << ", ";
+    os << ".pSrcImageFormat = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppSrcImageFormat));
+
+    os << ", ";
+    os << ".pDstImageFormat = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppDstImageFormat));
+
+    os << ", ";
+    os << ".pCopyRegion = ";
+
+    ur::details::printPtr(os,
+                          *(params->ppCopyRegion));
 
     os << ", ";
     os << ".imageCopyFlags = ";
 
     ur::details::printFlag<ur_exp_image_copy_flag_t>(os,
                                                      *(params->pimageCopyFlags));
-
-    os << ", ";
-    os << ".srcOffset = ";
-
-    os << *(params->psrcOffset);
-
-    os << ", ";
-    os << ".dstOffset = ";
-
-    os << *(params->pdstOffset);
-
-    os << ", ";
-    os << ".copyExtent = ";
-
-    os << *(params->pcopyExtent);
-
-    os << ", ";
-    os << ".hostExtent = ";
-
-    os << *(params->phostExtent);
 
     os << ", ";
     os << ".numEventsInWaitList = ";

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -158,6 +158,7 @@ Types
 * ${x}_exp_win32_handle_t
 * ${x}_exp_sampler_addr_modes_t
 * ${x}_exp_sampler_cubemap_properties_t
+* ${x}_exp_image_copy_region_t
 
 Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -240,6 +241,8 @@ Changelog
 | 14.0     || Rename func BindlessImagesDestroyExternalSemaphoreExp to   |
 |          || BindlessImagesReleaseExternalSemaphoreExp                  |
 +------------------------------------------------------------------------+
+| 15.0     | Added structures for supporting copying.                    |
++----------+-------------------------------------------------------------+
 
 Contributors
 --------------------------------------------------------------------------------

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -137,6 +137,9 @@ etors:
     - name: EXP_SAMPLER_CUBEMAP_PROPERTIES
       desc: $x_exp_sampler_cubemap_properties_t
       value: "0x2006"
+    - name: EXP_IMAGE_COPY_REGION
+      desc: $x_exp_image_copy_region_t
+      value: "0x2007"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -284,6 +287,21 @@ class: $xBindlessImages
 name: $x_exp_interop_semaphore_desc_t
 base: $x_base_desc_t
 members: []
+--- #--------------------------------------------------------------------------
+type: struct
+desc: "Describes the (sub-)regions and the extent to be copied"
+name: $x_exp_image_copy_region_t
+base: $x_base_desc_t
+members:
+    - type: ur_rect_offset_t
+      name: srcOffset
+      desc: "[in] the offset into the source image"
+    - type: ur_rect_offset_t
+      name: dstOffset
+      desc: "[in] the offset into the destination image"
+    - type: ur_rect_region_t
+      name: copyExtent
+      desc: "[in] the extent (region) of the image to copy"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "USM allocate pitched memory"
@@ -511,7 +529,7 @@ returns:
     - $X_RESULT_ERROR_ADAPTER_SPECIFIC
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Copy image data Host to Device or Device to Host"
+desc: "Copy image data Host to Device, Device to Host, or Device to Device"
 class: $xBindlessImages
 name: ImageCopyExp
 ordinal: "0"
@@ -524,33 +542,30 @@ params:
     - type: $x_queue_handle_t
       name: hQueue
       desc: "[in] handle of the queue object"
-    - type: void*
-      name: pDst
-      desc: "[in] location the data will be copied to"
     - type: const void*
       name: pSrc
       desc: "[in] location the data will be copied from"
-    - type: "const $x_image_format_t*"
-      name: pImageFormat
-      desc: "[in] pointer to image format specification"
+    - type: void*
+      name: pDst
+      desc: "[in] location the data will be copied to"
     - type: "const $x_image_desc_t*"
-      name: pImageDesc
+      name: pSrcImageDesc
       desc: "[in] pointer to image description"
+    - type: "const $x_image_desc_t*"
+      name: pDstImageDesc
+      desc: "[in] pointer to image description"
+    - type: "const $x_image_format_t*"
+      name: pSrcImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "const $x_image_format_t*"
+      name: pDstImageFormat
+      desc: "[in] pointer to image format specification"
+    - type: "$x_exp_image_copy_region_t*"
+      name: pCopyRegion
+      desc: "[in] Pointer to structure describing the (sub-)regions of source and destination images"
     - type: $x_exp_image_copy_flags_t
       name: imageCopyFlags
       desc: "[in] flags describing copy direction e.g. H2D or D2H"
-    - type: $x_rect_offset_t
-      name: srcOffset
-      desc: "[in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D image"
-    - type: $x_rect_offset_t
-      name: dstOffset
-      desc: "[in] defines the (x,y,z) destination offset in pixels in the 1D, 2D, or 3D image"
-    - type: $x_rect_region_t
-      name: copyExtent
-      desc: "[in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D region to copy"
-    - type: $x_rect_region_t
-      name: hostExtent
-      desc: "[in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D region on the host"    
     - type: uint32_t
       name: numEventsInWaitList
       desc: "[in] size of the event wait list"
@@ -568,7 +583,9 @@ returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
+      - "`pSrcImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pSrcImageDesc->type`"
+    - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
+      - "`pDstImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pDstImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
 --- #--------------------------------------------------------------------------

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -17,6 +17,7 @@
 #include "enqueue.hpp"
 #include "event.hpp"
 #include "image.hpp"
+#include "logger/ur_logger.hpp"
 #include "memory.hpp"
 #include "queue.hpp"
 #include "sampler.hpp"
@@ -634,28 +635,31 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    ur_queue_handle_t hQueue, void *pDst, const void *pSrc,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
-    ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
-    ur_rect_region_t hostExtent, uint32_t numEventsInWaitList,
+    ur_queue_handle_t hQueue, const void *pSrc, void *pDst,
+    const ur_image_desc_t *pSrcImageDesc, const ur_image_desc_t *pDstImageDesc,
+    const ur_image_format_t *pSrcImageFormat,
+    const ur_image_format_t *pDstImageFormat,
+    ur_exp_image_copy_region_t *pCopyRegion,
+    ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   UR_ASSERT((imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE ||
              imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST ||
              imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE),
             UR_RESULT_ERROR_INVALID_VALUE);
+  UR_ASSERT(pSrcImageFormat->channelOrder == pDstImageFormat->channelOrder,
+            UR_RESULT_ERROR_INVALID_ARGUMENT);
 
   unsigned int NumChannels = 0;
   size_t PixelSizeBytes = 0;
 
   UR_CHECK_ERROR(
-      urCalculateNumChannels(pImageFormat->channelOrder, &NumChannels));
+      urCalculateNumChannels(pSrcImageFormat->channelOrder, &NumChannels));
 
   // We need to get this now in bytes for calculating the total image size
   // later.
-  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType,
-                                            pImageFormat->channelOrder, nullptr,
-                                            &PixelSizeBytes));
+  UR_CHECK_ERROR(urToCudaImageChannelFormat(pSrcImageFormat->channelType,
+                                            pSrcImageFormat->channelOrder,
+                                            nullptr, &PixelSizeBytes));
 
   try {
     ScopedContext Active(hQueue->getDevice());
@@ -665,7 +669,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     // We have to use a different copy function for each image dimensionality.
 
     if (imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE) {
-      if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
+      if (pDstImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
         CUmemorytype memType;
 
         // Check what type of memory is pDst. If cuPointerGetAttribute returns
@@ -675,18 +679,19 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                   (CUdeviceptr)pDst) != CUDA_SUCCESS;
 
-        size_t CopyExtentBytes = PixelSizeBytes * copyExtent.width;
-        const char *SrcWithOffset =
-            static_cast<const char *>(pSrc) + (srcOffset.x * PixelSizeBytes);
+        size_t CopyExtentBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        const char *SrcWithOffset = static_cast<const char *>(pSrc) +
+                                    (pCopyRegion->srcOffset.x * PixelSizeBytes);
 
         if (isCudaArray) {
-          UR_CHECK_ERROR(
-              cuMemcpyHtoAAsync((CUarray)pDst, dstOffset.x * PixelSizeBytes,
-                                static_cast<const void *>(SrcWithOffset),
-                                CopyExtentBytes, Stream));
+          UR_CHECK_ERROR(cuMemcpyHtoAAsync(
+              (CUarray)pDst, pCopyRegion->dstOffset.x * PixelSizeBytes,
+              static_cast<const void *>(SrcWithOffset), CopyExtentBytes,
+              Stream));
         } else if (memType == CU_MEMORYTYPE_DEVICE) {
-          void *DstWithOffset = static_cast<void *>(
-              static_cast<char *>(pDst) + (PixelSizeBytes * dstOffset.x));
+          void *DstWithOffset =
+              static_cast<void *>(static_cast<char *>(pDst) +
+                                  (PixelSizeBytes * pCopyRegion->dstOffset.x));
           UR_CHECK_ERROR(
               cuMemcpyHtoDAsync((CUdeviceptr)DstWithOffset,
                                 static_cast<const void *>(SrcWithOffset),
@@ -695,68 +700,68 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
           // This should be unreachable.
           return UR_RESULT_ERROR_INVALID_VALUE;
         }
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
+      } else if (pDstImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         CUDA_MEMCPY2D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.srcHost = pSrc;
-        cpy_desc.srcPitch = hostExtent.width * PixelSizeBytes;
-        if (pImageDesc->rowPitch == 0) {
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.srcPitch = pSrcImageDesc->width * PixelSizeBytes;
+        if (pDstImageDesc->rowPitch == 0) {
           cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
           cpy_desc.dstArray = (CUarray)pDst;
         } else {
           // Pitched memory
           cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_DEVICE;
           cpy_desc.dstDevice = (CUdeviceptr)pDst;
-          cpy_desc.dstPitch = pImageDesc->rowPitch;
+          cpy_desc.dstPitch = pDstImageDesc->rowPitch;
         }
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
         UR_CHECK_ERROR(cuMemcpy2DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
+      } else if (pDstImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.srcHost = pSrc;
-        cpy_desc.srcPitch = hostExtent.width * PixelSizeBytes;
-        cpy_desc.srcHeight = hostExtent.height;
+        cpy_desc.srcPitch = pSrcImageDesc->width * PixelSizeBytes;
+        cpy_desc.srcHeight = pSrcImageDesc->height;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
-        cpy_desc.Depth = copyExtent.depth;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
+        cpy_desc.Depth = pCopyRegion->copyExtent.depth;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
+      } else if (pDstImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
+                 pDstImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
+                 pDstImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.srcHost = pSrc;
-        cpy_desc.srcPitch = hostExtent.width * PixelSizeBytes;
-        cpy_desc.srcHeight = hostExtent.height;
+        cpy_desc.srcPitch = pCopyRegion->copyExtent.width * PixelSizeBytes;
+        cpy_desc.srcHeight = pCopyRegion->copyExtent.height;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = std::max(uint64_t{1}, copyExtent.height);
-        cpy_desc.Depth = pImageDesc->arraySize;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = std::max(uint64_t{1}, pCopyRegion->copyExtent.height);
+        cpy_desc.Depth = pDstImageDesc->arraySize;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
       }
     } else if (imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST) {
-      if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
+      if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
         CUmemorytype memType;
         // Check what type of memory is pSrc. If cuPointerGetAttribute returns
         // somthing different from CUDA_SUCCESS then we know that pSrc memory
@@ -765,17 +770,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
                                   (CUdeviceptr)pSrc) != CUDA_SUCCESS;
 
-        size_t CopyExtentBytes = PixelSizeBytes * copyExtent.width;
-        void *DstWithOffset = static_cast<void *>(
-            static_cast<char *>(pDst) + (PixelSizeBytes * dstOffset.x));
+        size_t CopyExtentBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        void *DstWithOffset =
+            static_cast<void *>(static_cast<char *>(pDst) +
+                                (PixelSizeBytes * pCopyRegion->dstOffset.x));
 
         if (isCudaArray) {
-          UR_CHECK_ERROR(cuMemcpyAtoHAsync(DstWithOffset, (CUarray)pSrc,
-                                           PixelSizeBytes * srcOffset.x,
-                                           CopyExtentBytes, Stream));
+          UR_CHECK_ERROR(
+              cuMemcpyAtoHAsync(DstWithOffset, (CUarray)pSrc,
+                                PixelSizeBytes * pCopyRegion->srcOffset.x,
+                                CopyExtentBytes, Stream));
         } else if (memType == CU_MEMORYTYPE_DEVICE) {
           const char *SrcWithOffset =
-              static_cast<const char *>(pSrc) + (srcOffset.x * PixelSizeBytes);
+              static_cast<const char *>(pSrc) +
+              (pCopyRegion->srcOffset.x * PixelSizeBytes);
           UR_CHECK_ERROR(cuMemcpyDtoHAsync(DstWithOffset,
                                            (CUdeviceptr)SrcWithOffset,
                                            CopyExtentBytes, Stream));
@@ -783,131 +791,140 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
           // This should be unreachable.
           return UR_RESULT_ERROR_INVALID_VALUE;
         }
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         CUDA_MEMCPY2D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        if (pImageDesc->rowPitch == 0) {
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
+        cpy_desc.dstHost = pDst;
+        if (pSrcImageDesc->rowPitch == 0) {
           cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
           cpy_desc.srcArray = (CUarray)pSrc;
         } else {
           // Pitched memory
           cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_DEVICE;
-          cpy_desc.srcPitch = pImageDesc->rowPitch;
+          cpy_desc.srcPitch = pSrcImageDesc->rowPitch;
           cpy_desc.srcDevice = (CUdeviceptr)pSrc;
         }
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.dstHost = pDst;
-        cpy_desc.dstPitch = hostExtent.width * PixelSizeBytes;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
+        cpy_desc.dstPitch = pDstImageDesc->width * PixelSizeBytes;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
         UR_CHECK_ERROR(cuMemcpy2DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.dstHost = pDst;
-        cpy_desc.dstPitch = hostExtent.width * PixelSizeBytes;
-        cpy_desc.dstHeight = hostExtent.height;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
-        cpy_desc.Depth = copyExtent.depth;
+        cpy_desc.dstPitch = pDstImageDesc->width * PixelSizeBytes;
+        cpy_desc.dstHeight = pDstImageDesc->height;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
+        cpy_desc.Depth = pCopyRegion->copyExtent.depth;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
+                 pSrcImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
+                 pSrcImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_HOST;
         cpy_desc.dstHost = pDst;
-        cpy_desc.dstPitch = hostExtent.width * PixelSizeBytes;
-        cpy_desc.dstHeight = hostExtent.height;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = std::max(uint64_t{1}, copyExtent.height);
-        cpy_desc.Depth = pImageDesc->arraySize;
+        cpy_desc.dstPitch = pDstImageDesc->width * PixelSizeBytes;
+        cpy_desc.dstHeight = pDstImageDesc->height;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = std::max(uint64_t{1}, pCopyRegion->copyExtent.height);
+        cpy_desc.Depth = pSrcImageDesc->arraySize;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
       }
     } else {
       // imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE
 
+      // we don't support copying between different image types.
+      if (pSrcImageDesc->type != pDstImageDesc->type) {
+        logger::error(
+            "Unsupported copy operation between different type of images");
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+      }
+
       // All the following async copy function calls should be treated as
       // synchronous because of the explicit call to cuStreamSynchronize at
       // the end
-      if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
+      if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
         CUDA_MEMCPY2D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
         cpy_desc.srcY = 0;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
         cpy_desc.dstY = 0;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
         cpy_desc.Height = 1;
         UR_CHECK_ERROR(cuMemcpy2DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         CUDA_MEMCPY2D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
         UR_CHECK_ERROR(cuMemcpy2DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = copyExtent.height;
-        cpy_desc.Depth = copyExtent.depth;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = pCopyRegion->copyExtent.height;
+        cpy_desc.Depth = pCopyRegion->copyExtent.depth;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
-      } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
-                 pImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
+      } else if (pSrcImageDesc->type == UR_MEM_TYPE_IMAGE1D_ARRAY ||
+                 pSrcImageDesc->type == UR_MEM_TYPE_IMAGE2D_ARRAY ||
+                 pSrcImageDesc->type == UR_MEM_TYPE_IMAGE_CUBEMAP_EXP) {
         CUDA_MEMCPY3D cpy_desc = {};
-        cpy_desc.srcXInBytes = srcOffset.x * PixelSizeBytes;
-        cpy_desc.srcY = srcOffset.y;
-        cpy_desc.srcZ = srcOffset.z;
-        cpy_desc.dstXInBytes = dstOffset.x * PixelSizeBytes;
-        cpy_desc.dstY = dstOffset.y;
-        cpy_desc.dstZ = dstOffset.z;
+        cpy_desc.srcXInBytes = pCopyRegion->srcOffset.x * PixelSizeBytes;
+        cpy_desc.srcY = pCopyRegion->srcOffset.y;
+        cpy_desc.srcZ = pCopyRegion->srcOffset.z;
+        cpy_desc.dstXInBytes = pCopyRegion->dstOffset.x * PixelSizeBytes;
+        cpy_desc.dstY = pCopyRegion->dstOffset.y;
+        cpy_desc.dstZ = pCopyRegion->dstOffset.z;
         cpy_desc.srcMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.srcArray = (CUarray)pSrc;
         cpy_desc.dstMemoryType = CUmemorytype_enum::CU_MEMORYTYPE_ARRAY;
         cpy_desc.dstArray = (CUarray)pDst;
-        cpy_desc.WidthInBytes = PixelSizeBytes * copyExtent.width;
-        cpy_desc.Height = std::max(uint64_t{1}, copyExtent.height);
-        cpy_desc.Depth = pImageDesc->arraySize;
+        cpy_desc.WidthInBytes = PixelSizeBytes * pCopyRegion->copyExtent.width;
+        cpy_desc.Height = std::max(uint64_t{1}, pCopyRegion->copyExtent.height);
+        cpy_desc.Depth = pSrcImageDesc->arraySize;
         UR_CHECK_ERROR(cuMemcpy3DAsync(&cpy_desc, Stream));
       }
       // Synchronization is required here to handle the case of copying data

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -75,15 +75,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] const void *pSrc,
-    [[maybe_unused]] const ur_image_format_t *pImageFormat,
-    [[maybe_unused]] const ur_image_desc_t *pImageDesc,
+    [[maybe_unused]] ur_queue_handle_t hQueue,
+    [[maybe_unused]] const void *pSrc, [[maybe_unused]] void *pDst,
+    [[maybe_unused]] const ur_image_desc_t *pSrcImageDesc,
+    [[maybe_unused]] const ur_image_desc_t *pDstImageDesc,
+    [[maybe_unused]] const ur_image_format_t *pSrcImageFormat,
+    [[maybe_unused]] const ur_image_format_t *pDstImageFormat,
+    [[maybe_unused]] ur_exp_image_copy_region_t *pCopyRegion,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,
-    [[maybe_unused]] ur_rect_offset_t srcOffset,
-    [[maybe_unused]] ur_rect_offset_t dstOffset,
-    [[maybe_unused]] ur_rect_region_t copyExtent,
-    [[maybe_unused]] ur_rect_region_t hostExtent,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -751,25 +751,32 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
-    void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
-    const ur_image_desc_t *pImageDesc, ur_exp_image_copy_flags_t imageCopyFlags,
-    ur_rect_offset_t srcOffset, ur_rect_offset_t dstOffset,
-    ur_rect_region_t copyExtent, ur_rect_region_t hostExtent,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+    [[maybe_unused]] const void *pSrc, [[maybe_unused]] void *pDst,
+    [[maybe_unused]] const ur_image_desc_t *pSrcImageDesc,
+    [[maybe_unused]] const ur_image_desc_t *pDstImageDesc,
+    [[maybe_unused]] const ur_image_format_t *pSrcImageFormat,
+    [[maybe_unused]] const ur_image_format_t *pDstImageFormat,
+    [[maybe_unused]] ur_exp_image_copy_region_t *pCopyRegion,
+    [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,
+    [[maybe_unused]] uint32_t numEventsInWaitList,
+    [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
+    [[maybe_unused]] ur_event_handle_t *phEvent) {
   auto hQueue = this;
   std::scoped_lock<ur_shared_mutex> Lock(hQueue->Mutex);
 
   UR_ASSERT(hQueue, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT(pDst && pSrc && pImageFormat && pImageDesc,
+  UR_ASSERT(pDst && pSrc && pSrcImageFormat && pSrcImageDesc && pDstImageDesc &&
+                pCopyRegion,
             UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(pSrcImageDesc->type == pDstImageDesc->type,
+            UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT(!(UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags),
             UR_RESULT_ERROR_INVALID_ENUMERATION);
-  UR_ASSERT(!(pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type),
+  UR_ASSERT(!(pSrcImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pSrcImageDesc->type),
             UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR);
 
   ZeStruct<ze_image_desc_t> ZeImageDesc;
-  UR_CALL(ur2zeImageDesc(pImageFormat, pImageDesc, ZeImageDesc));
+  UR_CALL(ur2zeImageDesc(pSrcImageFormat, pSrcImageDesc, ZeImageDesc));
 
   bool UseCopyEngine = hQueue->useCopyEngine(/*PreferCopyEngine*/ true);
 
@@ -802,67 +809,79 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  uint32_t PixelSizeInBytes = getPixelSizeBytes(pImageFormat);
-
   if (imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE) {
-    uint32_t SrcRowPitch = hostExtent.width * PixelSizeInBytes;
-    uint32_t SrcSlicePitch = SrcRowPitch * hostExtent.height;
-    if (pImageDesc->rowPitch == 0) {
+    uint32_t SrcRowPitch =
+        pSrcImageDesc->width * getPixelSizeBytes(pSrcImageFormat);
+    uint32_t SrcSlicePitch = SrcRowPitch * pSrcImageDesc->height;
+    if (pDstImageDesc->rowPitch == 0) {
       // Copy to Non-USM memory
       ze_image_region_t DstRegion;
-      UR_CALL(getImageRegionHelper(ZeImageDesc, &dstOffset, &copyExtent,
-                                   DstRegion));
+      UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->dstOffset,
+                                   &pCopyRegion->copyExtent, DstRegion));
       auto *UrImage = static_cast<_ur_image *>(pDst);
       const char *SrcPtr =
-          static_cast<const char *>(pSrc) + srcOffset.z * SrcSlicePitch +
-          srcOffset.y * SrcRowPitch + srcOffset.x * PixelSizeInBytes;
+          static_cast<const char *>(pSrc) +
+          pCopyRegion->srcOffset.z * SrcSlicePitch +
+          pCopyRegion->srcOffset.y * SrcRowPitch +
+          pCopyRegion->srcOffset.x * getPixelSizeBytes(pSrcImageFormat);
       ZE2UR_CALL(zeCommandListAppendImageCopyFromMemoryExt,
                  (ZeCommandList, UrImage->ZeImage, SrcPtr, &DstRegion,
                   SrcRowPitch, SrcSlicePitch, ZeEvent, WaitList.Length,
                   WaitList.ZeEventList));
     } else {
       // Copy to pitched USM memory
-      uint32_t DstRowPitch = pImageDesc->rowPitch;
-      ze_copy_region_t ZeDstRegion = {
-          (uint32_t)dstOffset.x,       (uint32_t)dstOffset.y,
-          (uint32_t)dstOffset.z,       DstRowPitch,
-          (uint32_t)copyExtent.height, (uint32_t)copyExtent.depth};
+      uint32_t DstRowPitch = pDstImageDesc->rowPitch;
+      ze_copy_region_t ZeDstRegion = {(uint32_t)pCopyRegion->dstOffset.x,
+                                      (uint32_t)pCopyRegion->dstOffset.y,
+                                      (uint32_t)pCopyRegion->dstOffset.z,
+                                      DstRowPitch,
+                                      (uint32_t)pCopyRegion->copyExtent.height,
+                                      (uint32_t)pCopyRegion->copyExtent.depth};
       uint32_t DstSlicePitch = 0;
-      ze_copy_region_t ZeSrcRegion = {
-          (uint32_t)srcOffset.x,       (uint32_t)srcOffset.y,
-          (uint32_t)srcOffset.z,       SrcRowPitch,
-          (uint32_t)copyExtent.height, (uint32_t)copyExtent.depth};
+      ze_copy_region_t ZeSrcRegion = {(uint32_t)pCopyRegion->srcOffset.x,
+                                      (uint32_t)pCopyRegion->srcOffset.y,
+                                      (uint32_t)pCopyRegion->srcOffset.z,
+                                      SrcRowPitch,
+                                      (uint32_t)pCopyRegion->copyExtent.height,
+                                      (uint32_t)pCopyRegion->copyExtent.depth};
       ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
                  (ZeCommandList, pDst, &ZeDstRegion, DstRowPitch, DstSlicePitch,
                   pSrc, &ZeSrcRegion, SrcRowPitch, SrcSlicePitch, ZeEvent,
                   WaitList.Length, WaitList.ZeEventList));
     }
   } else if (imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_HOST) {
-    uint32_t DstRowPitch = hostExtent.width * PixelSizeInBytes;
-    uint32_t DstSlicePitch = DstRowPitch * hostExtent.height;
-    if (pImageDesc->rowPitch == 0) {
+    uint32_t DstRowPitch =
+        pDstImageDesc->width * getPixelSizeBytes(pDstImageFormat);
+    uint32_t DstSlicePitch = DstRowPitch * pDstImageDesc->height;
+    if (pSrcImageDesc->rowPitch == 0) {
       // Copy from Non-USM memory to host
       ze_image_region_t SrcRegion;
-      UR_CALL(getImageRegionHelper(ZeImageDesc, &srcOffset, &copyExtent,
-                                   SrcRegion));
+      UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->srcOffset,
+                                   &pCopyRegion->copyExtent, SrcRegion));
       auto *UrImage = static_cast<const _ur_image *>(pSrc);
-      char *DstPtr = static_cast<char *>(pDst) + dstOffset.z * DstSlicePitch +
-                     dstOffset.y * DstRowPitch + dstOffset.x * PixelSizeInBytes;
+      char *DstPtr =
+          static_cast<char *>(pDst) + pCopyRegion->dstOffset.z * DstSlicePitch +
+          pCopyRegion->dstOffset.y * DstRowPitch +
+          pCopyRegion->dstOffset.x * getPixelSizeBytes(pDstImageFormat);
       ZE2UR_CALL(zeCommandListAppendImageCopyToMemoryExt,
                  (ZeCommandList, DstPtr, UrImage->ZeImage, &SrcRegion,
                   DstRowPitch, DstSlicePitch, ZeEvent, WaitList.Length,
                   WaitList.ZeEventList));
     } else {
       // Copy from pitched USM memory to host
-      ze_copy_region_t ZeDstRegion = {
-          (uint32_t)dstOffset.x,       (uint32_t)dstOffset.y,
-          (uint32_t)dstOffset.z,       DstRowPitch,
-          (uint32_t)copyExtent.height, (uint32_t)copyExtent.depth};
-      uint32_t SrcRowPitch = pImageDesc->rowPitch;
-      ze_copy_region_t ZeSrcRegion = {
-          (uint32_t)srcOffset.x,       (uint32_t)srcOffset.y,
-          (uint32_t)srcOffset.z,       SrcRowPitch,
-          (uint32_t)copyExtent.height, (uint32_t)copyExtent.depth};
+      ze_copy_region_t ZeDstRegion = {(uint32_t)pCopyRegion->dstOffset.x,
+                                      (uint32_t)pCopyRegion->dstOffset.y,
+                                      (uint32_t)pCopyRegion->dstOffset.z,
+                                      DstRowPitch,
+                                      (uint32_t)pCopyRegion->copyExtent.height,
+                                      (uint32_t)pCopyRegion->copyExtent.depth};
+      uint32_t SrcRowPitch = pSrcImageDesc->rowPitch;
+      ze_copy_region_t ZeSrcRegion = {(uint32_t)pCopyRegion->srcOffset.x,
+                                      (uint32_t)pCopyRegion->srcOffset.y,
+                                      (uint32_t)pCopyRegion->srcOffset.z,
+                                      SrcRowPitch,
+                                      (uint32_t)pCopyRegion->copyExtent.height,
+                                      (uint32_t)pCopyRegion->copyExtent.depth};
       uint32_t SrcSlicePitch = 0;
       ZE2UR_CALL(zeCommandListAppendMemoryCopyRegion,
                  (ZeCommandList, pDst, &ZeDstRegion, DstRowPitch, DstSlicePitch,
@@ -871,11 +890,11 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
     }
   } else if (imageCopyFlags == UR_EXP_IMAGE_COPY_FLAG_DEVICE_TO_DEVICE) {
     ze_image_region_t DstRegion;
-    UR_CALL(
-        getImageRegionHelper(ZeImageDesc, &dstOffset, &copyExtent, DstRegion));
+    UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->dstOffset,
+                                 &pCopyRegion->copyExtent, DstRegion));
     ze_image_region_t SrcRegion;
-    UR_CALL(
-        getImageRegionHelper(ZeImageDesc, &srcOffset, &copyExtent, SrcRegion));
+    UR_CALL(getImageRegionHelper(ZeImageDesc, &pCopyRegion->srcOffset,
+                                 &pCopyRegion->copyExtent, SrcRegion));
     auto *UrImageDst = static_cast<_ur_image *>(pDst);
     auto *UrImageSrc = static_cast<const _ur_image *>(pSrc);
     ZE2UR_CALL(zeCommandListAppendImageCopyRegion,

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -381,11 +381,12 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
                                    const ur_event_handle_t *phEventWaitList,
                                    ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesImageCopyExp(
-      void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
-      const ur_image_desc_t *pImageDesc,
-      ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
-      ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
-      ur_rect_region_t hostExtent, uint32_t numEventsInWaitList,
+      const void *pSrc, void *pDst, const ur_image_desc_t *pSrcImageDesc,
+      const ur_image_desc_t *pDstImageDesc,
+      const ur_image_format_t *pSrcImageFormat,
+      const ur_image_format_t *pDstImageFormat,
+      ur_exp_image_copy_region_t *pCopyRegion,
+      ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesWaitExternalSemaphoreExp(

--- a/source/adapters/level_zero/queue_api.cpp
+++ b/source/adapters/level_zero/queue_api.cpp
@@ -255,16 +255,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
                                       phEventWaitList, phEvent);
 }
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    ur_queue_handle_t hQueue, void *pDst, const void *pSrc,
-    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
-    ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
-    ur_rect_region_t hostExtent, uint32_t numEventsInWaitList,
+    ur_queue_handle_t hQueue, const void *pSrc, void *pDst,
+    const ur_image_desc_t *pSrcImageDesc, const ur_image_desc_t *pDstImageDesc,
+    const ur_image_format_t *pSrcImageFormat,
+    const ur_image_format_t *pDstImageFormat,
+    ur_exp_image_copy_region_t *pCopyRegion,
+    ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   return hQueue->bindlessImagesImageCopyExp(
-      pDst, pSrc, pImageFormat, pImageDesc, imageCopyFlags, srcOffset,
-      dstOffset, copyExtent, hostExtent, numEventsInWaitList, phEventWaitList,
-      phEvent);
+      pSrc, pDst, pSrcImageDesc, pDstImageDesc, pSrcImageFormat,
+      pDstImageFormat, pCopyRegion, imageCopyFlags, numEventsInWaitList,
+      phEventWaitList, phEvent);
 }
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,

--- a/source/adapters/level_zero/queue_api.hpp
+++ b/source/adapters/level_zero/queue_api.hpp
@@ -123,10 +123,10 @@ struct ur_queue_handle_t_ {
                                            const ur_event_handle_t *,
                                            ur_event_handle_t *) = 0;
   virtual ur_result_t bindlessImagesImageCopyExp(
-      void *, const void *, const ur_image_format_t *, const ur_image_desc_t *,
-      ur_exp_image_copy_flags_t, ur_rect_offset_t, ur_rect_offset_t,
-      ur_rect_region_t, ur_rect_region_t, uint32_t, const ur_event_handle_t *,
-      ur_event_handle_t *) = 0;
+      const void *, void *, const ur_image_desc_t *, const ur_image_desc_t *,
+      const ur_image_format_t *, const ur_image_format_t *,
+      ur_exp_image_copy_region_t *, ur_exp_image_copy_flags_t, uint32_t,
+      const ur_event_handle_t *, ur_event_handle_t *) = 0;
   virtual ur_result_t bindlessImagesWaitExternalSemaphoreExp(
       ur_exp_interop_semaphore_handle_t, bool, uint64_t, uint32_t,
       const ur_event_handle_t *, ur_event_handle_t *) = 0;

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -481,21 +481,21 @@ ur_result_t ur_queue_immediate_in_order_t::enqueueWriteHostPipe(
 }
 
 ur_result_t ur_queue_immediate_in_order_t::bindlessImagesImageCopyExp(
-    void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
-    const ur_image_desc_t *pImageDesc, ur_exp_image_copy_flags_t imageCopyFlags,
-    ur_rect_offset_t srcOffset, ur_rect_offset_t dstOffset,
-    ur_rect_region_t copyExtent, ur_rect_region_t hostExtent,
-    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
-    ur_event_handle_t *phEvent) {
+    const void *pSrc, void *pDst, const ur_image_desc_t *pSrcImageDesc,
+    const ur_image_desc_t *pDstImageDesc,
+    const ur_image_format_t *pSrcImageFormat,
+    const ur_image_format_t *pDstImageFormat,
+    ur_exp_image_copy_region_t *pCopyRegion,
+    ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = pDst;
   std::ignore = pSrc;
-  std::ignore = pImageFormat;
-  std::ignore = pImageDesc;
+  std::ignore = pSrcImageDesc;
+  std::ignore = pDstImageDesc;
   std::ignore = imageCopyFlags;
-  std::ignore = srcOffset;
-  std::ignore = dstOffset;
-  std::ignore = copyExtent;
-  std::ignore = hostExtent;
+  std::ignore = pSrcImageFormat;
+  std::ignore = pDstImageFormat;
+  std::ignore = pCopyRegion;
   std::ignore = numEventsInWaitList;
   std::ignore = phEventWaitList;
   std::ignore = phEvent;

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -180,11 +180,12 @@ public:
                                    const ur_event_handle_t *phEventWaitList,
                                    ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesImageCopyExp(
-      void *pDst, const void *pSrc, const ur_image_format_t *pImageFormat,
-      const ur_image_desc_t *pImageDesc,
-      ur_exp_image_copy_flags_t imageCopyFlags, ur_rect_offset_t srcOffset,
-      ur_rect_offset_t dstOffset, ur_rect_region_t copyExtent,
-      ur_rect_region_t hostExtent, uint32_t numEventsInWaitList,
+      const void *pSrc, void *pDst, const ur_image_desc_t *pSrcImageDesc,
+      const ur_image_desc_t *pDstImageDesc,
+      const ur_image_format_t *pSrcImageFormat,
+      const ur_image_format_t *pDstImageFormat,
+      ur_exp_image_copy_region_t *pCopyRegion,
+      ur_exp_image_copy_flags_t imageCopyFlags, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesWaitExternalSemaphoreExp(

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -7453,25 +7453,19 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 /// @brief Intercept function for urBindlessImagesImageCopyExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7486,15 +7480,14 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_result_t result = UR_RESULT_SUCCESS;
 
     ur_bindless_images_image_copy_exp_params_t params = {&hQueue,
-                                                         &pDst,
                                                          &pSrc,
-                                                         &pImageFormat,
-                                                         &pImageDesc,
+                                                         &pDst,
+                                                         &pSrcImageDesc,
+                                                         &pDstImageDesc,
+                                                         &pSrcImageFormat,
+                                                         &pDstImageFormat,
+                                                         &pCopyRegion,
                                                          &imageCopyFlags,
-                                                         &srcOffset,
-                                                         &dstOffset,
-                                                         &copyExtent,
-                                                         &hostExtent,
                                                          &numEventsInWaitList,
                                                          &phEventWaitList,
                                                          &phEvent};

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -75,15 +75,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] const void *pSrc,
-    [[maybe_unused]] const ur_image_format_t *pImageFormat,
-    [[maybe_unused]] const ur_image_desc_t *pImageDesc,
+    [[maybe_unused]] ur_queue_handle_t hQueue,
+    [[maybe_unused]] const void *pSrc, [[maybe_unused]] void *pDst,
+    [[maybe_unused]] const ur_image_desc_t *pSrcImageDesc,
+    [[maybe_unused]] const ur_image_desc_t *pDstImageDesc,
+    [[maybe_unused]] const ur_image_format_t *pSrcImageFormat,
+    [[maybe_unused]] const ur_image_format_t *pDstImageFormat,
+    [[maybe_unused]] ur_exp_image_copy_region_t *pCopyRegion,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,
-    [[maybe_unused]] ur_rect_offset_t srcOffset,
-    [[maybe_unused]] ur_rect_offset_t dstOffset,
-    [[maybe_unused]] ur_rect_region_t copyExtent,
-    [[maybe_unused]] ur_rect_region_t hostExtent,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -75,15 +75,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
-    [[maybe_unused]] ur_queue_handle_t hQueue, [[maybe_unused]] void *pDst,
-    [[maybe_unused]] const void *pSrc,
-    [[maybe_unused]] const ur_image_format_t *pImageFormat,
-    [[maybe_unused]] const ur_image_desc_t *pImageDesc,
+    [[maybe_unused]] ur_queue_handle_t hQueue,
+    [[maybe_unused]] const void *pSrc, [[maybe_unused]] void *pDst,
+    [[maybe_unused]] const ur_image_desc_t *pSrcImageDesc,
+    [[maybe_unused]] const ur_image_desc_t *pDstImageDesc,
+    [[maybe_unused]] const ur_image_format_t *pSrcImageFormat,
+    [[maybe_unused]] const ur_image_format_t *pDstImageFormat,
+    [[maybe_unused]] ur_exp_image_copy_region_t *pCopyRegion,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,
-    [[maybe_unused]] ur_rect_offset_t srcOffset,
-    [[maybe_unused]] ur_rect_offset_t dstOffset,
-    [[maybe_unused]] ur_rect_region_t copyExtent,
-    [[maybe_unused]] ur_rect_region_t hostExtent,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
     [[maybe_unused]] ur_event_handle_t *phEvent) {

--- a/source/common/stype_map_helpers.def
+++ b/source/common/stype_map_helpers.def
@@ -96,5 +96,7 @@ struct stype_map<ur_exp_sampler_addr_modes_t> : stype_map_impl<UR_STRUCTURE_TYPE
 template <>
 struct stype_map<ur_exp_sampler_cubemap_properties_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES> {};
 template <>
+struct stype_map<ur_exp_image_copy_region_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_IMAGE_COPY_REGION> {};
+template <>
 struct stype_map<ur_exp_enqueue_native_command_properties_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_ENQUEUE_NATIVE_COMMAND_PROPERTIES> {};
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5769,25 +5769,19 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 /// @brief Intercept function for urBindlessImagesImageCopyExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -5807,15 +5801,14 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     }
 
     ur_bindless_images_image_copy_exp_params_t params = {&hQueue,
-                                                         &pDst,
                                                          &pSrc,
-                                                         &pImageFormat,
-                                                         &pImageDesc,
+                                                         &pDst,
+                                                         &pSrcImageDesc,
+                                                         &pDstImageDesc,
+                                                         &pSrcImageFormat,
+                                                         &pDstImageFormat,
+                                                         &pCopyRegion,
                                                          &imageCopyFlags,
-                                                         &srcOffset,
-                                                         &dstOffset,
-                                                         &copyExtent,
-                                                         &hostExtent,
                                                          &numEventsInWaitList,
                                                          &phEventWaitList,
                                                          &phEvent};
@@ -5826,9 +5819,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     getContext()->logger.info("---> urBindlessImagesImageCopyExp");
 
     ur_result_t result = pfnImageCopyExp(
-        hQueue, pDst, pSrc, pImageFormat, pImageDesc, imageCopyFlags, srcOffset,
-        dstOffset, copyExtent, hostExtent, numEventsInWaitList, phEventWaitList,
-        phEvent);
+        hQueue, pSrc, pDst, pSrcImageDesc, pDstImageDesc, pSrcImageFormat,
+        pDstImageFormat, pCopyRegion, imageCopyFlags, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     getContext()->notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP,
                              "urBindlessImagesImageCopyExp", &params, &result,

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7193,25 +7193,19 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 /// @brief Intercept function for urBindlessImagesImageCopyExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -7235,19 +7229,31 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pDst) {
-            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-        }
-
         if (NULL == pSrc) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == pImageFormat) {
+        if (NULL == pDst) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == pImageDesc) {
+        if (NULL == pSrcImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pDstImageDesc) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pSrcImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pDstImageFormat) {
+            return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+        }
+
+        if (NULL == pCopyRegion) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -7255,7 +7261,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
+        if (pSrcImageDesc &&
+            UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pSrcImageDesc->type) {
+            return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
+        }
+
+        if (pDstImageDesc &&
+            UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pDstImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
 
@@ -7274,9 +7286,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     }
 
     ur_result_t result = pfnImageCopyExp(
-        hQueue, pDst, pSrc, pImageFormat, pImageDesc, imageCopyFlags, srcOffset,
-        dstOffset, copyExtent, hostExtent, numEventsInWaitList, phEventWaitList,
-        phEvent);
+        hQueue, pSrc, pDst, pSrcImageDesc, pDstImageDesc, pSrcImageFormat,
+        pDstImageFormat, pCopyRegion, imageCopyFlags, numEventsInWaitList,
+        phEventWaitList, phEvent);
 
     return result;
 }

--- a/source/loader/loader.def.in
+++ b/source/loader/loader.def.in
@@ -309,6 +309,7 @@ EXPORTS
 	urPrintExpExternalSemaphoreType
 	urPrintExpFileDescriptor
 	urPrintExpImageCopyFlags
+	urPrintExpImageCopyRegion
 	urPrintExpInteropMemDesc
 	urPrintExpInteropSemaphoreDesc
 	urPrintExpLaunchProperty

--- a/source/loader/loader.map.in
+++ b/source/loader/loader.map.in
@@ -309,6 +309,7 @@
 		urPrintExpExternalSemaphoreType;
 		urPrintExpFileDescriptor;
 		urPrintExpImageCopyFlags;
+		urPrintExpImageCopyRegion;
 		urPrintExpInteropMemDesc;
 		urPrintExpInteropSemaphoreDesc;
 		urPrintExpLaunchProperty;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6363,25 +6363,19 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 /// @brief Intercept function for urBindlessImagesImageCopyExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6416,9 +6410,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     }
 
     // forward to device-platform
-    result = pfnImageCopyExp(hQueue, pDst, pSrc, pImageFormat, pImageDesc,
-                             imageCopyFlags, srcOffset, dstOffset, copyExtent,
-                             hostExtent, numEventsInWaitList,
+    result = pfnImageCopyExp(hQueue, pSrc, pDst, pSrcImageDesc, pDstImageDesc,
+                             pSrcImageFormat, pDstImageFormat, pCopyRegion,
+                             imageCopyFlags, numEventsInWaitList,
                              phEventWaitListLocal.data(), phEvent);
 
     if (UR_RESULT_SUCCESS != result) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6824,7 +6824,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Copy image data Host to Device or Device to Host
+/// @brief Copy image data Host to Device, Device to Host, or Device to Device
 ///
 /// @remarks
 ///   _Analogues_
@@ -6841,39 +6841,37 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == pImageFormat`
-///         + `NULL == pImageDesc`
+///         + `NULL == pDst`
+///         + `NULL == pSrcImageDesc`
+///         + `NULL == pDstImageDesc`
+///         + `NULL == pSrcImageFormat`
+///         + `NULL == pDstImageFormat`
+///         + `NULL == pCopyRegion`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
+///         + `pSrcImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pSrcImageDesc->type`
+///         + `pDstImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pDstImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
@@ -6891,9 +6889,9 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageCopyExp(hQueue, pDst, pSrc, pImageFormat, pImageDesc,
-                           imageCopyFlags, srcOffset, dstOffset, copyExtent,
-                           hostExtent, numEventsInWaitList, phEventWaitList,
+    return pfnImageCopyExp(hQueue, pSrc, pDst, pSrcImageDesc, pDstImageDesc,
+                           pSrcImageFormat, pDstImageFormat, pCopyRegion,
+                           imageCopyFlags, numEventsInWaitList, phEventWaitList,
                            phEvent);
 } catch (...) {
     return exceptionToResult(std::current_exception());

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -971,6 +971,15 @@ ur_result_t urPrintExpInteropSemaphoreDesc(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
+ur_result_t
+urPrintExpImageCopyRegion(const struct ur_exp_image_copy_region_t params,
+                          char *buffer, const size_t buff_size,
+                          size_t *out_size) {
+    std::stringstream ss;
+    ss << params;
+    return str_copy(&ss, buffer, buff_size, out_size);
+}
+
 ur_result_t urPrintExpCommandBufferInfo(enum ur_exp_command_buffer_info_t value,
                                         char *buffer, const size_t buff_size,
                                         size_t *out_size) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5815,7 +5815,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Copy image data Host to Device or Device to Host
+/// @brief Copy image data Host to Device, Device to Host, or Device to Device
 ///
 /// @remarks
 ///   _Analogues_
@@ -5832,39 +5832,37 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hQueue`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pDst`
 ///         + `NULL == pSrc`
-///         + `NULL == pImageFormat`
-///         + `NULL == pImageDesc`
+///         + `NULL == pDst`
+///         + `NULL == pSrcImageDesc`
+///         + `NULL == pDstImageDesc`
+///         + `NULL == pSrcImageFormat`
+///         + `NULL == pDstImageFormat`
+///         + `NULL == pCopyRegion`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_IMAGE_COPY_FLAGS_MASK & imageCopyFlags`
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
+///         + `pSrcImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pSrcImageDesc->type`
+///         + `pDstImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pDstImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    void *pDst,               ///< [in] location the data will be copied to
     const void *pSrc,         ///< [in] location the data will be copied from
+    void *pDst,               ///< [in] location the data will be copied to
+    const ur_image_desc_t *pSrcImageDesc, ///< [in] pointer to image description
+    const ur_image_desc_t *pDstImageDesc, ///< [in] pointer to image description
     const ur_image_format_t
-        *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
+        *pSrcImageFormat, ///< [in] pointer to image format specification
+    const ur_image_format_t
+        *pDstImageFormat, ///< [in] pointer to image format specification
+    ur_exp_image_copy_region_t *
+        pCopyRegion, ///< [in] Pointer to structure describing the (sub-)regions of source and
+                     ///< destination images
     ur_exp_image_copy_flags_t
         imageCopyFlags, ///< [in] flags describing copy direction e.g. H2D or D2H
-    ur_rect_offset_t
-        srcOffset, ///< [in] defines the (x,y,z) source offset in pixels in the 1D, 2D, or 3D
-                   ///< image
-    ur_rect_offset_t
-        dstOffset, ///< [in] defines the (x,y,z) destination offset in pixels in the 1D, 2D,
-                   ///< or 3D image
-    ur_rect_region_t
-        copyExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region to copy
-    ur_rect_region_t
-        hostExtent, ///< [in] defines the (width, height, depth) in pixels of the 1D, 2D, or 3D
-                    ///< region on the host
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
         phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of


### PR DESCRIPTION
The new design, proposed through this patch, addresses the current problems/limitations for urBindlessImagesImageCopyExp:
- unused or redundant arguments.
- lack of support for new features such as subregion layered image copies.
- host versus device instead of source versus destination.

The API accepts two image descriptors and two image formats which accommodate for copying between two different image types and possible formats.

The copy information is captured by a new struct, namely `ur_exp_image_copy_region_t`. It enables subregion copy for layered images and mipmaps.