### PR TITLE
[L0] Use Intel Level Zero Driver String extension

### DIFF
--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -49,9 +49,6 @@ ur_result_t initPlatforms(PlatformVec &platforms) noexcept try {
   for (uint32_t I = 0; I < ZeDriverCount; ++I) {
     auto platform = std::make_unique<ur_platform_handle_t_>(ZeDrivers[I]);
     UR_CALL(platform->initialize());
-    ZE2UR_CALL(zelLoaderTranslateHandle,
-               (ZEL_HANDLE_DRIVER, platform->ZeDriver,
-                (void **)&platform->ZeDriverHandleExpTranslated));
 
     // Save a copy in the cache for future uses.
     platforms.push_back(std::move(platform));

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -447,6 +447,22 @@ const bool ExposeCSliceInAffinityPartitioning = [] {
 const std::pair<int, int>
 getRangeOfAllowedCopyEngines(const ur_device_handle_t &Device);
 
+class ZeDriverVersionStringExtension {
+  // Pointer to function for Intel Driver Version String
+  ze_result_t (*zeIntelGetDriverVersionStringPointer)(
+      ze_driver_handle_t hDriver, char *, size_t *) = nullptr;
+
+public:
+  // Whether platform supports Intel Driver Version String.
+  bool Supported;
+
+  ZeDriverVersionStringExtension() : Supported{false} {}
+
+  void setZeDriverVersionString(ur_platform_handle_t_ *Platform);
+  void getDriverVersionString(ze_driver_handle_t DriverHandle,
+                              char *pDriverVersion, size_t *pVersionSize);
+};
+
 class ZeUSMImportExtension {
   // Pointers to functions that import/release host memory into USM
   ze_result_t (*zexDriverImportExternalPointer)(ze_driver_handle_t hDriver,

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1299,6 +1299,32 @@ ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   return UR_RESULT_SUCCESS;
 }
 
+void ZeDriverVersionStringExtension::setZeDriverVersionString(
+    ur_platform_handle_t_ *Platform) {
+  // Check if Intel Driver Version String is available. If yes, save the API
+  // pointer. The pointer will be used when reading the Driver Version for
+  // users.
+  ze_driver_handle_t DriverHandle = Platform->ZeDriver;
+  if (auto extension = Platform->zeDriverExtensionMap.find(
+          "ZE_intel_get_driver_version_string");
+      extension != Platform->zeDriverExtensionMap.end()) {
+    if (ZE_CALL_NOCHECK(zeDriverGetExtensionFunctionAddress,
+                        (DriverHandle, "zeIntelGetDriverVersionString",
+                         reinterpret_cast<void **>(
+                             &zeIntelGetDriverVersionStringPointer))) == 0) {
+      // Intel Driver Version String is Supported by this Driver.
+      Supported = true;
+    }
+  }
+}
+
+void ZeDriverVersionStringExtension::getDriverVersionString(
+    ze_driver_handle_t DriverHandle, char *pDriverVersion,
+    size_t *pVersionSize) {
+  ZE_CALL_NOCHECK(zeIntelGetDriverVersionStringPointer,
+                  (DriverHandle, pDriverVersion, pVersionSize));
+}
+
 void ZeUSMImportExtension::setZeUSMImport(ur_platform_handle_t_ *Platform) {
   // Check if USM hostptr import feature is available. If yes, save the API
   // pointers. The pointers will be used for both import/release of SYCL buffer

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -28,6 +28,10 @@ struct ur_platform_handle_t_ : public _ur_platform {
   // internal driver handle to allow calls to driver experimental apis.
   ze_driver_handle_t ZeDriverHandleExpTranslated;
 
+  // Helper wrapper for working with Driver Version String extension in Level
+  // Zero.
+  ZeDriverVersionStringExtension ZeDriverVersionString;
+
   // Cache versions info from zeDriverGetProperties.
   std::string ZeDriverVersion;
   std::string ZeDriverApiVersion;


### PR DESCRIPTION
- Given zeIntelGetDriverVersionString is available, then use the new driver extension to read the driver runtime version string.