### PR TITLE
[L0] Use zesInit for SysMan API usage

### DIFF
--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -27,6 +27,7 @@ struct ur_adapter_handle_t_ {
   std::mutex Mutex;
 
   std::optional<ze_result_t> ZeResult;
+  std::optional<ze_result_t> ZesResult;
   ZeCache<Result<PlatformVec>> PlatformCache;
   logger::Logger &logger;
 };

--- a/source/adapters/level_zero/device.hpp
+++ b/source/adapters/level_zero/device.hpp
@@ -60,8 +60,9 @@ struct ur_ze_external_memory_data {
 struct ur_device_handle_t_ : _ur_object {
   ur_device_handle_t_(ze_device_handle_t Device, ur_platform_handle_t Plt,
                       ur_device_handle_t ParentDevice = nullptr)
-      : ZeDevice{Device}, Platform{Plt}, RootDevice{ParentDevice},
-        ZeDeviceProperties{}, ZeDeviceComputeProperties{} {
+      : ZeDevice{Device}, ZesDevice{nullptr}, Platform{Plt},
+        RootDevice{ParentDevice}, ZeDeviceProperties{},
+        ZeDeviceComputeProperties{} {
     // NOTE: one must additionally call initialize() to complete
     // UR device creation.
   }
@@ -121,6 +122,12 @@ struct ur_device_handle_t_ : _ur_object {
   // change. Therefore it can be accessed without holding a lock on this
   // _ur_device_handle_t.
   const ze_device_handle_t ZeDevice;
+
+  // Level Zero SysMan device handle.
+  // This field is only set at _ur_device_handle_t creation time, and cannot
+  // change. Therefore it can be accessed without holding a lock on this
+  // _ur_device_handle_t.
+  zes_device_handle_t ZesDevice;
 
   // Keep the subdevices that are partitioned from this ur_device_handle_t for
   // reuse The order of sub-devices in this vector is repeated from the

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -19,13 +19,18 @@ typedef size_t DeviceId;
 
 struct ur_platform_handle_t_ : public _ur_platform {
   ur_platform_handle_t_(ze_driver_handle_t Driver)
-      : ZeDriver{Driver}, ZeApiVersion{ZE_API_VERSION_CURRENT} {}
+      : ZeDriver{Driver}, ZesDriver{nullptr}, ZeApiVersion{
+                                                  ZE_API_VERSION_CURRENT} {}
   // Performs initialization of a newly constructed PI platform.
   ur_result_t initialize();
 
   // Level Zero lacks the notion of a platform, but there is a driver, which is
   // a pretty good fit to keep here.
   ze_driver_handle_t ZeDriver;
+
+  // Level Zero Sysman Driver Handle. This handle is only used for accessing
+  // Sysman features are accessed thru this driver handle.
+  zes_driver_handle_t ZesDriver;
 
   // Given a multi driver scenario, the driver handle must be translated to the
   // internal driver handle to allow calls to driver experimental apis.

--- a/test/conformance/device/device_adapter_level_zero-v2.match
+++ b/test/conformance/device/device_adapter_level_zero-v2.match
@@ -1,3 +1,2 @@
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
-urDeviceGetInfoTest.Success/UR_DEVICE_INFO_GLOBAL_MEM_FREE

--- a/test/conformance/device/device_adapter_level_zero.match
+++ b/test/conformance/device/device_adapter_level_zero.match
@@ -1,3 +1,2 @@
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
-urDeviceGetInfoTest.Success/UR_DEVICE_INFO_GLOBAL_MEM_FREE


### PR DESCRIPTION
- Change to using zesInit and zes data structures for accessing L0
  SysMan functionality.
- Updated Platform & Devices to store zes handles if sysman support is
  available.
- Given Legacy Environment Variable from user, then fallback to
  old functionality.
- Fixed Return code on error to be consistently unsupported enumeration.