### PR TITLE
[L0] Use all devices from a context in urProgramBuild

### DIFF
--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -284,8 +284,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
     ur_program_handle_t
         *Program ///< [out] pointer to handle of program object created.
 ) {
-  return urProgramLinkExp(Context, Count, Context->Devices.data(), 1, Programs,
-                          Options, Program);
+  return urProgramLinkExp(Context, Context->Devices.size(),
+                          Context->Devices.data(), Count, Programs, Options,
+                          Program);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -114,7 +114,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(
     const char *Options          ///< [in][optional] pointer to build options
                                  ///< null-terminated string.
 ) {
-  return urProgramBuildExp(Program, 1, Context->Devices.data(), Options);
+  return urProgramBuildExp(Program, Context->Devices.size(),
+                           Context->Devices.data(), Options);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(

--- a/test/conformance/kernel/urKernelCreate.cpp
+++ b/test/conformance/kernel/urKernelCreate.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <uur/fixtures.h>
+#include <uur/raii.h>
 
 struct urKernelCreateTest : uur::urProgramTest {
     void SetUp() override {
@@ -50,4 +51,41 @@ TEST_P(urKernelCreateTest, InvalidKernelName) {
     std::string invalid_name = "incorrect_kernel_name";
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_KERNEL_NAME,
                      urKernelCreate(program, invalid_name.data(), &kernel));
+}
+
+using urMultiDeviceKernelCreateTest = uur::urMultiDeviceQueueTest;
+
+TEST_F(urMultiDeviceKernelCreateTest, Success) {
+    constexpr size_t global_offset = 0;
+    constexpr size_t n_dimensions = 1;
+    constexpr size_t global_size = 100;
+    constexpr size_t local_size = 100;
+
+    auto kernelName =
+        uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
+
+    std::shared_ptr<std::vector<char>> il_binary;
+    uur::KernelsEnvironment::instance->LoadSource("foo", il_binary);
+
+    auto &devices = uur::KernelsEnvironment::instance->devices;
+    for (size_t i = 0; i < devices.size(); i++) {
+        uur::raii::Program program;
+        uur::raii::Kernel kernel;
+
+        const ur_program_properties_t properties = {
+            UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES, nullptr, 0, nullptr};
+        ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
+            platform, context, devices[i], *il_binary, &properties,
+            program.ptr()));
+
+        ASSERT_SUCCESS(urProgramBuild(context, program.get(), nullptr));
+        ASSERT_SUCCESS(
+            urKernelCreate(program.get(), kernelName.data(), kernel.ptr()));
+
+        ASSERT_SUCCESS(urEnqueueKernelLaunch(
+            queues[i], kernel.get(), n_dimensions, &global_offset, &local_size,
+            &global_size, 0, nullptr, nullptr));
+
+        ASSERT_SUCCESS(urQueueFinish(queues[i]));
+    }
 }

--- a/test/conformance/kernel/urKernelCreate.cpp
+++ b/test/conformance/kernel/urKernelCreate.cpp
@@ -55,7 +55,7 @@ TEST_P(urKernelCreateTest, InvalidKernelName) {
 
 using urMultiDeviceKernelCreateTest = uur::urMultiDeviceQueueTest;
 
-TEST_F(urMultiDeviceKernelCreateTest, Success) {
+TEST_F(urMultiDeviceKernelCreateTest, WithProgramBuild) {
     constexpr size_t global_offset = 0;
     constexpr size_t n_dimensions = 1;
     constexpr size_t global_size = 100;
@@ -81,6 +81,47 @@ TEST_F(urMultiDeviceKernelCreateTest, Success) {
         ASSERT_SUCCESS(urProgramBuild(context, program.get(), nullptr));
         ASSERT_SUCCESS(
             urKernelCreate(program.get(), kernelName.data(), kernel.ptr()));
+
+        ASSERT_SUCCESS(urEnqueueKernelLaunch(
+            queues[i], kernel.get(), n_dimensions, &global_offset, &local_size,
+            &global_size, 0, nullptr, nullptr));
+
+        ASSERT_SUCCESS(urQueueFinish(queues[i]));
+    }
+}
+
+TEST_F(urMultiDeviceKernelCreateTest, WithProgramCompileAndLink) {
+    constexpr size_t global_offset = 0;
+    constexpr size_t n_dimensions = 1;
+    constexpr size_t global_size = 100;
+    constexpr size_t local_size = 100;
+
+    auto kernelName =
+        uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
+
+    std::shared_ptr<std::vector<char>> il_binary;
+    uur::KernelsEnvironment::instance->LoadSource("foo", il_binary);
+
+    auto &devices = uur::KernelsEnvironment::instance->devices;
+    for (size_t i = 0; i < devices.size(); i++) {
+        uur::raii::Program program;
+        uur::raii::Kernel kernel;
+
+        const ur_program_properties_t properties = {
+            UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES, nullptr, 0, nullptr};
+        ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
+            platform, context, devices[i], *il_binary, &properties,
+            program.ptr()));
+
+        ASSERT_SUCCESS(urProgramCompile(context, program.get(), nullptr));
+
+        uur::raii::Program linked_program;
+        ASSERT_EQ_RESULT(UR_RESULT_SUCCESS,
+                         urProgramLink(context, 1, program.ptr(), nullptr,
+                                       linked_program.ptr()));
+
+        ASSERT_SUCCESS(urKernelCreate(linked_program.get(), kernelName.data(),
+                                      kernel.ptr()));
 
         ASSERT_SUCCESS(urEnqueueKernelLaunch(
             queues[i], kernel.get(), n_dimensions, &global_offset, &local_size,

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1500,6 +1500,27 @@ struct urGlobalVariableTest : uur::urKernelExecutionTest {
     GlobalVar<int> global_var;
 };
 
+struct urMultiDeviceQueueTest : urMultiDeviceContextTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urMultiDeviceContextTest::SetUp());
+        queues.reserve(DevicesEnvironment::instance->devices.size());
+        for (const auto &device : DevicesEnvironment::instance->devices) {
+            ur_queue_handle_t queue = nullptr;
+            ASSERT_SUCCESS(urQueueCreate(context, device, 0, &queue));
+            queues.push_back(queue);
+        }
+    }
+
+    void TearDown() override {
+        for (const auto &queue : queues) {
+            EXPECT_SUCCESS(urQueueRelease(queue));
+        }
+        UUR_RETURN_ON_FATAL_FAILURE(urMultiDeviceContextTest::TearDown());
+    }
+
+    std::vector<ur_queue_handle_t> queues;
+};
+
 } // namespace uur
 
 #endif // UR_CONFORMANCE_INCLUDE_FIXTURES_H_INCLUDED


### PR DESCRIPTION
Using just the first device makes creating a kernel from that program for any other devices impossible. urEnqueueKernelLaunch fails with UR_RESULT_ERROR_INVALID_QUEUE.

I don't know if using only the first device was intentional or not (perhaps an optimization?) but the test that I added passes for opencl so I think it would make sense to make L0 behave similarly.