### PR TITLE
[L0] Fix Driver Version check to use extension and tuple check

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -610,8 +610,8 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
   // In-order command-lists are not available in old driver version.
-  bool CompatibleDriver = isDriverVersionNewerOrSimilar(
-      Context->getPlatform()->ZeDriver, 1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
+      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
   return CompatibleDriver
              ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
              : false;

--- a/source/adapters/level_zero/common.cpp
+++ b/source/adapters/level_zero/common.cpp
@@ -67,28 +67,6 @@ ur_result_t ze2urResult(ze_result_t ZeResult) {
   }
 }
 
-/// Checks the version of the level-zero driver.
-/// @param ZeDriver Level Zero Driver handle
-/// @param VersionMajor Major verion number to compare to.
-/// @param VersionMinor Minor verion number to compare to.
-/// @param VersionBuild Build verion number to compare to.
-/// @return true is the version of the driver is higher than or equal to the
-/// compared version
-bool isDriverVersionNewerOrSimilar(ze_driver_handle_t ZeDriver,
-                                   uint32_t VersionMajor, uint32_t VersionMinor,
-                                   uint32_t VersionBuild) {
-  ZeStruct<ze_driver_properties_t> ZeDriverProperties;
-  ZE2UR_CALL(zeDriverGetProperties, (ZeDriver, &ZeDriverProperties));
-  uint32_t DriverVersion = ZeDriverProperties.driverVersion;
-  auto DriverVersionMajor = (DriverVersion & 0xFF000000) >> 24;
-  auto DriverVersionMinor = (DriverVersion & 0x00FF0000) >> 16;
-  auto DriverVersionBuild = DriverVersion & 0x0000FFFF;
-
-  return ((DriverVersionMajor >= VersionMajor) &&
-          (DriverVersionMinor >= VersionMinor) &&
-          (DriverVersionBuild >= VersionBuild));
-}
-
 // This function will ensure compatibility with both Linux and Windows for
 // setting environment variables.
 bool setEnvVar(const char *name, const char *value) {

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -317,11 +317,6 @@ bool setEnvVar(const char *name, const char *value);
 // Map Level Zero runtime error code to UR error code.
 ur_result_t ze2urResult(ze_result_t ZeResult);
 
-/// Checks the version of the level-zero driver.
-bool isDriverVersionNewerOrSimilar(ze_driver_handle_t ZeDriver,
-                                   uint32_t VersionMajor, uint32_t VersionMinor,
-                                   uint32_t VersionBuild);
-
 // Trace a call to Level-Zero RT
 #define ZE2UR_CALL(ZeName, ZeArgs)                                             \
   {                                                                            \

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1173,12 +1173,10 @@ bool ur_device_handle_t_::useDriverInOrderLists() {
   // Use in-order lists implementation from L0 driver instead
   // of adapter's implementation.
 
-  ze_driver_handle_t ZeDriver = this->Platform->ZeDriver;
-
   static const bool UseDriverInOrderLists = [&] {
     const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-    bool CompatibleDriver = isDriverVersionNewerOrSimilar(
-        ZeDriver, 1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+    bool CompatibleDriver = this->Platform->isDriverVersionNewerOrSimilar(
+        1, 3, L0_DRIVER_INORDER_MIN_VERSION);
     if (!UrRet)
       return CompatibleDriver;
     return std::atoi(UrRet) != 0;

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -266,6 +266,67 @@ ur_result_t ur_platform_handle_t_::initialize() {
   return UR_RESULT_SUCCESS;
 }
 
+/// Checks the version of the level-zero driver.
+/// @param VersionMajor Major verion number to compare to.
+/// @param VersionMinor Minor verion number to compare to.
+/// @param VersionBuild Build verion number to compare to.
+/// @return true is the version of the driver is higher than or equal to the
+/// compared version
+bool ur_platform_handle_t_::isDriverVersionNewerOrSimilar(
+    uint32_t VersionMajor, uint32_t VersionMinor, uint32_t VersionBuild) {
+  uint32_t DriverVersionMajor = 0;
+  uint32_t DriverVersionMinor = 0;
+  uint32_t DriverVersionBuild = 0;
+  if (!ZeDriverVersionString.Supported) {
+    ZeStruct<ze_driver_properties_t> ZeDriverProperties;
+    ZE2UR_CALL(zeDriverGetProperties, (ZeDriver, &ZeDriverProperties));
+    uint32_t DriverVersion = ZeDriverProperties.driverVersion;
+    DriverVersionMajor = (DriverVersion & 0xFF000000) >> 24;
+    DriverVersionMinor = (DriverVersion & 0x00FF0000) >> 16;
+    DriverVersionBuild = DriverVersion & 0x0000FFFF;
+  } else {
+    std::string ZeDriverVersion;
+    size_t sizeOfDriverString = 0;
+    ZeDriverVersionString.getDriverVersionString(ZeDriverHandleExpTranslated,
+                                                 nullptr, &sizeOfDriverString);
+    ZeDriverVersion.resize(sizeOfDriverString);
+    ZeDriverVersionString.getDriverVersionString(ZeDriverHandleExpTranslated,
+                                                 ZeDriverVersion.data(),
+                                                 &sizeOfDriverString);
+
+    // Intel driver version string is in the format:
+    // Major.Minor.Build+Hotfix where hotfix is optional.
+    std::stringstream VersionString(ZeDriverVersion);
+
+    std::string VersionValue;
+    std::vector<std::string> VersionValues;
+    char VersionDelim = '.';
+    char HotfixDelim = '+';
+
+    while (getline(VersionString, VersionValue, VersionDelim)) {
+      VersionValues.push_back(VersionValue);
+    }
+    // If the extension exists, but the string value comes by empty or
+    // malformed, assume this is a developer driver.
+    if (VersionValues.size() >= 3) {
+      DriverVersionMajor = atoi(VersionValues[0].c_str());
+      DriverVersionMinor = atoi(VersionValues[1].c_str());
+      std::stringstream HotfixString(VersionValues[2]);
+      std::vector<std::string> BuildHotfixVersionValues;
+      // Check to see if there is a hotfix value and strip it off.
+      while (getline(HotfixString, VersionValue, HotfixDelim)) {
+        BuildHotfixVersionValues.push_back(VersionValue);
+      }
+      DriverVersionBuild = atoi(BuildHotfixVersionValues[0].c_str());
+    } else {
+      return true;
+    }
+  }
+  return std::make_tuple(DriverVersionMajor, DriverVersionMinor,
+                         DriverVersionBuild) >=
+         std::make_tuple(VersionMajor, VersionMinor, VersionBuild);
+}
+
 // Get the cached PI device created for the L0 device handle.
 // Return NULL if no such PI device found.
 ur_device_handle_t

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -62,6 +62,11 @@ struct ur_platform_handle_t_ : public _ur_platform {
   // If not found, then nullptr is returned.
   ur_device_handle_t getDeviceFromNativeHandle(ze_device_handle_t);
 
+  /// Checks the version of the level-zero driver.
+  bool isDriverVersionNewerOrSimilar(uint32_t VersionMajor,
+                                     uint32_t VersionMinor,
+                                     uint32_t VersionBuild);
+
   // Keep track of all contexts in the platform. This is needed to manage
   // a lifetime of memory allocations in each context when there are kernels
   // with indirect access.


### PR DESCRIPTION
- Fixed the isDriverVersionNewerOrSimilar to use the new intel driver version string if it exists and use a tuple to compare the minimum and existing versions.
- Moved version check within the platform handle.