### PR TITLE
[L0] Phase 2 of Counter-Based Event Implementation

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -557,9 +557,12 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
 
 ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
     bool HostVisible, bool WithProfiling, ur_device_handle_t Device,
-    bool CounterBasedEventEnabled) {
+    bool CounterBasedEventEnabled, bool UsingImmCmdList) {
   std::scoped_lock<ur_mutex> Lock(EventCacheMutex);
   auto Cache = getEventCache(HostVisible, WithProfiling, Device);
+  if (CounterBasedEventEnabled) {
+    Cache = getCounterBasedEventCache(UsingImmCmdList, Device);
+  }
   if (Cache->empty())
     return nullptr;
 
@@ -570,7 +573,8 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   }
   Cache->erase(It);
   // We have to reset event before using it.
-  Event->reset();
+  if (!CounterBasedEventEnabled)
+    Event->reset();
   return Event;
 }
 
@@ -582,9 +586,16 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
     Device = Legacy(Event->UrQueue)->Device;
   }
 
-  auto Cache = getEventCache(Event->isHostVisible(),
-                             Event->isProfilingEnabled(), Device);
-  Cache->emplace_back(Event);
+  if (Event->CounterBasedEventsEnabled) {
+    auto Cache = getCounterBasedEventCache(
+        !Legacy(Event->UrQueue) || Legacy(Event->UrQueue)->UsingImmCmdLists,
+        Device);
+    Cache->emplace_back(Event);
+  } else {
+    auto Cache = getEventCache(Event->isHostVisible(),
+                               Event->isProfilingEnabled(), Device);
+    Cache->emplace_back(Event);
+  }
 }
 
 ur_result_t

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1194,7 +1194,7 @@ ur_queue_handle_legacy_t_::ur_queue_handle_legacy_t_(
     return std::atoi(UrRet) != 0;
   }();
   this->CounterBasedEventsEnabled =
-      UsingImmCmdLists && isInOrderQueue() && Device->useDriverInOrderLists() &&
+      isInOrderQueue() && Device->useDriverInOrderLists() &&
       useDriverCounterBasedEvents &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
 }


### PR DESCRIPTION
-enable counter-based events for regular commandlist -counter-based events may be reused even though they are not done -when ref count goes to not used by external clients value it means that event may be reused by subsequent calls -move events that are no longer externally visible to re-usable pool and reuse those more aggressively

intel/llvm PR: intel/llvm#14754