### PR TITLE
Handle CUDA_ERROR_NO_DEVICE returned from cuInit()

### DIFF
--- a/source/adapters/cuda/platform.cpp
+++ b/source/adapters/cuda/platform.cpp
@@ -69,7 +69,11 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
     std::call_once(
         InitFlag,
         [](ur_result_t &Result) {
-          UR_CHECK_ERROR(cuInit(0));
+          CUresult InitResult = cuInit(0);
+          if (InitResult == CUDA_ERROR_NO_DEVICE) {
+            return; // No devices found which is not an error so exit early.
+          }
+          UR_CHECK_ERROR(InitResult);
           int NumDevices = 0;
           UR_CHECK_ERROR(cuDeviceGetCount(&NumDevices));
           try {


### PR DESCRIPTION
During testing of https://github.com/intel/llvm/pull/14145 the CUDA adapter was returning a hard error when being initialized on a system with no NVIDIA GPU. This corner case should not be an error condition so this patch specially handles `CUDA_ERROR_NO_DEVICE` being returned from `cuInit()` (which is an undocumented error code) to exit early from the CUDA adapter initialization.
