### PR TITLE
fix scorecard job

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ${{ github.repository_owner == 'oneapi-src' && 'intel-ubuntu-22.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
The scorecard action must run on the official GitHub-hosted ubuntu runners...

This fixes:
```
2024/08/05 13:35:24 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job should have exactly 1 'Ubuntu' virtual environment, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}
```
currently happening on [main](https://github.com/oneapi-src/unified-runtime/actions/runs/10249788286/job/28353963030).