### PR TITLE
Enable PrintTrace when SYCL UR tracing is enabled

### DIFF
--- a/source/ur/ur.cpp
+++ b/source/ur/ur.cpp
@@ -14,10 +14,12 @@
 
 // Controls tracing UR calls from within the UR itself.
 bool PrintTrace = [] {
+  const char *UrRet = std::getenv("SYCL_UR_TRACE");
   const char *PiRet = std::getenv("SYCL_PI_TRACE");
-  const char *Trace = PiRet ? PiRet : nullptr;
+  const char *Trace = UrRet ? UrRet : (PiRet ? PiRet : nullptr);
   const int TraceValue = Trace ? std::stoi(Trace) : 0;
-  if (TraceValue == -1 || TraceValue == 2) { // Means print all traces
+  if ((PiRet && (TraceValue == -1 || TraceValue == 2)) ||
+      (UrRet && TraceValue != 0)) {
     return true;
   }
   return false;


### PR DESCRIPTION
This will allow `PrintTrace` to keep working after https://github.com/intel/llvm/pull/14145 is merged