### PR TITLE
Initalize mock callbacks earlier

### DIFF
--- a/source/mock/ur_mock_helpers.cpp
+++ b/source/mock/ur_mock_helpers.cpp
@@ -13,10 +13,8 @@
 #include "ur_mock_helpers.hpp"
 
 namespace mock {
+static callbacks_t callbacks = {};
 
-callbacks_t &getCallbacks() {
-    static callbacks_t callbacks;
-    return callbacks;
-}
+callbacks_t &getCallbacks() { return callbacks; }
 
 } // namespace mock


### PR DESCRIPTION
Avoid use after static destruction in sycl unittests by moving the initialization of `mock::callbacks` from static function scope to static global scope.