### PR TITLE
[OpenCL] Add OpenCL version check for independent forward progress query

### DIFF
--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -887,7 +887,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_AVAILABLE:
   case UR_DEVICE_INFO_COMPILER_AVAILABLE:
   case UR_DEVICE_INFO_LINKER_AVAILABLE:
-  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC:
+  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
+    /* CL type: cl_bool
+     * UR type: ur_bool_t */
+
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+                        sizeof(cl_bool), &CLValue, nullptr));
+
+    /* cl_bool is uint32_t and ur_bool_t is bool */
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
   case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {
     /* CL type: cl_bool
      * UR type: ur_bool_t */

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -909,15 +909,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     /* Independent forward progress query is only supported as of OpenCL 2.1
      * if version is older we return a default false. */
     if (DevVer >= oclv::V2_1) {
-        cl_bool CLValue;
-        CL_RETURN_ON_FAILURE(
-            clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                            sizeof(cl_bool), &CLValue, nullptr));
+      cl_bool CLValue;
+      CL_RETURN_ON_FAILURE(
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+                          sizeof(cl_bool), &CLValue, nullptr));
 
-        /* cl_bool is uint32_t and ur_bool_t is bool */
-        return ReturnValue(static_cast<ur_bool_t>(CLValue));
+      /* cl_bool is uint32_t and ur_bool_t is bool */
+      return ReturnValue(static_cast<ur_bool_t>(CLValue));
     } else {
-        return ReturnValue(false);
+      return ReturnValue(false);
     }
   }
   case UR_DEVICE_INFO_VENDOR_ID:

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -906,6 +906,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     oclv::OpenCLVersion DevVer;
     CL_RETURN_ON_FAILURE(cl_adapter::getDeviceVersion(
         cl_adapter::cast<cl_device_id>(hDevice), DevVer));
+    /* Independent forward progress query is only supported as of OpenCL 2.1
+     * if version is older we return a default false. */
     if (DevVer >= oclv::V2_1) {
         cl_bool CLValue;
         CL_RETURN_ON_FAILURE(

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -892,13 +892,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     /* CL type: cl_bool
      * UR type: ur_bool_t */
 
-    cl_bool CLValue;
-    CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                        sizeof(cl_bool), &CLValue, nullptr));
+    oclv::OpenCLVersion DevVer;
+    CL_RETURN_ON_FAILURE(cl_adapter::getDeviceVersion(
+        cl_adapter::cast<cl_device_id>(hDevice), DevVer));
+    if (DevVer >= oclv::V2_1) {
+        cl_bool CLValue;
+        CL_RETURN_ON_FAILURE(
+            clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+                            sizeof(cl_bool), &CLValue, nullptr));
 
-    /* cl_bool is uint32_t and ur_bool_t is bool */
-    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+        /* cl_bool is uint32_t and ur_bool_t is bool */
+        return ReturnValue(static_cast<ur_bool_t>(CLValue));
+    } else {
+        return ReturnValue(false);
+    }
   }
   case UR_DEVICE_INFO_VENDOR_ID:
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:


### PR DESCRIPTION
As per [OpenCL docs](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetDeviceInfo.html), `CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS` is missing in OpenCL versions prior to 2.1. This change adds a check to the OpenCL version to ensure it is newer than 2.1, otherwise returning a default value for independent forward progress.