### PR TITLE
[Bindless][Exp] Rename external semaphore destroy func to release

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -164,7 +164,7 @@ typedef enum ur_function_t {
     UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP = 142,                    ///< Enumerator for ::urBindlessImagesMipmapFreeExp
     UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP = 144,             ///< Enumerator for ::urBindlessImagesMapExternalArrayExp
     UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP = 145,                ///< Enumerator for ::urBindlessImagesReleaseInteropExp
-    UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP = 147,     ///< Enumerator for ::urBindlessImagesDestroyExternalSemaphoreExp
+    UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP = 147,     ///< Enumerator for ::urBindlessImagesReleaseExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP = 148,        ///< Enumerator for ::urBindlessImagesWaitExternalSemaphoreExp
     UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP = 149,      ///< Enumerator for ::urBindlessImagesSignalExternalSemaphoreExp
     UR_FUNCTION_ENQUEUE_USM_FILL_2D = 151,                                ///< Enumerator for ::urEnqueueUSMFill2D
@@ -7944,7 +7944,7 @@ urBindlessImagesMapExternalArrayExp(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy interop memory
+/// @brief Release interop memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -7965,7 +7965,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext,           ///< [in] handle of the context object
     ur_device_handle_t hDevice,             ///< [in] handle of the device object
-    ur_exp_interop_mem_handle_t hInteropMem ///< [in][release] handle of interop memory to be freed
+    ur_exp_interop_mem_handle_t hInteropMem ///< [in][release] handle of interop memory to be destroyed
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8000,7 +8000,7 @@ urBindlessImagesImportExternalSemaphoreExp(
 );
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy the external semaphore handle
+/// @brief Release the external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -8018,7 +8018,7 @@ urBindlessImagesImportExternalSemaphoreExp(
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 UR_APIEXPORT ur_result_t UR_APICALL
-urBindlessImagesDestroyExternalSemaphoreExp(
+urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext,                       ///< [in] handle of the context object
     ur_device_handle_t hDevice,                         ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
@@ -11235,14 +11235,14 @@ typedef struct ur_bindless_images_import_external_semaphore_exp_params_t {
 } ur_bindless_images_import_external_semaphore_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function parameters for urBindlessImagesDestroyExternalSemaphoreExp
+/// @brief Function parameters for urBindlessImagesReleaseExternalSemaphoreExp
 /// @details Each entry is a pointer to the parameter passed to the function;
 ///     allowing the callback the ability to modify the parameter's value
-typedef struct ur_bindless_images_destroy_external_semaphore_exp_params_t {
+typedef struct ur_bindless_images_release_external_semaphore_exp_params_t {
     ur_context_handle_t *phContext;
     ur_device_handle_t *phDevice;
     ur_exp_interop_semaphore_handle_t *phInteropSemaphore;
-} ur_bindless_images_destroy_external_semaphore_exp_params_t;
+} ur_bindless_images_release_external_semaphore_exp_params_t;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function parameters for urBindlessImagesWaitExternalSemaphoreExp

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1656,8 +1656,8 @@ typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesImportExternalSemaphoreExp_t
     ur_exp_interop_semaphore_handle_t *);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Function-pointer for urBindlessImagesDestroyExternalSemaphoreExp
-typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesDestroyExternalSemaphoreExp_t)(
+/// @brief Function-pointer for urBindlessImagesReleaseExternalSemaphoreExp
+typedef ur_result_t(UR_APICALL *ur_pfnBindlessImagesReleaseExternalSemaphoreExp_t)(
     ur_context_handle_t,
     ur_device_handle_t,
     ur_exp_interop_semaphore_handle_t);
@@ -1701,7 +1701,7 @@ typedef struct ur_bindless_images_exp_dditable_t {
     ur_pfnBindlessImagesMapExternalArrayExp_t pfnMapExternalArrayExp;
     ur_pfnBindlessImagesReleaseInteropExp_t pfnReleaseInteropExp;
     ur_pfnBindlessImagesImportExternalSemaphoreExp_t pfnImportExternalSemaphoreExp;
-    ur_pfnBindlessImagesDestroyExternalSemaphoreExp_t pfnDestroyExternalSemaphoreExp;
+    ur_pfnBindlessImagesReleaseExternalSemaphoreExp_t pfnReleaseExternalSemaphoreExp;
     ur_pfnBindlessImagesWaitExternalSemaphoreExp_t pfnWaitExternalSemaphoreExp;
     ur_pfnBindlessImagesSignalExternalSemaphoreExp_t pfnSignalExternalSemaphoreExp;
 } ur_bindless_images_exp_dditable_t;

--- a/include/ur_print.h
+++ b/include/ur_print.h
@@ -2155,12 +2155,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseInteropExpParams
 UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesImportExternalSemaphoreExpParams(const struct ur_bindless_images_import_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print ur_bindless_images_destroy_external_semaphore_exp_params_t struct
+/// @brief Print ur_bindless_images_release_external_semaphore_exp_params_t struct
 /// @returns
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         - `buff_size < out_size`
-UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesDestroyExternalSemaphoreExpParams(const struct ur_bindless_images_destroy_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
+UR_APIEXPORT ur_result_t UR_APICALL urPrintBindlessImagesReleaseExternalSemaphoreExpParams(const struct ur_bindless_images_release_external_semaphore_exp_params_t *params, char *buffer, const size_t buff_size, size_t *out_size);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Print ur_bindless_images_wait_external_semaphore_exp_params_t struct

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -752,8 +752,8 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_function_t value) {
     case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP";
         break;
-    case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP:
-        os << "UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP";
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP:
+        os << "UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP";
         break;
     case UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP:
         os << "UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP";
@@ -15191,10 +15191,10 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Print operator for the ur_bindless_images_destroy_external_semaphore_exp_params_t type
+/// @brief Print operator for the ur_bindless_images_release_external_semaphore_exp_params_t type
 /// @returns
 ///     std::ostream &
-inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_destroy_external_semaphore_exp_params_t *params) {
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct ur_bindless_images_release_external_semaphore_exp_params_t *params) {
 
     os << ".hContext = ";
 
@@ -17747,8 +17747,8 @@ inline ur_result_t UR_APICALL printFunctionParams(std::ostream &os, ur_function_
     case UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP: {
         os << (const struct ur_bindless_images_import_external_semaphore_exp_params_t *)params;
     } break;
-    case UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP: {
-        os << (const struct ur_bindless_images_destroy_external_semaphore_exp_params_t *)params;
+    case UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP: {
+        os << (const struct ur_bindless_images_release_external_semaphore_exp_params_t *)params;
     } break;
     case UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP: {
         os << (const struct ur_bindless_images_wait_external_semaphore_exp_params_t *)params;

--- a/scripts/core/EXP-BINDLESS-IMAGES.rst
+++ b/scripts/core/EXP-BINDLESS-IMAGES.rst
@@ -138,7 +138,7 @@ Enums
     * ${X}_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_INTEROP_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP
-    * ${X}_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP
+    * ${X}_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
     * ${X}_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP
 
@@ -181,7 +181,7 @@ Functions
    * ${x}BindlessImagesMapExternalArrayExp
    * ${x}BindlessImagesReleaseInteropExp
    * ${x}BindlessImagesImportExternalSemaphoreExp
-   * ${x}BindlessImagesDestroyExternalSemaphoreExp
+   * ${x}BindlessImagesReleaseExternalSemaphoreExp
    * ${x}BindlessImagesWaitExternalSemaphoreExp
    * ${x}BindlessImagesSignalExternalSemaphoreExp
 
@@ -236,6 +236,9 @@ Changelog
 |          || Introduced resource enums for DX12 interop:                |
 |          ||  - ${X}_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE       |
 |          ||  - ${X}_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE    |
++------------------------------------------------------------------------+
+| 14.0     || Rename func BindlessImagesDestroyExternalSemaphoreExp to   |
+|          || BindlessImagesReleaseExternalSemaphoreExp                  |
 +------------------------------------------------------------------------+
 
 Contributors

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -717,7 +717,7 @@ returns:
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Destroy interop memory"
+desc: "Release interop memory"
 class: $xBindlessImages
 name: ReleaseInteropExp
 ordinal: "0"
@@ -732,7 +732,7 @@ params:
       desc: "[in] handle of the device object"
     - type: $x_exp_interop_mem_handle_t
       name: hInteropMem
-      desc: "[in][release] handle of interop memory to be freed"
+      desc: "[in][release] handle of interop memory to be destroyed"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -765,9 +765,9 @@ returns:
     - $X_RESULT_ERROR_INVALID_VALUE
 --- #--------------------------------------------------------------------------
 type: function
-desc: "Destroy the external semaphore handle"
+desc: "Release the external semaphore"
 class: $xBindlessImages
-name: DestroyExternalSemaphoreExp
+name: ReleaseExternalSemaphoreExp
 ordinal: "0"
 analogue:
     - "**cuDestroyExternalSemaphore**"

--- a/scripts/core/registry.yml
+++ b/scripts/core/registry.yml
@@ -406,8 +406,8 @@ etors:
 - name: BINDLESS_IMAGES_RELEASE_INTEROP_EXP
   desc: Enumerator for $xBindlessImagesReleaseInteropExp
   value: '145'
-- name: BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP
-  desc: Enumerator for $xBindlessImagesDestroyExternalSemaphoreExp
+- name: BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP
+  desc: Enumerator for $xBindlessImagesReleaseExternalSemaphoreExp
   value: '147'
 - name: BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP
   desc: Enumerator for $xBindlessImagesWaitExternalSemaphoreExp

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -1226,7 +1226,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
   UR_ASSERT(std::find(hContext->getDevices().begin(),

--- a/source/adapters/cuda/ur_interface_loader.cpp
+++ b/source/adapters/cuda/ur_interface_loader.cpp
@@ -343,8 +343,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
-  pDdiTable->pfnDestroyExternalSemaphoreExp =
-      urBindlessImagesDestroyExternalSemaphoreExp;
+  pDdiTable->pfnReleaseExternalSemaphoreExp =
+      urBindlessImagesReleaseExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =
       urBindlessImagesWaitExternalSemaphoreExp;
   pDdiTable->pfnSignalExternalSemaphoreExp =

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -149,7 +149,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -1100,7 +1100,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_interop_semaphore_handle_t hInteropSemaphore) {
   std::ignore = hContext;

--- a/source/adapters/level_zero/ur_interface_loader.cpp
+++ b/source/adapters/level_zero/ur_interface_loader.cpp
@@ -390,8 +390,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
-  pDdiTable->pfnDestroyExternalSemaphoreExp =
-      urBindlessImagesDestroyExternalSemaphoreExp;
+  pDdiTable->pfnReleaseExternalSemaphoreExp =
+      urBindlessImagesReleaseExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =
       urBindlessImagesWaitExternalSemaphoreExp;
   pDdiTable->pfnSignalExternalSemaphoreExp =

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -7813,7 +7813,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7914,8 +7914,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t
@@ -7923,12 +7923,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 
-    ur_bindless_images_destroy_external_semaphore_exp_params_t params = {
+    ur_bindless_images_release_external_semaphore_exp_params_t params = {
         &hContext, &hDevice, &hInteropSemaphore};
 
     auto beforeCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_before_callback(
-            "urBindlessImagesDestroyExternalSemaphoreExp"));
+            "urBindlessImagesReleaseExternalSemaphoreExp"));
     if (beforeCallback) {
         result = beforeCallback(&params);
         if (result != UR_RESULT_SUCCESS) {
@@ -7938,7 +7938,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 
     auto replaceCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_replace_callback(
-            "urBindlessImagesDestroyExternalSemaphoreExp"));
+            "urBindlessImagesReleaseExternalSemaphoreExp"));
     if (replaceCallback) {
         result = replaceCallback(&params);
     } else {
@@ -7953,7 +7953,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 
     auto afterCallback = reinterpret_cast<ur_mock_callback_t>(
         mock::getCallbacks().get_after_callback(
-            "urBindlessImagesDestroyExternalSemaphoreExp"));
+            "urBindlessImagesReleaseExternalSemaphoreExp"));
     if (afterCallback) {
         return afterCallback(&params);
     }
@@ -10279,8 +10279,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnImportExternalSemaphoreExp =
         driver::urBindlessImagesImportExternalSemaphoreExp;
 
-    pDdiTable->pfnDestroyExternalSemaphoreExp =
-        driver::urBindlessImagesDestroyExternalSemaphoreExp;
+    pDdiTable->pfnReleaseExternalSemaphoreExp =
+        driver::urBindlessImagesReleaseExternalSemaphoreExp;
 
     pDdiTable->pfnWaitExternalSemaphoreExp =
         driver::urBindlessImagesWaitExternalSemaphoreExp;

--- a/source/adapters/native_cpu/image.cpp
+++ b/source/adapters/native_cpu/image.cpp
@@ -149,7 +149,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {

--- a/source/adapters/native_cpu/ur_interface_loader.cpp
+++ b/source/adapters/native_cpu/ur_interface_loader.cpp
@@ -332,8 +332,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
-  pDdiTable->pfnDestroyExternalSemaphoreExp =
-      urBindlessImagesDestroyExternalSemaphoreExp;
+  pDdiTable->pfnReleaseExternalSemaphoreExp =
+      urBindlessImagesReleaseExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =
       urBindlessImagesWaitExternalSemaphoreExp;
   pDdiTable->pfnSignalExternalSemaphoreExp =

--- a/source/adapters/opencl/image.cpp
+++ b/source/adapters/opencl/image.cpp
@@ -149,7 +149,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     [[maybe_unused]] ur_context_handle_t hContext,
     [[maybe_unused]] ur_device_handle_t hDevice,
     [[maybe_unused]] ur_exp_interop_semaphore_handle_t hInteropSemaphore) {

--- a/source/adapters/opencl/ur_interface_loader.cpp
+++ b/source/adapters/opencl/ur_interface_loader.cpp
@@ -350,8 +350,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
   pDdiTable->pfnReleaseInteropExp = urBindlessImagesReleaseInteropExp;
   pDdiTable->pfnImportExternalSemaphoreExp =
       urBindlessImagesImportExternalSemaphoreExp;
-  pDdiTable->pfnDestroyExternalSemaphoreExp =
-      urBindlessImagesDestroyExternalSemaphoreExp;
+  pDdiTable->pfnReleaseExternalSemaphoreExp =
+      urBindlessImagesReleaseExternalSemaphoreExp;
   pDdiTable->pfnWaitExternalSemaphoreExp =
       urBindlessImagesWaitExternalSemaphoreExp;
   pDdiTable->pfnSignalExternalSemaphoreExp =

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -6055,7 +6055,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
 ) {
     auto pfnReleaseInteropExp =
         getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
@@ -6135,41 +6135,41 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t
         hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
 ) {
-    auto pfnDestroyExternalSemaphoreExp =
+    auto pfnReleaseExternalSemaphoreExp =
         getContext()
-            ->urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+            ->urDdiTable.BindlessImagesExp.pfnReleaseExternalSemaphoreExp;
 
-    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+    if (nullptr == pfnReleaseExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
     }
 
-    ur_bindless_images_destroy_external_semaphore_exp_params_t params = {
+    ur_bindless_images_release_external_semaphore_exp_params_t params = {
         &hContext, &hDevice, &hInteropSemaphore};
     uint64_t instance = getContext()->notify_begin(
-        UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP,
-        "urBindlessImagesDestroyExternalSemaphoreExp", &params);
+        UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesReleaseExternalSemaphoreExp", &params);
 
     getContext()->logger.info(
-        "---> urBindlessImagesDestroyExternalSemaphoreExp");
+        "---> urBindlessImagesReleaseExternalSemaphoreExp");
 
     ur_result_t result =
-        pfnDestroyExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
 
     getContext()->notify_end(
-        UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP,
-        "urBindlessImagesDestroyExternalSemaphoreExp", &params, &result,
+        UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
+        "urBindlessImagesReleaseExternalSemaphoreExp", &params, &result,
         instance);
 
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
-        args_str, UR_FUNCTION_BINDLESS_IMAGES_DESTROY_EXTERNAL_SEMAPHORE_EXP,
+        args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
         &params);
     getContext()->logger.info("({}) -> {};\n", args_str.str(), result);
 
@@ -8134,10 +8134,10 @@ __urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnImportExternalSemaphoreExp =
         ur_tracing_layer::urBindlessImagesImportExternalSemaphoreExp;
 
-    dditable.pfnDestroyExternalSemaphoreExp =
-        pDdiTable->pfnDestroyExternalSemaphoreExp;
-    pDdiTable->pfnDestroyExternalSemaphoreExp =
-        ur_tracing_layer::urBindlessImagesDestroyExternalSemaphoreExp;
+    dditable.pfnReleaseExternalSemaphoreExp =
+        pDdiTable->pfnReleaseExternalSemaphoreExp;
+    pDdiTable->pfnReleaseExternalSemaphoreExp =
+        ur_tracing_layer::urBindlessImagesReleaseExternalSemaphoreExp;
 
     dditable.pfnWaitExternalSemaphoreExp =
         pDdiTable->pfnWaitExternalSemaphoreExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7541,7 +7541,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
 ) {
     auto pfnReleaseInteropExp =
         getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
@@ -7640,18 +7640,18 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t
         hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
 ) {
-    auto pfnDestroyExternalSemaphoreExp =
+    auto pfnReleaseExternalSemaphoreExp =
         getContext()
-            ->urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
+            ->urDdiTable.BindlessImagesExp.pfnReleaseExternalSemaphoreExp;
 
-    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+    if (nullptr == pfnReleaseExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -7680,7 +7680,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
     }
 
     ur_result_t result =
-        pfnDestroyExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
 
     return result;
 }
@@ -9745,10 +9745,10 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     pDdiTable->pfnImportExternalSemaphoreExp =
         ur_validation_layer::urBindlessImagesImportExternalSemaphoreExp;
 
-    dditable.pfnDestroyExternalSemaphoreExp =
-        pDdiTable->pfnDestroyExternalSemaphoreExp;
-    pDdiTable->pfnDestroyExternalSemaphoreExp =
-        ur_validation_layer::urBindlessImagesDestroyExternalSemaphoreExp;
+    dditable.pfnReleaseExternalSemaphoreExp =
+        pDdiTable->pfnReleaseExternalSemaphoreExp;
+    pDdiTable->pfnReleaseExternalSemaphoreExp =
+        ur_validation_layer::urBindlessImagesReleaseExternalSemaphoreExp;
 
     dditable.pfnWaitExternalSemaphoreExp =
         pDdiTable->pfnWaitExternalSemaphoreExp;

--- a/source/loader/loader.def.in
+++ b/source/loader/loader.def.in
@@ -5,7 +5,6 @@ EXPORTS
 	urAdapterGetLastError
 	urAdapterRelease
 	urAdapterRetain
-	urBindlessImagesDestroyExternalSemaphoreExp
 	urBindlessImagesImageAllocateExp
 	urBindlessImagesImageCopyExp
 	urBindlessImagesImageFreeExp
@@ -15,6 +14,7 @@ EXPORTS
 	urBindlessImagesMapExternalArrayExp
 	urBindlessImagesMipmapFreeExp
 	urBindlessImagesMipmapGetLevelExp
+	urBindlessImagesReleaseExternalSemaphoreExp
 	urBindlessImagesReleaseInteropExp
 	urBindlessImagesSampledImageCreateExp
 	urBindlessImagesSampledImageHandleDestroyExp
@@ -174,7 +174,6 @@ EXPORTS
 	urPrintApiVersion
 	urPrintBaseDesc
 	urPrintBaseProperties
-	urPrintBindlessImagesDestroyExternalSemaphoreExpParams
 	urPrintBindlessImagesImageAllocateExpParams
 	urPrintBindlessImagesImageCopyExpParams
 	urPrintBindlessImagesImageFreeExpParams
@@ -184,6 +183,7 @@ EXPORTS
 	urPrintBindlessImagesMapExternalArrayExpParams
 	urPrintBindlessImagesMipmapFreeExpParams
 	urPrintBindlessImagesMipmapGetLevelExpParams
+	urPrintBindlessImagesReleaseExternalSemaphoreExpParams
 	urPrintBindlessImagesReleaseInteropExpParams
 	urPrintBindlessImagesSampledImageCreateExpParams
 	urPrintBindlessImagesSampledImageHandleDestroyExpParams

--- a/source/loader/loader.map.in
+++ b/source/loader/loader.map.in
@@ -5,7 +5,6 @@
 		urAdapterGetLastError;
 		urAdapterRelease;
 		urAdapterRetain;
-		urBindlessImagesDestroyExternalSemaphoreExp;
 		urBindlessImagesImageAllocateExp;
 		urBindlessImagesImageCopyExp;
 		urBindlessImagesImageFreeExp;
@@ -15,6 +14,7 @@
 		urBindlessImagesMapExternalArrayExp;
 		urBindlessImagesMipmapFreeExp;
 		urBindlessImagesMipmapGetLevelExp;
+		urBindlessImagesReleaseExternalSemaphoreExp;
 		urBindlessImagesReleaseInteropExp;
 		urBindlessImagesSampledImageCreateExp;
 		urBindlessImagesSampledImageHandleDestroyExp;
@@ -174,7 +174,6 @@
 		urPrintApiVersion;
 		urPrintBaseDesc;
 		urPrintBaseProperties;
-		urPrintBindlessImagesDestroyExternalSemaphoreExpParams;
 		urPrintBindlessImagesImageAllocateExpParams;
 		urPrintBindlessImagesImageCopyExpParams;
 		urPrintBindlessImagesImageFreeExpParams;
@@ -184,6 +183,7 @@
 		urPrintBindlessImagesMapExternalArrayExpParams;
 		urPrintBindlessImagesMipmapFreeExpParams;
 		urPrintBindlessImagesMipmapGetLevelExpParams;
+		urPrintBindlessImagesReleaseExternalSemaphoreExpParams;
 		urPrintBindlessImagesReleaseInteropExpParams;
 		urPrintBindlessImagesSampledImageCreateExpParams;
 		urPrintBindlessImagesSampledImageHandleDestroyExpParams;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6644,7 +6644,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6727,8 +6727,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Intercept function for urBindlessImagesDestroyExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+/// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
+__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t
@@ -6740,9 +6740,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_context_object_t *>(hContext)->dditable;
-    auto pfnDestroyExternalSemaphoreExp =
-        dditable->ur.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
-    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+    auto pfnReleaseExternalSemaphoreExp =
+        dditable->ur.BindlessImagesExp.pfnReleaseExternalSemaphoreExp;
+    if (nullptr == pfnReleaseExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
@@ -6759,7 +6759,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
 
     // forward to device-platform
     result =
-        pfnDestroyExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+        pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
 
     return result;
 }
@@ -8692,8 +8692,8 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
                 ur_loader::urBindlessImagesReleaseInteropExp;
             pDdiTable->pfnImportExternalSemaphoreExp =
                 ur_loader::urBindlessImagesImportExternalSemaphoreExp;
-            pDdiTable->pfnDestroyExternalSemaphoreExp =
-                ur_loader::urBindlessImagesDestroyExternalSemaphoreExp;
+            pDdiTable->pfnReleaseExternalSemaphoreExp =
+                ur_loader::urBindlessImagesReleaseExternalSemaphoreExp;
             pDdiTable->pfnWaitExternalSemaphoreExp =
                 ur_loader::urBindlessImagesWaitExternalSemaphoreExp;
             pDdiTable->pfnSignalExternalSemaphoreExp =

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7109,7 +7109,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy interop memory
+/// @brief Release interop memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -7130,7 +7130,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
     ) try {
     auto pfnReleaseInteropExp =
         ur_lib::getContext()->urDdiTable.BindlessImagesExp.pfnReleaseInteropExp;
@@ -7190,7 +7190,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy the external semaphore handle
+/// @brief Release the external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -7207,20 +7207,20 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 ///         + `NULL == hInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t
         hInteropSemaphore ///< [in][release] handle of interop semaphore to be destroyed
     ) try {
-    auto pfnDestroyExternalSemaphoreExp =
+    auto pfnReleaseExternalSemaphoreExp =
         ur_lib::getContext()
-            ->urDdiTable.BindlessImagesExp.pfnDestroyExternalSemaphoreExp;
-    if (nullptr == pfnDestroyExternalSemaphoreExp) {
+            ->urDdiTable.BindlessImagesExp.pfnReleaseExternalSemaphoreExp;
+    if (nullptr == pfnReleaseExternalSemaphoreExp) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
 
-    return pfnDestroyExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
+    return pfnReleaseExternalSemaphoreExp(hContext, hDevice, hInteropSemaphore);
 } catch (...) {
     return exceptionToResult(std::current_exception());
 }

--- a/source/loader/ur_print.cpp
+++ b/source/loader/ur_print.cpp
@@ -1227,8 +1227,8 @@ ur_result_t urPrintBindlessImagesImportExternalSemaphoreExpParams(
     return str_copy(&ss, buffer, buff_size, out_size);
 }
 
-ur_result_t urPrintBindlessImagesDestroyExternalSemaphoreExpParams(
-    const struct ur_bindless_images_destroy_external_semaphore_exp_params_t
+ur_result_t urPrintBindlessImagesReleaseExternalSemaphoreExpParams(
+    const struct ur_bindless_images_release_external_semaphore_exp_params_t
         *params,
     char *buffer, const size_t buff_size, size_t *out_size) {
     std::stringstream ss;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -6049,7 +6049,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy interop memory
+/// @brief Release interop memory
 ///
 /// @remarks
 ///   _Analogues_
@@ -6070,7 +6070,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseInteropExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_mem_handle_t
-        hInteropMem ///< [in][release] handle of interop memory to be freed
+        hInteropMem ///< [in][release] handle of interop memory to be destroyed
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -6113,7 +6113,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// @brief Destroy the external semaphore handle
+/// @brief Release the external semaphore
 ///
 /// @remarks
 ///   _Analogues_
@@ -6130,7 +6130,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 ///         + `NULL == hInteropSemaphore`
 ///     - ::UR_RESULT_ERROR_INVALID_CONTEXT
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-ur_result_t UR_APICALL urBindlessImagesDestroyExternalSemaphoreExp(
+ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_interop_semaphore_handle_t


### PR DESCRIPTION
Rename function urBindlessImagesDestroyExternalSemaphoreExp to urBindlessImagesReleaseExternalSemaphoreExp.

This name change is to clarify exactly what is happening to the external semaphore. That is, it is being released not destroyed.

Corresponding DPC++ PR: https://github.com/intel/llvm/pull/14535