### PR TITLE
Fix unintended crash in catch blocks.

### DIFF
--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -461,12 +461,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
       UR_CHECK_ERROR(cuArray3DCreate(&ImageArray, &array_desc));
       *phImageMem = (ur_exp_image_mem_native_handle_t)ImageArray;
     } catch (ur_result_t Err) {
-      if (ImageArray) {
+      if (ImageArray != CUarray{}) {
         UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
       }
       return Err;
     } catch (...) {
-      if (ImageArray) {
+      if (ImageArray != CUarray{}) {
         UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
       }
       return UR_RESULT_ERROR_UNKNOWN;

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -455,21 +455,25 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
   // Allocate a cuArray
   if (pImageDesc->numMipLevel == 1) {
-    CUarray ImageArray;
+    CUarray ImageArray{};
 
     try {
       UR_CHECK_ERROR(cuArray3DCreate(&ImageArray, &array_desc));
       *phImageMem = (ur_exp_image_mem_native_handle_t)ImageArray;
     } catch (ur_result_t Err) {
-      cuArrayDestroy(ImageArray);
+      if (ImageArray) {
+        UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
+      }
       return Err;
     } catch (...) {
-      cuArrayDestroy(ImageArray);
+      if (ImageArray) {
+        UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
+      }
       return UR_RESULT_ERROR_UNKNOWN;
     }
   } else // Allocate a cuMipmappedArray
   {
-    CUmipmappedArray mip_array;
+    CUmipmappedArray mip_array{};
     array_desc.Flags = CUDA_ARRAY3D_SURFACE_LDST;
 
     try {
@@ -477,10 +481,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
                                             pImageDesc->numMipLevel));
       *phImageMem = (ur_exp_image_mem_native_handle_t)mip_array;
     } catch (ur_result_t Err) {
-      cuMipmappedArrayDestroy(mip_array);
+      if (mip_array) {
+        UR_CHECK_ERROR(cuMipmappedArrayDestroy(mip_array));
+      }
       return Err;
     } catch (...) {
-      cuMipmappedArrayDestroy(mip_array);
+      if (mip_array) {
+        UR_CHECK_ERROR(cuMipmappedArrayDestroy(mip_array));
+      }
       return UR_RESULT_ERROR_UNKNOWN;
     }
   }

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -439,7 +439,7 @@ ur_result_t allocateMemObjOnDeviceIfNeeded(ur_mem_handle_t Mem,
       UR_CHECK_ERROR(cuMemAlloc(&DevPtr, Buffer.Size));
     }
   } else {
-    CUarray ImageArray;
+    CUarray ImageArray{};
     CUsurfObject Surface;
     try {
       auto &Image = std::get<SurfaceMem>(Mem->Mem);

--- a/source/adapters/cuda/memory.cpp
+++ b/source/adapters/cuda/memory.cpp
@@ -465,12 +465,12 @@ ur_result_t allocateMemObjOnDeviceIfNeeded(ur_mem_handle_t Mem,
       UR_CHECK_ERROR(cuSurfObjectCreate(&Surface, &ImageResDesc));
       Image.SurfObjs[DeviceIdx] = Surface;
     } catch (ur_result_t Err) {
-      if (ImageArray) {
+      if (ImageArray != CUarray{}) {
         UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
       }
       return Err;
     } catch (...) {
-      if (ImageArray) {
+      if (ImageArray != CUarray{}) {
         UR_CHECK_ERROR(cuArrayDestroy(ImageArray));
       }
       return UR_RESULT_ERROR_UNKNOWN;

--- a/source/adapters/hip/memory.cpp
+++ b/source/adapters/hip/memory.cpp
@@ -498,7 +498,7 @@ ur_result_t allocateMemObjOnDeviceIfNeeded(ur_mem_handle_t Mem,
       UR_CHECK_ERROR(hipMalloc(&DevPtr, Buffer.Size));
     }
   } else {
-    hipArray *ImageArray;
+    hipArray *ImageArray{};
     hipSurfaceObject_t Surface;
     try {
       auto &Image = std::get<SurfaceMem>(Mem->Mem);


### PR DESCRIPTION
Ensure that handles are default initialised and checked before attempting to destroy.

DPC++ PR: [ [Bindless] Fix unintended crash in catch blocks #14966 ](https://github.com/intel/llvm/pull/14966)