### PR TITLE
Fix mock on Windows, add logging of adapter load/unload

### DIFF
--- a/source/adapters/mock/ur_mock.cpp
+++ b/source/adapters/mock/ur_mock.cpp
@@ -29,7 +29,7 @@ ur_result_t mock_urPlatformGetInfo(void *pParams) {
     }
 
     if (*params.ppropName == UR_PLATFORM_INFO_NAME) {
-        const char mock_platform_name[] = "UR_PLATFORM_MOCK";
+        const char mock_platform_name[] = "Mock Platform";
         if (*params.ppPropSizeRet) {
             **params.ppPropSizeRet = sizeof(mock_platform_name);
         }

--- a/source/common/windows/ur_lib_loader.cpp
+++ b/source/common/windows/ur_lib_loader.cpp
@@ -19,14 +19,18 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
             logger::error(
                 "Failed to unload the library with the handle at address {}",
                 handle);
+        } else {
+            logger::info("unloaded adapter 0x{}", handle);
         }
     }
 }
 
 std::unique_ptr<HMODULE, LibLoader::lib_dtor>
 LibLoader::loadAdapterLibrary(const char *name) {
-    return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(
+    auto handle = std::unique_ptr<HMODULE, LibLoader::lib_dtor>(
         LoadLibraryExA(name, nullptr, 0));
+    logger::info("loaded adapter 0x{} ({})", handle, name);
+    return handle;
 }
 
 void *LibLoader::getFunctionPtr(HMODULE handle, const char *func_name) {

--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -188,10 +188,9 @@ class AdapterRegistry {
         adaptersLoadPaths.clear();
 
         std::vector<fs::path> loadPaths;
-        auto adapterNamePathOpt = getAdapterNameAsPath(mockAdapterName);
+        auto adapterNamePath = fs::path{mockAdapterName};
         auto loaderLibPathOpt = getLoaderLibPath();
-        if (adapterNamePathOpt.has_value() && loaderLibPathOpt.has_value()) {
-            const auto &adapterNamePath = adapterNamePathOpt.value();
+        if (loaderLibPathOpt.has_value()) {
             const auto &loaderLibPath = loaderLibPathOpt.value();
             loadPaths.emplace_back(loaderLibPath / adapterNamePath);
         }

--- a/test/loader/platforms/null_platform.match
+++ b/test/loader/platforms/null_platform.match
@@ -1,3 +1,3 @@
 <TEST>[INFO]: urLoaderInit succeeded.
 <TEST>[INFO]: urPlatformGet found 1 platforms
-<TEST>[INFO]: Found UR_PLATFORM_MOCK
+<TEST>[INFO]: Found Mock Platform


### PR DESCRIPTION
Change the value of the `mock_platform_name` to avoid mismatches in string size when using replacement entry points in mock tests.

Also add logging of adapter load and unload as this proved useful in tracking down this issue & will enable fixes of other tests.