### PR TITLE
[RFC] Fixing dangling pointers caused by urCommandBufferRelease

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8314,7 +8314,7 @@ urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferReleaseExp(
-    ur_exp_command_buffer_handle_t hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+    ur_exp_command_buffer_handle_t &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/ur_ddi.h
+++ b/include/ur_ddi.h
@@ -1904,7 +1904,7 @@ typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferRetainExp_t)(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urCommandBufferReleaseExp
 typedef ur_result_t(UR_APICALL *ur_pfnCommandBufferReleaseExp_t)(
-    ur_exp_command_buffer_handle_t);
+    ur_exp_command_buffer_handle_t&);
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Function-pointer for urCommandBufferFinalizeExp

--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -21,12 +21,13 @@
 
 namespace {
 ur_result_t
-commandBufferReleaseInternal(ur_exp_command_buffer_handle_t CommandBuffer) {
+commandBufferReleaseInternal(ur_exp_command_buffer_handle_t &CommandBuffer) {
   if (CommandBuffer->decrementInternalReferenceCount() != 0) {
     return UR_RESULT_SUCCESS;
   }
 
   delete CommandBuffer;
+  CommandBuffer = nullptr;
   return UR_RESULT_SUCCESS;
 }
 
@@ -320,7 +321,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t &hCommandBuffer) {
   if (hCommandBuffer->decrementExternalReferenceCount() == 0) {
     // External ref count has reached zero, internal release of created
     // commands.

--- a/source/adapters/hip/command_buffer.cpp
+++ b/source/adapters/hip/command_buffer.cpp
@@ -23,12 +23,13 @@
 
 namespace {
 ur_result_t
-commandBufferReleaseInternal(ur_exp_command_buffer_handle_t CommandBuffer) {
+commandBufferReleaseInternal(ur_exp_command_buffer_handle_t &CommandBuffer) {
   if (CommandBuffer->decrementInternalReferenceCount() != 0) {
     return UR_RESULT_SUCCESS;
   }
 
   delete CommandBuffer;
+  CommandBuffer = nullptr;
   return UR_RESULT_SUCCESS;
 }
 
@@ -303,7 +304,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t &hCommandBuffer) {
   if (hCommandBuffer->decrementExternalReferenceCount() == 0) {
     // External ref count has reached zero, internal release of created
     // commands.

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -699,11 +699,12 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t CommandBuffer) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t CommandBuffer) {
+urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t &CommandBuffer) {
   if (!CommandBuffer->RefCount.decrementAndTest())
     return UR_RESULT_SUCCESS;
 
   delete CommandBuffer;
+  CommandBuffer = nullptr;
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -8198,7 +8198,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 /// @brief Intercept function for urCommandBufferReleaseExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/adapters/native_cpu/command_buffer.cpp
+++ b/source/adapters/native_cpu/command_buffer.cpp
@@ -33,7 +33,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t) {
+urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t &) {
   detail::ur::die("Experimental Command-buffer feature is not "
                   "implemented for the NativeCPU adapter.");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/source/adapters/opencl/command_buffer.cpp
+++ b/source/adapters/opencl/command_buffer.cpp
@@ -13,12 +13,13 @@
 
 namespace {
 ur_result_t
-commandBufferReleaseInternal(ur_exp_command_buffer_handle_t CommandBuffer) {
+commandBufferReleaseInternal(ur_exp_command_buffer_handle_t &CommandBuffer) {
   if (CommandBuffer->decrementInternalReferenceCount() != 0) {
     return UR_RESULT_SUCCESS;
   }
 
   delete CommandBuffer;
+  CommandBuffer = nullptr;
   return UR_RESULT_SUCCESS;
 }
 
@@ -109,7 +110,7 @@ urCommandBufferRetainExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t hCommandBuffer) {
+urCommandBufferReleaseExp(ur_exp_command_buffer_handle_t &hCommandBuffer) {
   if (hCommandBuffer->decrementExternalReferenceCount() == 0) {
     // External ref count has reached zero, internal release of created
     // commands.

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -6367,7 +6367,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 /// @brief Intercept function for urCommandBufferReleaseExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
     auto pfnReleaseExp =
         getContext()->urDdiTable.CommandBufferExp.pfnReleaseExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -7892,7 +7892,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 /// @brief Intercept function for urCommandBufferReleaseExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
     auto pfnReleaseExp =
         getContext()->urDdiTable.CommandBufferExp.pfnReleaseExp;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -6996,7 +6996,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 /// @brief Intercept function for urCommandBufferReleaseExp
 __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7418,7 +7418,7 @@ ur_result_t UR_APICALL urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
     ) try {
     auto pfnReleaseExp =
         ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnReleaseExp;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -6299,7 +6299,7 @@ ur_result_t UR_APICALL urCommandBufferRetainExp(
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
-        hCommandBuffer ///< [in][release] Handle of the command-buffer object.
+        &hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
Some functions in the UR leaves dangling pointers, [such as `commandBufferReleaseInternal`, which is called by `urCommandBufferReleaseExp`](https://github.com/oneapi-src/unified-runtime/blob/3d8fe8d298cec8db624fc230fa5c0e19865aa6f1/source/adapters/opencl/command_buffer.cpp#L21). Coverity has detected that on intel/llvm, when [`urCommandBufferReleaseExp` is called from the pi](https://github.com/intel/llvm/blob/4329b0c5f0f72f13aa72753f25578aed27525136/sycl/plugins/unified_runtime/pi2ur.hpp#L4631) with tracing enabled, dangling pointers left by `urCommandBufferReleaseExp` are used again [here](https://github.com/intel/llvm/blob/4329b0c5f0f72f13aa72753f25578aed27525136/sycl/source/detail/plugin.hpp#L222) (specifically, the `pi_ext_command_buffer`/`ur_exp_command_buffer_handle_t` fed into `Args`, which was already freed in `urCommandBufferRelease`).

The best course of action to fix this Coverity hit, to the best of my knowledge, is to fix the dangling pointers left by e.g. `urCommandBufferReleaseExp`. This PR contains a potential fix by taking references of `ur_exp_command_buffer_handle_t` when calling `urCommandBufferReleases` instead, and setting the pointers to `nullptr` after they are deleted. This would allow code using `urCommandBufferReleaseExp` to actually catch that the command buffer has been freed.

Unfortunately, this requires the API to be changed, as I've changed the function signature of `urCommandBufferReleaseExp`. I'm also aware that changing only `urCommandBufferRelease` may result in asymmetry within the API. Thus, if this change was to be adopted, more functions may also have to be changed in a similar manner. Thus, I am opening this PR as an RFC to see what other people think of this, and to see if there are any potential issues with this approach.

Additionally, if anyone has better ideas for fixing/handling this issue/Coverity hit without changing the UR API, please feel free to let me know. From what I can tell, this is the course of action that'll result in the least amount of problems in the future.

The respective draft DPC++ testing PR is here: https://github.com/intel/llvm/pull/14782