### PR TITLE
[UR][L0] Fix undefined behavior caused by shifting more than bits count

### DIFF
--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1545,8 +1545,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 ) {
   const uint64_t &ZeTimerResolution =
       Device->ZeDeviceProperties->timerResolution;
-  const uint64_t TimestampMaxCount =
-      ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
+  const uint64_t TimestampMaxCount = Device->getTimestampMask();
   uint64_t DeviceClockCount, Dummy;
 
   ZE2UR_CALL(zeDeviceGetGlobalTimestamps,

--- a/source/adapters/level_zero/device.hpp
+++ b/source/adapters/level_zero/device.hpp
@@ -186,6 +186,12 @@ struct ur_device_handle_t_ : _ur_object {
                .ZeIndex >= 0;
   }
 
+  uint64_t getTimestampMask() {
+    auto ValidBits = ZeDeviceProperties->kernelTimestampValidBits;
+    assert(ValidBits <= 64);
+    return ValidBits == 64 ? ~0ULL : (1ULL << ValidBits) - 1ULL;
+  }
+
   // Cache of the immutable device properties.
   ZeCache<ZeStruct<ze_device_properties_t>> ZeDeviceProperties;
   ZeCache<ZeStruct<ze_device_compute_properties_t>> ZeDeviceComputeProperties;

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -493,8 +493,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
                                   : Event->Context->Devices[0];
 
   uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
-  const uint64_t TimestampMaxValue =
-      ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
+  const uint64_t TimestampMaxValue = Device->getTimestampMask();
 
   UrReturnHelper ReturnValue(PropValueSize, PropValue, PropValueSizeRet);
 

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1550,8 +1550,7 @@ ur_result_t ur_queue_handle_legacy_t_::active_barriers::clear() {
 
 void ur_queue_handle_legacy_t_::clearEndTimeRecordings() {
   uint64_t ZeTimerResolution = Device->ZeDeviceProperties->timerResolution;
-  const uint64_t TimestampMaxValue =
-      ((1ULL << Device->ZeDeviceProperties->kernelTimestampValidBits) - 1ULL);
+  const uint64_t TimestampMaxValue = Device->getTimestampMask();
 
   for (auto Entry : EndTimeRecordings) {
     auto &Event = Entry.first;


### PR DESCRIPTION
Shifting more than number of bits in the type is undefined behavior. Current code results in incorrect TimestampMaxValue calculation when valid bits >= 64 for the device. This PR is fixing this.


intel/llvm PR: https://github.com/intel/llvm/pull/14360