### PR TITLE
Treat bindless images handle types as native handles

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7326,11 +7326,11 @@ urEnqueueWriteHostPipe(
 #endif
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of bindless image
-typedef struct ur_exp_image_handle_t_ *ur_exp_image_handle_t;
+typedef uintptr_t ur_exp_image_native_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of bindless image memory
-typedef struct ur_exp_image_mem_handle_t_ *ur_exp_image_mem_handle_t;
+typedef uintptr_t ur_exp_image_mem_native_handle_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Handle of interop memory
@@ -7548,14 +7548,13 @@ urUSMPitchedAllocExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t hImage  ///< [in][release] pointer to handle of image object to destroy
+    ur_context_handle_t hContext,       ///< [in] handle of the context object
+    ur_device_handle_t hDevice,         ///< [in] handle of the device object
+    ur_exp_image_native_handle_t hImage ///< [in][release] pointer to handle of image object to destroy
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7573,14 +7572,13 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
-    ur_context_handle_t hContext, ///< [in] handle of the context object
-    ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t hImage  ///< [in][release] pointer to handle of image object to destroy
+    ur_context_handle_t hContext,       ///< [in] handle of the context object
+    ur_device_handle_t hDevice,         ///< [in] handle of the device object
+    ur_exp_image_native_handle_t hImage ///< [in][release] pointer to handle of image object to destroy
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7606,16 +7604,16 @@ urBindlessImagesSampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImageAllocateExp(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_device_handle_t hDevice,            ///< [in] handle of the device object
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t *phImageMem  ///< [out] pointer to handle of image memory allocated
+    ur_context_handle_t hContext,                ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                  ///< [in] handle of the device object
+    const ur_image_format_t *pImageFormat,       ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,           ///< [in] pointer to image description
+    ur_exp_image_mem_native_handle_t *phImageMem ///< [out] pointer to handle of image memory allocated
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7633,14 +7631,13 @@ urBindlessImagesImageAllocateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImageFreeExp(
-    ur_context_handle_t hContext,       ///< [in] handle of the context object
-    ur_device_handle_t hDevice,         ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t hImageMem ///< [in][release] handle of image memory to be freed
+    ur_context_handle_t hContext,              ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                ///< [in] handle of the device object
+    ur_exp_image_mem_native_handle_t hImageMem ///< [in][release] handle of image memory to be freed
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7658,7 +7655,6 @@ urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -7666,18 +7662,18 @@ urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageCreateExp(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_device_handle_t hDevice,            ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t hImageMem,   ///< [in] handle to memory from which to create the image
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    ur_exp_image_handle_t *phImage         ///< [out] pointer to handle of image object created
+    ur_context_handle_t hContext,               ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                 ///< [in] handle of the device object
+    ur_exp_image_mem_native_handle_t hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t *pImageFormat,      ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,          ///< [in] pointer to image description
+    ur_exp_image_native_handle_t *phImage       ///< [out] pointer to handle of image object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7695,7 +7691,6 @@ urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -7704,20 +7699,20 @@ urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSampledImageCreateExp(
-    ur_context_handle_t hContext,          ///< [in] handle of the context object
-    ur_device_handle_t hDevice,            ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t hImageMem,   ///< [in] handle to memory from which to create the image
-    const ur_image_format_t *pImageFormat, ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,     ///< [in] pointer to image description
-    ur_sampler_handle_t hSampler,          ///< [in] sampler to be used
-    ur_exp_image_handle_t *phImage         ///< [out] pointer to handle of image object created
+    ur_context_handle_t hContext,               ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                 ///< [in] handle of the device object
+    ur_exp_image_mem_native_handle_t hImageMem, ///< [in] handle to memory from which to create the image
+    const ur_image_format_t *pImageFormat,      ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,          ///< [in] pointer to image description
+    ur_sampler_handle_t hSampler,               ///< [in] sampler to be used
+    ur_exp_image_native_handle_t *phImage       ///< [out] pointer to handle of image object created
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7747,7 +7742,7 @@ urBindlessImagesSampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -7785,7 +7780,7 @@ urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hImageMem`
+///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
@@ -7799,10 +7794,11 @@ urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,                    ///< [out][optional] returned query value
-    size_t *pPropSizeRet                 ///< [out][optional] returned query value size
+    ur_context_handle_t hContext,               ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t hImageMem, ///< [in] handle to the image memory
+    ur_image_info_t propName,                   ///< [in] queried info name
+    void *pPropValue,                           ///< [out][optional] returned query value
+    size_t *pPropSizeRet                        ///< [out][optional] returned query value size
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7820,18 +7816,17 @@ urBindlessImagesImageGetInfoExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesMipmapGetLevelExp(
-    ur_context_handle_t hContext,         ///< [in] handle of the context object
-    ur_device_handle_t hDevice,           ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t hImageMem,  ///< [in] memory handle to the mipmap image
-    uint32_t mipmapLevel,                 ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t *phImageMem ///< [out] returning memory handle to the individual image
+    ur_context_handle_t hContext,                ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                  ///< [in] handle of the device object
+    ur_exp_image_mem_native_handle_t hImageMem,  ///< [in] memory handle to the mipmap image
+    uint32_t mipmapLevel,                        ///< [in] requested level of the mipmap
+    ur_exp_image_mem_native_handle_t *phImageMem ///< [out] returning memory handle to the individual image
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7849,14 +7844,13 @@ urBindlessImagesMipmapGetLevelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesMipmapFreeExp(
-    ur_context_handle_t hContext,  ///< [in] handle of the context object
-    ur_device_handle_t hDevice,    ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t hMem ///< [in][release] handle of image memory to be freed
+    ur_context_handle_t hContext,         ///< [in] handle of the context object
+    ur_device_handle_t hDevice,           ///< [in] handle of the device object
+    ur_exp_image_mem_native_handle_t hMem ///< [in][release] handle of image memory to be freed
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7911,18 +7905,18 @@ urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesMapExternalArrayExp(
-    ur_context_handle_t hContext,            ///< [in] handle of the context object
-    ur_device_handle_t hDevice,              ///< [in] handle of the device object
-    const ur_image_format_t *pImageFormat,   ///< [in] pointer to image format specification
-    const ur_image_desc_t *pImageDesc,       ///< [in] pointer to image description
-    ur_exp_interop_mem_handle_t hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *phImageMem    ///< [out] image memory handle to the externally allocated memory
+    ur_context_handle_t hContext,                ///< [in] handle of the context object
+    ur_device_handle_t hDevice,                  ///< [in] handle of the device object
+    const ur_image_format_t *pImageFormat,       ///< [in] pointer to image format specification
+    const ur_image_desc_t *pImageDesc,           ///< [in] pointer to image description
+    ur_exp_interop_mem_handle_t hInteropMem,     ///< [in] interop memory handle to the external memory
+    ur_exp_image_mem_native_handle_t *phImageMem ///< [out] image memory handle to the externally allocated memory
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11043,7 +11037,7 @@ typedef struct ur_enqueue_native_command_exp_params_t {
 typedef struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_handle_t *phImage;
+    ur_exp_image_native_handle_t *phImage;
 } ur_bindless_images_unsampled_image_handle_destroy_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11053,7 +11047,7 @@ typedef struct ur_bindless_images_unsampled_image_handle_destroy_exp_params_t {
 typedef struct ur_bindless_images_sampled_image_handle_destroy_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_handle_t *phImage;
+    ur_exp_image_native_handle_t *phImage;
 } ur_bindless_images_sampled_image_handle_destroy_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11065,7 +11059,7 @@ typedef struct ur_bindless_images_image_allocate_exp_params_t {
     ur_device_handle_t *phDevice;
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
-    ur_exp_image_mem_handle_t **pphImageMem;
+    ur_exp_image_mem_native_handle_t **pphImageMem;
 } ur_bindless_images_image_allocate_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11075,7 +11069,7 @@ typedef struct ur_bindless_images_image_allocate_exp_params_t {
 typedef struct ur_bindless_images_image_free_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_mem_handle_t *phImageMem;
+    ur_exp_image_mem_native_handle_t *phImageMem;
 } ur_bindless_images_image_free_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11085,10 +11079,10 @@ typedef struct ur_bindless_images_image_free_exp_params_t {
 typedef struct ur_bindless_images_unsampled_image_create_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_mem_handle_t *phImageMem;
+    ur_exp_image_mem_native_handle_t *phImageMem;
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
-    ur_exp_image_handle_t **pphImage;
+    ur_exp_image_native_handle_t **pphImage;
 } ur_bindless_images_unsampled_image_create_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11098,11 +11092,11 @@ typedef struct ur_bindless_images_unsampled_image_create_exp_params_t {
 typedef struct ur_bindless_images_sampled_image_create_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_mem_handle_t *phImageMem;
+    ur_exp_image_mem_native_handle_t *phImageMem;
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
     ur_sampler_handle_t *phSampler;
-    ur_exp_image_handle_t **pphImage;
+    ur_exp_image_native_handle_t **pphImage;
 } ur_bindless_images_sampled_image_create_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11130,7 +11124,8 @@ typedef struct ur_bindless_images_image_copy_exp_params_t {
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
 typedef struct ur_bindless_images_image_get_info_exp_params_t {
-    ur_exp_image_mem_handle_t *phImageMem;
+    ur_context_handle_t *phContext;
+    ur_exp_image_mem_native_handle_t *phImageMem;
     ur_image_info_t *ppropName;
     void **ppPropValue;
     size_t **ppPropSizeRet;
@@ -11143,9 +11138,9 @@ typedef struct ur_bindless_images_image_get_info_exp_params_t {
 typedef struct ur_bindless_images_mipmap_get_level_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_mem_handle_t *phImageMem;
+    ur_exp_image_mem_native_handle_t *phImageMem;
     uint32_t *pmipmapLevel;
-    ur_exp_image_mem_handle_t **pphImageMem;
+    ur_exp_image_mem_native_handle_t **pphImageMem;
 } ur_bindless_images_mipmap_get_level_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11155,7 +11150,7 @@ typedef struct ur_bindless_images_mipmap_get_level_exp_params_t {
 typedef struct ur_bindless_images_mipmap_free_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
-    ur_exp_image_mem_handle_t *phMem;
+    ur_exp_image_mem_native_handle_t *phMem;
 } ur_bindless_images_mipmap_free_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11181,7 +11176,7 @@ typedef struct ur_bindless_images_map_external_array_exp_params_t {
     const ur_image_format_t **ppImageFormat;
     const ur_image_desc_t **ppImageDesc;
     ur_exp_interop_mem_handle_t *phInteropMem;
-    ur_exp_image_mem_handle_t **pphImageMem;
+    ur_exp_image_mem_native_handle_t **pphImageMem;
 } ur_bindless_images_map_external_array_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1531,14 +1531,14 @@ typedef ur_result_t(UR_APICALL *ur_pfnGetEnqueueExpProcAddrTable_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesUnsampledImageHandleDestroyExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_handle_t);
+    ur_exp_image_native_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesSampledImageHandleDestroyExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageHandleDestroyExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_handle_t);
+    ur_exp_image_native_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImageAllocateExp
@@ -1547,35 +1547,35 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageAllocateExp_t)(
     ur_device_handle_t,
     const ur_image_format_t *,
     const ur_image_desc_t *,
-    ur_exp_image_mem_handle_t *);
+    ur_exp_image_mem_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImageFreeExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageFreeExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_mem_handle_t);
+    ur_exp_image_mem_native_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesUnsampledImageCreateExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesUnsampledImageCreateExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_mem_handle_t,
+    ur_exp_image_mem_native_handle_t,
     const ur_image_format_t *,
     const ur_image_desc_t *,
-    ur_exp_image_handle_t *);
+    ur_exp_image_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesSampledImageCreateExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesSampledImageCreateExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_mem_handle_t,
+    ur_exp_image_mem_native_handle_t,
     const ur_image_format_t *,
     const ur_image_desc_t *,
     ur_sampler_handle_t,
-    ur_exp_image_handle_t *);
+    ur_exp_image_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImageCopyExp
@@ -1597,7 +1597,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageCopyExp_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImageGetInfoExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageGetInfoExp_t)(
-    ur_exp_image_mem_handle_t,
+    ur_context_handle_t,
+    ur_exp_image_mem_native_handle_t,
     ur_image_info_t,
     void *,
     size_t *);
@@ -1607,16 +1608,16 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImageGetInfoExp_t)(
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMipmapGetLevelExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_mem_handle_t,
+    ur_exp_image_mem_native_handle_t,
     uint32_t,
-    ur_exp_image_mem_handle_t *);
+    ur_exp_image_mem_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesMipmapFreeExp
 typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMipmapFreeExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
-    ur_exp_image_mem_handle_t);
+    ur_exp_image_mem_native_handle_t);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesImportExternalMemoryExp
@@ -1636,7 +1637,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesMapExternalArrayExp_t)(
     const ur_image_format_t *,
     const ur_image_desc_t *,
     ur_exp_interop_mem_handle_t,
-    ur_exp_image_mem_handle_t *);
+    ur_exp_image_mem_native_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urBindlessImagesReleaseInteropExp

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -39,8 +39,6 @@ struct is_handle<ur_kernel_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_queue_handle_t> : std::true_type {};
 template <>
-struct is_handle<ur_native_handle_t> : std::true_type {};
-template <>
 struct is_handle<ur_sampler_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_mem_handle_t> : std::true_type {};
@@ -49,13 +47,11 @@ struct is_handle<ur_physical_mem_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_usm_pool_handle_t> : std::true_type {};
 template <>
-struct is_handle<ur_exp_image_handle_t> : std::true_type {};
-template <>
-struct is_handle<ur_exp_image_mem_handle_t> : std::true_type {};
-template <>
 struct is_handle<ur_exp_interop_mem_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_exp_interop_semaphore_handle_t> : std::true_type {};
+template <>
+struct is_handle<ur_exp_win32_handle_t> : std::true_type {};
 template <>
 struct is_handle<ur_exp_command_buffer_handle_t> : std::true_type {};
 template <>
@@ -14646,8 +14642,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImage = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImage));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImage)));
 
     return os;
 }
@@ -14672,8 +14668,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImage = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImage));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImage)));
 
     return os;
 }
@@ -14736,8 +14732,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImageMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImageMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImageMem)));
 
     return os;
 }
@@ -14762,8 +14758,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImageMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImageMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImageMem)));
 
     os << ", ";
     os << ".pImageFormat = ";
@@ -14806,8 +14802,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImageMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImageMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImageMem)));
 
     os << ", ";
     os << ".pImageFormat = ";
@@ -14929,10 +14925,16 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 ///     std::ostream &
 inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_image_get_info_exp_params_t *params) {
 
-    os << ".hImageMem = ";
+    os << ".hContext = ";
 
     ur::details::printPtr(os,
-                          *(params->phImageMem));
+                          *(params->phContext));
+
+    os << ", ";
+    os << ".hImageMem = ";
+
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImageMem)));
 
     os << ", ";
     os << ".propName = ";
@@ -14974,8 +14976,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hImageMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phImageMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phImageMem)));
 
     os << ", ";
     os << ".mipmapLevel = ";
@@ -15011,8 +15013,8 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << ", ";
     os << ".hMem = ";
 
-    ur::details::printPtr(os,
-                          *(params->phMem));
+    ur::details::printPtr(os, reinterpret_cast<void *>(
+                                  *(params->phMem)));
 
     return os;
 }

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -148,8 +148,8 @@ Enums
 Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * ${x}_exp_sampler_mip_properties_t
-* ${x}_exp_image_handle_t
-* ${x}_exp_image_mem_handle_t
+* ${x}_exp_image_native_handle_t
+* ${x}_exp_image_mem_native_handle_t
 * ${x}_exp_interop_mem_handle_t
 * ${x}_exp_interop_semaphore_handle_t
 * ${x}_exp_interop_mem_desc_t

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -15,12 +15,12 @@ ordinal: "99"
 type: handle
 desc: "Handle of bindless image"
 class: $xBindlessImages
-name: "$x_exp_image_handle_t"
+name: "$x_exp_image_native_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
 desc: "Handle of bindless image memory"
 class: $xBindlessImages
-name: "$x_exp_image_mem_handle_t"
+name: "$x_exp_image_mem_native_handle_t"
 --- #--------------------------------------------------------------------------
 type: handle
 desc: "Handle of interop memory"
@@ -355,7 +355,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_handle_t
+    - type: $x_exp_image_native_handle_t
       name: hImage
       desc: "[in][release] pointer to handle of image object to destroy"
 returns:
@@ -376,7 +376,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_handle_t
+    - type: $x_exp_image_native_handle_t
       name: hImage
       desc: "[in][release] pointer to handle of image object to destroy"
 returns:
@@ -404,14 +404,14 @@ params:
     - type: "const $x_image_desc_t*"
       name: pImageDesc
       desc: "[in] pointer to image description"
-    - type: $x_exp_image_mem_handle_t*
+    - type: $x_exp_image_mem_native_handle_t*
       name: phImageMem
       desc: "[out] pointer to handle of image memory allocated"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`"
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
 --- #--------------------------------------------------------------------------
@@ -429,7 +429,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_exp_image_mem_native_handle_t
       name: hImageMem
       desc: "[in][release] handle of image memory to be freed"
 returns:
@@ -450,7 +450,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_exp_image_mem_native_handle_t
       name: hImageMem
       desc: "[in] handle to memory from which to create the image"
     - type: "const $x_image_format_t*"
@@ -459,14 +459,14 @@ params:
     - type: "const $x_image_desc_t*"
       name: pImageDesc
       desc: "[in] pointer to image description"
-    - type: $x_exp_image_handle_t*
+    - type: $x_exp_image_native_handle_t*
       name: phImage
       desc: "[out] pointer to handle of image object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`"
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
     - $X_RESULT_ERROR_ADAPTER_SPECIFIC
@@ -485,7 +485,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_exp_image_mem_native_handle_t
       name: hImageMem
       desc: "[in] handle to memory from which to create the image"
     - type: "const $x_image_format_t*"
@@ -497,14 +497,14 @@ params:
     - type: $x_sampler_handle_t
       name: hSampler
       desc: "[in] sampler to be used"
-    - type: $x_exp_image_handle_t*
+    - type: $x_exp_image_native_handle_t*
       name: phImage
       desc: "[out] pointer to handle of image object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`"
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_SAMPLER
     - $X_RESULT_ERROR_INVALID_OPERATION
@@ -568,7 +568,7 @@ returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`"
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
 --- #--------------------------------------------------------------------------
@@ -578,7 +578,10 @@ class: $xBindlessImages
 name: ImageGetInfoExp
 ordinal: "0"
 params:
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_context_handle_t
+      name: hContext
+      desc: "[in] handle of the context object"
+    - type: $x_exp_image_mem_native_handle_t
       name: hImageMem
       desc: "[in] handle to the image memory"
     - type: $x_image_info_t
@@ -615,13 +618,13 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_exp_image_mem_native_handle_t
       name: hImageMem
       desc: "[in] memory handle to the mipmap image"
     - type: uint32_t
       name: mipmapLevel
       desc: "[in] requested level of the mipmap"
-    - type: "$x_exp_image_mem_handle_t*"
+    - type: "$x_exp_image_mem_native_handle_t*"
       name: phImageMem
       desc: "[out] returning memory handle to the individual image"
 returns:
@@ -642,7 +645,7 @@ params:
     - type: $x_device_handle_t
       name: hDevice
       desc: "[in] handle of the device object"
-    - type: $x_exp_image_mem_handle_t
+    - type: $x_exp_image_mem_native_handle_t
       name: hMem
       desc: "[in][release] handle of image memory to be freed"
 returns:
@@ -701,14 +704,14 @@ params:
     - type: $x_exp_interop_mem_handle_t
       name: hInteropMem
       desc: "[in] interop memory handle to the external memory"
-    - type: $x_exp_image_mem_handle_t*
+    - type: $x_exp_image_mem_native_handle_t*
       name: phImageMem
       desc: "[out] image memory handle to the externally allocated memory"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
     - $X_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR:
-      - "`pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`"
+      - "`pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`"
     - $X_RESULT_ERROR_INVALID_IMAGE_SIZE
     - $X_RESULT_ERROR_INVALID_OPERATION
     - $X_RESULT_ERROR_OUT_OF_RESOURCES

--- a/scripts/parse_specs.py
+++ b/scripts/parse_specs.py
@@ -764,7 +764,7 @@ def _generate_returns(obj, meta):
             elif type_traits.is_funcptr(param['type'], meta):
                 _append(rets, "$X_RESULT_ERROR_INVALID_NULL_POINTER", "`NULL == %s`" % accessor)
 
-            elif type_traits.is_handle(param['type']) and not type_traits.is_ipc_handle(item['type']):
+            elif type_traits.is_handle(param['type']) and not type_traits.is_ipc_handle(item['type']) and not type_traits.is_native_handle(item['type']):
                 _append(rets, "$X_RESULT_ERROR_INVALID_NULL_HANDLE", "`NULL == %s`" % accessor)
 
         def append_enum_checks(param, accessor: str):

--- a/scripts/templates/print.hpp.mako
+++ b/scripts/templates/print.hpp.mako
@@ -115,7 +115,7 @@ namespace ${x}::details {
 template <typename T> struct is_handle : std::false_type {};
 %for spec in specs:
 %for obj in spec['objects']:
-%if re.match(r"handle", obj['type']):
+%if th.type_traits.is_handle(th.make_type_name(n, tags, obj)) and not th.type_traits.is_native_handle(th.make_type_name(n, tags, obj)):
 template <> struct is_handle<${th.make_type_name(n, tags, obj)}> : std::true_type {};
 %endif
 %endfor

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -235,7 +235,7 @@ cudaToUrImageChannelFormat(CUarray_format cuda_format,
 ur_result_t urTextureCreate(ur_sampler_handle_t hSampler,
                             const ur_image_desc_t *pImageDesc,
                             const CUDA_RESOURCE_DESC &ResourceDesc,
-                            ur_exp_image_handle_t *phRetImage) {
+                            ur_exp_image_native_handle_t *phRetImage) {
 
   try {
     /// pi_sampler_properties
@@ -324,7 +324,7 @@ ur_result_t urTextureCreate(ur_sampler_handle_t hSampler,
     CUtexObject Texture;
     UR_CHECK_ERROR(
         cuTexObjectCreate(&Texture, &ResourceDesc, &ImageTexDesc, nullptr));
-    *phRetImage = (ur_exp_image_handle_t)Texture;
+    *phRetImage = (ur_exp_image_native_handle_t)Texture;
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {
@@ -372,9 +372,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesUnsampledImageHandleDestroyExp(ur_context_handle_t hContext,
-                                               ur_device_handle_t hDevice,
-                                               ur_exp_image_handle_t hImage) {
+urBindlessImagesUnsampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    ur_exp_image_native_handle_t hImage) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -385,9 +385,9 @@ urBindlessImagesUnsampledImageHandleDestroyExp(ur_context_handle_t hContext,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesSampledImageHandleDestroyExp(ur_context_handle_t hContext,
-                                             ur_device_handle_t hDevice,
-                                             ur_exp_image_handle_t hImage) {
+urBindlessImagesSampledImageHandleDestroyExp(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    ur_exp_image_native_handle_t hImage) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -400,7 +400,7 @@ urBindlessImagesSampledImageHandleDestroyExp(ur_context_handle_t hContext,
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
-    ur_exp_image_mem_handle_t *phImageMem) {
+    ur_exp_image_mem_native_handle_t *phImageMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -458,7 +458,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
     try {
       UR_CHECK_ERROR(cuArray3DCreate(&ImageArray, &array_desc));
-      *phImageMem = (ur_exp_image_mem_handle_t)ImageArray;
+      *phImageMem = (ur_exp_image_mem_native_handle_t)ImageArray;
     } catch (ur_result_t Err) {
       cuArrayDestroy(ImageArray);
       return Err;
@@ -474,7 +474,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     try {
       UR_CHECK_ERROR(cuMipmappedArrayCreate(&mip_array, &array_desc,
                                             pImageDesc->numMipLevel));
-      *phImageMem = (ur_exp_image_mem_handle_t)mip_array;
+      *phImageMem = (ur_exp_image_mem_native_handle_t)mip_array;
     } catch (ur_result_t Err) {
       cuMipmappedArrayDestroy(mip_array);
       return Err;
@@ -489,7 +489,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_handle_t hImageMem) {
+    ur_exp_image_mem_native_handle_t hImageMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -508,9 +508,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_handle_t hImageMem, const ur_image_format_t *pImageFormat,
+    ur_exp_image_mem_native_handle_t hImageMem,
+    const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    ur_exp_image_handle_t *phImage) {
+    ur_exp_image_native_handle_t *phImage) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -540,7 +541,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     // CUDA deals with unsampled images.
     CUsurfObject surface;
     UR_CHECK_ERROR(cuSurfObjectCreate(&surface, &image_res_desc));
-    *phImage = (ur_exp_image_handle_t)surface;
+    *phImage = (ur_exp_image_native_handle_t)surface;
 
   } catch (ur_result_t Err) {
     return Err;
@@ -553,9 +554,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_handle_t hImageMem, const ur_image_format_t *pImageFormat,
-    const ur_image_desc_t *pImageDesc, ur_sampler_handle_t hSampler,
-    ur_exp_image_handle_t *phImage) {
+    ur_exp_image_mem_native_handle_t hImageMem,
+    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
+    ur_sampler_handle_t hSampler, ur_exp_image_native_handle_t *phImage) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -928,8 +929,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ur_image_info_t propName,
-    void *pPropValue, size_t *pPropSizeRet) {
+    ur_context_handle_t, ur_exp_image_mem_native_handle_t hImageMem,
+    ur_image_info_t propName, void *pPropValue, size_t *pPropSizeRet) {
 
   CUDA_ARRAY3D_DESCRIPTOR ArrayDesc;
   UR_CHECK_ERROR(cuArray3DGetDescriptor(&ArrayDesc, (CUarray)hImageMem));
@@ -992,8 +993,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_handle_t hImageMem, uint32_t mipmapLevel,
-    ur_exp_image_mem_handle_t *phImageMem) {
+    ur_exp_image_mem_native_handle_t hImageMem, uint32_t mipmapLevel,
+    ur_exp_image_mem_native_handle_t *phImageMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1004,7 +1005,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     CUarray ImageArray;
     UR_CHECK_ERROR(cuMipmappedArrayGetLevel(
         &ImageArray, (CUmipmappedArray)hImageMem, mipmapLevel));
-    *phImageMem = (ur_exp_image_mem_handle_t)ImageArray;
+    *phImageMem = (ur_exp_image_mem_native_handle_t)ImageArray;
   } catch (ur_result_t Err) {
     return Err;
   } catch (...) {
@@ -1016,7 +1017,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
-    ur_exp_image_mem_handle_t hMem) {
+    ur_exp_image_mem_native_handle_t hMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1096,7 +1097,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_interop_mem_handle_t hInteropMem,
-    ur_exp_image_mem_handle_t *phImageMem) {
+    ur_exp_image_mem_native_handle_t *phImageMem) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),
                       hContext->getDevices().end(),
                       hDevice) != hContext->getDevices().end(),
@@ -1131,12 +1132,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
         &memMipMap, (CUexternalMemory)hInteropMem, &mipmapDesc));
 
     if (pImageDesc->numMipLevel > 1) {
-      *phImageMem = (ur_exp_image_mem_handle_t)memMipMap;
+      *phImageMem = (ur_exp_image_mem_native_handle_t)memMipMap;
     } else {
       CUarray memArray;
       UR_CHECK_ERROR(cuMipmappedArrayGetLevel(&memArray, memMipMap, 0));
 
-      *phImageMem = (ur_exp_image_mem_handle_t)memArray;
+      *phImageMem = (ur_exp_image_mem_native_handle_t)memArray;
     }
 
   } catch (ur_result_t Err) {

--- a/source/adapters/cuda/image.hpp
+++ b/source/adapters/cuda/image.hpp
@@ -31,4 +31,4 @@ ur_result_t urTextureCreate(ur_context_handle_t hContext,
                             ur_sampler_desc_t SamplerDesc,
                             const ur_image_desc_t *pImageDesc,
                             CUDA_RESOURCE_DESC ResourceDesc,
-                            ur_exp_image_handle_t *phRetImage);
+                            ur_exp_image_native_handle_t *phRetImage);

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -25,7 +25,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -33,7 +33,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -42,35 +42,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_sampler_handle_t hSampler,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -91,7 +91,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] ur_image_info_t propName,
     [[maybe_unused]] void *pPropValue, [[maybe_unused]] size_t *pPropSizeRet) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -100,16 +101,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] uint32_t mipmapLevel,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
-                              [[maybe_unused]] ur_device_handle_t hDevice,
-                              [[maybe_unused]] ur_exp_image_mem_handle_t hMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -128,7 +129,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -25,7 +25,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -33,7 +33,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -42,35 +42,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_sampler_handle_t hSampler,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -91,7 +91,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] ur_image_info_t propName,
     [[maybe_unused]] void *pPropValue, [[maybe_unused]] size_t *pPropSizeRet) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -100,16 +101,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] uint32_t mipmapLevel,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
-                              [[maybe_unused]] ur_device_handle_t hDevice,
-                              [[maybe_unused]] ur_exp_image_mem_handle_t hMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -128,7 +129,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/null/ur_nullddi.cpp
+++ b/source/adapters/null/ur_nullddi.cpp
@@ -4232,7 +4232,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4258,7 +4258,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4285,7 +4285,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4299,7 +4299,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     } else {
         // generic implementation
         *phImageMem =
-            reinterpret_cast<ur_exp_image_mem_handle_t>(d_context.get());
+            reinterpret_cast<ur_exp_image_mem_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -4312,7 +4312,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4336,12 +4336,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4354,7 +4354,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
                                             pImageFormat, pImageDesc, phImage);
     } else {
         // generic implementation
-        *phImage = reinterpret_cast<ur_exp_image_handle_t>(d_context.get());
+        *phImage =
+            reinterpret_cast<ur_exp_image_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -4367,13 +4368,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4387,7 +4388,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
                                      pImageDesc, hSampler, phImage);
     } else {
         // generic implementation
-        *phImage = reinterpret_cast<ur_exp_image_handle_t>(d_context.get());
+        *phImage =
+            reinterpret_cast<ur_exp_image_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -4454,10 +4456,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4465,8 +4469,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     auto pfnImageGetInfoExp =
         d_context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
     if (nullptr != pfnImageGetInfoExp) {
-        result =
-            pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+        result = pfnImageGetInfoExp(hContext, hImageMem, propName, pPropValue,
+                                    pPropSizeRet);
     } else {
         // generic implementation
     }
@@ -4481,10 +4485,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4498,7 +4502,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     } else {
         // generic implementation
         *phImageMem =
-            reinterpret_cast<ur_exp_image_mem_handle_t>(d_context.get());
+            reinterpret_cast<ur_exp_image_mem_native_handle_t>(d_context.get());
     }
 
     return result;
@@ -4511,7 +4515,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4573,7 +4577,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4587,7 +4591,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     } else {
         // generic implementation
         *phImageMem =
-            reinterpret_cast<ur_exp_image_mem_handle_t>(d_context.get());
+            reinterpret_cast<ur_exp_image_mem_native_handle_t>(d_context.get());
     }
 
     return result;

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -25,7 +25,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -33,7 +33,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_handle_t hImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t hImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -42,35 +42,35 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_sampler_handle_t hSampler,
-    [[maybe_unused]] ur_exp_image_handle_t *phImage) {
+    [[maybe_unused]] ur_exp_image_native_handle_t *phImage) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -91,7 +91,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] ur_image_info_t propName,
     [[maybe_unused]] void *pPropValue, [[maybe_unused]] size_t *pPropSizeRet) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
@@ -100,16 +101,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
-    [[maybe_unused]] ur_exp_image_mem_handle_t hImageMem,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hImageMem,
     [[maybe_unused]] uint32_t mipmapLevel,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesMipmapFreeExp([[maybe_unused]] ur_context_handle_t hContext,
-                              [[maybe_unused]] ur_device_handle_t hDevice,
-                              [[maybe_unused]] ur_exp_image_mem_handle_t hMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+    [[maybe_unused]] ur_context_handle_t hContext,
+    [[maybe_unused]] ur_device_handle_t hDevice,
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t hMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -128,7 +129,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     [[maybe_unused]] const ur_image_format_t *pImageFormat,
     [[maybe_unused]] const ur_image_desc_t *pImageDesc,
     [[maybe_unused]] ur_exp_interop_mem_handle_t hInteropMem,
-    [[maybe_unused]] ur_exp_image_mem_handle_t *phImageMem) {
+    [[maybe_unused]] ur_exp_image_mem_native_handle_t *phImageMem) {
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -5460,7 +5460,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     auto pfnUnsampledImageHandleDestroyExp =
@@ -5502,7 +5502,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     auto pfnSampledImageHandleDestroyExp =
@@ -5545,7 +5545,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
 ) {
     auto pfnImageAllocateExp =
@@ -5583,7 +5583,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
 ) {
     auto pfnImageFreeExp = context.urDdiTable.BindlessImagesExp.pfnImageFreeExp;
@@ -5619,12 +5619,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     auto pfnUnsampledImageCreateExp =
@@ -5663,13 +5663,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     auto pfnSampledImageCreateExp =
@@ -5784,10 +5784,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
 ) {
     auto pfnImageGetInfoExp =
         context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
@@ -5797,15 +5799,15 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     }
 
     ur_bindless_images_image_get_info_exp_params_t params = {
-        &hImageMem, &propName, &pPropValue, &pPropSizeRet};
+        &hContext, &hImageMem, &propName, &pPropValue, &pPropSizeRet};
     uint64_t instance =
         context.notify_begin(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP,
                              "urBindlessImagesImageGetInfoExp", &params);
 
     context.logger.info("---> urBindlessImagesImageGetInfoExp");
 
-    ur_result_t result =
-        pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+    ur_result_t result = pfnImageGetInfoExp(hContext, hImageMem, propName,
+                                            pPropValue, pPropSizeRet);
 
     context.notify_end(UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP,
                        "urBindlessImagesImageGetInfoExp", &params, &result,
@@ -5824,10 +5826,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
 ) {
     auto pfnMipmapGetLevelExp =
@@ -5865,7 +5867,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
 ) {
     auto pfnMipmapFreeExp =
@@ -5952,7 +5954,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
     auto pfnMapExternalArrayExp =

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -6856,7 +6856,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     auto pfnUnsampledImageHandleDestroyExp =
@@ -6872,10 +6872,6 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hImage) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -6902,7 +6898,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     auto pfnSampledImageHandleDestroyExp =
@@ -6918,10 +6914,6 @@ urBindlessImagesSampledImageHandleDestroyExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hImage) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -6950,7 +6942,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
 ) {
     auto pfnImageAllocateExp =
@@ -6981,7 +6973,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type) {
+        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
     }
@@ -7007,7 +6999,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
 ) {
     auto pfnImageFreeExp = context.urDdiTable.BindlessImagesExp.pfnImageFreeExp;
@@ -7022,10 +7014,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hImageMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -7050,12 +7038,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     auto pfnUnsampledImageCreateExp =
@@ -7074,10 +7062,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
-        if (NULL == hImageMem) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
         if (NULL == pImageFormat) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
@@ -7090,7 +7074,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type) {
+        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
     }
@@ -7116,13 +7100,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     auto pfnSampledImageCreateExp =
@@ -7138,10 +7122,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hImageMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
@@ -7161,7 +7141,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type) {
+        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
     }
@@ -7253,7 +7233,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type) {
+        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
 
@@ -7282,10 +7262,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
 ) {
     auto pfnImageGetInfoExp =
         context.urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
@@ -7295,7 +7277,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     }
 
     if (context.enableParameterValidation) {
-        if (NULL == hImageMem) {
+        if (NULL == hContext) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
@@ -7308,8 +7290,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
         }
     }
 
-    ur_result_t result =
-        pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+    if (context.enableLifetimeValidation &&
+        !refCountContext.isReferenceValid(hContext)) {
+        refCountContext.logInvalidReference(hContext);
+    }
+
+    ur_result_t result = pfnImageGetInfoExp(hContext, hImageMem, propName,
+                                            pPropValue, pPropSizeRet);
 
     return result;
 }
@@ -7319,10 +7306,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
 ) {
     auto pfnMipmapGetLevelExp =
@@ -7338,10 +7325,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hImageMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
 
@@ -7371,7 +7354,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
 ) {
     auto pfnMipmapFreeExp =
@@ -7387,10 +7370,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
         }
 
         if (NULL == hDevice) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
-        if (NULL == hMem) {
             return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
         }
     }
@@ -7478,7 +7457,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
     auto pfnMapExternalArrayExp =
@@ -7513,7 +7492,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type) {
+        if (pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type) {
             return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
         }
     }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -26,8 +26,6 @@ ur_sampler_factory_t ur_sampler_factory;
 ur_mem_factory_t ur_mem_factory;
 ur_physical_mem_factory_t ur_physical_mem_factory;
 ur_usm_pool_factory_t ur_usm_pool_factory;
-ur_exp_image_factory_t ur_exp_image_factory;
-ur_exp_image_mem_factory_t ur_exp_image_mem_factory;
 ur_exp_interop_mem_factory_t ur_exp_interop_mem_factory;
 ur_exp_interop_semaphore_factory_t ur_exp_interop_semaphore_factory;
 ur_exp_command_buffer_factory_t ur_exp_command_buffer_factory;
@@ -5818,7 +5816,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5837,9 +5835,6 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
-    // convert loader handle to platform handle
-    hImage = reinterpret_cast<ur_exp_image_object_t *>(hImage)->handle;
-
     // forward to device-platform
     result = pfnUnsampledImageHandleDestroyExp(hContext, hDevice, hImage);
 
@@ -5852,7 +5847,7 @@ __urdlllocal ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5871,9 +5866,6 @@ urBindlessImagesSampledImageHandleDestroyExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
-    // convert loader handle to platform handle
-    hImage = reinterpret_cast<ur_exp_image_object_t *>(hImage)->handle;
-
     // forward to device-platform
     result = pfnSampledImageHandleDestroyExp(hContext, hDevice, hImage);
 
@@ -5888,7 +5880,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5915,14 +5907,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
         return result;
     }
 
-    try {
-        // convert platform handle to loader handle
-        *phImageMem = reinterpret_cast<ur_exp_image_mem_handle_t>(
-            ur_exp_image_mem_factory.getInstance(*phImageMem, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-    }
-
     return result;
 }
 
@@ -5931,7 +5915,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5949,10 +5933,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
-    // convert loader handle to platform handle
-    hImageMem =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
-
     // forward to device-platform
     result = pfnImageFreeExp(hContext, hDevice, hImageMem);
 
@@ -5964,12 +5944,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5988,24 +5968,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
-    // convert loader handle to platform handle
-    hImageMem =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
-
     // forward to device-platform
     result = pfnUnsampledImageCreateExp(hContext, hDevice, hImageMem,
                                         pImageFormat, pImageDesc, phImage);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phImage = reinterpret_cast<ur_exp_image_handle_t>(
-            ur_exp_image_factory.getInstance(*phImage, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     return result;
@@ -6016,13 +5984,13 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -6042,10 +6010,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
     // convert loader handle to platform handle
-    hImageMem =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
-
-    // convert loader handle to platform handle
     hSampler = reinterpret_cast<ur_sampler_object_t *>(hSampler)->handle;
 
     // forward to device-platform
@@ -6055,14 +6019,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phImage = reinterpret_cast<ur_exp_image_handle_t>(
-            ur_exp_image_factory.getInstance(*phImage, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     return result;
@@ -6148,27 +6104,28 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     // extract platform's function pointer table
-    auto dditable =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->dditable;
+    auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
     auto pfnImageGetInfoExp = dditable->ur.BindlessImagesExp.pfnImageGetInfoExp;
     if (nullptr == pfnImageGetInfoExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
     // convert loader handle to platform handle
-    hImageMem =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
+    hContext = reinterpret_cast<ur_context_object_t *>(hContext)->handle;
 
     // forward to device-platform
-    result = pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+    result = pfnImageGetInfoExp(hContext, hImageMem, propName, pPropValue,
+                                pPropSizeRet);
 
     return result;
 }
@@ -6178,10 +6135,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -6200,24 +6157,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
 
-    // convert loader handle to platform handle
-    hImageMem =
-        reinterpret_cast<ur_exp_image_mem_object_t *>(hImageMem)->handle;
-
     // forward to device-platform
     result = pfnMipmapGetLevelExp(hContext, hDevice, hImageMem, mipmapLevel,
                                   phImageMem);
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phImageMem = reinterpret_cast<ur_exp_image_mem_handle_t>(
-            ur_exp_image_mem_factory.getInstance(*phImageMem, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     return result;
@@ -6228,7 +6173,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -6245,9 +6190,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
     // convert loader handle to platform handle
     hDevice = reinterpret_cast<ur_device_object_t *>(hDevice)->handle;
-
-    // convert loader handle to platform handle
-    hMem = reinterpret_cast<ur_exp_image_mem_object_t *>(hMem)->handle;
 
     // forward to device-platform
     result = pfnMipmapFreeExp(hContext, hDevice, hMem);
@@ -6313,7 +6255,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -6342,14 +6284,6 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
     if (UR_RESULT_SUCCESS != result) {
         return result;
-    }
-
-    try {
-        // convert platform handle to loader handle
-        *phImageMem = reinterpret_cast<ur_exp_image_mem_handle_t>(
-            ur_exp_image_mem_factory.getInstance(*phImageMem, dditable));
-    } catch (std::bad_alloc &) {
-        result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
     }
 
     return result;

--- a/source/loader/ur_ldrddi.hpp
+++ b/source/loader/ur_ldrddi.hpp
@@ -64,14 +64,6 @@ using ur_usm_pool_object_t = object_t<ur_usm_pool_handle_t>;
 using ur_usm_pool_factory_t =
     singleton_factory_t<ur_usm_pool_object_t, ur_usm_pool_handle_t>;
 
-using ur_exp_image_object_t = object_t<ur_exp_image_handle_t>;
-using ur_exp_image_factory_t =
-    singleton_factory_t<ur_exp_image_object_t, ur_exp_image_handle_t>;
-
-using ur_exp_image_mem_object_t = object_t<ur_exp_image_mem_handle_t>;
-using ur_exp_image_mem_factory_t =
-    singleton_factory_t<ur_exp_image_mem_object_t, ur_exp_image_mem_handle_t>;
-
 using ur_exp_interop_mem_object_t = object_t<ur_exp_interop_mem_handle_t>;
 using ur_exp_interop_mem_factory_t =
     singleton_factory_t<ur_exp_interop_mem_object_t,

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -6544,13 +6544,12 @@ ur_result_t UR_APICALL urUSMPitchedAllocExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
     ) try {
     auto pfnUnsampledImageHandleDestroyExp =
@@ -6580,13 +6579,12 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
     ) try {
     auto pfnSampledImageHandleDestroyExp =
@@ -6624,7 +6622,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
@@ -6633,7 +6631,7 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
     ) try {
     auto pfnImageAllocateExp =
@@ -6663,13 +6661,12 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
     ) try {
     auto pfnImageFreeExp =
@@ -6698,7 +6695,6 @@ ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -6706,19 +6702,19 @@ ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
     ) try {
     auto pfnUnsampledImageCreateExp =
@@ -6749,7 +6745,6 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -6758,7 +6753,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
@@ -6766,13 +6761,13 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
     ) try {
     auto pfnSampledImageCreateExp =
@@ -6814,7 +6809,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
@@ -6872,7 +6867,7 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hImageMem`
+///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
@@ -6885,10 +6880,12 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
     ) try {
     auto pfnImageGetInfoExp =
         ur_lib::context->urDdiTable.BindlessImagesExp.pfnImageGetInfoExp;
@@ -6896,7 +6893,8 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnImageGetInfoExp(hImageMem, propName, pPropValue, pPropSizeRet);
+    return pfnImageGetInfoExp(hContext, hImageMem, propName, pPropValue,
+                              pPropSizeRet);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }
@@ -6916,7 +6914,6 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -6924,10 +6921,10 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
     ) try {
     auto pfnMipmapGetLevelExp =
@@ -6957,13 +6954,12 @@ ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
     ) try {
     auto pfnMipmapFreeExp =
@@ -7043,7 +7039,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -7055,7 +7051,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
     ) try {
     auto pfnMapExternalArrayExp =

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5594,13 +5594,12 @@ ur_result_t UR_APICALL urUSMPitchedAllocExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5622,13 +5621,12 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImage`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         hImage ///< [in][release] pointer to handle of image object to destroy
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5658,7 +5656,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
@@ -5667,7 +5665,7 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] pointer to handle of image memory allocated
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5689,13 +5687,12 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem ///< [in][release] handle of image memory to be freed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5717,7 +5714,6 @@ ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
 ///         + `NULL == pImageDesc`
@@ -5725,19 +5721,19 @@ ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5759,7 +5755,6 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///         + `NULL == hSampler`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == pImageFormat`
@@ -5768,7 +5763,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_SAMPLER
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
@@ -5776,13 +5771,13 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem, ///< [in] handle to memory from which to create the image
     const ur_image_format_t
         *pImageFormat, ///< [in] pointer to image format specification
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_sampler_handle_t hSampler,      ///< [in] sampler to be used
-    ur_exp_image_handle_t
+    ur_exp_image_native_handle_t
         *phImage ///< [out] pointer to handle of image object created
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5816,7 +5811,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 ///     - ::UR_RESULT_ERROR_INVALID_QUEUE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
@@ -5864,7 +5859,7 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hImageMem`
+///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
 ///         + `::UR_IMAGE_INFO_DEPTH < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
@@ -5877,10 +5872,12 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
-    ur_exp_image_mem_handle_t hImageMem, ///< [in] handle to the image memory
-    ur_image_info_t propName,            ///< [in] queried info name
-    void *pPropValue,    ///< [out][optional] returned query value
-    size_t *pPropSizeRet ///< [out][optional] returned query value size
+    ur_context_handle_t hContext, ///< [in] handle of the context object
+    ur_exp_image_mem_native_handle_t
+        hImageMem,            ///< [in] handle to the image memory
+    ur_image_info_t propName, ///< [in] queried info name
+    void *pPropValue,         ///< [out][optional] returned query value
+    size_t *pPropSizeRet      ///< [out][optional] returned query value size
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -5901,7 +5898,6 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phImageMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
@@ -5909,10 +5905,10 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hImageMem,        ///< [in] memory handle to the mipmap image
     uint32_t mipmapLevel, ///< [in] requested level of the mipmap
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         *phImageMem ///< [out] returning memory handle to the individual image
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5934,13 +5930,12 @@ ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///         + `NULL == hDevice`
-///         + `NULL == hMem`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
-    ur_exp_image_mem_handle_t
+    ur_exp_image_mem_native_handle_t
         hMem ///< [in][release] handle of image memory to be freed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -6004,7 +5999,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR
-///         + `pImageDesc && UR_MEM_TYPE_IMAGE1D_ARRAY < pImageDesc->type`
+///         + `pImageDesc && UR_MEM_TYPE_IMAGE_CUBEMAP_EXP < pImageDesc->type`
 ///     - ::UR_RESULT_ERROR_INVALID_IMAGE_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_OPERATION
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
@@ -6016,7 +6011,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     const ur_image_desc_t *pImageDesc, ///< [in] pointer to image description
     ur_exp_interop_mem_handle_t
         hInteropMem, ///< [in] interop memory handle to the external memory
-    ur_exp_image_mem_handle_t *
+    ur_exp_image_mem_native_handle_t *
         phImageMem ///< [out] image memory handle to the externally allocated memory
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;


### PR DESCRIPTION
The bindless image extension added new handle types, however some of them are used in the SYCL Runtime in ways that contradict how handles are expected to be implemented, by casting them directly between other types. This breaks when UR is used with the UR loader, which transparently wraps handles to allow dispatching to specific adapters. This usage implies they are more like native handles, so they should be implemented like native handles.

Rename the image and image_mem types - if they end in `native_handle_t`, they are treated as native handles. Also update ImageGetInfoExp to take a context handle so it still possible for the loader to dispatch to the adapters.

Also fix incorrect return condition for `UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR` in bindless image functions