### PR TITLE
[CUDA] Don't import XPTI symbols in the plugin library

### DIFF
--- a/source/adapters/cuda/CMakeLists.txt
+++ b/source/adapters/cuda/CMakeLists.txt
@@ -98,6 +98,7 @@ if (UR_ENABLE_TRACING)
   endif()
   target_compile_definitions(${TARGET_NAME} PRIVATE
     XPTI_ENABLE_INSTRUMENTATION
+    XPTI_STATIC_LIBRARY
     )
   target_include_directories(${TARGET_NAME} PUBLIC
     ${XPTI_INCLUDES}


### PR DESCRIPTION
All other uses of XPTI also use the static library. This fixes compilation issues with `dllimport/dllexport` on Windows.