### PR TITLE
Refactor L0 command-buffer cleanup.

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -424,9 +424,7 @@ ur_exp_command_buffer_handle_t_::ur_exp_command_buffer_handle_t_(
   urDeviceRetain(Device);
 }
 
-// The ur_exp_command_buffer_handle_t_ destructor releases all the memory
-// objects allocated for command_buffer management.
-ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
+void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
   // Release the memory allocated to the Context stored in the command_buffer
   urContextRelease(Context);
 
@@ -703,6 +701,7 @@ urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
   if (!CommandBuffer->RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
+  CommandBuffer->cleanupCommandBufferResources();
   delete CommandBuffer;
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -34,8 +34,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       ur_event_handle_t WaitEvent, ur_event_handle_t AllResetEvent,
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
-  ~ur_exp_command_buffer_handle_t_();
-
   void registerSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
                          ur_event_handle_t Event);
 
@@ -64,6 +62,10 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
    * @return The chosen command list.
    */
   ze_command_list_handle_t chooseCommandList(bool PreferCopyEngine);
+
+  // Releases the resources associated with the command-buffer before the
+  // command-buffer object is destroyed.
+  void cleanupCommandBufferResources();
 
   // UR context associated with this command-buffer
   ur_context_handle_t Context;


### PR DESCRIPTION
Coverity has reported that there is the possibility of the command-buffer destructor throwing an exception from its calls
to `CleanupCompletedEvent`.

This is from an underlying `throw` in [GetQueue](https://github.com/oneapi-src/unified-runtime/blob/main/source/adapters/level_zero/queue.hpp#L890) when a `dynamic_cast` doesn't behave as expected. I initially tried
changing this to an assert but the V2 Level Zero adapter is triggering this case while in it's developmental state, so an assert brings down the whole test suite rather than just being reported as a fail (the UR loader catches exceptions and returns them as error codes).

Therefore this PR addresses the Coverity report by moving the calls to `CleanupCompletedEvent()` outside of the command-buffer destructor. This allows us to cleanup prior to calling the destructor, without the risk of throwing an exception.

DPC++ PR https://github.com/intel/llvm/pull/14503