### PR TITLE
Add a workaround for urEnqueue loader problems with ADAPTER_SPECIFIC

### DIFF
--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -272,9 +272,16 @@ namespace ur_loader
         %>
         %for i, item in enumerate(epilogue):
         %if 0 == i and not item['release'] and not item['retain'] and not th.always_wrap_outputs(obj):
-        if( ${X}_RESULT_SUCCESS != result )
+        ## TODO: Remove once we have a concrete way for submitting warnings in place.
+        %if re.match(r"urEnqueue\w+", th.make_func_name(n, tags, obj)):
+        // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+        if( ${X}_RESULT_SUCCESS != result && ${X}_RESULT_ERROR_ADAPTER_SPECIFIC != result )
+            return result;
+        %else:
+        if( ${X}_RESULT_SUCCESS != result)
             return result;
 
+        %endif
         %endif
         ## Before we can re-enable the releases we will need ref-counted object_t.
         ## See unified-runtime github issue #1784

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4144,10 +4144,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
                         pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
                         phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4200,10 +4201,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     result = pfnEventsWait(hQueue, numEventsInWaitList,
                            phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4257,10 +4259,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
                                       phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4322,10 +4325,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
                               numEventsInWaitList, phEventWaitListLocal.data(),
                               phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4389,10 +4393,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
                                pSrc, numEventsInWaitList,
                                phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4467,10 +4472,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4548,10 +4554,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
         numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4617,10 +4624,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
                               dstOffset, size, numEventsInWaitList,
                               phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4696,10 +4704,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
         srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
         numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4761,10 +4770,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
                               size, numEventsInWaitList,
                               phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4831,10 +4841,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
                              rowPitch, slicePitch, pDst, numEventsInWaitList,
                              phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4902,10 +4913,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
                               rowPitch, slicePitch, pSrc, numEventsInWaitList,
                               phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -4977,10 +4989,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
                              region, numEventsInWaitList,
                              phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5044,10 +5057,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
                              size, numEventsInWaitList,
                              phEventWaitListLocal.data(), phEvent, ppRetMap);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5105,10 +5119,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     result = pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
                          phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5169,10 +5184,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
         pfnUSMFill(hQueue, pMem, patternSize, pPattern, size,
                    numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5231,10 +5247,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
         pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
                      phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5290,10 +5307,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     result = pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
                             phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5334,10 +5352,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     // forward to device-platform
     result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5403,10 +5422,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
         pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height,
                      numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5471,10 +5491,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
                             width, height, numEventsInWaitList,
                             phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5540,10 +5561,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
         numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5609,10 +5631,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
         hQueue, hProgram, name, blockingRead, count, offset, pDst,
         numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5681,10 +5704,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
                              size, numEventsInWaitList,
                              phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -5753,10 +5777,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
                               size, numEventsInWaitList,
                               phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -7592,10 +7617,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
         pLocalWorkSize, numEventsInWaitList, phEventWaitListLocal.data(),
         phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {
@@ -7689,10 +7715,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     result = pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
                                       phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         *phEvent = reinterpret_cast<ur_event_handle_t>(
@@ -8102,10 +8129,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
         hQueue, pfnNativeEnqueue, data, numMemsInMemList, phMemListLocal.data(),
         pProperties, numEventsInWaitList, phEventWaitListLocal.data(), phEvent);
 
-    if (UR_RESULT_SUCCESS != result) {
+    // In the event of ERROR_ADAPTER_SPECIFIC we should still attempt to wrap any output handles below.
+    if (UR_RESULT_SUCCESS != result &&
+        UR_RESULT_ERROR_ADAPTER_SPECIFIC != result) {
         return result;
     }
-
     try {
         // convert platform handle to loader handle
         if (nullptr != phEvent) {


### PR DESCRIPTION
This is a temporarily fix for a problem with `urEnqueue` entries in `ldrddi` loader. The problem is that these entries could return a valid `Event` handle while in the same time the entry is returning `UR_RESULT_ADAPTER_SPECIFIC_ERROR` like in [here](https://github.com/oneapi-src/unified-runtime/blob/01af5602345ac3289cc084eb19bf266c054da075/source/adapters/hip/enqueue.cpp#L1395C14-L1395C46). This would cause a seg-fault where the loader wrapper would not be called on this event handle like in [here](https://github.com/oneapi-src/unified-runtime/blob/01af5602345ac3289cc084eb19bf266c054da075/source/loader/ur_ldrddi.cpp#L5298) and later when `urEventRelease` is called on this valid event handle, it will pass by the loader to extract the dditable from the handle like in [here](https://github.com/oneapi-src/unified-runtime/blob/01af5602345ac3289cc084eb19bf266c054da075/source/loader/ur_ldrddi.cpp#L3972) and that will be invalid as that is not a loader handle but the original event handle. 