### PR TITLE
[L0] Return the build log on compilation failure

### DIFF
--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -209,8 +209,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuildExp(
         }
       }
       hProgram->ZeModuleMap.insert(std::make_pair(ZeDevice, ZeModuleHandle));
-      hProgram->ZeBuildLogMap.insert(std::make_pair(ZeDevice, ZeBuildLog));
     }
+    hProgram->ZeBuildLogMap.insert(std::make_pair(ZeDevice, ZeBuildLog));
   }
 
   // We no longer need the IL / native code.


### PR DESCRIPTION
Right now we never return the build log for L0 on build failure because we only add `ZeBuildLog` to `ZeBuildLogMap` if `ZeResult` is `ZE_RESULT_SUCCESS`.

I was running a SYCL program that didn't build and noticed the the log was printed for OCL but not L0, so I debugged into why L0 wasn't and found this.

I manually confirmed this fixes it.