### PR TITLE
[CMake] Add flag to disable fuzztesting

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_Declare(
 
 set(UR_TEST_DEVICES_COUNT 1 CACHE STRING "Count of devices on which conformance and adapters tests will be run")
 set(UR_TEST_PLATFORMS_COUNT 1 CACHE STRING "Count of platforms on which conformance and adapters tests will be run")
+set(UR_TEST_FUZZTESTS ON CACHE BOOL "Run fuzz tests if using clang and UR_DPCXX is specified")
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
@@ -30,6 +31,6 @@ add_subdirectory(mock)
 if(UR_BUILD_TOOLS)
   add_subdirectory(tools)
 endif()
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND UR_DPCXX)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND UR_DPCXX AND UR_TEST_FUZZTESTS)
     add_subdirectory(fuzz)
 endif()


### PR DESCRIPTION
Default is enabled; this should not be a visible change without changing your cmake configuration.