### PR TITLE
Suppress e2e test failures in L0 and OpenCL

### DIFF
--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -21,9 +21,9 @@ jobs:
       config: ""
       unit: "gpu"
       # Failing tests
-      xfail: "Config/select_device.cpp;DeviceCodeSplit/grf.cpp;ESIMD/grf.cpp;ESIMD/named_barriers/loop_extended.cpp;KernelAndProgram/target_register_alloc_mode.cpp;Matrix/SG32/element_wise_all_ops.cpp;Matrix/SG32/get_coord_int8_matB.cpp;Matrix/get_coord_int8_matB.cpp;Matrix/joint_matrix_prefetch.cpp;Matrix/joint_matrix_rowmajorA_rowmajorB.cpp;Plugin/level_zero_barrier_optimization.cpp"
+      xfail: "Config/select_device.cpp;DeviceCodeSplit/grf.cpp;ESIMD/grf.cpp;KernelAndProgram/target_register_alloc_mode.cpp;Matrix/SG32/get_coord_int8_matB.cpp;Matrix/get_coord_int8_matB.cpp;Matrix/joint_matrix_prefetch.cpp;Matrix/joint_matrix_rowmajorA_rowmajorB.cpp;Plugin/level_zero_barrier_optimization.cpp"
       # Flaky tests
-      filter_out: ""
+      filter_out: "ESIMD/named_barriers/loop_extended.cpp"
       # These runners by default spawn upwards of 260 workers.
       # We also add a time out just in case some test hangs
       extra_lit_flags: "--param gpu-intel-pvc=True --param gpu-intel-pvc-1T=True -sv -j 100 --max-time=3600"

--- a/.github/workflows/e2e_opencl.yml
+++ b/.github/workflows/e2e_opencl.yml
@@ -20,4 +20,5 @@ jobs:
       prefix: ""
       config: ""
       unit: "cpu"
+      xfail: "AOT/double.cpp;AOT/half.cpp;AOT/reqd-sg-size.cpp;Basic/built-ins/marray_geometric.cpp;KernelCompiler/kernel_compiler_spirv.cpp;KernelCompiler/opencl_queries.cpp"
       extra_lit_flags: "-sv --max-time=3600"


### PR DESCRIPTION
This should make the e2e jobs green for the time being.