### PR TITLE
[L0] create abstraction for ur_event_handle_t

### DIFF
--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -35,7 +35,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
       const ur_exp_command_buffer_desc_t *Desc, const bool IsInOrderCmdList);
 
   void registerSyncPoint(ur_exp_command_buffer_sync_point_t SyncPoint,
-                         ur_event_handle_t Event);
+                         ur_event_handle_legacy_t Event);
 
   ur_exp_command_buffer_sync_point_t getNextSyncPoint() const {
     return NextSyncPoint;
@@ -82,13 +82,13 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   ze_command_list_handle_t ZeCopyCommandList;
   // Event which will signals the most recent execution of the command-buffer
   // has finished
-  ur_event_handle_t SignalEvent = nullptr;
+  ur_event_handle_legacy_t SignalEvent = nullptr;
   // Event which a command-buffer waits on until the wait-list dependencies
   // passed to a command-buffer enqueue have been satisfied.
-  ur_event_handle_t WaitEvent = nullptr;
+  ur_event_handle_legacy_t WaitEvent = nullptr;
   // Event which a command-buffer waits on until the main command-list event
   // have been reset.
-  ur_event_handle_t AllResetEvent = nullptr;
+  ur_event_handle_legacy_t AllResetEvent = nullptr;
   // This flag is must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
@@ -100,7 +100,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // itself.
   ze_fence_handle_t ZeActiveFence;
   // Map of sync_points to ur_events
-  std::unordered_map<ur_exp_command_buffer_sync_point_t, ur_event_handle_t>
+  std::unordered_map<ur_exp_command_buffer_sync_point_t,
+                     ur_event_handle_legacy_t>
       SyncPoints;
   // Next sync_point value (may need to consider ways to reuse values if 32-bits
   // is not enough)

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -512,4 +512,21 @@ extern thread_local int32_t ErrorAdapterNativeCode;
                                       ur_result_t ErrorCode,
                                       int32_t AdapterErrorCode);
 
+// Get specific implementation of UR type from the handle
+template <typename UrType, typename UrHandle> UrType GetImpl(UrHandle Handle) {
+  if (!Handle)
+    return nullptr;
+  auto *H = dynamic_cast<UrType>(Handle);
+  if (!H) {
+    if constexpr (std::is_same_v<UrHandle, ur_queue_handle_t>) {
+      throw UR_RESULT_ERROR_INVALID_QUEUE;
+    } else if constexpr (std::is_same_v<UrHandle, ur_event_handle_t>) {
+      throw UR_RESULT_ERROR_INVALID_EVENT;
+    } else {
+      throw UR_RESULT_ERROR_UNKNOWN;
+    }
+  }
+  return H;
+}
+
 #define L0_DRIVER_INORDER_MIN_VERSION 29534

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -170,7 +170,7 @@ struct ur_context_handle_t_ : _ur_object {
   ur_mutex EventCacheMutex;
 
   // Caches for events.
-  using EventCache = std::vector<std::list<ur_event_handle_t>>;
+  using EventCache = std::vector<std::list<ur_event_handle_legacy_t>>;
   EventCache EventCaches{4};
   std::vector<std::unordered_map<ur_device_handle_t, size_t>>
       EventCachesDeviceMap{4};
@@ -204,14 +204,14 @@ struct ur_context_handle_t_ : _ur_object {
                                              bool CounterBasedEventEnabled,
                                              bool UsingImmCmdList);
 
-  // Get ur_event_handle_t from cache.
-  ur_event_handle_t getEventFromContextCache(bool HostVisible,
-                                             bool WithProfiling,
-                                             ur_device_handle_t Device,
-                                             bool CounterBasedEventEnabled);
+  // Get ur_event_handle_legacy_t from cache.
+  ur_event_handle_legacy_t
+  getEventFromContextCache(bool HostVisible, bool WithProfiling,
+                           ur_device_handle_t Device,
+                           bool CounterBasedEventEnabled);
 
-  // Add ur_event_handle_t to cache.
-  void addEventToContextCache(ur_event_handle_t);
+  // Add ur_event_handle_legacy_t to cache.
+  void addEventToContextCache(ur_event_handle_legacy_t);
 
   enum EventPoolCacheType {
     HostVisibleCacheType,
@@ -271,7 +271,7 @@ struct ur_context_handle_t_ : _ur_object {
 
   // Decrement number of events living in the pool upon event destroy
   // and return the pool to the cache if there are no unreleased events.
-  ur_result_t decrementUnreleasedEventsInPool(ur_event_handle_t Event);
+  ur_result_t decrementUnreleasedEventsInPool(ur_event_handle_legacy_t Event);
 
   // Retrieves a command list for executing on this device along with
   // a fence to be used in tracking the execution of this command list.
@@ -296,7 +296,7 @@ struct ur_context_handle_t_ : _ur_object {
   ur_result_t getAvailableCommandList(
       ur_queue_handle_legacy_t Queue, ur_command_list_ptr_t &CommandList,
       bool UseCopyEngine, uint32_t NumEventsInWaitList,
-      const ur_event_handle_t *EventWaitList, bool AllowBatching = false,
+      const ur_event_handle_legacy_t *EventWaitList, bool AllowBatching = false,
       ze_command_queue_handle_t *ForcedCmdQueue = nullptr);
 
   // Checks if Device is covered by this context.

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -768,8 +768,10 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
     [[maybe_unused]] ur_exp_image_copy_region_t *pCopyRegion,
     [[maybe_unused]] ur_exp_image_copy_flags_t imageCopyFlags,
     [[maybe_unused]] uint32_t numEventsInWaitList,
-    [[maybe_unused]] const ur_event_handle_t *phEventWaitList,
-    [[maybe_unused]] ur_event_handle_t *phEvent) {
+    [[maybe_unused]] const ur_event_handle_t *phUrEventWaitList,
+    [[maybe_unused]] ur_event_handle_t *phUrEvent) {
+  auto phEventWaitList = Legacy(phUrEventWaitList);
+  auto phEvent = Legacy(phUrEvent);
   auto hQueue = this;
   std::scoped_lock<ur_shared_mutex> Lock(hQueue->Mutex);
 
@@ -804,9 +806,9 @@ ur_result_t ur_queue_handle_legacy_t_::bindlessImagesImageCopyExp(
       OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = phEvent == nullptr;
-  ur_event_handle_t *Event = phEvent ? phEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = phEvent ? phEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(hQueue, Event, UR_COMMAND_MEM_IMAGE_COPY,
                                        CommandList, IsInternal,
                                        /*IsMultiDevice*/ false));

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -121,18 +121,20 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueKernelLaunch(
                         ///< implementation will choose the work-group size.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before the kernel execution. If nullptr, the
-                        ///< numEventsInWaitList must be 0, indicating that no
-                        ///< wait event.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before the kernel execution. If nullptr, the
+                          ///< numEventsInWaitList must be 0, indicating that no
+                          ///< wait event.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular kernel execution instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular kernel execution instance.
 ) {
   UR_ASSERT(WorkDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
   UR_ASSERT(WorkDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   ze_kernel_handle_t ZeKernel{};
   UR_CALL(getZeKernel(Queue, Kernel, &ZeKernel));
@@ -245,9 +247,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueKernelLaunch(
       true /* AllowBatching */));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent{};
+  ur_event_handle_legacy_t InternalEvent{};
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
 
   UR_CALL(createEventAndAssociateQueue(Queue, Event, UR_COMMAND_KERNEL_LAUNCH,
                                        CommandList, IsInternal, false));
@@ -330,18 +332,20 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueCooperativeKernelLaunchExp(
                         ///< implementation will choose the work-group size.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before the kernel execution. If nullptr, the
-                        ///< numEventsInWaitList must be 0, indicating that no
-                        ///< wait event.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before the kernel execution. If nullptr, the
+                          ///< numEventsInWaitList must be 0, indicating that no
+                          ///< wait event.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular kernel execution instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular kernel execution instance.
 ) {
   UR_ASSERT(WorkDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
   UR_ASSERT(WorkDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
 
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   auto ZeDevice = Queue->Device->ZeDevice;
 
@@ -509,9 +513,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueCooperativeKernelLaunchExp(
       true /* AllowBatching */));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent{};
+  ur_event_handle_legacy_t InternalEvent{};
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
 
   UR_CALL(createEventAndAssociateQueue(Queue, Event, UR_COMMAND_KERNEL_LAUNCH,
                                        CommandList, IsInternal, false));
@@ -586,15 +590,17 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueDeviceGlobalVariableWrite(
     const void *Src, ///< [in] pointer to where the data must be copied from.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list.
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before the kernel execution. If nullptr, the
-                        ///< numEventsInWaitList must be 0, indicating that no
-                        ///< wait event.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before the kernel execution. If nullptr, the
+                          ///< numEventsInWaitList must be 0, indicating that no
+                          ///< wait event.
     ur_event_handle_t
-        *Event ///< [in,out][optional] return an event object that identifies
-               ///< this particular kernel execution instance.
+        *UrEvent ///< [in,out][optional] return an event object that identifies
+                 ///< this particular kernel execution instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto Event = Legacy(UrEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
@@ -635,15 +641,17 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueDeviceGlobalVariableRead(
     void *Dst,         ///< [in] pointer to where the data must be copied to.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list.
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be
-                        ///< complete before the kernel execution. If
-                        ///< nullptr, the numEventsInWaitList must be 0,
-                        ///< indicating that no wait event.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be
+                          ///< complete before the kernel execution. If
+                          ///< nullptr, the numEventsInWaitList must be 0,
+                          ///< indicating that no wait event.
     ur_event_handle_t
-        *Event ///< [in,out][optional] return an event object that
-               ///< identifies this particular kernel execution instance.
+        *UrEvent ///< [in,out][optional] return an event object that
+                 ///< identifies this particular kernel execution instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto Event = Legacy(UrEvent);
   auto Queue = this;
 
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -49,8 +49,8 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
                                  ur_queue_handle_legacy_t Queue, void *Dst,
                                  ur_bool_t BlockingWrite, size_t Size,
                                  const void *Src, uint32_t NumEventsInWaitList,
-                                 const ur_event_handle_t *EventWaitList,
-                                 ur_event_handle_t *OutEvent,
+                                 const ur_event_handle_legacy_t *EventWaitList,
+                                 ur_event_handle_legacy_t *OutEvent,
                                  bool PreferCopyEngine) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
@@ -68,9 +68,9 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
       OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, CommandType, CommandList,
                                        IsInternal, false));
   UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
@@ -104,8 +104,8 @@ ur_result_t enqueueMemCopyRectHelper(
     ur_rect_offset_t DstOrigin, ur_rect_region_t Region, size_t SrcRowPitch,
     size_t DstRowPitch, size_t SrcSlicePitch, size_t DstSlicePitch,
     ur_bool_t Blocking, uint32_t NumEventsInWaitList,
-    const ur_event_handle_t *EventWaitList, ur_event_handle_t *OutEvent,
-    bool PreferCopyEngine) {
+    const ur_event_handle_legacy_t *EventWaitList,
+    ur_event_handle_legacy_t *OutEvent, bool PreferCopyEngine) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
   _ur_ze_event_list_t TmpWaitList;
@@ -122,9 +122,9 @@ ur_result_t enqueueMemCopyRectHelper(
       OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, CommandType, CommandList,
                                        IsInternal, false));
   UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
@@ -184,13 +184,12 @@ ur_result_t enqueueMemCopyRectHelper(
 }
 
 // PI interfaces must have queue's and buffer's mutexes locked on entry.
-static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
-                                        ur_queue_handle_legacy_t Queue,
-                                        void *Ptr, const void *Pattern,
-                                        size_t PatternSize, size_t Size,
-                                        uint32_t NumEventsInWaitList,
-                                        const ur_event_handle_t *EventWaitList,
-                                        ur_event_handle_t *OutEvent) {
+static ur_result_t
+enqueueMemFillHelper(ur_command_t CommandType, ur_queue_handle_legacy_t Queue,
+                     void *Ptr, const void *Pattern, size_t PatternSize,
+                     size_t Size, uint32_t NumEventsInWaitList,
+                     const ur_event_handle_legacy_t *EventWaitList,
+                     ur_event_handle_legacy_t *OutEvent) {
   auto &Device = Queue->Device;
 
   // Make sure that pattern size matches the capability of the copy queues.
@@ -231,9 +230,9 @@ static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
       OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, CommandType, CommandList,
                                        IsInternal, false));
   UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
@@ -330,8 +329,8 @@ static ur_result_t enqueueMemImageCommandHelper(
     ur_bool_t IsBlocking, ur_rect_offset_t *SrcOrigin,
     ur_rect_offset_t *DstOrigin, ur_rect_region_t *Region, size_t RowPitch,
     size_t SlicePitch, uint32_t NumEventsInWaitList,
-    const ur_event_handle_t *EventWaitList, ur_event_handle_t *OutEvent,
-    bool PreferCopyEngine = false) {
+    const ur_event_handle_legacy_t *EventWaitList,
+    ur_event_handle_legacy_t *OutEvent, bool PreferCopyEngine = false) {
   bool UseCopyEngine = Queue->useCopyEngine(PreferCopyEngine);
 
   _ur_ze_event_list_t TmpWaitList;
@@ -348,9 +347,9 @@ static ur_result_t enqueueMemImageCommandHelper(
       OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, CommandType, CommandList,
                                        IsInternal, false));
   UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
@@ -469,16 +468,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferRead(
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
+        *phUrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                            ///< pointer to a list of events that must be
+                            ///< complete before this command can be executed.
+                            ///< If nullptr, the numEventsInWaitList must be 0,
+                            ///< indicating that this command does not wait on
+                            ///< any event to complete.
     ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        *phUrEvent ///< [in,out][optional] return an event object that
+                   ///< identifies this particular command instance.
 ) {
+  auto phEventWaitList = Legacy(phUrEventWaitList);
+  auto phEvent = Legacy(phUrEvent);
   auto Queue = this;
   ur_mem_handle_t_ *Src = ur_cast<ur_mem_handle_t_ *>(hBuffer);
 
@@ -505,16 +506,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferWrite(
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
+        *phUrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                            ///< pointer to a list of events that must be
+                            ///< complete before this command can be executed.
+                            ///< If nullptr, the numEventsInWaitList must be 0,
+                            ///< indicating that this command does not wait on
+                            ///< any event to complete.
     ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        *phUrEvent ///< [in,out][optional] return an event object that
+                   ///< identifies this particular command instance.
 ) {
+  auto phEventWaitList = Legacy(phUrEventWaitList);
+  auto phEvent = Legacy(phUrEvent);
   auto Queue = this;
   ur_mem_handle_t_ *Buffer = ur_cast<ur_mem_handle_t_ *>(hBuffer);
 
@@ -550,16 +553,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferReadRect(
     void *pDst, ///< [in] pointer to host memory where data is to be read into
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< pointer to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
+        *phUrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                            ///< pointer to a list of events that must be
+                            ///< complete before this command can be executed.
+                            ///< If nullptr, the numEventsInWaitList must be 0,
+                            ///< indicating that this command does not wait on
+                            ///< any event to complete.
     ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        *phUrEvent ///< [in,out][optional] return an event object that
+                   ///< identifies this particular command instance.
 ) {
+  auto phEventWaitList = Legacy(phUrEventWaitList);
+  auto phEvent = Legacy(phUrEvent);
   auto Queue = this;
   ur_mem_handle_t_ *Buffer = ur_cast<ur_mem_handle_t_ *>(hBuffer);
 
@@ -597,16 +602,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferWriteRect(
         *pSrc, ///< [in] pointer to host memory where data is to be written from
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *phEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                          ///< points to a list of events that must be complete
-                          ///< before this command can be executed. If nullptr,
-                          ///< the numEventsInWaitList must be 0, indicating
-                          ///< that this command does not wait on any event to
-                          ///< complete.
+        *phUrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                            ///< points to a list of events that must be
+                            ///< complete before this command can be executed.
+                            ///< If nullptr, the numEventsInWaitList must be 0,
+                            ///< indicating that this command does not wait on
+                            ///< any event to complete.
     ur_event_handle_t
-        *phEvent ///< [in,out][optional] return an event object that identifies
-                 ///< this particular command instance.
+        *phUrEvent ///< [in,out][optional] return an event object that
+                   ///< identifies this particular command instance.
 ) {
+  auto phEventWaitList = Legacy(phUrEventWaitList);
+  auto phEvent = Legacy(phUrEvent);
   auto Queue = this;
   ur_mem_handle_t_ *Buffer = ur_cast<ur_mem_handle_t_ *>(hBuffer);
 
@@ -632,16 +639,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferCopy(
     size_t Size,      ///< [in] size in bytes of data being copied
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   _ur_buffer *SrcBuffer = ur_cast<_ur_buffer *>(BufferSrc);
   _ur_buffer *DstBuffer = ur_cast<_ur_buffer *>(BufferDst);
@@ -694,16 +703,18 @@ ur_queue_handle_legacy_t_::enqueueMemBufferCopyRect( ///< [in] handle of the
                           ///< destination buffer object
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   _ur_buffer *SrcBuffer = ur_cast<_ur_buffer *>(BufferSrc);
   _ur_buffer *DstBuffer = ur_cast<_ur_buffer *>(BufferDst);
@@ -743,16 +754,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferFill(
     size_t Size, ///< [in] fill size in bytes, must be a multiple of patternSize
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(Queue->Mutex,
                                                           Buffer->Mutex);
@@ -780,16 +793,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemImageRead(
     void *Dst, ///< [in] pointer to host memory where image is to be read into
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(Queue->Mutex,
                                                           Image->Mutex);
@@ -812,16 +827,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemImageWrite(
     void *Src, ///< [in] pointer to host memory where image is to be read into
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex> Lock(Queue->Mutex,
                                                           Image->Mutex);
@@ -844,16 +861,18 @@ ur_queue_handle_legacy_t_::enqueueMemImageCopy( ///< [in] handle of
                                 ///< pixels of the 1D, 2D, or 3D image
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::shared_lock<ur_shared_mutex> SrcLock(ImageSrc->Mutex, std::defer_lock);
   std::scoped_lock<std::shared_lock<ur_shared_mutex>, ur_shared_mutex,
@@ -880,26 +899,28 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferMap(
     size_t Size,   ///< [in] size in bytes of the buffer region being mapped
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent, ///< [in,out][optional] return an event object that
-                   ///< identifies this particular command instance.
-    void **RetMap  ///< [in,out] return mapped pointer.  TODO: move it before
-                   ///< numEventsInWaitList?
+        *UrOutEvent, ///< [in,out][optional] return an event object that
+                     ///< identifies this particular command instance.
+    void **RetMap    ///< [in,out] return mapped pointer.  TODO: move it before
+                     ///< numEventsInWaitList?
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   auto Buffer = ur_cast<_ur_buffer *>(Buf);
 
   UR_ASSERT(!Buffer->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   ze_event_handle_t ZeEvent = nullptr;
 
   bool UseCopyEngine = false;
@@ -951,7 +972,7 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferMap(
   if (Buffer->OnHost) {
     // Wait on incoming events before doing the copy
     if (NumEventsInWaitList > 0)
-      UR_CALL(urEventWait(NumEventsInWaitList, EventWaitList));
+      UR_CALL(urEventWait(NumEventsInWaitList, UrEventWaitList));
 
     if (Queue->isInOrderQueue())
       UR_CALL(urQueueFinish(Queue));
@@ -1010,7 +1031,8 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemBufferMap(
         Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList));
 
     // Add the event to the command list.
-    CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
+    CommandList->second.append(
+        reinterpret_cast<ur_event_handle_legacy_t>(*Event));
     (*Event)->RefCount.increment();
 
     const auto &ZeCommandList = CommandList->first;
@@ -1045,16 +1067,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemUnmap(
     void *MappedPtr,     ///< [in] mapped host address
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   UR_ASSERT(!Mem->isImage(), UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
@@ -1063,9 +1087,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemUnmap(
   bool UseCopyEngine = false;
 
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   {
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
@@ -1107,7 +1131,7 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemUnmap(
   if (Buffer->OnHost) {
     // Wait on incoming events before doing the copy
     if (NumEventsInWaitList > 0)
-      UR_CALL(urEventWait(NumEventsInWaitList, EventWaitList));
+      UR_CALL(urEventWait(NumEventsInWaitList, UrEventWaitList));
 
     if (Queue->isInOrderQueue())
       UR_CALL(urQueueFinish(Queue));
@@ -1136,7 +1160,8 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueMemUnmap(
       reinterpret_cast<ur_queue_handle_legacy_t>(Queue), CommandList,
       UseCopyEngine, NumEventsInWaitList, EventWaitList));
 
-  CommandList->second.append(reinterpret_cast<ur_event_handle_t>(*Event));
+  CommandList->second.append(
+      reinterpret_cast<ur_event_handle_legacy_t>(*Event));
   (*Event)->RefCount.increment();
 
   const auto &ZeCommandList = CommandList->first;
@@ -1174,16 +1199,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMMemcpy(
     size_t Size,     ///< [in] size in bytes to be copied
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
@@ -1206,16 +1233,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMPrefetch(
     ur_usm_migration_flags_t Flags, ///< [in] USM prefetch flags
     uint32_t NumEventsInWaitList,   ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating
-                        ///< that this command does not wait on any event to
-                        ///< complete.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   std::ignore = Flags;
   // Lock automatically releases when this goes out of scope.
@@ -1242,9 +1271,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMPrefetch(
 
   // TODO: do we need to create a unique command type for this?
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent;
+  ur_event_handle_legacy_t InternalEvent;
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, UR_COMMAND_USM_PREFETCH,
                                        CommandList, IsInternal, false));
   ZeEvent = (*Event)->ZeEvent;
@@ -1273,9 +1302,10 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMAdvise(
     size_t Size,                  ///< [in] size in bytes to be advised
     ur_usm_advice_flags_t Advice, ///< [in] USM memory advice
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
+        *UrOutEvent ///< [in,out][optional] return an event object that
+                    ///< identifies this particular command instance.
 ) {
+  auto OutEvent = Legacy(UrOutEvent);
   auto Queue = this;
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
@@ -1298,9 +1328,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMAdvise(
 
   // TODO: do we need to create a unique command type for this?
   ze_event_handle_t ZeEvent = nullptr;
-  ur_event_handle_t InternalEvent{};
+  ur_event_handle_legacy_t InternalEvent{};
   bool IsInternal = OutEvent == nullptr;
-  ur_event_handle_t *Event = OutEvent ? OutEvent : &InternalEvent;
+  ur_event_handle_legacy_t *Event = OutEvent ? OutEvent : &InternalEvent;
   UR_CALL(createEventAndAssociateQueue(Queue, Event, UR_COMMAND_USM_ADVISE,
                                        CommandList, IsInternal, false));
   ZeEvent = (*Event)->ZeEvent;
@@ -1371,15 +1401,17 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMMemcpy2D(
     size_t Height,   ///< [in] the height of columns to be copied.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before the kernel execution. If nullptr, the
-                        ///< numEventsInWaitList must be 0, indicating that no
-                        ///< wait event.
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before the kernel execution. If nullptr, the
+                          ///< numEventsInWaitList must be 0, indicating that no
+                          ///< wait event.
     ur_event_handle_t
-        *Event ///< [in,out][optional] return an event object that identifies
-               ///< this particular kernel execution instance.
+        *UrEvent ///< [in,out][optional] return an event object that identifies
+                 ///< this particular kernel execution instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto Event = Legacy(UrEvent);
   auto Queue = this;
   ur_rect_offset_t ZeroOffset{0, 0, 0};
   ur_rect_region_t Region{Width, Height, 0};
@@ -2285,15 +2317,18 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueUSMFill(
     size_t Size, ///< [in] size in bytes to be set. Must be a multiple of
                  ///< patternSize.
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t *
-        EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                       ///< pointer to a list of events that must be complete
-                       ///< before this command can be executed. If nullptr, the
-                       ///< numEventsInWaitList must be 0, indicating that this
-                       ///< command does not wait on any event to complete.
-    ur_event_handle_t *Event ///< [out][optional] return an event object that
-                             ///< identifies this particular command instance.
+    const ur_event_handle_t
+        *UrEventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                          ///< pointer to a list of events that must be complete
+                          ///< before this command can be executed. If nullptr,
+                          ///< the numEventsInWaitList must be 0, indicating
+                          ///< that this command does not wait on any event to
+                          ///< complete.
+    ur_event_handle_t *UrEvent ///< [out][optional] return an event object that
+                               ///< identifies this particular command instance.
 ) {
+  auto EventWaitList = Legacy(UrEventWaitList);
+  auto Event = Legacy(UrEvent);
   auto Queue = this;
   std::scoped_lock<ur_shared_mutex> Lock(Queue->Mutex);
 

--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -50,8 +50,8 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
                                  ur_queue_handle_legacy_t Queue, void *Dst,
                                  ur_bool_t BlockingWrite, size_t Size,
                                  const void *Src, uint32_t NumEventsInWaitList,
-                                 const ur_event_handle_t *EventWaitList,
-                                 ur_event_handle_t *OutEvent,
+                                 const ur_event_handle_legacy_t *EventWaitList,
+                                 ur_event_handle_legacy_t *OutEvent,
                                  bool PreferCopyEngine);
 
 ur_result_t enqueueMemCopyRectHelper(
@@ -60,8 +60,8 @@ ur_result_t enqueueMemCopyRectHelper(
     ur_rect_offset_t DstOrigin, ur_rect_region_t Region, size_t SrcRowPitch,
     size_t DstRowPitch, size_t SrcSlicePitch, size_t DstSlicePitch,
     ur_bool_t Blocking, uint32_t NumEventsInWaitList,
-    const ur_event_handle_t *EventWaitList, ur_event_handle_t *OutEvent,
-    bool PreferCopyEngine = false);
+    const ur_event_handle_legacy_t *EventWaitList,
+    ur_event_handle_legacy_t *OutEvent, bool PreferCopyEngine = false);
 
 struct ur_mem_handle_t_ : _ur_object {
   // Keeps the PI context of this memory handle.

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -31,6 +31,9 @@
 struct ur_queue_handle_legacy_t_;
 using ur_queue_handle_legacy_t = ur_queue_handle_legacy_t_ *;
 
+struct ur_event_handle_legacy_t_;
+using ur_event_handle_legacy_t = ur_event_handle_legacy_t_ *;
+
 extern "C" {
 ur_result_t urQueueReleaseInternal(ur_queue_handle_legacy_t Queue);
 } // extern "C"
@@ -88,7 +91,7 @@ private:
 
   // Internal barrier event that is signaled on completion of the batched
   // events.
-  ur_event_handle_t barrierEvent;
+  ur_event_handle_legacy_t barrierEvent;
 
   // Current batch state. Don't use directly.
   state st;
@@ -117,16 +120,16 @@ struct ur_completion_batches {
   // returned to indicate that there are no batches available.
   // This is safe, but will increase how many events are associated
   // with the active batch.
-  ur_result_t tryCleanup(ur_queue_handle_legacy_t queue,
-                         ze_command_list_handle_t cmdlist,
-                         std::vector<ur_event_handle_t> &EventList,
-                         std::vector<ur_event_handle_t> &EventListToCleanup);
+  ur_result_t
+  tryCleanup(ur_queue_handle_legacy_t queue, ze_command_list_handle_t cmdlist,
+             std::vector<ur_event_handle_legacy_t> &EventList,
+             std::vector<ur_event_handle_legacy_t> &EventListToCleanup);
 
   // Adds an event to the the active batch.
   // Ideally, all events that are appended here are then provided in the
   // vector for cleanup. Otherwise the event batch will simply ignore
   // missing events when it comes time for cleanup.
-  void append(ur_event_handle_t event);
+  void append(ur_event_handle_legacy_t event);
 
   // Resets all the batches without waiting for event completion.
   // Only safe when the command list was fully synchronized through
@@ -137,13 +140,15 @@ private:
   // Checks the state of all previously sealed batches. If any are complete,
   // moves the associated events from the EventList to EventListToCleanup,
   // and then resets the batch for reuse.
-  ur_result_t cleanup(std::vector<ur_event_handle_t> &EventList,
-                      std::vector<ur_event_handle_t> &EventListToCleanup);
+  ur_result_t
+  cleanup(std::vector<ur_event_handle_legacy_t> &EventList,
+          std::vector<ur_event_handle_legacy_t> &EventListToCleanup);
 
   // Moves the completed events from EventList to EventListToCleanup.
-  void moveCompletedEvents(ur_completion_batch_it it,
-                           std::vector<ur_event_handle_t> &EventList,
-                           std::vector<ur_event_handle_t> &EventListToCleanup);
+  void moveCompletedEvents(
+      ur_completion_batch_it it,
+      std::vector<ur_event_handle_legacy_t> &EventList,
+      std::vector<ur_event_handle_legacy_t> &EventListToCleanup);
 
   // Find or creates an empty batch. This might fail if there are now empty
   // batches and a batch limit has been reached.
@@ -158,7 +163,7 @@ ur_result_t resetCommandLists(ur_queue_handle_legacy_t Queue);
 ur_result_t
 CleanupEventsInImmCmdLists(ur_queue_handle_legacy_t UrQueue,
                            bool QueueLocked = false, bool QueueSynced = false,
-                           ur_event_handle_t CompletedEvent = nullptr);
+                           ur_event_handle_legacy_t CompletedEvent = nullptr);
 
 // Structure describing the specific use of a command-list in a queue.
 // This is because command-lists are re-used across multiple queues
@@ -219,9 +224,9 @@ struct ur_command_list_info_t {
   // completion.
   // TODO: use this for optimizing events in the same command-list, e.g.
   // only have last one visible to the host.
-  std::vector<ur_event_handle_t> EventList;
+  std::vector<ur_event_handle_legacy_t> EventList;
   size_t size() const { return EventList.size(); }
-  void append(ur_event_handle_t Event);
+  void append(ur_event_handle_legacy_t Event);
 };
 
 // The map type that would track all command-lists in a queue.
@@ -556,7 +561,7 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   // this queue. this is used to add dependency with the last command to add
   // in-order semantics and updated with the latest event each time a new
   // command is enqueued.
-  ur_event_handle_t LastCommandEvent = nullptr;
+  ur_event_handle_legacy_t LastCommandEvent = nullptr;
 
   // Indicates if we own the ZeCommandQueue or it came from interop that
   // asked to not transfer the ownership to SYCL RT.
@@ -599,11 +604,11 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   // A helper structure to keep active barriers of the queue.
   // It additionally manages ref-count of events in this list.
   struct active_barriers {
-    std::vector<ur_event_handle_t> Events;
-    void add(ur_event_handle_t &Event);
+    std::vector<ur_event_handle_legacy_t> Events;
+    void add(ur_event_handle_legacy_t &Event);
     ur_result_t clear();
     bool empty() { return Events.empty(); }
-    std::vector<ur_event_handle_t> &vector() { return Events; }
+    std::vector<ur_event_handle_legacy_t> &vector() { return Events; }
   };
   // A collection of currently active barriers.
   // These should be inserted into a command list whenever an available command
@@ -676,7 +681,7 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   // requested type of event. Each list contains events which can be reused
   // inside all command lists in the queue as described in the 2-event model.
   // Leftover events in the cache are relased at the queue destruction.
-  std::vector<std::list<ur_event_handle_t>> EventCaches{2};
+  std::vector<std::list<ur_event_handle_legacy_t>> EventCaches{2};
   std::vector<std::unordered_map<ur_device_handle_t, size_t>>
       EventCachesDeviceMap{2};
 
@@ -691,7 +696,7 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
     // case the event will mark this for deletion when the queue sees fit.
     bool EventHasDied = false;
   };
-  std::map<ur_event_handle_t, end_time_recording> EndTimeRecordings;
+  std::map<ur_event_handle_legacy_t, end_time_recording> EndTimeRecordings;
 
   // Clear the end time recording timestamps entries.
   void clearEndTimeRecordings();
@@ -737,7 +742,7 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   // not used by any command but its ZeEvent is used by many ur_event_handle_t
   // objects. Commands to wait and reset ZeEvent must be submitted to the queue
   // before calling this method.
-  ur_result_t addEventToQueueCache(ur_event_handle_t Event);
+  ur_result_t addEventToQueueCache(ur_event_handle_legacy_t Event);
 
   // Returns true if any commands for this queue are allowed to
   // be batched together.
@@ -769,8 +774,8 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   // two times in a row and have to do round-robin between two events. Otherwise
   // it picks an event from the beginning of the cache and returns it. Event
   // from the last command is always appended to the end of the list.
-  ur_event_handle_t getEventFromQueueCache(bool IsMultiDevice,
-                                           bool HostVisible);
+  ur_event_handle_legacy_t getEventFromQueueCache(bool IsMultiDevice,
+                                                  bool HostVisible);
 
   // Returns true if an OpenCommandList has commands that need to be submitted.
   // If IsCopy is 'true', then the OpenCommandList containing copy commands is
@@ -834,11 +839,11 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   /// @return PI_SUCCESS if successful, PI error code otherwise.
   ur_result_t
   resetCommandList(ur_command_list_ptr_t CommandList, bool MakeAvailable,
-                   std::vector<ur_event_handle_t> &EventListToCleanup,
+                   std::vector<ur_event_handle_legacy_t> &EventListToCleanup,
                    bool CheckStatus = true);
 
   // Gets the open command containing the event, or CommandListMap.end()
-  ur_command_list_ptr_t eventOpenCommandList(ur_event_handle_t Event);
+  ur_command_list_ptr_t eventOpenCommandList(ur_event_handle_legacy_t Event);
 
   // Return the queue group to use based on standard/immediate commandlist mode,
   // and if immediate mode, the thread-specific group.
@@ -883,18 +888,9 @@ struct ur_queue_handle_legacy_t_ : _ur_object, public ur_queue_handle_t_ {
   size_t getImmdCmmdListsEventCleanupThreshold();
 };
 
-template <typename QueueT> QueueT GetQueue(ur_queue_handle_t Queue) {
-  if (!Queue)
-    return nullptr;
-  auto *Q = dynamic_cast<QueueT>(Queue);
-  if (!Q) {
-    throw UR_RESULT_ERROR_INVALID_QUEUE;
-  }
-  return Q;
-}
-
+// Get legacy implementation
 static inline ur_queue_handle_legacy_t Legacy(ur_queue_handle_t Queue) {
-  return GetQueue<ur_queue_handle_legacy_t>(Queue);
+  return GetImpl<ur_queue_handle_legacy_t>(Queue);
 }
 
 // This helper function creates a ur_event_handle_t and associate a
@@ -910,12 +906,11 @@ static inline ur_queue_handle_legacy_t Legacy(ur_queue_handle_t Queue) {
 //        multiple devices.
 // \param ForceHostVisible tells if the event must be created in
 //        the host-visible pool
-ur_result_t
-createEventAndAssociateQueue(ur_queue_handle_legacy_t Queue,
-                             ur_event_handle_t *Event, ur_command_t CommandType,
-                             ur_command_list_ptr_t CommandList, bool IsInternal,
-                             bool IsMultiDevice,
-                             std::optional<bool> HostVisible = std::nullopt);
+ur_result_t createEventAndAssociateQueue(
+    ur_queue_handle_legacy_t Queue, ur_event_handle_legacy_t *Event,
+    ur_command_t CommandType, ur_command_list_ptr_t CommandList,
+    bool IsInternal, bool IsMultiDevice,
+    std::optional<bool> HostVisible = std::nullopt);
 
 // This helper function checks to see if an event for a command can be included
 // at the end of a command list batch. This will only be true if the event does
@@ -923,7 +918,7 @@ createEventAndAssociateQueue(ur_queue_handle_legacy_t Queue,
 // this batch.
 bool eventCanBeBatched(ur_queue_handle_legacy_t Queue, bool UseCopyEngine,
                        uint32_t NumEventsInWaitList,
-                       const ur_event_handle_t *EventWaitList);
+                       const ur_event_handle_legacy_t *EventWaitList);
 
 // This helper function checks to see if a signal event at the end of a command
 // should be set. If the Queue is out of order and the command has no
@@ -931,13 +926,14 @@ bool eventCanBeBatched(ur_queue_handle_legacy_t Queue, bool UseCopyEngine,
 // a command list batch. The signal event will be appended at the end of the
 // batch to be signalled at the end of the command list.
 ur_result_t setSignalEvent(ur_queue_handle_legacy_t Queue, bool UseCopyEngine,
-                           ze_event_handle_t *ZeEvent, ur_event_handle_t *Event,
+                           ze_event_handle_t *ZeEvent,
+                           ur_event_handle_legacy_t *Event,
                            uint32_t NumEventsInWaitList,
-                           const ur_event_handle_t *EventWaitList,
+                           const ur_event_handle_legacy_t *EventWaitList,
                            ze_command_queue_handle_t ZeQueue);
 
 // Helper function to perform the necessary cleanup of the events from reset cmd
 // list.
 ur_result_t CleanupEventListFromResetCmdList(
-    std::vector<ur_event_handle_t> &EventListToCleanup,
+    std::vector<ur_event_handle_legacy_t> &EventListToCleanup,
     bool QueueLocked = false);


### PR DESCRIPTION
to allow switching the implementation to v2::ur_event_handle_t. This is similar to how ur_queue_handle_t behaves right now.