### PR TITLE
Introduce more loader logging

### DIFF
--- a/source/common/linux/ur_lib_loader.cpp
+++ b/source/common/linux/ur_lib_loader.cpp
@@ -23,6 +23,8 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
             logger::error(
                 "Failed to unload the library with the handle at address {}",
                 handle);
+        } else {
+            logger::info("unloaded adapter 0x{}", handle);
         }
     }
 }
@@ -42,8 +44,9 @@ LibLoader::loadAdapterLibrary(const char *name) {
         mode |= RTLD_DEEPBIND;
     }
 #endif
-
-    return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(dlopen(name, mode));
+    HMODULE handle = dlopen(name, mode);
+    logger::info("loaded adapter 0x{} ({})", handle, name);
+    return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(handle);
 }
 
 void *LibLoader::getFunctionPtr(HMODULE handle, const char *func_name) {

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -212,7 +212,10 @@ ur_result_t urLoaderTearDown() {
         delete context;
     });
 
-    return ret == 0 ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_UNINITIALIZED;
+    ur_result_t result =
+        ret == 0 ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_UNINITIALIZED;
+    logger::info("---> urLoaderTearDown() -> {}", result);
+    return result;
 }
 
 ur_result_t


### PR DESCRIPTION
Helps with fixing SYCL e2e tests which expect an ordered shutdown of libraries.