### PR TITLE
[DeviceSanitizer] refactor options

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.hpp
@@ -164,7 +164,7 @@ struct DeviceGlobalInfo {
 
 class SanitizerInterceptor {
   public:
-    explicit SanitizerInterceptor(logger::Logger &logger);
+    explicit SanitizerInterceptor(AsanOptions &Options);
 
     ~SanitizerInterceptor();
 
@@ -261,7 +261,6 @@ class SanitizerInterceptor {
     ur_shared_mutex m_AllocationMapMutex;
 
     std::unique_ptr<Quarantine> m_Quarantine;
-    logger::Logger &logger;
 };
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan_options.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-// #include "common/ur_util.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur/ur.hpp"
 

--- a/source/loader/layers/sanitizer/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan_options.hpp
@@ -111,9 +111,8 @@ struct AsanOptions {
                 MinRZSize = std::stoul(Value);
                 if (MinRZSize < 16) {
                     MinRZSize = 16;
-                    getContext()->logger.warning(
-                        "Trying to set redzone size to a "
-                        "value less than 16 is ignored");
+                    logger.warning("Trying to set redzone size to a "
+                                   "value less than 16 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"redzone\" should be an integer");
@@ -127,9 +126,8 @@ struct AsanOptions {
                 MaxRZSize = std::stoul(Value);
                 if (MaxRZSize > 2048) {
                     MaxRZSize = 2048;
-                    getContext()->logger.warning(
-                        "Trying to set max redzone size to a "
-                        "value greater than 2048 is ignored");
+                    logger.warning("Trying to set max redzone size to a "
+                                   "value greater than 2048 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"max_redzone\" should be an integer");

--- a/source/loader/layers/sanitizer/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan_options.hpp
@@ -12,9 +12,9 @@
 
 #pragma once
 
-#include "common/ur_util.hpp"
+// #include "common/ur_util.hpp"
+#include "logger/ur_logger.hpp"
 #include "ur/ur.hpp"
-#include "ur_sanitizer_layer.hpp"
 
 #include <algorithm>
 #include <cstring>

--- a/source/loader/layers/sanitizer/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan_options.hpp
@@ -27,11 +27,6 @@ struct AsanOptions {
     AsanOptions(AsanOptions &other) = delete;
     void operator=(const AsanOptions &) = delete;
 
-    static AsanOptions &getInstance(logger::Logger &logger) {
-        static AsanOptions instance(logger);
-        return instance;
-    }
-
     bool Debug = false;
     uint64_t MinRZSize = 16;
     uint64_t MaxRZSize = 2048;
@@ -39,7 +34,6 @@ struct AsanOptions {
     bool DetectLocals = true;
     bool DetectPrivates = true;
 
-  private:
     AsanOptions(logger::Logger &logger) {
         auto OptionsEnvMap = getenv_to_map("UR_LAYER_ASAN_OPTIONS");
         if (!OptionsEnvMap.has_value()) {
@@ -117,8 +111,9 @@ struct AsanOptions {
                 MinRZSize = std::stoul(Value);
                 if (MinRZSize < 16) {
                     MinRZSize = 16;
-                    logger.warning("Trying to set redzone size to a "
-                                   "value less than 16 is ignored");
+                    getContext()->logger.warning(
+                        "Trying to set redzone size to a "
+                        "value less than 16 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"redzone\" should be an integer");
@@ -132,18 +127,23 @@ struct AsanOptions {
                 MaxRZSize = std::stoul(Value);
                 if (MaxRZSize > 2048) {
                     MaxRZSize = 2048;
-                    logger.warning("Trying to set max redzone size to a "
-                                   "value greater than 2048 is ignored");
+                    getContext()->logger.warning(
+                        "Trying to set max redzone size to a "
+                        "value greater than 2048 is ignored");
                 }
             } catch (...) {
                 die("<SANITIZER>[ERROR]: \"max_redzone\" should be an integer");
             }
         }
+
+        logger.debug("AsanOptions result:");
+        logger.debug("AsanOptions.Debug={}", Debug);
+        logger.debug("AsanOptions.MinRZSize={}", MinRZSize);
+        logger.debug("AsanOptions.MaxRZSize={}", MaxRZSize);
+        logger.debug("AsanOptions.MaxQuarantineSizeMB={}", MaxQuarantineSizeMB);
+        logger.debug("AsanOptions.DetectLocals={}", DetectLocals);
+        logger.debug("AsanOptions.DetectPrivates={}", DetectPrivates);
     }
 };
-
-inline const AsanOptions &Options(logger::Logger &logger) {
-    return AsanOptions::getInstance(logger);
-}
 
 } // namespace ur_sanitizer_layer

--- a/source/loader/layers/sanitizer/asan_report.cpp
+++ b/source/loader/layers/sanitizer/asan_report.cpp
@@ -124,7 +124,7 @@ void ReportUseAfterFree(const DeviceSanitizerReport &Report,
     getContext()->logger.always("  #0 {} {}:{}", Func, File, Report.Line);
     getContext()->logger.always("");
 
-    if (Options(getContext()->logger).MaxQuarantineSizeMB > 0) {
+    if (getContext()->options.MaxQuarantineSizeMB > 0) {
         auto AllocInfoItOp =
             getContext()->interceptor->findAllocInfoByAddress(Report.Address);
 

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -20,7 +20,7 @@ context_t *getContext() { return context_t::get_direct(); }
 context_t::context_t()
     : logger(logger::create_logger("sanitizer", false, false,
                                    logger::Level::WARN)),
-      AsanOptions options(logger),
+      options(logger),
       interceptor(std::make_unique<SanitizerInterceptor>(options)) {}
 
 ur_result_t context_t::tearDown() { return UR_RESULT_SUCCESS; }

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.cpp
@@ -20,7 +20,8 @@ context_t *getContext() { return context_t::get_direct(); }
 context_t::context_t()
     : logger(logger::create_logger("sanitizer", false, false,
                                    logger::Level::WARN)),
-      interceptor(std::make_unique<SanitizerInterceptor>(logger)) {}
+      AsanOptions options(logger),
+      interceptor(std::make_unique<SanitizerInterceptor>(options)) {}
 
 ur_result_t context_t::tearDown() { return UR_RESULT_SUCCESS; }
 

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
@@ -12,10 +12,10 @@
 
 #pragma once
 
+#include "asan_options.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur/ur.hpp"
 #include "ur_proxy_layer.hpp"
-#include "asan_options.hpp"
 
 #define SANITIZER_COMP_NAME "sanitizer layer"
 

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
@@ -35,6 +35,7 @@ class __urdlllocal context_t : public proxy_layer_context_t,
   public:
     ur_dditable_t urDdiTable = {};
     logger::Logger logger;
+    AsanOptions options;
     std::unique_ptr<SanitizerInterceptor> interceptor;
     SanitizerType enabledType = SanitizerType::None;
 

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
@@ -15,6 +15,7 @@
 #include "logger/ur_logger.hpp"
 #include "ur/ur.hpp"
 #include "ur_proxy_layer.hpp"
+#include "asan_options.hpp"
 
 #define SANITIZER_COMP_NAME "sanitizer layer"
 


### PR DESCRIPTION
A follow-up of https://github.com/oneapi-src/unified-runtime/pull/1862, refactor AsanOptions to avoid initialization deadlock.

SYCLOS PR: https://github.com/intel/llvm/pull/14579