### PR TITLE
[ASAN] fix recursive initialization of sanitizer context

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.hpp
@@ -164,7 +164,7 @@ struct DeviceGlobalInfo {
 
 class SanitizerInterceptor {
   public:
-    explicit SanitizerInterceptor();
+    explicit SanitizerInterceptor(logger::Logger &logger);
 
     ~SanitizerInterceptor();
 
@@ -261,6 +261,7 @@ class SanitizerInterceptor {
     ur_shared_mutex m_AllocationMapMutex;
 
     std::unique_ptr<Quarantine> m_Quarantine;
+    logger::Logger &logger;
 };
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan_options.hpp
@@ -27,8 +27,8 @@ struct AsanOptions {
     AsanOptions(AsanOptions &other) = delete;
     void operator=(const AsanOptions &) = delete;
 
-    static AsanOptions &getInstance() {
-        static AsanOptions instance;
+    static AsanOptions &getInstance(logger::Logger &logger) {
+        static AsanOptions instance(logger);
         return instance;
     }
 
@@ -40,7 +40,7 @@ struct AsanOptions {
     bool DetectPrivates = true;
 
   private:
-    AsanOptions() {
+    AsanOptions(logger::Logger &logger) {
         auto OptionsEnvMap = getenv_to_map("UR_LAYER_ASAN_OPTIONS");
         if (!OptionsEnvMap.has_value()) {
             return;
@@ -117,9 +117,8 @@ struct AsanOptions {
                 MinRZSize = std::stoul(Value);
                 if (MinRZSize < 16) {
                     MinRZSize = 16;
-                    getContext()->logger.warning(
-                        "Trying to set redzone size to a "
-                        "value less than 16 is ignored");
+                    logger.warning("Trying to set redzone size to a "
+                                   "value less than 16 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"redzone\" should be an integer");
@@ -133,9 +132,8 @@ struct AsanOptions {
                 MaxRZSize = std::stoul(Value);
                 if (MaxRZSize > 2048) {
                     MaxRZSize = 2048;
-                    getContext()->logger.warning(
-                        "Trying to set max redzone size to a "
-                        "value greater than 2048 is ignored");
+                    logger.warning("Trying to set max redzone size to a "
+                                   "value greater than 2048 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"max_redzone\" should be an integer");
@@ -144,6 +142,8 @@ struct AsanOptions {
     }
 };
 
-inline const AsanOptions &Options() { return AsanOptions::getInstance(); }
+inline const AsanOptions &Options(logger::Logger &logger) {
+    return AsanOptions::getInstance(logger);
+}
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/asan_report.cpp
+++ b/source/loader/layers/sanitizer/asan_report.cpp
@@ -124,7 +124,7 @@ void ReportUseAfterFree(const DeviceSanitizerReport &Report,
     getContext()->logger.always("  #0 {} {}:{}", Func, File, Report.Line);
     getContext()->logger.always("");
 
-    if (Options().MaxQuarantineSizeMB > 0) {
+    if (Options(getContext()->logger).MaxQuarantineSizeMB > 0) {
         auto AllocInfoItOp =
             getContext()->interceptor->findAllocInfoByAddress(Report.Address);
 

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -20,7 +20,7 @@ context_t *getContext() { return context_t::get_direct(); }
 context_t::context_t()
     : logger(logger::create_logger("sanitizer", false, false,
                                    logger::Level::WARN)),
-      interceptor(std::make_unique<SanitizerInterceptor>()) {}
+      interceptor(std::make_unique<SanitizerInterceptor>(logger)) {}
 
 ur_result_t context_t::tearDown() { return UR_RESULT_SUCCESS; }
 


### PR DESCRIPTION
The AsanOptions class, a singleton, was being instantiated inside of the sanitizer context constructor, but, inside of its contructor, it was using the logger from inside of the context. This only worked before because the context variable was a global and the logger just so happened to be initialized prior to the AsanOptions.

Now that the layer contexts are not globals, this was causing a deadlock on trying to retrieve a context while it was being initialized. The fix is to pass the logger manually to the AsanOptions class.

A better fix might be to refactor AsanOptions to no longer be a singleton, but I was trying to minimize changes since this is blocking intel/llvm update.