### PR TITLE
Remove the power of 2 pattern size requirement from USMFill

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -6894,7 +6894,6 @@ urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST

--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8387,7 +8387,6 @@ urCommandBufferAppendUSMMemcpyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -1061,7 +1061,6 @@ returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`patternSize == 0 || size == 0`"
         - "`patternSize > size`"
-        - "`(patternSize & (patternSize - 1)) != 0`"
         - "`size % patternSize != 0`"
         - "If `size` is higher than the allocation size of `ptr`"
     - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -408,7 +408,6 @@ returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`patternSize == 0 || size == 0`"
         - "`patternSize > size`"
-        - "`(patternSize & (patternSize - 1)) != 0`"
         - "`size % patternSize != 0`"
         - "If `size` is higher than the allocation size of `ptr`"
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -5979,10 +5979,6 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if ((patternSize & (patternSize - 1)) != 0) {
-            return UR_RESULT_ERROR_INVALID_SIZE;
-        }
-
         if (size % patternSize != 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -8085,10 +8085,6 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
 
-        if ((patternSize & (patternSize - 1)) != 0) {
-            return UR_RESULT_ERROR_INVALID_SIZE;
-        }
-
         if (size % patternSize != 0) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -5887,7 +5887,6 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7539,7 +7539,6 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5023,7 +5023,6 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -6403,7 +6403,6 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `patternSize == 0 || size == 0`
 ///         + `patternSize > size`
-///         + `(patternSize & (patternSize - 1)) != 0`
 ///         + `size % patternSize != 0`
 ///         + If `size` is higher than the allocation size of `ptr`
 ///     - ::UR_RESULT_ERROR_INVALID_MEM_OBJECT


### PR DESCRIPTION
All adapters have sufficiently robust workarounds that this is no longer necessary, and the sycl runtime is now using USMFill in such a way that if we enable the validation layer this case will get hit and break stuff.