### PR TITLE
Bump UMF version

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -23,8 +23,8 @@ if (NOT DEFINED UMF_REPO)
 endif()
 
 if (NOT DEFINED UMF_TAG)
-    # Merge pull request #637 from kswiecicki/fix-dpool-poison-macro
-    set(UMF_TAG 1c34aae4c804e133c1273f30b1d6441ebb766f2f)
+    # Merge pull request #638 from kswiecicki/umf-compile-options
+    set(UMF_TAG 9f91964fabfbc8536b2eec6f54cb85feeab61667)
 endif()
 
 message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")


### PR DESCRIPTION
UMF compile options caused errors on some SYCL runners. Bump UMF to a version that should resolve these errors.

Logs: https://github.com/intel/llvm/actions/runs/10106492701/job/27948711538