### PR TITLE
[Bindless][Exp] Rename interop related structs/funcs with "external"

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -163,7 +163,6 @@ typedef enum ur_function_t {
     UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP = 141,               ///< Enumerator for ::urBindlessImagesMipmapGetLevelExp
     UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142,                    ///< Enumerator for ::urBindlessImagesMipmapFreeExp
     UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144,             ///< Enumerator for ::urBindlessImagesMapExternalArrayExp
-    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145,                ///< Enumerator for ::urBindlessImagesReleaseInteropExp
     UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP = 147,     ///< Enumerator for ::urBindlessImagesReleaseExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,        ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,      ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
@@ -227,6 +226,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP = 227,      ///< Enumerator for ::urBindlessImagesImportExternalSemaphoreExp
     UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP = 228,                         ///< Enumerator for ::urEnqueueNativeCommandExp
     UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED = 229,                  ///< Enumerator for ::urLoaderConfigSetMockingEnabled
+    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP = 230,        ///< Enumerator for ::urBindlessImagesReleaseExternalMemoryExp
     /// @cond
     UR_FUNCTION_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -277,8 +277,8 @@ typedef enum ur_structure_type_t {
     UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_POINTER_ARG_DESC = 0x1003,   ///< ::ur_exp_command_buffer_update_pointer_arg_desc_t
     UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_VALUE_ARG_DESC = 0x1004,     ///< ::ur_exp_command_buffer_update_value_arg_desc_t
     UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES = 0x2000,                   ///< ::ur_exp_sampler_mip_properties_t
-    UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC = 0x2001,                         ///< ::ur_exp_interop_mem_desc_t
-    UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC = 0x2002,                   ///< ::ur_exp_interop_semaphore_desc_t
+    UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC = 0x2001,                        ///< ::ur_exp_external_mem_desc_t
+    UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC = 0x2002,                  ///< ::ur_exp_external_semaphore_desc_t
     UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR = 0x2003,                          ///< ::ur_exp_file_descriptor_t
     UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE = 0x2004,                             ///< ::ur_exp_win32_handle_t
     UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES = 0x2005,                       ///< ::ur_exp_sampler_addr_modes_t
@@ -1655,9 +1655,9 @@ typedef enum ur_device_info_t {
                                                                      ///< device
     UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP = 0x200B,      ///< [::ur_bool_t] returns true if the device supports using images created
                                                                      ///< from individual mipmap levels
-    UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP = 0x200C,       ///< [::ur_bool_t] returns true if the device supports importing external
+    UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP = 0x200C,      ///< [::ur_bool_t] returns true if the device supports importing external
                                                                      ///< memory resources
-    UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP = 0x200E,    ///< [::ur_bool_t] returns true if the device supports importing external
+    UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP = 0x200E,   ///< [::ur_bool_t] returns true if the device supports importing external
                                                                      ///< semaphore resources
     UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP = 0x2010,                     ///< [::ur_bool_t] returns true if the device supports allocating and
                                                                      ///< accessing cubemap resources
@@ -5710,36 +5710,36 @@ urQueueFlush(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Command type
 typedef enum ur_command_t {
-    UR_COMMAND_KERNEL_LAUNCH = 0,                     ///< Event created by ::urEnqueueKernelLaunch
-    UR_COMMAND_EVENTS_WAIT = 1,                       ///< Event created by ::urEnqueueEventsWait
-    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,          ///< Event created by ::urEnqueueEventsWaitWithBarrier
-    UR_COMMAND_MEM_BUFFER_READ = 3,                   ///< Event created by ::urEnqueueMemBufferRead
-    UR_COMMAND_MEM_BUFFER_WRITE = 4,                  ///< Event created by ::urEnqueueMemBufferWrite
-    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,              ///< Event created by ::urEnqueueMemBufferReadRect
-    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,             ///< Event created by ::urEnqueueMemBufferWriteRect
-    UR_COMMAND_MEM_BUFFER_COPY = 7,                   ///< Event created by ::urEnqueueMemBufferCopy
-    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,              ///< Event created by ::urEnqueueMemBufferCopyRect
-    UR_COMMAND_MEM_BUFFER_FILL = 9,                   ///< Event created by ::urEnqueueMemBufferFill
-    UR_COMMAND_MEM_IMAGE_READ = 10,                   ///< Event created by ::urEnqueueMemImageRead
-    UR_COMMAND_MEM_IMAGE_WRITE = 11,                  ///< Event created by ::urEnqueueMemImageWrite
-    UR_COMMAND_MEM_IMAGE_COPY = 12,                   ///< Event created by ::urEnqueueMemImageCopy
-    UR_COMMAND_MEM_BUFFER_MAP = 14,                   ///< Event created by ::urEnqueueMemBufferMap
-    UR_COMMAND_MEM_UNMAP = 16,                        ///< Event created by ::urEnqueueMemUnmap
-    UR_COMMAND_USM_FILL = 17,                         ///< Event created by ::urEnqueueUSMFill
-    UR_COMMAND_USM_MEMCPY = 18,                       ///< Event created by ::urEnqueueUSMMemcpy
-    UR_COMMAND_USM_PREFETCH = 19,                     ///< Event created by ::urEnqueueUSMPrefetch
-    UR_COMMAND_USM_ADVISE = 20,                       ///< Event created by ::urEnqueueUSMAdvise
-    UR_COMMAND_USM_FILL_2D = 21,                      ///< Event created by ::urEnqueueUSMFill2D
-    UR_COMMAND_USM_MEMCPY_2D = 22,                    ///< Event created by ::urEnqueueUSMMemcpy2D
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 23,     ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
-    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 24,      ///< Event created by ::urEnqueueDeviceGlobalVariableRead
-    UR_COMMAND_READ_HOST_PIPE = 25,                   ///< Event created by ::urEnqueueReadHostPipe
-    UR_COMMAND_WRITE_HOST_PIPE = 26,                  ///< Event created by ::urEnqueueWriteHostPipe
-    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 0x1000,   ///< Event created by ::urCommandBufferEnqueueExp
-    UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP = 0x2000,   ///< Event created by ::urBindlessImagesWaitExternalSemaphoreExp
-    UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP = 0x2001, ///< Event created by ::urBindlessImagesSignalExternalSemaphoreExp
-    UR_COMMAND_TIMESTAMP_RECORDING_EXP = 0x2002,      ///< Event created by ::urEnqueueTimestampRecordingExp
-    UR_COMMAND_ENQUEUE_NATIVE_EXP = 0x2004,           ///< Event created by ::urEnqueueNativeCommandExp
+    UR_COMMAND_KERNEL_LAUNCH = 0,                      ///< Event created by ::urEnqueueKernelLaunch
+    UR_COMMAND_EVENTS_WAIT = 1,                        ///< Event created by ::urEnqueueEventsWait
+    UR_COMMAND_EVENTS_WAIT_WITH_BARRIER = 2,           ///< Event created by ::urEnqueueEventsWaitWithBarrier
+    UR_COMMAND_MEM_BUFFER_READ = 3,                    ///< Event created by ::urEnqueueMemBufferRead
+    UR_COMMAND_MEM_BUFFER_WRITE = 4,                   ///< Event created by ::urEnqueueMemBufferWrite
+    UR_COMMAND_MEM_BUFFER_READ_RECT = 5,               ///< Event created by ::urEnqueueMemBufferReadRect
+    UR_COMMAND_MEM_BUFFER_WRITE_RECT = 6,              ///< Event created by ::urEnqueueMemBufferWriteRect
+    UR_COMMAND_MEM_BUFFER_COPY = 7,                    ///< Event created by ::urEnqueueMemBufferCopy
+    UR_COMMAND_MEM_BUFFER_COPY_RECT = 8,               ///< Event created by ::urEnqueueMemBufferCopyRect
+    UR_COMMAND_MEM_BUFFER_FILL = 9,                    ///< Event created by ::urEnqueueMemBufferFill
+    UR_COMMAND_MEM_IMAGE_READ = 10,                    ///< Event created by ::urEnqueueMemImageRead
+    UR_COMMAND_MEM_IMAGE_WRITE = 11,                   ///< Event created by ::urEnqueueMemImageWrite
+    UR_COMMAND_MEM_IMAGE_COPY = 12,                    ///< Event created by ::urEnqueueMemImageCopy
+    UR_COMMAND_MEM_BUFFER_MAP = 14,                    ///< Event created by ::urEnqueueMemBufferMap
+    UR_COMMAND_MEM_UNMAP = 16,                         ///< Event created by ::urEnqueueMemUnmap
+    UR_COMMAND_USM_FILL = 17,                          ///< Event created by ::urEnqueueUSMFill
+    UR_COMMAND_USM_MEMCPY = 18,                        ///< Event created by ::urEnqueueUSMMemcpy
+    UR_COMMAND_USM_PREFETCH = 19,                      ///< Event created by ::urEnqueueUSMPrefetch
+    UR_COMMAND_USM_ADVISE = 20,                        ///< Event created by ::urEnqueueUSMAdvise
+    UR_COMMAND_USM_FILL_2D = 21,                       ///< Event created by ::urEnqueueUSMFill2D
+    UR_COMMAND_USM_MEMCPY_2D = 22,                     ///< Event created by ::urEnqueueUSMMemcpy2D
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_WRITE = 23,      ///< Event created by ::urEnqueueDeviceGlobalVariableWrite
+    UR_COMMAND_DEVICE_GLOBAL_VARIABLE_READ = 24,       ///< Event created by ::urEnqueueDeviceGlobalVariableRead
+    UR_COMMAND_READ_HOST_PIPE = 25,                    ///< Event created by ::urEnqueueReadHostPipe
+    UR_COMMAND_WRITE_HOST_PIPE = 26,                   ///< Event created by ::urEnqueueWriteHostPipe
+    UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP = 0x1000,    ///< Event created by ::urCommandBufferEnqueueExp
+    UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP = 0x2000,   ///< Event created by ::urBindlessImagesWaitExternalSemaphoreExp
+    UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP = 0x2001, ///< Event created by ::urBindlessImagesSignalExternalSemaphoreExp
+    UR_COMMAND_TIMESTAMP_RECORDING_EXP = 0x2002,       ///< Event created by ::urEnqueueTimestampRecordingExp
+    UR_COMMAND_ENQUEUE_NATIVE_EXP = 0x2004,            ///< Event created by ::urEnqueueNativeCommandExp
     /// @cond
     UR_COMMAND_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -7364,12 +7364,12 @@ typedef uintptr_t ur_exp_image_native_handle_t;
 typedef uintptr_t ur_exp_image_mem_native_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Handle of interop memory
-typedef struct ur_exp_interop_mem_handle_t_ *ur_exp_interop_mem_handle_t;
+/// @brief Handle of external memory
+typedef struct ur_exp_external_mem_handle_t_ *ur_exp_external_mem_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Handle of interop semaphore
-typedef struct ur_exp_interop_semaphore_handle_t_ *ur_exp_interop_semaphore_handle_t;
+/// @brief Handle of external semaphore
+typedef struct ur_exp_external_semaphore_handle_t_ *ur_exp_external_semaphore_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Dictates the type of memory copy.
@@ -7491,22 +7491,22 @@ typedef struct ur_exp_sampler_cubemap_properties_t {
 } ur_exp_sampler_cubemap_properties_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Describes an interop memory resource descriptor
-typedef struct ur_exp_interop_mem_desc_t {
+/// @brief Describes an external memory resource descriptor
+typedef struct ur_exp_external_mem_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
-                               ///< ::UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC
+                               ///< ::UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
-} ur_exp_interop_mem_desc_t;
+} ur_exp_external_mem_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Describes an interop semaphore resource descriptor
-typedef struct ur_exp_interop_semaphore_desc_t {
+/// @brief Describes an external semaphore resource descriptor
+typedef struct ur_exp_external_semaphore_desc_t {
     ur_structure_type_t stype; ///< [in] type of this structure, must be
-                               ///< ::UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
+                               ///< ::UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC
     const void *pNext;         ///< [in][optional] pointer to extension-specific structure
 
-} ur_exp_interop_semaphore_desc_t;
+} ur_exp_external_semaphore_desc_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Describes the (sub-)regions and the extent to be copied
@@ -7914,23 +7914,23 @@ urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropMemDesc`
-///         + `NULL == phInteropMem`
+///         + `NULL == pExternalMemDesc`
+///         + `NULL == phExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportExternalMemoryExp(
-    ur_context_handle_t hContext,               ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                 ///< [in] handle of the device object
-    size_t size,                                ///< [in] size of the external memory
-    ur_exp_external_mem_type_t memHandleType,   ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t *phInteropMem   ///< [out] interop memory handle to the external memory
+    ur_context_handle_t hContext,                 ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                   ///< [in] handle of the device object
+    size_t size,                                  ///< [in] size of the external memory
+    ur_exp_external_mem_type_t memHandleType,     ///< [in] type of external memory handle
+    ur_exp_external_mem_desc_t *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t *phExternalMem   ///< [out] external memory handle to the external memory
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Map an interop memory handle to an image memory handle
+/// @brief Map an external memory handle to an image memory handle
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -7940,7 +7940,7 @@ urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -7958,12 +7958,12 @@ urBindlessImagesMapExternalArrayExp(
     ur_device_handle_t hDevice,                  ///< [in] handle of the device object
     const ur_image_format_t *pImageFormat,       ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc,           ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t hInteropMem,     ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t hExternalMem,   ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *phImageMem ///< [out] image memory handle to the externally allocated memory
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Release interop memory
+/// @brief Release external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -7977,14 +7977,14 @@ urBindlessImagesMapExternalArrayExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesReleaseInteropExp(
-    ur_context_handle_t hContext,           ///< [in] handle of the context object
-    ur_device_handle_t hDevice,             ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t hInteropMem ///< [in][release] handle of interop memory to be destroyed
+urBindlessImagesReleaseExternalMemoryExp(
+    ur_context_handle_t hContext,             ///< [in] handle of the context object
+    ur_device_handle_t hDevice,               ///< [in] handle of the device object
+    ur_exp_external_mem_handle_t hExternalMem ///< [in][release] handle of external memory to be destroyed
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8005,17 +8005,17 @@ urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropSemaphoreDesc`
-///         + `NULL == phInteropSemaphore`
+///         + `NULL == pExternalSemaphoreDesc`
+///         + `NULL == phExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImportExternalSemaphoreExp(
-    ur_context_handle_t hContext,                           ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                             ///< [in] handle of the device object
-    ur_exp_external_semaphore_type_t semHandleType,         ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *phInteropSemaphore   ///< [out] interop semaphore handle to the external semaphore
+    ur_context_handle_t hContext,                             ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                               ///< [in] handle of the device object
+    ur_exp_external_semaphore_type_t semHandleType,           ///< [in] type of external memory handle
+    ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *phExternalSemaphore   ///< [out] external semaphore handle to the external semaphore
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8033,14 +8033,14 @@ urBindlessImagesImportExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropSemaphore`
+///         + `NULL == hExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesReleaseExternalSemaphoreExp(
-    ur_context_handle_t hContext,                       ///< [in] handle of the context object
-    ur_device_handle_t hDevice,                         ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_context_handle_t hContext,                         ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                           ///< [in] handle of the device object
+    ur_exp_external_semaphore_handle_t hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8062,21 +8062,21 @@ urBindlessImagesReleaseExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesWaitExternalSemaphoreExp(
-    ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
-    bool hasWaitValue,                            ///< [in] indicates whether the samephore is capable and should wait on a
-                                                  ///< certain value.
-                                                  ///< Otherwise the semaphore is treated like a binary state, and
-                                                  ///< `waitValue` is ignored.
-    uint64_t waitValue,                           ///< [in] the value to be waited on
-    uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                  ///< events that must be complete before this command can be executed.
-                                                  ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                                  ///< previously enqueued commands
-                                                  ///< must be complete.
-    ur_event_handle_t *phEvent                    ///< [out][optional] return an event object that identifies this particular
-                                                  ///< command instance.
+    ur_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+    ur_exp_external_semaphore_handle_t hSemaphore, ///< [in] external semaphore handle
+    bool hasWaitValue,                             ///< [in] indicates whether the samephore is capable and should wait on a
+                                                   ///< certain value.
+                                                   ///< Otherwise the semaphore is treated like a binary state, and
+                                                   ///< `waitValue` is ignored.
+    uint64_t waitValue,                            ///< [in] the value to be waited on
+    uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                   ///< events that must be complete before this command can be executed.
+                                                   ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                   ///< previously enqueued commands
+                                                   ///< must be complete.
+    ur_event_handle_t *phEvent                     ///< [out][optional] return an event object that identifies this particular
+                                                   ///< command instance.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8099,21 +8099,21 @@ urBindlessImagesWaitExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSignalExternalSemaphoreExp(
-    ur_queue_handle_t hQueue,                     ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t hSemaphore, ///< [in] interop semaphore handle
-    bool hasSignalValue,                          ///< [in] indicates whether the samephore is capable and should signal on a
-                                                  ///< certain value.
-                                                  ///< Otherwise the semaphore is treated like a binary state, and
-                                                  ///< `signalValue` is ignored.
-    uint64_t signalValue,                         ///< [in] the value to be signalled
-    uint32_t numEventsInWaitList,                 ///< [in] size of the event wait list
-    const ur_event_handle_t *phEventWaitList,     ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
-                                                  ///< events that must be complete before this command can be executed.
-                                                  ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
-                                                  ///< previously enqueued commands
-                                                  ///< must be complete.
-    ur_event_handle_t *phEvent                    ///< [out][optional] return an event object that identifies this particular
-                                                  ///< command instance.
+    ur_queue_handle_t hQueue,                      ///< [in] handle of the queue object
+    ur_exp_external_semaphore_handle_t hSemaphore, ///< [in] external semaphore handle
+    bool hasSignalValue,                           ///< [in] indicates whether the samephore is capable and should signal on a
+                                                   ///< certain value.
+                                                   ///< Otherwise the semaphore is treated like a binary state, and
+                                                   ///< `signalValue` is ignored.
+    uint64_t signalValue,                          ///< [in] the value to be signalled
+    uint32_t numEventsInWaitList,                  ///< [in] size of the event wait list
+    const ur_event_handle_t *phEventWaitList,      ///< [in][optional][range(0, numEventsInWaitList)] pointer to a list of
+                                                   ///< events that must be complete before this command can be executed.
+                                                   ///< If nullptr, the numEventsInWaitList must be 0, indicating that all
+                                                   ///< previously enqueued commands
+                                                   ///< must be complete.
+    ur_event_handle_t *phEvent                     ///< [out][optional] return an event object that identifies this particular
+                                                   ///< command instance.
 );
 
 #if !defined(__GNUC__)
@@ -11214,8 +11214,8 @@ typedef struct ur_bindless_images_import_external_memory_exp_params_t {
     ur_device_handle_t *phDevice;
     size_t *psize;
     ur_exp_external_mem_type_t *pmemHandleType;
-    ur_exp_interop_mem_desc_t **ppInteropMemDesc;
-    ur_exp_interop_mem_handle_t **pphInteropMem;
+    ur_exp_external_mem_desc_t **ppExternalMemDesc;
+    ur_exp_external_mem_handle_t **pphExternalMem;
 } ur_bindless_images_import_external_memory_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11227,19 +11227,19 @@ typedef struct ur_bindless_images_map_external_array_exp_params_t {
     ur_device_handle_t *phDevice;
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
-    ur_exp_interop_mem_handle_t *phInteropMem;
+    ur_exp_external_mem_handle_t *phExternalMem;
     ur_exp_image_mem_native_handle_t **pphImageMem;
 } ur_bindless_images_map_external_array_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urBindlessImagesReleaseInteropExp
+/// @brief Function parameters for urBindlessImagesReleaseExternalMemoryExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_bindless_images_release_interop_exp_params_t {
+typedef struct ur_bindless_images_release_external_memory_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_interop_mem_handle_t *phInteropMem;
-} ur_bindless_images_release_interop_exp_params_t;
+    ur_exp_external_mem_handle_t *phExternalMem;
+} ur_bindless_images_release_external_memory_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesImportExternalSemaphoreExp
@@ -11249,8 +11249,8 @@ typedef struct ur_bindless_images_import_external_semaphore_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
     ur_exp_external_semaphore_type_t *psemHandleType;
-    ur_exp_interop_semaphore_desc_t **ppInteropSemaphoreDesc;
-    ur_exp_interop_semaphore_handle_t **pphInteropSemaphore;
+    ur_exp_external_semaphore_desc_t **ppExternalSemaphoreDesc;
+    ur_exp_external_semaphore_handle_t **pphExternalSemaphore;
 } ur_bindless_images_import_external_semaphore_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11260,7 +11260,7 @@ typedef struct ur_bindless_images_import_external_semaphore_exp_params_t {
 typedef struct ur_bindless_images_release_external_semaphore_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_interop_semaphore_handle_t *phInteropSemaphore;
+    ur_exp_external_semaphore_handle_t *phExternalSemaphore;
 } ur_bindless_images_release_external_semaphore_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11269,7 +11269,7 @@ typedef struct ur_bindless_images_release_external_semaphore_exp_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_bindless_images_wait_external_semaphore_exp_params_t {
     ur_queue_handle_t *phQueue;
-    ur_exp_interop_semaphore_handle_t *phSemaphore;
+    ur_exp_external_semaphore_handle_t *phSemaphore;
     bool *phasWaitValue;
     uint64_t *pwaitValue;
     uint32_t *pnumEventsInWaitList;
@@ -11283,7 +11283,7 @@ typedef struct ur_bindless_images_wait_external_semaphore_exp_params_t {
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_bindless_images_signal_external_semaphore_exp_params_t {
     ur_queue_handle_t *phQueue;
-    ur_exp_interop_semaphore_handle_t *phSemaphore;
+    ur_exp_external_semaphore_handle_t *phSemaphore;
     bool *phasSignalValue;
     uint64_t *psignalValue;
     uint32_t *pnumEventsInWaitList;

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1626,8 +1626,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalMemoryExp_t)(
     ur_device_handle_t,
     size_t,
     ur_exp_external_mem_type_t,
-    ur_exp_interop_mem_desc_t *,
-    ur_exp_interop_mem_handle_t *);
+    ur_exp_external_mem_desc_t *,
+    ur_exp_external_mem_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesMapExternalArrayExp
@@ -1636,15 +1636,15 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMapExternalArrayExp_t)(
     ur_device_handle_t,
     const ur_image_format_t *,
     const ur_image_desc_t *,
-    ur_exp_interop_mem_handle_t,
+    ur_exp_external_mem_handle_t,
     ur_exp_image_mem_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urBindlessImagesReleaseInteropExp
-typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseInteropExp_t)(
+/// @brief Function-pointer for urBindlessImagesReleaseExternalMemoryExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseExternalMemoryExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_interop_mem_handle_t);
+    ur_exp_external_mem_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImportExternalSemaphoreExp
@@ -1652,21 +1652,21 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreExp_t
     ur_context_handle_t,
     ur_device_handle_t,
     ur_exp_external_semaphore_type_t,
-    ur_exp_interop_semaphore_desc_t *,
-    ur_exp_interop_semaphore_handle_t *);
+    ur_exp_external_semaphore_desc_t *,
+    ur_exp_external_semaphore_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesReleaseExternalSemaphoreExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseExternalSemaphoreExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_interop_semaphore_handle_t);
+    ur_exp_external_semaphore_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesWaitExternalSemaphoreExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesWaitExternalSemaphoreExp_t)(
     ur_queue_handle_t,
-    ur_exp_interop_semaphore_handle_t,
+    ur_exp_external_semaphore_handle_t,
     bool,
     uint64_t,
     uint32_t,
@@ -1677,7 +1677,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesWaitExternalSemaphoreExp_t)(
 /// @brief Function-pointer for urBindlessImagesSignalExternalSemaphoreExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSignalExternalSemaphoreExp_t)(
     ur_queue_handle_t,
-    ur_exp_interop_semaphore_handle_t,
+    ur_exp_external_semaphore_handle_t,
     bool,
     uint64_t,
     uint32_t,
@@ -1699,7 +1699,7 @@ typedef struct ur_bindless_images_exp_dditable_t {
     ur_pfnBindlessImagesMipmapFreeExp_t pfnMipmapFreeExp;
     ur_pfnBindlessImagesImportExternalMemoryExp_t pfnImportExternalMemoryExp;
     ur_pfnBindlessImagesMapExternalArrayExp_t pfnMapExternalArrayExp;
-    ur_pfnBindlessImagesReleaseInteropExp_t pfnReleaseInteropExp;
+    ur_pfnBindlessImagesReleaseExternalMemoryExp_t pfnReleaseExternalMemoryExp;
     ur_pfnBindlessImagesImportExternalSemaphoreExp_t pfnImportExternalSemaphoreExp;
     ur_pfnBindlessImagesReleaseExternalSemaphoreExp_t pfnReleaseExternalSemaphoreExp;
     ur_pfnBindlessImagesWaitExternalSemaphoreExp_t pfnWaitExternalSemaphoreExp;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -947,20 +947,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerAddrModes(const struct ur_e
 UR_APIEXPORT ur_result_t UR_APICALL urPrintExpSamplerCubemapProperties(const struct ur_exp_sampler_cubemap_properties_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_exp_interop_mem_desc_t struct
+/// @brief Print ur_exp_external_mem_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropMemDesc(const struct ur_exp_interop_mem_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpExternalMemDesc(const struct ur_exp_external_mem_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_exp_interop_semaphore_desc_t struct
+/// @brief Print ur_exp_external_semaphore_desc_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintExpInteropSemaphoreDesc(const struct ur_exp_interop_semaphore_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintExpExternalSemaphoreDesc(const struct ur_exp_external_semaphore_desc_t params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_exp_image_copy_region_t struct
@@ -2147,12 +2147,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalMemoryExp
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesMapExternalArrayExpParams(const struct ur_bindless_images_map_external_array_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_release_interop_exp_params_t struct
+/// @brief Print ur_bindless_images_release_external_memory_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseInteropExpParams(const struct ur_bindless_images_release_interop_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseExternalMemoryExpParams(const struct ur_bindless_images_release_external_memory_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_import_external_semaphore_exp_params_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -47,9 +47,9 @@ struct is_handle<ur_physical_mem_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_usm_pool_handle_t> : std::true_type {};
 template <>
-struct is_handle<ur_exp_interop_mem_handle_t> : std::true_type {};
+struct is_handle<ur_exp_external_mem_handle_t> : std::true_type {};
 template <>
-struct is_handle<ur_exp_interop_semaphore_handle_t> : std::true_type {};
+struct is_handle<ur_exp_external_semaphore_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_exp_win32_handle_t> : std::true_type {};
 template <>
@@ -332,8 +332,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_mip_properties_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_addr_modes_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_sampler_cubemap_properties_t params);
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_mem_desc_t params);
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_interop_semaphore_desc_t params);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_external_mem_desc_t params);
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_external_semaphore_desc_t params);
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_exp_image_copy_region_t params);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_info_t value);
 inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_command_info_t value);
@@ -750,9 +750,6 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP";
         break;
-    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP:
-        os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP";
-        break;
     case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP";
         break;
@@ -942,6 +939,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED:
         os << "UR_FUNCTION_LOADER_CONFIG_SET_MOCKING_ENABLED";
         break;
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -1077,11 +1077,11 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_structure_type_t value
     case UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES:
         os << "UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES";
         break;
-    case UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC:
-        os << "UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC";
+    case UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC";
         break;
-    case UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC:
-        os << "UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC";
+    case UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC:
+        os << "UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC";
         break;
     case UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR:
         os << "UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR";
@@ -1323,13 +1323,13 @@ inline ur_result_t printStruct(std::ostream &os, const void *ptr) {
         printPtr(os, pstruct);
     } break;
 
-    case UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC: {
-        const ur_exp_interop_mem_desc_t *pstruct = (const ur_exp_interop_mem_desc_t *)ptr;
+    case UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC: {
+        const ur_exp_external_mem_desc_t *pstruct = (const ur_exp_external_mem_desc_t *)ptr;
         printPtr(os, pstruct);
     } break;
 
-    case UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC: {
-        const ur_exp_interop_semaphore_desc_t *pstruct = (const ur_exp_interop_semaphore_desc_t *)ptr;
+    case UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC: {
+        const ur_exp_external_semaphore_desc_t *pstruct = (const ur_exp_external_semaphore_desc_t *)ptr;
         printPtr(os, pstruct);
     } break;
 
@@ -2580,11 +2580,11 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP";
         break;
-    case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP:
-        os << "UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP";
+    case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP";
         break;
-    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP:
-        os << "UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP";
+    case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP:
+        os << "UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP";
         break;
     case UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP:
         os << "UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP";
@@ -4214,7 +4214,7 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
 
         os << ")";
     } break;
-    case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP: {
+    case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP: {
         const ur_bool_t *tptr = (const ur_bool_t *)ptr;
         if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
@@ -4226,7 +4226,7 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
 
         os << ")";
     } break;
-    case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP: {
+    case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP: {
         const ur_bool_t *tptr = (const ur_bool_t *)ptr;
         if (sizeof(ur_bool_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_bool_t) << ")";
@@ -8890,11 +8890,11 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_command_t value) {
     case UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP:
         os << "UR_COMMAND_COMMAND_BUFFER_ENQUEUE_EXP";
         break;
-    case UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP:
-        os << "UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP";
+    case UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP:
+        os << "UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP";
         break;
-    case UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP:
-        os << "UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP";
+    case UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP:
+        os << "UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP";
         break;
     case UR_COMMAND_TIMESTAMP_RECORDING_EXP:
         os << "UR_COMMAND_TIMESTAMP_RECORDING_EXP";
@@ -9591,11 +9591,11 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_sampler_cu
     return os;
 }
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_exp_interop_mem_desc_t type
+/// @brief Print operator for the ur_exp_external_mem_desc_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_interop_mem_desc_t params) {
-    os << "(struct ur_exp_interop_mem_desc_t){";
+inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_external_mem_desc_t params) {
+    os << "(struct ur_exp_external_mem_desc_t){";
 
     os << ".stype = ";
 
@@ -9611,11 +9611,11 @@ inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_interop_me
     return os;
 }
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_exp_interop_semaphore_desc_t type
+/// @brief Print operator for the ur_exp_external_semaphore_desc_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_interop_semaphore_desc_t params) {
-    os << "(struct ur_exp_interop_semaphore_desc_t){";
+inline std::ostream &operator<<(std::ostream &os, const struct ur_exp_external_semaphore_desc_t params) {
+    os << "(struct ur_exp_external_semaphore_desc_t){";
 
     os << ".stype = ";
 
@@ -15132,16 +15132,16 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << *(params->pmemHandleType);
 
     os << ", ";
-    os << ".pInteropMemDesc = ";
+    os << ".pExternalMemDesc = ";
 
     ur::details::printPtr(os,
-                          *(params->ppInteropMemDesc));
+                          *(params->ppExternalMemDesc));
 
     os << ", ";
-    os << ".phInteropMem = ";
+    os << ".phExternalMem = ";
 
     ur::details::printPtr(os,
-                          *(params->pphInteropMem));
+                          *(params->pphExternalMem));
 
     return os;
 }
@@ -15176,10 +15176,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->ppImageDesc));
 
     os << ", ";
-    os << ".hInteropMem = ";
+    os << ".hExternalMem = ";
 
     ur::details::printPtr(os,
-                          *(params->phInteropMem));
+                          *(params->phExternalMem));
 
     os << ", ";
     os << ".phImageMem = ";
@@ -15191,10 +15191,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_bindless_images_release_interop_exp_params_t type
+/// @brief Print operator for the ur_bindless_images_release_external_memory_exp_params_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_release_interop_exp_params_t *params) {
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_release_external_memory_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -15208,10 +15208,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->phDevice));
 
     os << ", ";
-    os << ".hInteropMem = ";
+    os << ".hExternalMem = ";
 
     ur::details::printPtr(os,
-                          *(params->phInteropMem));
+                          *(params->phExternalMem));
 
     return os;
 }
@@ -15239,16 +15239,16 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << *(params->psemHandleType);
 
     os << ", ";
-    os << ".pInteropSemaphoreDesc = ";
+    os << ".pExternalSemaphoreDesc = ";
 
     ur::details::printPtr(os,
-                          *(params->ppInteropSemaphoreDesc));
+                          *(params->ppExternalSemaphoreDesc));
 
     os << ", ";
-    os << ".phInteropSemaphore = ";
+    os << ".phExternalSemaphore = ";
 
     ur::details::printPtr(os,
-                          *(params->pphInteropSemaphore));
+                          *(params->pphExternalSemaphore));
 
     return os;
 }
@@ -15271,10 +15271,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
                           *(params->phDevice));
 
     os << ", ";
-    os << ".hInteropSemaphore = ";
+    os << ".hExternalSemaphore = ";
 
     ur::details::printPtr(os,
-                          *(params->phInteropSemaphore));
+                          *(params->phExternalSemaphore));
 
     return os;
 }
@@ -17804,8 +17804,8 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     case UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP: {
         os << (const struct ur_bindless_images_map_external_array_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP: {
-        os << (const struct ur_bindless_images_release_interop_exp_params_t *)params;
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP: {
+        os << (const struct ur_bindless_images_release_external_memory_exp_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP: {
         os << (const struct ur_bindless_images_import_external_semaphore_exp_params_t *)params;

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -66,8 +66,8 @@ Enums
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ${x}_structure_type_t
     ${X}_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES
-    ${X}_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC
-    ${X}_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC
+    ${X}_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC
+    ${X}_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC
     ${X}_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
     ${X}_STRUCTURE_TYPE_EXP_WIN32_HANDLE
     ${X}_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
@@ -86,8 +86,8 @@ Enums
     * ${X}_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP
     * ${X}_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP
     * ${X}_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP
-    * ${X}_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP
-    * ${X}_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP
+    * ${X}_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP
+    * ${X}_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP
     * ${X}_DEVICE_INFO_CUBEMAP_SUPPORT_EXP
     * ${X}_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP
     * ${X}_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_EXP
@@ -101,8 +101,8 @@ Enums
     * ${X}_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_EXP
 
 * ${x}_command_t
-    * ${X}_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP
-    * ${X}_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP
+    * ${X}_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP
+    * ${X}_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP
 
 * ${x}_exp_image_copy_flags_t
     * ${X}_EXP_IMAGE_COPY_FLAG_HOST_TO_DEVICE
@@ -137,7 +137,7 @@ Enums
     * ${X}_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
-    * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP
+    * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
@@ -151,10 +151,10 @@ Types
 * ${x}_exp_sampler_mip_properties_t
 * ${x}_exp_image_native_handle_t
 * ${x}_exp_image_mem_native_handle_t
-* ${x}_exp_interop_mem_handle_t
-* ${x}_exp_interop_semaphore_handle_t
-* ${x}_exp_interop_mem_desc_t
-* ${x}_exp_interop_semaphore_desc_t
+* ${x}_exp_external_mem_handle_t
+* ${x}_exp_external_semaphore_handle_t
+* ${x}_exp_external_mem_desc_t
+* ${x}_exp_external_semaphore_desc_t
 * ${x}_exp_file_descriptor_t
 * ${x}_exp_win32_handle_t
 * ${x}_exp_sampler_addr_modes_t
@@ -181,7 +181,7 @@ Functions
 * Interop
    * ${x}BindlessImagesImportExternalMemoryExp
    * ${x}BindlessImagesMapExternalArrayExp
-   * ${x}BindlessImagesReleaseInteropExp
+   * ${x}BindlessImagesReleaseExternalMemoryExp
    * ${x}BindlessImagesImportExternalSemaphoreExp
    * ${x}BindlessImagesReleaseExternalSemaphoreExp
    * ${x}BindlessImagesWaitExternalSemaphoreExp
@@ -246,6 +246,9 @@ Changelog
 +----------+-------------------------------------------------------------+
 | 16.0     || Update device queries to resolve inconsistencies and       |
 |          || missing queries.                                           |
++----------+-------------------------------------------------------------+
+| 17.0     || Rename interop related structs and funcs with "external"   |
+|          || keyword over "interop".                                    |
 +----------+-------------------------------------------------------------+
 
 Contributors

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -23,14 +23,14 @@ class: $xBindlessImages
 name: "$x_exp_image_mem_native_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
-desc: "Handle of interop memory"
+desc: "Handle of external memory"
 class: $xBindlessImages
-name: "$x_exp_interop_mem_handle_t"
+name: "$x_exp_external_mem_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
-desc: "Handle of interop semaphore"
+desc: "Handle of external semaphore"
 class: $xBindlessImages
-name: "$x_exp_interop_semaphore_handle_t"
+name: "$x_exp_external_semaphore_handle_t"
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true
@@ -74,10 +74,10 @@ etors:
     - name: MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP
       value: "0x200B"
       desc: "[$x_bool_t] returns true if the device supports using images created from individual mipmap levels"
-    - name: INTEROP_MEMORY_IMPORT_SUPPORT_EXP
+    - name: EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP
       value: "0x200C"
       desc: "[$x_bool_t] returns true if the device supports importing external memory resources"
-    - name: INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP
+    - name: EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP
       value: "0x200E"
       desc: "[$x_bool_t] returns true if the device supports importing external semaphore resources"
     - name: CUBEMAP_SUPPORT_EXP
@@ -122,11 +122,11 @@ etors:
     - name: EXP_SAMPLER_MIP_PROPERTIES
       desc: $x_exp_sampler_mip_properties_t
       value: "0x2000"
-    - name: EXP_INTEROP_MEM_DESC
-      desc: $x_exp_interop_mem_desc_t
+    - name: EXP_EXTERNAL_MEM_DESC
+      desc: $x_exp_external_mem_desc_t
       value: "0x2001"
-    - name: EXP_INTEROP_SEMAPHORE_DESC
-      desc: $x_exp_interop_semaphore_desc_t
+    - name: EXP_EXTERNAL_SEMAPHORE_DESC
+      desc: $x_exp_external_semaphore_desc_t
       value: "0x2002"
     - name: EXP_FILE_DESCRIPTOR
       desc: $x_exp_file_descriptor_t
@@ -149,10 +149,10 @@ extend: true
 desc: "Command Type experimental enumerations."
 name: $x_command_t
 etors:
-    - name: INTEROP_SEMAPHORE_WAIT_EXP
+    - name: EXTERNAL_SEMAPHORE_WAIT_EXP
       value: "0x2000"
       desc: Event created by $xBindlessImagesWaitExternalSemaphoreExp
-    - name: INTEROP_SEMAPHORE_SIGNAL_EXP
+    - name: EXTERNAL_SEMAPHORE_SIGNAL_EXP
       value: "0x2001"
       desc: Event created by $xBindlessImagesSignalExternalSemaphoreExp
 --- #--------------------------------------------------------------------------
@@ -278,16 +278,16 @@ members:
       desc: "[in] enables or disables seamless cubemap filtering between cubemap faces"
 --- #--------------------------------------------------------------------------
 type: struct
-desc: "Describes an interop memory resource descriptor"
+desc: "Describes an external memory resource descriptor"
 class: $xBindlessImages
-name: $x_exp_interop_mem_desc_t
+name: $x_exp_external_mem_desc_t
 base: $x_base_desc_t
 members: []
 --- #--------------------------------------------------------------------------
 type: struct
-desc: "Describes an interop semaphore resource descriptor"
+desc: "Describes an external semaphore resource descriptor"
 class: $xBindlessImages
-name: $x_exp_interop_semaphore_desc_t
+name: $x_exp_external_semaphore_desc_t
 base: $x_base_desc_t
 members: []
 --- #--------------------------------------------------------------------------
@@ -692,19 +692,19 @@ params:
     - type: $x_exp_external_mem_type_t
       name: memHandleType
       desc: "[in] type of external memory handle"
-    - type: $x_exp_interop_mem_desc_t*
-      name: pInteropMemDesc
-      desc: "[in] the interop memory descriptor"
-    - type: $x_exp_interop_mem_handle_t*
-      name: phInteropMem
-      desc: "[out] interop memory handle to the external memory"
+    - type: $x_exp_external_mem_desc_t*
+      name: pExternalMemDesc
+      desc: "[in] the external memory descriptor"
+    - type: $x_exp_external_mem_handle_t*
+      name: phExternalMem
+      desc: "[out] external memory handle to the external memory"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Map an interop memory handle to an image memory handle"
+desc: "Map an external memory handle to an image memory handle"
 class: $xBindlessImages
 name: MapExternalArrayExp
 ordinal: "0"
@@ -721,9 +721,9 @@ params:
     - type: "const $x_image_desc_t*"
       name: pImageDesc
       desc: "[in] pointer to image description"
-    - type: $x_exp_interop_mem_handle_t
-      name: hInteropMem
-      desc: "[in] interop memory handle to the external memory"
+    - type: $x_exp_external_mem_handle_t
+      name: hExternalMem
+      desc: "[in] external memory handle to the external memory"
     - type: $x_exp_image_mem_native_handle_t*
       name: phImageMem
       desc: "[out] image memory handle to the externally allocated memory"
@@ -737,9 +737,9 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Release interop memory"
+desc: "Release external memory"
 class: $xBindlessImages
-name: ReleaseInteropExp
+name: ReleaseExternalMemoryExp
 ordinal: "0"
 analogue:
     - "**cuDestroyExternalMemory**"
@@ -750,9 +750,9 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_interop_mem_handle_t
-      name: hInteropMem
-      desc: "[in][release] handle of interop memory to be destroyed"
+    - type: $x_exp_external_mem_handle_t
+      name: hExternalMem
+      desc: "[in][release] handle of external memory to be destroyed"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -774,12 +774,12 @@ params:
     - type: $x_exp_external_semaphore_type_t
       name: semHandleType
       desc: "[in] type of external memory handle"
-    - type: $x_exp_interop_semaphore_desc_t*
-      name: pInteropSemaphoreDesc
-      desc: "[in] the interop semaphore descriptor"
-    - type: $x_exp_interop_semaphore_handle_t*
-      name: phInteropSemaphore
-      desc: "[out] interop semaphore handle to the external semaphore"
+    - type: $x_exp_external_semaphore_desc_t*
+      name: pExternalSemaphoreDesc
+      desc: "[in] the external semaphore descriptor"
+    - type: $x_exp_external_semaphore_handle_t*
+      name: phExternalSemaphore
+      desc: "[out] external semaphore handle to the external semaphore"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -798,9 +798,9 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_interop_semaphore_handle_t
-      name: hInteropSemaphore
-      desc: "[in][release] handle of interop semaphore to be destroyed"
+    - type: $x_exp_external_semaphore_handle_t
+      name: hExternalSemaphore
+      desc: "[in][release] handle of external semaphore to be destroyed"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -816,9 +816,9 @@ params:
     - type: $x_queue_handle_t
       name: hQueue
       desc: "[in] handle of the queue object"
-    - type: $x_exp_interop_semaphore_handle_t
+    - type: $x_exp_external_semaphore_handle_t
       name: hSemaphore
-      desc: "[in] interop semaphore handle"
+      desc: "[in] external semaphore handle"
     - type: bool
       name: hasWaitValue
       desc: |
@@ -855,9 +855,9 @@ params:
     - type: $x_queue_handle_t
       name: hQueue
       desc: "[in] handle of the queue object"
-    - type: $x_exp_interop_semaphore_handle_t
+    - type: $x_exp_external_semaphore_handle_t
       name: hSemaphore
-      desc: "[in] interop semaphore handle"
+      desc: "[in] external semaphore handle"
     - type: bool
       name: hasSignalValue
       desc: | 

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -403,9 +403,6 @@ etors:
 - name: BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
   desc: Enumerator for $xBindlessImagesMapExternalArrayExp
   value: '144'
-- name: BINDLESS_IMAGES_RELEASE_INTEROP_EXP
-  desc: Enumerator for $xBindlessImagesReleaseInteropExp
-  value: '145'
 - name: BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP
   desc: Enumerator for $xBindlessImagesReleaseExternalSemaphoreExp
   value: '147'
@@ -595,6 +592,9 @@ etors:
 - name: LOADER_CONFIG_SET_MOCKING_ENABLED
   desc: Enumerator for $xLoaderConfigSetMockingEnabled
   value: '229'
+- name: BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP
+  desc: Enumerator for $xBindlessImagesReleaseExternalMemoryExp
+  value: '230'
 ---
 type: enum
 desc: Defines structure types

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -899,11 +899,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(true);
   }
 
-  case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP: {
+  case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP: {
     // CUDA supports importing external memory.
     return ReturnValue(true);
   }
-  case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP: {
+  case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP: {
     // CUDA supports importing external semaphores.
     return ReturnValue(true);
   }

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -1058,8 +1058,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, size_t size,
     ur_exp_external_mem_type_t memHandleType,
-    ur_exp_interop_mem_desc_t *pInteropMemDesc,
-    ur_exp_interop_mem_handle_t *phInteropMem) {
+    ur_exp_external_mem_desc_t *pExternalMemDesc,
+    ur_exp_external_mem_handle_t *phExternalMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1071,7 +1071,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     CUDA_EXTERNAL_MEMORY_HANDLE_DESC extMemDesc = {};
     extMemDesc.size = size;
 
-    void *pNext = const_cast<void *>(pInteropMemDesc->pNext);
+    void *pNext = const_cast<void *>(pExternalMemDesc->pNext);
     while (pNext != nullptr) {
       const ur_base_desc_t *BaseDesc =
           static_cast<const ur_base_desc_t *>(pNext);
@@ -1103,7 +1103,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
     CUexternalMemory extMem;
     UR_CHECK_ERROR(cuImportExternalMemory(&extMem, &extMemDesc));
-    *phInteropMem = (ur_exp_interop_mem_handle_t)extMem;
+    *phExternalMem = (ur_exp_external_mem_handle_t)extMem;
 
   } catch (ur_result_t Err) {
     return Err;
@@ -1117,7 +1117,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    ur_exp_interop_mem_handle_t hInteropMem,
+    ur_exp_external_mem_handle_t hExternalMem,
     ur_exp_image_mem_native_handle_t *phImageMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
@@ -1150,7 +1150,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     // If desired, a CUarray is retrieved from the mipmaps 0th level
     CUmipmappedArray memMipMap;
     UR_CHECK_ERROR(cuExternalMemoryGetMappedMipmappedArray(
-        &memMipMap, (CUexternalMemory)hInteropMem, &mipmapDesc));
+        &memMipMap, (CUexternalMemory)hExternalMem, &mipmapDesc));
 
     if (pImageDesc->numMipLevel > 1) {
       *phImageMem = (ur_exp_image_mem_native_handle_t)memMipMap;
@@ -1169,9 +1169,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_interop_mem_handle_t hInteropMem) {
+    ur_exp_external_mem_handle_t hExternalMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1179,7 +1179,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 
   try {
     ScopedContext Active(hDevice);
-    UR_CHECK_ERROR(cuDestroyExternalMemory((CUexternalMemory)hInteropMem));
+    UR_CHECK_ERROR(cuDestroyExternalMemory((CUexternalMemory)hExternalMem));
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {
@@ -1191,8 +1191,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_external_semaphore_type_t semHandleType,
-    ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle) {
+    ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
+    ur_exp_external_semaphore_handle_t *phExternalSemaphoreHandle) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1203,7 +1203,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
     CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC extSemDesc = {};
 
-    void *pNext = const_cast<void *>(pInteropSemaphoreDesc->pNext);
+    void *pNext = const_cast<void *>(pExternalSemaphoreDesc->pNext);
     while (pNext != nullptr) {
       const ur_base_desc_t *BaseDesc =
           static_cast<const ur_base_desc_t *>(pNext);
@@ -1234,7 +1234,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     CUexternalSemaphore semaphore;
     UR_CHECK_ERROR(cuImportExternalSemaphore(&semaphore, &extSemDesc));
 
-    *phInteropSemaphoreHandle = (ur_exp_interop_semaphore_handle_t)semaphore;
+    *phExternalSemaphoreHandle = (ur_exp_external_semaphore_handle_t)semaphore;
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {
@@ -1245,7 +1245,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
+    ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1254,7 +1254,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
   try {
     ScopedContext Active(hDevice);
     UR_CHECK_ERROR(
-        cuDestroyExternalSemaphore((CUexternalSemaphore)hInteropSemaphore));
+        cuDestroyExternalSemaphore((CUexternalSemaphore)hExternalSemaphore));
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {
@@ -1264,7 +1264,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
-    ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
+    ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasValue, uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
 
@@ -1286,7 +1286,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
     if (phEvent) {
       auto NewEvent = ur_event_handle_t_::makeNative(
-          UR_COMMAND_INTEROP_SEMAPHORE_WAIT_EXP, hQueue, Stream);
+          UR_COMMAND_EXTERNAL_SEMAPHORE_WAIT_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
     }
@@ -1299,7 +1299,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
-    ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
+    ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasValue, uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
 
@@ -1321,7 +1321,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
     if (phEvent) {
       auto NewEvent = ur_event_handle_t_::makeNative(
-          UR_COMMAND_INTEROP_SEMAPHORE_SIGNAL_EXP, hQueue, Stream);
+          UR_COMMAND_EXTERNAL_SEMAPHORE_SIGNAL_EXP, hQueue, Stream);
       NewEvent->record();
       *phEvent = NewEvent;
     }

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -340,7 +340,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImportExternalMemoryExp =
       urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
-  pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
+  pDdiTable->pfnReleaseExternalMemoryExp =
+      urBindlessImagesReleaseExternalMemoryExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnReleaseExternalSemaphoreExp =

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -117,8 +117,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
     [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
-    [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_desc_t *pExternalMemDesc,
+    [[maybe_unused]] ur_exp_external_mem_handle_t *phExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -127,15 +127,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -143,21 +143,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
-    [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
@@ -167,7 +167,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1002,11 +1002,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     // L0 does not support creation of images from individual mipmap levels.
     return ReturnValue(false);
   }
-  case UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP: {
+  case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP: {
     // L0 does not support importing external memory.
     return ReturnValue(false);
   }
-  case UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP: {
+  case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP: {
     // L0 does not support importing external semaphores.
     return ReturnValue(false);
   }

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -984,17 +984,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, size_t size,
     ur_exp_external_mem_type_t memHandleType,
-    ur_exp_interop_mem_desc_t *pInteropMemDesc,
-    ur_exp_interop_mem_handle_t *phInteropMem) {
+    ur_exp_external_mem_desc_t *pExternalMemDesc,
+    ur_exp_external_mem_handle_t *phExternalMem) {
 
   UR_ASSERT(hContext && hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-  UR_ASSERT(pInteropMemDesc && phInteropMem,
+  UR_ASSERT(pExternalMemDesc && phExternalMem,
             UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
   struct ur_ze_external_memory_data *externalMemoryData =
       new struct ur_ze_external_memory_data;
 
-  void *pNext = const_cast<void *>(pInteropMemDesc->pNext);
+  void *pNext = const_cast<void *>(pExternalMemDesc->pNext);
   while (pNext != nullptr) {
     const ur_base_desc_t *BaseDesc = static_cast<const ur_base_desc_t *>(pNext);
     if (BaseDesc->stype == UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR) {
@@ -1034,23 +1034,23 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
   }
   externalMemoryData->size = size;
 
-  *phInteropMem =
-      reinterpret_cast<ur_exp_interop_mem_handle_t>(externalMemoryData);
+  *phExternalMem =
+      reinterpret_cast<ur_exp_external_mem_handle_t>(externalMemoryData);
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    ur_exp_interop_mem_handle_t hInteropMem,
+    ur_exp_external_mem_handle_t hExternalMem,
     ur_exp_image_mem_native_handle_t *phImageMem) {
 
-  UR_ASSERT(hContext && hDevice && hInteropMem,
+  UR_ASSERT(hContext && hDevice && hExternalMem,
             UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(pImageFormat && pImageDesc, UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
   struct ur_ze_external_memory_data *externalMemoryData =
-      reinterpret_cast<ur_ze_external_memory_data *>(hInteropMem);
+      reinterpret_cast<ur_ze_external_memory_data *>(hExternalMem);
 
   ze_image_bindless_exp_desc_t ZeImageBindlessDesc = {};
   ZeImageBindlessDesc.stype = ZE_STRUCTURE_TYPE_BINDLESS_IMAGE_EXP_DESC;
@@ -1074,15 +1074,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_interop_mem_handle_t hInteropMem) {
+    ur_exp_external_mem_handle_t hExternalMem) {
 
-  UR_ASSERT(hContext && hDevice && hInteropMem,
+  UR_ASSERT(hContext && hDevice && hExternalMem,
             UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
   struct ur_ze_external_memory_data *externalMemoryData =
-      reinterpret_cast<ur_ze_external_memory_data *>(hInteropMem);
+      reinterpret_cast<ur_ze_external_memory_data *>(hExternalMem);
 
   UR_CALL(urMemRelease(externalMemoryData->urMemoryHandle));
 
@@ -1107,13 +1107,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_external_semaphore_type_t semHandleType,
-    ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    ur_exp_interop_semaphore_handle_t *phInteropSemaphoreHandle) {
+    ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
+    ur_exp_external_semaphore_handle_t *phExternalSemaphoreHandle) {
   std::ignore = hContext;
   std::ignore = hDevice;
   std::ignore = semHandleType;
-  std::ignore = pInteropSemaphoreDesc;
-  std::ignore = phInteropSemaphoreHandle;
+  std::ignore = pExternalSemaphoreDesc;
+  std::ignore = phExternalSemaphoreHandle;
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -1121,17 +1121,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
+    ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   std::ignore = hContext;
   std::ignore = hDevice;
-  std::ignore = hInteropSemaphore;
+  std::ignore = hExternalSemaphore;
   logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
                 "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t ur_queue_handle_legacy_t_::bindlessImagesWaitExternalSemaphoreExp(
-    ur_exp_interop_semaphore_handle_t hSemaphore, bool hasValue,
+    ur_exp_external_semaphore_handle_t hSemaphore, bool hasValue,
     uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hSemaphore;
@@ -1146,7 +1146,7 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesWaitExternalSemaphoreExp(
 }
 
 ur_result_t ur_queue_handle_legacy_t_::bindlessImagesSignalExternalSemaphoreExp(
-    ur_exp_interop_semaphore_handle_t hSemaphore, bool hasValue,
+    ur_exp_external_semaphore_handle_t hSemaphore, bool hasValue,
     uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hSemaphore;

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -390,12 +390,12 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesWaitExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t hSemaphore, bool hasWaitValue,
+      ur_exp_external_semaphore_handle_t hSemaphore, bool hasWaitValue,
       uint64_t waitValue, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesSignalExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t hSemaphore, bool hasSignalValue,
+      ur_exp_external_semaphore_handle_t hSemaphore, bool hasSignalValue,
       uint64_t signalValue, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;

--- a/source/adapters/level_zero/queue_api.cpp
+++ b/source/adapters/level_zero/queue_api.cpp
@@ -268,7 +268,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
       phEventWaitList, phEvent);
 }
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
-    ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
+    ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasWaitValue, uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   return hQueue->bindlessImagesWaitExternalSemaphoreExp(
@@ -276,7 +276,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
       phEvent);
 }
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
-    ur_queue_handle_t hQueue, ur_exp_interop_semaphore_handle_t hSemaphore,
+    ur_queue_handle_t hQueue, ur_exp_external_semaphore_handle_t hSemaphore,
     bool hasSignalValue, uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   return hQueue->bindlessImagesSignalExternalSemaphoreExp(

--- a/source/adapters/level_zero/queue_api.hpp
+++ b/source/adapters/level_zero/queue_api.hpp
@@ -128,10 +128,10 @@ struct ur_queue_handle_t_ {
       ur_exp_image_copy_region_t *, ur_exp_image_copy_flags_t, uint32_t,
       const ur_event_handle_t *, ur_event_handle_t *) = 0;
   virtual ur_result_t bindlessImagesWaitExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t, bool, uint64_t, uint32_t,
+      ur_exp_external_semaphore_handle_t, bool, uint64_t, uint32_t,
       const ur_event_handle_t *, ur_event_handle_t *) = 0;
   virtual ur_result_t bindlessImagesSignalExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t, bool, uint64_t, uint32_t,
+      ur_exp_external_semaphore_handle_t, bool, uint64_t, uint32_t,
       const ur_event_handle_t *, ur_event_handle_t *) = 0;
   virtual ur_result_t enqueueCooperativeKernelLaunchExp(
       ur_kernel_handle_t, uint32_t, const size_t *, const size_t *,

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -387,7 +387,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImportExternalMemoryExp =
       urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
-  pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
+  pDdiTable->pfnReleaseExternalMemoryExp =
+      urBindlessImagesReleaseExternalMemoryExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnReleaseExternalSemaphoreExp =

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -504,7 +504,7 @@ ur_result_t ur_queue_immediate_in_order_t::bindlessImagesImageCopyExp(
 
 ur_result_t
 ur_queue_immediate_in_order_t::bindlessImagesWaitExternalSemaphoreExp(
-    ur_exp_interop_semaphore_handle_t hSemaphore, bool hasWaitValue,
+    ur_exp_external_semaphore_handle_t hSemaphore, bool hasWaitValue,
     uint64_t waitValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hSemaphore;
@@ -518,7 +518,7 @@ ur_queue_immediate_in_order_t::bindlessImagesWaitExternalSemaphoreExp(
 
 ur_result_t
 ur_queue_immediate_in_order_t::bindlessImagesSignalExternalSemaphoreExp(
-    ur_exp_interop_semaphore_handle_t hSemaphore, bool hasSignalValue,
+    ur_exp_external_semaphore_handle_t hSemaphore, bool hasSignalValue,
     uint64_t signalValue, uint32_t numEventsInWaitList,
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   std::ignore = hSemaphore;

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -189,12 +189,12 @@ public:
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesWaitExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t hSemaphore, bool hasWaitValue,
+      ur_exp_external_semaphore_handle_t hSemaphore, bool hasWaitValue,
       uint64_t waitValue, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;
   ur_result_t bindlessImagesSignalExternalSemaphoreExp(
-      ur_exp_interop_semaphore_handle_t hSemaphore, bool hasSignalValue,
+      ur_exp_external_semaphore_handle_t hSemaphore, bool hasSignalValue,
       uint64_t signalValue, uint32_t numEventsInWaitList,
       const ur_event_handle_t *phEventWaitList,
       ur_event_handle_t *phEvent) override;

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -7699,16 +7699,16 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     ur_bindless_images_import_external_memory_exp_params_t params = {
-        &hContext,      &hDevice,         &size,
-        &memHandleType, &pInteropMemDesc, &phInteropMem};
+        &hContext,      &hDevice,          &size,
+        &memHandleType, &pExternalMemDesc, &phExternalMem};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
@@ -7727,7 +7727,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
         result = replaceCallback(&params);
     } else {
 
-        *phInteropMem = mock::createDummyHandle<ur_exp_interop_mem_handle_t>();
+        *phExternalMem =
+            mock::createDummyHandle<ur_exp_external_mem_handle_t>();
         result = UR_RESULT_SUCCESS;
     }
 
@@ -7755,16 +7756,16 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     ur_bindless_images_map_external_array_exp_params_t params = {
-        &hContext,   &hDevice,     &pImageFormat,
-        &pImageDesc, &hInteropMem, &phImageMem};
+        &hContext,   &hDevice,      &pImageFormat,
+        &pImageDesc, &hExternalMem, &phImageMem};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
@@ -7805,21 +7806,21 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesReleaseInteropExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    ur_bindless_images_release_interop_exp_params_t params = {
-        &hContext, &hDevice, &hInteropMem};
+    ur_bindless_images_release_external_memory_exp_params_t params = {
+        &hContext, &hDevice, &hExternalMem};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
-            "urBindlessImagesReleaseInteropExp"));
+            "urBindlessImagesReleaseExternalMemoryExp"));
     if (beforeCallback) {
         result = beforeCallback(&params);
         if (result != UR_RESULT_SUCCESS) {
@@ -7829,12 +7830,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 
     auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_replace_callback(
-            "urBindlessImagesReleaseInteropExp"));
+            "urBindlessImagesReleaseExternalMemoryExp"));
     if (replaceCallback) {
         result = replaceCallback(&params);
     } else {
 
-        mock::releaseDummyHandle(hInteropMem);
+        mock::releaseDummyHandle(hExternalMem);
         result = UR_RESULT_SUCCESS;
     }
 
@@ -7844,7 +7845,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 
     auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_after_callback(
-            "urBindlessImagesReleaseInteropExp"));
+            "urBindlessImagesReleaseExternalMemoryExp"));
     if (afterCallback) {
         return afterCallback(&params);
     }
@@ -7861,16 +7862,16 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     ur_bindless_images_import_external_semaphore_exp_params_t params = {
-        &hContext, &hDevice, &semHandleType, &pInteropSemaphoreDesc,
-        &phInteropSemaphore};
+        &hContext, &hDevice, &semHandleType, &pExternalSemaphoreDesc,
+        &phExternalSemaphore};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
@@ -7889,8 +7890,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
         result = replaceCallback(&params);
     } else {
 
-        *phInteropSemaphore =
-            mock::createDummyHandle<ur_exp_interop_semaphore_handle_t>();
+        *phExternalSemaphore =
+            mock::createDummyHandle<ur_exp_external_semaphore_handle_t>();
         result = UR_RESULT_SUCCESS;
     }
 
@@ -7915,13 +7916,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     ur_bindless_images_release_external_semaphore_exp_params_t params = {
-        &hContext, &hDevice, &hInteropSemaphore};
+        &hContext, &hDevice, &hExternalSemaphore};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
@@ -7940,7 +7941,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
         result = replaceCallback(&params);
     } else {
 
-        mock::releaseDummyHandle(hInteropSemaphore);
+        mock::releaseDummyHandle(hExternalSemaphore);
         result = UR_RESULT_SUCCESS;
     }
 
@@ -7964,8 +7965,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -8034,8 +8035,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.
@@ -10271,7 +10272,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnMapExternalArrayExp =
         driver::urBindlessImagesMapExternalArrayExp;
 
-    pDdiTable->pfnReleaseInteropExp = driver::urBindlessImagesReleaseInteropExp;
+    pDdiTable->pfnReleaseExternalMemoryExp =
+        driver::urBindlessImagesReleaseExternalMemoryExp;
 
     pDdiTable->pfnImportExternalSemaphoreExp =
         driver::urBindlessImagesImportExternalSemaphoreExp;

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -117,8 +117,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
     [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
-    [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_desc_t *pExternalMemDesc,
+    [[maybe_unused]] ur_exp_external_mem_handle_t *phExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -127,15 +127,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -143,21 +143,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
-    [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
@@ -167,7 +167,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -329,7 +329,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImportExternalMemoryExp =
       urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
-  pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
+  pDdiTable->pfnReleaseExternalMemoryExp =
+      urBindlessImagesReleaseExternalMemoryExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnReleaseExternalSemaphoreExp =

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -117,8 +117,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice, [[maybe_unused]] size_t size,
     [[maybe_unused]] ur_exp_external_mem_type_t memHandleType,
-    [[maybe_unused]] ur_exp_interop_mem_desc_t *pInteropMemDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t *phInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_desc_t *pExternalMemDesc,
+    [[maybe_unused]] ur_exp_external_mem_handle_t *phExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -127,15 +127,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem,
     [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem) {
+    [[maybe_unused]] ur_exp_external_mem_handle_t hExternalMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -143,21 +143,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_external_semaphore_type_t semHandleType,
-    [[maybe_unused]] ur_exp_interop_semaphore_desc_t *pInteropSemaphoreDesc,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t *phInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t
+        *phExternalSemaphoreHandle) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hExternalSemaphore) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t waitValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
@@ -167,7 +168,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     [[maybe_unused]] ur_queue_handle_t hQueue,
-    [[maybe_unused]] ur_exp_interop_semaphore_handle_t hSemaphore,
+    [[maybe_unused]] ur_exp_external_semaphore_handle_t hSemaphore,
     [[maybe_unused]] bool hasValue, [[maybe_unused]] uint64_t signalValue,
     [[maybe_unused]] uint32_t numEventsInWaitList,
     [[maybe_unused]] const ur_event_handle_t *phEventWaitList,

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -347,7 +347,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnImportExternalMemoryExp =
       urBindlessImagesImportExternalMemoryExp;
   pDdiTable->pfnMapExternalArrayExp = urBindlessImagesMapExternalArrayExp;
-  pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
+  pDdiTable->pfnReleaseExternalMemoryExp =
+      urBindlessImagesReleaseExternalMemoryExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
   pDdiTable->pfnReleaseExternalSemaphoreExp =

--- a/source/common/stype_map_helpers.def
+++ b/source/common/stype_map_helpers.def
@@ -84,9 +84,9 @@ struct stype_map<ur_exp_command_buffer_update_value_arg_desc_t> : stype_map_impl
 template <>
 struct stype_map<ur_exp_sampler_mip_properties_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_SAMPLER_MIP_PROPERTIES> {};
 template <>
-struct stype_map<ur_exp_interop_mem_desc_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_INTEROP_MEM_DESC> {};
+struct stype_map<ur_exp_external_mem_desc_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_EXTERNAL_MEM_DESC> {};
 template <>
-struct stype_map<ur_exp_interop_semaphore_desc_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_INTEROP_SEMAPHORE_DESC> {};
+struct stype_map<ur_exp_external_semaphore_desc_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_EXTERNAL_SEMAPHORE_DESC> {};
 template <>
 struct stype_map<ur_exp_file_descriptor_t> : stype_map_impl<UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR> {};
 template <>

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5966,10 +5966,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
 ) {
     auto pfnImportExternalMemoryExp =
         getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
@@ -5979,16 +5979,17 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     }
 
     ur_bindless_images_import_external_memory_exp_params_t params = {
-        &hContext,      &hDevice,         &size,
-        &memHandleType, &pInteropMemDesc, &phInteropMem};
+        &hContext,      &hDevice,          &size,
+        &memHandleType, &pExternalMemDesc, &phExternalMem};
     uint64_t instance = getContext()->notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
         "urBindlessImagesImportExternalMemoryExp", &params);
 
     getContext()->logger.info("---> urBindlessImagesImportExternalMemoryExp");
 
-    ur_result_t result = pfnImportExternalMemoryExp(
-        hContext, hDevice, size, memHandleType, pInteropMemDesc, phInteropMem);
+    ur_result_t result =
+        pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
+                                   pExternalMemDesc, phExternalMem);
 
     getContext()->notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
@@ -6011,8 +6012,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
@@ -6024,8 +6025,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     }
 
     ur_bindless_images_map_external_array_exp_params_t params = {
-        &hContext,   &hDevice,     &pImageFormat,
-        &pImageDesc, &hInteropMem, &phImageMem};
+        &hContext,   &hDevice,      &pImageFormat,
+        &pImageDesc, &hExternalMem, &phImageMem};
     uint64_t instance = getContext()->notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP,
         "urBindlessImagesMapExternalArrayExp", &params);
@@ -6033,7 +6034,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     getContext()->logger.info("---> urBindlessImagesMapExternalArrayExp");
 
     ur_result_t result = pfnMapExternalArrayExp(
-        hContext, hDevice, pImageFormat, pImageDesc, hInteropMem, phImageMem);
+        hContext, hDevice, pImageFormat, pImageDesc, hExternalMem, phImageMem);
 
     getContext()->notify_end(UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP,
                              "urBindlessImagesMapExternalArrayExp", &params,
@@ -6048,37 +6049,39 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesReleaseInteropExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
 ) {
-    auto pfnReleaseInteropExp =
-        getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+    auto pfnReleaseExternalMemoryExp =
+        getContext()->urDdiTable.BindlessImagesExp.pfnReleaseExternalMemoryExp;
 
-    if (nullptr == pfnReleaseInteropExp) {
+    if (nullptr == pfnReleaseExternalMemoryExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_bindless_images_release_interop_exp_params_t params = {
-        &hContext, &hDevice, &hInteropMem};
+    ur_bindless_images_release_external_memory_exp_params_t params = {
+        &hContext, &hDevice, &hExternalMem};
     uint64_t instance = getContext()->notify_begin(
-        UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP,
-        "urBindlessImagesReleaseInteropExp", &params);
+        UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
+        "urBindlessImagesReleaseExternalMemoryExp", &params);
 
-    getContext()->logger.info("---> urBindlessImagesReleaseInteropExp");
+    getContext()->logger.info("---> urBindlessImagesReleaseExternalMemoryExp");
 
-    ur_result_t result = pfnReleaseInteropExp(hContext, hDevice, hInteropMem);
+    ur_result_t result =
+        pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
 
-    getContext()->notify_end(UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP,
-                             "urBindlessImagesReleaseInteropExp", &params,
-                             &result, instance);
+    getContext()->notify_end(
+        UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
+        "urBindlessImagesReleaseExternalMemoryExp", &params, &result, instance);
 
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
-        args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP, &params);
+        args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
+        &params);
     getContext()->logger.info("({}) -> {};\n", args_str.str(), result);
 
     return result;
@@ -6091,10 +6094,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
 ) {
     auto pfnImportExternalSemaphoreExp =
         getContext()
@@ -6105,8 +6108,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     }
 
     ur_bindless_images_import_external_semaphore_exp_params_t params = {
-        &hContext, &hDevice, &semHandleType, &pInteropSemaphoreDesc,
-        &phInteropSemaphore};
+        &hContext, &hDevice, &semHandleType, &pExternalSemaphoreDesc,
+        &phExternalSemaphore};
     uint64_t instance = getContext()->notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
         "urBindlessImagesImportExternalSemaphoreExp", &params);
@@ -6115,8 +6118,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
         "---> urBindlessImagesImportExternalSemaphoreExp");
 
     ur_result_t result = pfnImportExternalSemaphoreExp(
-        hContext, hDevice, semHandleType, pInteropSemaphoreDesc,
-        phInteropSemaphore);
+        hContext, hDevice, semHandleType, pExternalSemaphoreDesc,
+        phExternalSemaphore);
 
     getContext()->notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
@@ -6137,8 +6140,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
 ) {
     auto pfnReleaseExternalSemaphoreExp =
         getContext()
@@ -6149,7 +6152,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     }
 
     ur_bindless_images_release_external_semaphore_exp_params_t params = {
-        &hContext, &hDevice, &hInteropSemaphore};
+        &hContext, &hDevice, &hExternalSemaphore};
     uint64_t instance = getContext()->notify_begin(
         UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
         "urBindlessImagesReleaseExternalSemaphoreExp", &params);
@@ -6158,7 +6161,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
         "---> urBindlessImagesReleaseExternalSemaphoreExp");
 
     ur_result_t result =
-        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hExternalSemaphore);
 
     getContext()->notify_end(
         UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
@@ -6178,8 +6181,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -6235,8 +6238,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.
@@ -8123,9 +8126,10 @@ __urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnMapExternalArrayExp =
         ur_tracing_layer::urBindlessImagesMapExternalArrayExp;
 
-    dditable.pfnReleaseInteropExp = pDdiTable->pfnReleaseInteropExp;
-    pDdiTable->pfnReleaseInteropExp =
-        ur_tracing_layer::urBindlessImagesReleaseInteropExp;
+    dditable.pfnReleaseExternalMemoryExp =
+        pDdiTable->pfnReleaseExternalMemoryExp;
+    pDdiTable->pfnReleaseExternalMemoryExp =
+        ur_tracing_layer::urBindlessImagesReleaseExternalMemoryExp;
 
     dditable.pfnImportExternalSemaphoreExp =
         pDdiTable->pfnImportExternalSemaphoreExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7432,10 +7432,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
 ) {
     auto pfnImportExternalMemoryExp =
         getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
@@ -7453,11 +7453,11 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pInteropMemDesc) {
+        if (NULL == pExternalMemDesc) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == phInteropMem) {
+        if (NULL == phExternalMem) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -7476,8 +7476,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
         getContext()->refCountContext->logInvalidReference(hDevice);
     }
 
-    ur_result_t result = pfnImportExternalMemoryExp(
-        hContext, hDevice, size, memHandleType, pInteropMemDesc, phInteropMem);
+    ur_result_t result =
+        pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
+                                   pExternalMemDesc, phExternalMem);
 
     return result;
 }
@@ -7490,8 +7491,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
@@ -7511,7 +7512,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == hInteropMem) {
+        if (NULL == hExternalMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
@@ -7543,23 +7544,23 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     }
 
     ur_result_t result = pfnMapExternalArrayExp(
-        hContext, hDevice, pImageFormat, pImageDesc, hInteropMem, phImageMem);
+        hContext, hDevice, pImageFormat, pImageDesc, hExternalMem, phImageMem);
 
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesReleaseInteropExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
 ) {
-    auto pfnReleaseInteropExp =
-        getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
+    auto pfnReleaseExternalMemoryExp =
+        getContext()->urDdiTable.BindlessImagesExp.pfnReleaseExternalMemoryExp;
 
-    if (nullptr == pfnReleaseInteropExp) {
+    if (nullptr == pfnReleaseExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -7572,7 +7573,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == hInteropMem) {
+        if (NULL == hExternalMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -7587,7 +7588,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
         getContext()->refCountContext->logInvalidReference(hDevice);
     }
 
-    ur_result_t result = pfnReleaseInteropExp(hContext, hDevice, hInteropMem);
+    ur_result_t result =
+        pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
 
     return result;
 }
@@ -7599,10 +7601,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
 ) {
     auto pfnImportExternalSemaphoreExp =
         getContext()
@@ -7621,11 +7623,11 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == pInteropSemaphoreDesc) {
+        if (NULL == pExternalSemaphoreDesc) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (NULL == phInteropSemaphore) {
+        if (NULL == phExternalSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
@@ -7646,8 +7648,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     }
 
     ur_result_t result = pfnImportExternalSemaphoreExp(
-        hContext, hDevice, semHandleType, pInteropSemaphoreDesc,
-        phInteropSemaphore);
+        hContext, hDevice, semHandleType, pExternalSemaphoreDesc,
+        phExternalSemaphore);
 
     return result;
 }
@@ -7657,8 +7659,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
 ) {
     auto pfnReleaseExternalSemaphoreExp =
         getContext()
@@ -7677,7 +7679,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == hInteropSemaphore) {
+        if (NULL == hExternalSemaphore) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -7693,7 +7695,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     }
 
     ur_result_t result =
-        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hExternalSemaphore);
 
     return result;
 }
@@ -7702,8 +7704,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -7762,8 +7764,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.
@@ -9749,9 +9751,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnMapExternalArrayExp =
         ur_validation_layer::urBindlessImagesMapExternalArrayExp;
 
-    dditable.pfnReleaseInteropExp = pDdiTable->pfnReleaseInteropExp;
-    pDdiTable->pfnReleaseInteropExp =
-        ur_validation_layer::urBindlessImagesReleaseInteropExp;
+    dditable.pfnReleaseExternalMemoryExp =
+        pDdiTable->pfnReleaseExternalMemoryExp;
+    pDdiTable->pfnReleaseExternalMemoryExp =
+        ur_validation_layer::urBindlessImagesReleaseExternalMemoryExp;
 
     dditable.pfnImportExternalSemaphoreExp =
         pDdiTable->pfnImportExternalSemaphoreExp;

--- a/source/loader/loader.def.in
+++ b/source/loader/loader.def.in
@@ -14,8 +14,8 @@ EXPORTS
 	urBindlessImagesMapExternalArrayExp
 	urBindlessImagesMipmapFreeExp
 	urBindlessImagesMipmapGetLevelExp
+	urBindlessImagesReleaseExternalMemoryExp
 	urBindlessImagesReleaseExternalSemaphoreExp
-	urBindlessImagesReleaseInteropExp
 	urBindlessImagesSampledImageCreateExp
 	urBindlessImagesSampledImageHandleDestroyExp
 	urBindlessImagesSignalExternalSemaphoreExp
@@ -183,8 +183,8 @@ EXPORTS
 	urPrintBindlessImagesMapExternalArrayExpParams
 	urPrintBindlessImagesMipmapFreeExpParams
 	urPrintBindlessImagesMipmapGetLevelExpParams
+	urPrintBindlessImagesReleaseExternalMemoryExpParams
 	urPrintBindlessImagesReleaseExternalSemaphoreExpParams
-	urPrintBindlessImagesReleaseInteropExpParams
 	urPrintBindlessImagesSampledImageCreateExpParams
 	urPrintBindlessImagesSampledImageHandleDestroyExpParams
 	urPrintBindlessImagesSignalExternalSemaphoreExpParams
@@ -305,13 +305,13 @@ EXPORTS
 	urPrintExpCommandBufferUpdateValueArgDesc
 	urPrintExpEnqueueNativeCommandFlags
 	urPrintExpEnqueueNativeCommandProperties
+	urPrintExpExternalMemDesc
 	urPrintExpExternalMemType
+	urPrintExpExternalSemaphoreDesc
 	urPrintExpExternalSemaphoreType
 	urPrintExpFileDescriptor
 	urPrintExpImageCopyFlags
 	urPrintExpImageCopyRegion
-	urPrintExpInteropMemDesc
-	urPrintExpInteropSemaphoreDesc
 	urPrintExpLaunchProperty
 	urPrintExpLaunchPropertyId
 	urPrintExpPeerInfo

--- a/source/loader/loader.map.in
+++ b/source/loader/loader.map.in
@@ -14,8 +14,8 @@
 		urBindlessImagesMapExternalArrayExp;
 		urBindlessImagesMipmapFreeExp;
 		urBindlessImagesMipmapGetLevelExp;
+		urBindlessImagesReleaseExternalMemoryExp;
 		urBindlessImagesReleaseExternalSemaphoreExp;
-		urBindlessImagesReleaseInteropExp;
 		urBindlessImagesSampledImageCreateExp;
 		urBindlessImagesSampledImageHandleDestroyExp;
 		urBindlessImagesSignalExternalSemaphoreExp;
@@ -183,8 +183,8 @@
 		urPrintBindlessImagesMapExternalArrayExpParams;
 		urPrintBindlessImagesMipmapFreeExpParams;
 		urPrintBindlessImagesMipmapGetLevelExpParams;
+		urPrintBindlessImagesReleaseExternalMemoryExpParams;
 		urPrintBindlessImagesReleaseExternalSemaphoreExpParams;
-		urPrintBindlessImagesReleaseInteropExpParams;
 		urPrintBindlessImagesSampledImageCreateExpParams;
 		urPrintBindlessImagesSampledImageHandleDestroyExpParams;
 		urPrintBindlessImagesSignalExternalSemaphoreExpParams;
@@ -305,13 +305,13 @@
 		urPrintExpCommandBufferUpdateValueArgDesc;
 		urPrintExpEnqueueNativeCommandFlags;
 		urPrintExpEnqueueNativeCommandProperties;
+		urPrintExpExternalMemDesc;
 		urPrintExpExternalMemType;
+		urPrintExpExternalSemaphoreDesc;
 		urPrintExpExternalSemaphoreType;
 		urPrintExpFileDescriptor;
 		urPrintExpImageCopyFlags;
 		urPrintExpImageCopyRegion;
-		urPrintExpInteropMemDesc;
-		urPrintExpInteropSemaphoreDesc;
 		urPrintExpLaunchProperty;
 		urPrintExpLaunchPropertyId;
 		urPrintExpPeerInfo;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6552,10 +6552,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6577,7 +6577,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
     // forward to device-platform
     result = pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
-                                        pInteropMemDesc, phInteropMem);
+                                        pExternalMemDesc, phExternalMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6585,9 +6585,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
     try {
         // convert platform handle to loader handle
-        *phInteropMem = reinterpret_cast<ur_exp_interop_mem_handle_t>(
-            context->factories.ur_exp_interop_mem_factory.getInstance(
-                *phInteropMem, dditable));
+        *phExternalMem = reinterpret_cast<ur_exp_external_mem_handle_t>(
+            context->factories.ur_exp_external_mem_factory.getInstance(
+                *phExternalMem, dditable));
     } catch (std::bad_alloc &) {
         result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -6603,8 +6603,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
@@ -6627,12 +6627,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    hInteropMem =
-        reinterpret_cast<ur_exp_interop_mem_object_t *>(hInteropMem)->handle;
+    hExternalMem =
+        reinterpret_cast<ur_exp_external_mem_object_t *>(hExternalMem)->handle;
 
     // forward to device-platform
     result = pfnMapExternalArrayExp(hContext, hDevice, pImageFormat, pImageDesc,
-                                    hInteropMem, phImageMem);
+                                    hExternalMem, phImageMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6642,12 +6642,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesReleaseInteropExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6655,9 +6655,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnReleaseInteropExp =
-        dditable->ur.BindlessImagesExp.pfnReleaseInteropExp;
-    if (nullptr == pfnReleaseInteropExp) {
+    auto pfnReleaseExternalMemoryExp =
+        dditable->ur.BindlessImagesExp.pfnReleaseExternalMemoryExp;
+    if (nullptr == pfnReleaseExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -6668,11 +6668,11 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    hInteropMem =
-        reinterpret_cast<ur_exp_interop_mem_object_t *>(hInteropMem)->handle;
+    hExternalMem =
+        reinterpret_cast<ur_exp_external_mem_object_t *>(hExternalMem)->handle;
 
     // forward to device-platform
-    result = pfnReleaseInteropExp(hContext, hDevice, hInteropMem);
+    result = pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
 
     return result;
 }
@@ -6684,10 +6684,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6709,8 +6709,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
     // forward to device-platform
     result = pfnImportExternalSemaphoreExp(hContext, hDevice, semHandleType,
-                                           pInteropSemaphoreDesc,
-                                           phInteropSemaphore);
+                                           pExternalSemaphoreDesc,
+                                           phExternalSemaphore);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
@@ -6718,10 +6718,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
     try {
         // convert platform handle to loader handle
-        *phInteropSemaphore =
-            reinterpret_cast<ur_exp_interop_semaphore_handle_t>(
-                context->factories.ur_exp_interop_semaphore_factory.getInstance(
-                    *phInteropSemaphore, dditable));
+        *phExternalSemaphore =
+            reinterpret_cast<ur_exp_external_semaphore_handle_t>(
+                context->factories.ur_exp_external_semaphore_factory
+                    .getInstance(*phExternalSemaphore, dditable));
     } catch (std::bad_alloc &) {
         result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
@@ -6734,8 +6734,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6756,13 +6756,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    hInteropSemaphore =
-        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hInteropSemaphore)
-            ->handle;
+    hExternalSemaphore = reinterpret_cast<ur_exp_external_semaphore_object_t *>(
+                             hExternalSemaphore)
+                             ->handle;
 
     // forward to device-platform
     result =
-        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hExternalSemaphore);
 
     return result;
 }
@@ -6771,8 +6771,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -6807,7 +6807,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
     // convert loader handle to platform handle
     hSemaphore =
-        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hSemaphore)
+        reinterpret_cast<ur_exp_external_semaphore_object_t *>(hSemaphore)
             ->handle;
 
     // convert loader handles to platform handles
@@ -6845,8 +6845,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.
@@ -6881,7 +6881,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
     // convert loader handle to platform handle
     hSemaphore =
-        reinterpret_cast<ur_exp_interop_semaphore_object_t *>(hSemaphore)
+        reinterpret_cast<ur_exp_external_semaphore_object_t *>(hSemaphore)
             ->handle;
 
     // convert loader handles to platform handles
@@ -8691,8 +8691,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
                 ur_loader::urBindlessImagesImportExternalMemoryExp;
             pDdiTable->pfnMapExternalArrayExp =
                 ur_loader::urBindlessImagesMapExternalArrayExp;
-            pDdiTable->pfnReleaseInteropExp =
-                ur_loader::urBindlessImagesReleaseInteropExp;
+            pDdiTable->pfnReleaseExternalMemoryExp =
+                ur_loader::urBindlessImagesReleaseExternalMemoryExp;
             pDdiTable->pfnImportExternalSemaphoreExp =
                 ur_loader::urBindlessImagesImportExternalSemaphoreExp;
             pDdiTable->pfnReleaseExternalSemaphoreExp =

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -65,16 +65,16 @@ using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
 using ur_usm_pool_factory_t =
     singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
 
-using ur_exp_interop_mem_object_t = object_t<ur_exp_interop_mem_handle_t>;
-using ur_exp_interop_mem_factory_t =
-    singleton_factory_t<ur_exp_interop_mem_object_t,
-                        ur_exp_interop_mem_handle_t>;
+using ur_exp_external_mem_object_t = object_t<ur_exp_external_mem_handle_t>;
+using ur_exp_external_mem_factory_t =
+    singleton_factory_t<ur_exp_external_mem_object_t,
+                        ur_exp_external_mem_handle_t>;
 
-using ur_exp_interop_semaphore_object_t =
-    object_t<ur_exp_interop_semaphore_handle_t>;
-using ur_exp_interop_semaphore_factory_t =
-    singleton_factory_t<ur_exp_interop_semaphore_object_t,
-                        ur_exp_interop_semaphore_handle_t>;
+using ur_exp_external_semaphore_object_t =
+    object_t<ur_exp_external_semaphore_handle_t>;
+using ur_exp_external_semaphore_factory_t =
+    singleton_factory_t<ur_exp_external_semaphore_object_t,
+                        ur_exp_external_semaphore_handle_t>;
 
 using ur_exp_command_buffer_object_t = object_t<ur_exp_command_buffer_handle_t>;
 using ur_exp_command_buffer_factory_t =
@@ -100,8 +100,8 @@ struct handle_factories {
     ur_mem_factory_t ur_mem_factory;
     ur_physical_mem_factory_t ur_physical_mem_factory;
     ur_usm_pool_factory_t ur_usm_pool_factory;
-    ur_exp_interop_mem_factory_t ur_exp_interop_mem_factory;
-    ur_exp_interop_semaphore_factory_t ur_exp_interop_semaphore_factory;
+    ur_exp_external_mem_factory_t ur_exp_external_mem_factory;
+    ur_exp_external_semaphore_factory_t ur_exp_external_semaphore_factory;
     ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
     ur_exp_command_buffer_command_factory_t
         ur_exp_command_buffer_command_factory;

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7035,8 +7035,8 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropMemDesc`
-///         + `NULL == phInteropMem`
+///         + `NULL == pExternalMemDesc`
+///         + `NULL == phExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -7046,10 +7046,10 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
     ) try {
     auto pfnImportExternalMemoryExp =
         ur_lib::getContext()
@@ -7059,13 +7059,13 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     }
 
     return pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
-                                      pInteropMemDesc, phInteropMem);
+                                      pExternalMemDesc, phExternalMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Map an interop memory handle to an image memory handle
+/// @brief Map an external memory handle to an image memory handle
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -7075,7 +7075,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -7093,8 +7093,8 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
     ) try {
@@ -7106,13 +7106,13 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     }
 
     return pfnMapExternalArrayExp(hContext, hDevice, pImageFormat, pImageDesc,
-                                  hInteropMem, phImageMem);
+                                  hExternalMem, phImageMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Release interop memory
+/// @brief Release external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -7126,22 +7126,23 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
     ) try {
-    auto pfnReleaseInteropExp =
-        ur_lib::getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
-    if (nullptr == pfnReleaseInteropExp) {
+    auto pfnReleaseExternalMemoryExp =
+        ur_lib::getContext()
+            ->urDdiTable.BindlessImagesExp.pfnReleaseExternalMemoryExp;
+    if (nullptr == pfnReleaseExternalMemoryExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnReleaseInteropExp(hContext, hDevice, hInteropMem);
+    return pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -7164,8 +7165,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropSemaphoreDesc`
-///         + `NULL == phInteropSemaphore`
+///         + `NULL == pExternalSemaphoreDesc`
+///         + `NULL == phExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
@@ -7173,10 +7174,10 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
     ) try {
     auto pfnImportExternalSemaphoreExp =
         ur_lib::getContext()
@@ -7186,8 +7187,8 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     }
 
     return pfnImportExternalSemaphoreExp(hContext, hDevice, semHandleType,
-                                         pInteropSemaphoreDesc,
-                                         phInteropSemaphore);
+                                         pExternalSemaphoreDesc,
+                                         phExternalSemaphore);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -7207,14 +7208,14 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropSemaphore`
+///         + `NULL == hExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
     ) try {
     auto pfnReleaseExternalSemaphoreExp =
         ur_lib::getContext()
@@ -7223,7 +7224,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+    return pfnReleaseExternalSemaphoreExp(hContext, hDevice,
+                                          hExternalSemaphore);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -7247,8 +7249,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -7300,8 +7302,8 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -955,16 +955,16 @@ ur_result_t urPrintExpSamplerCubemapProperties(
 }
 
 ur_result_t
-urPrintExpInteropMemDesc(const struct ur_exp_interop_mem_desc_t params,
-                         char *buffer, const size_t buff_size,
-                         size_t *out_size) {
+urPrintExpExternalMemDesc(const struct ur_exp_external_mem_desc_t params,
+                          char *buffer, const size_t buff_size,
+                          size_t *out_size) {
     std::stringstream ss;
     ss << params;
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintExpInteropSemaphoreDesc(
-    const struct ur_exp_interop_semaphore_desc_t params, char *buffer,
+ur_result_t urPrintExpExternalSemaphoreDesc(
+    const struct ur_exp_external_semaphore_desc_t params, char *buffer,
     const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;
@@ -1219,8 +1219,9 @@ ur_result_t urPrintBindlessImagesMapExternalArrayExpParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintBindlessImagesReleaseInteropExpParams(
-    const struct ur_bindless_images_release_interop_exp_params_t *params,
+ur_result_t urPrintBindlessImagesReleaseExternalMemoryExpParams(
+    const struct ur_bindless_images_release_external_memory_exp_params_t
+        *params,
     char *buffer, const size_t buff_size, size_t *out_size) {
     std::stringstream ss;
     ss << params;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5993,8 +5993,8 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE < memHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropMemDesc`
-///         + `NULL == phInteropMem`
+///         + `NULL == pExternalMemDesc`
+///         + `NULL == phExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT
@@ -6004,17 +6004,17 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     size_t size,                  ///< [in] size of the external memory
     ur_exp_external_mem_type_t
         memHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_mem_desc_t
-        *pInteropMemDesc, ///< [in] the interop memory descriptor
-    ur_exp_interop_mem_handle_t
-        *phInteropMem ///< [out] interop memory handle to the external memory
+    ur_exp_external_mem_desc_t
+        *pExternalMemDesc, ///< [in] the external memory descriptor
+    ur_exp_external_mem_handle_t
+        *phExternalMem ///< [out] external memory handle to the external memory
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Map an interop memory handle to an image memory handle
+/// @brief Map an external memory handle to an image memory handle
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
@@ -6024,7 +6024,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -6042,8 +6042,8 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t
-        hInteropMem, ///< [in] interop memory handle to the external memory
+    ur_exp_external_mem_handle_t
+        hExternalMem, ///< [in] external memory handle to the external memory
     ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
@@ -6052,7 +6052,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Release interop memory
+/// @brief Release external memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -6066,14 +6066,14 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropMem`
+///         + `NULL == hExternalMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
+ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be destroyed
+    ur_exp_external_mem_handle_t
+        hExternalMem ///< [in][release] handle of external memory to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -6097,8 +6097,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE < semHandleType`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
-///         + `NULL == pInteropSemaphoreDesc`
-///         + `NULL == phInteropSemaphore`
+///         + `NULL == pExternalSemaphoreDesc`
+///         + `NULL == phExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
@@ -6106,10 +6106,10 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
         semHandleType, ///< [in] type of external memory handle
-    ur_exp_interop_semaphore_desc_t
-        *pInteropSemaphoreDesc, ///< [in] the interop semaphore descriptor
-    ur_exp_interop_semaphore_handle_t *
-        phInteropSemaphore ///< [out] interop semaphore handle to the external semaphore
+    ur_exp_external_semaphore_desc_t
+        *pExternalSemaphoreDesc, ///< [in] the external semaphore descriptor
+    ur_exp_external_semaphore_handle_t *
+        phExternalSemaphore ///< [out] external semaphore handle to the external semaphore
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -6130,14 +6130,14 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hInteropSemaphore`
+///         + `NULL == hExternalSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_interop_semaphore_handle_t
-        hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
+    ur_exp_external_semaphore_handle_t
+        hExternalSemaphore ///< [in][release] handle of external semaphore to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -6162,8 +6162,8 @@ ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasWaitValue, ///< [in] indicates whether the samephore is capable and should wait on a
                       ///< certain value.
@@ -6205,8 +6205,8 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
-    ur_exp_interop_semaphore_handle_t
-        hSemaphore, ///< [in] interop semaphore handle
+    ur_exp_external_semaphore_handle_t
+        hSemaphore, ///< [in] external semaphore handle
     bool
         hasSignalValue, ///< [in] indicates whether the samephore is capable and should signal on a
                         ///< certain value.

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -372,10 +372,10 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
         hDevice, UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP);
     std::cout << prefix;
     printDeviceInfo<ur_bool_t>(
-        hDevice, UR_DEVICE_INFO_INTEROP_MEMORY_IMPORT_SUPPORT_EXP);
+        hDevice, UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP);
     std::cout << prefix;
     printDeviceInfo<ur_bool_t>(
-        hDevice, UR_DEVICE_INFO_INTEROP_SEMAPHORE_IMPORT_SUPPORT_EXP);
+        hDevice, UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP);
     std::cout << prefix;
     printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP);
     std::cout << prefix;


### PR DESCRIPTION
Rename interop related structs, functions, and enums with the "external" keyword over "interop".