### PR TITLE
[L0] Add missing check for WorkDim to KernelLaunch funcs

### DIFF
--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -130,8 +130,10 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueKernelLaunch(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular kernel execution instance.
 ) {
-  auto Queue = this;
+  UR_ASSERT(WorkDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+  UR_ASSERT(WorkDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
+  auto Queue = this;
   ze_kernel_handle_t ZeKernel{};
   UR_CALL(getZeKernel(Queue, Kernel, &ZeKernel));
 
@@ -337,6 +339,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueCooperativeKernelLaunchExp(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular kernel execution instance.
 ) {
+  UR_ASSERT(WorkDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+  UR_ASSERT(WorkDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+
   auto Queue = this;
   auto ZeDevice = Queue->Device->ZeDevice;
 


### PR DESCRIPTION
This fixes urEnqueueKernelLaunchTest.InvalidWorkDimension.

There might be more failing tests in enqueue. Right now this test seems to crash (in the driver) on Arcs so I'm not sure if we even run all the tests from enqueue.cpp I found this on PVC where the error was reported differently and didn't match with the matchfile.

I'm not sure what the best approach is here, but maybe we should just filter out the tests we know fail in the driver so that we can run all of them?