### PR TITLE
Add option to force use of libstdc++ on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ option(VAL_USE_LIBBACKTRACE_BACKTRACE "enable libbacktrace validation backtrace 
 option(UR_ENABLE_ASSERTIONS "Enable assertions for all build types" OFF)
 option(UR_BUILD_XPTI_LIBS "Build the XPTI libraries when tracing is enabled" ON)
 option(UR_STATIC_LOADER "Build loader as a static library" OFF)
+option(UR_FORCE_LIBSTDCXX "Force use of libstdc++ in a build using libc++ on Linux" OFF)
 set(UR_DPCXX "" CACHE FILEPATH "Path of the DPC++ compiler executable")
 set(UR_DPCXX_BUILD_FLAGS "" CACHE STRING "Build flags to pass to DPC++ when compiling device programs")
 set(UR_SYCL_LIBRARY_DIR "" CACHE PATH
@@ -94,6 +95,21 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows AND NOT CMAKE_GENERATOR STREQUAL Ninja)
     set(CUSTOM_COMMAND_BINARY_DIR ${CUSTOM_COMMAND_BINARY_DIR}/$<CONFIG>)
 endif()
 
+if(UR_FORCE_LIBSTDCXX AND CMAKE_SYSTEM_NAME STREQUAL Linux)
+    # Remove flags to specify using libc++ or static libstdc++ in order to
+    # support sitatuions where the libstdc++ ABI is required.
+    foreach(flags CMAKE_CXX_FLAGS CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+        string(REPLACE "-stdlib=libc++" "" ${flags} "${${flags}}")
+        string(REPLACE "-static-libstdc++" "" ${flags} "${${flags}}")
+    endforeach()
+    # Globally link against pthread, this is necessary when forcing use of
+    # libstdc++ in a libc++ build as the FindThreads module may have already
+    # been invoked and detected that pthread symbols are provided by libc++
+    # which is not the case for libstdc++.
+    add_compile_options(-pthread)
+    link_libraries(pthread)
+endif()
+
 if(NOT MSVC)
     # Determine if libstdc++ is being used.
     check_cxx_source_compiles("
@@ -103,7 +119,7 @@ if(NOT MSVC)
         #endif
         int main() {}"
         USING_LIBSTDCXX)
-    if(USING_LIBSTDCXX)
+    if(UR_FORCE_LIBSTDCXX OR USING_LIBSTDCXX)
         # Support older versions of GCC where the <filesystem> header is not
         # available and <experimental/filesystem> must be used instead. This
         # requires linking against libstdc++fs.a, on systems where <filesystem>


### PR DESCRIPTION
The UR_FORCE_LIBSTDCXX option defaults to OFF can be used in situations where the build is configured to use libc++ but the libstdc++ ABI is required for stability reasons.