### PR TITLE
[CTS] Fix naming of exp_enqueue_native test

### DIFF
--- a/test/conformance/exp_enqueue_native/CMakeLists.txt
+++ b/test/conformance/exp_enqueue_native/CMakeLists.txt
@@ -5,14 +5,14 @@
 
 if (UR_BUILD_ADAPTER_CUDA)
   add_conformance_test_with_kernels_environment(
-    exp_enqueue_native_cuda
+    exp_enqueue_native
     enqueue_native_cuda.cpp
   )
-  target_include_directories(test-exp_enqueue_native_cuda PRIVATE
+  target_include_directories(test-exp_enqueue_native PRIVATE
       ${PROJECT_SOURCE_DIR}/source
       ${PROJECT_SOURCE_DIR}/source/adapters/cuda
   )
-  target_link_libraries(test-exp_enqueue_native_cuda PRIVATE cudadrv)
+  target_link_libraries(test-exp_enqueue_native PRIVATE cudadrv)
 endif()
 
 # TODO: Add more tests for different triples


### PR DESCRIPTION
This was tripping up the CTS parsing script and the `adapter-cuda` part of the name is added automatically.