### PR TITLE
[L0] Enable L0 Driver Init to init all device types with filtering

### DIFF
--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -207,6 +207,15 @@ const int UrL0LeaksDebug = [] {
   return std::atoi(UrRet);
 }();
 
+// Enable for UR L0 Adapter to Init all L0 Drivers on the system with filtering
+// in place for only currently used Drivers.
+const int UrL0InitAllDrivers = [] {
+  const char *UrRet = std::getenv("UR_L0_INIT_ALL_DRIVERS");
+  if (!UrRet)
+    return 0;
+  return std::atoi(UrRet);
+}();
+
 // Controls Level Zero calls serialization to w/a Level Zero driver being not MT
 // ready. Recognized values (can be used as a bit mask):
 enum {


### PR DESCRIPTION
- Change zeInit usage to optionally init all driver types with all flags set, then
  filter the drivers currently supported.
- Enables for L0 application to init all driver types which unblocks
  other libraries using L0 drivers and enables for future use of other
driver types.
- Added Environment Variable UR_L0_INIT_ALL_DRIVERS which will set all
  driver type flags when enabled.