### PR TITLE
[L0] fix Coverity issues for L0 Adapter

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1034,7 +1034,7 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event) {
         EndTimeRecording.EventHasDied = true;
       } else {
         // Otherwise we evict the entry.
-        Legacy(Event->UrQueue)->EndTimeRecordings.erase(Entry);
+        Queue->EndTimeRecordings.erase(Entry);
       }
     }
   }

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -1033,6 +1033,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
         break;
       case UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD:
       default:
+        delete importWin32;
+        delete externalMemoryData;
         return UR_RESULT_ERROR_INVALID_VALUE;
       }
       importWin32->handle = Win32Handle->handle;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -599,7 +599,7 @@ ur_result_t ur_queue_handle_legacy_t_::queueRelease() {
       // internal reference count. When the External Reference count == 0, then
       // cleanup of the queue begins and the final decrement of the internal
       // reference count is completed.
-      Queue->RefCount.decrementAndTest();
+      static_cast<void>(Queue->RefCount.decrementAndTest());
       return UR_RESULT_SUCCESS;
     }
 

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -311,8 +311,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(
   // L0 supports alignment up to 64KB and silently ignores higher values.
   // We flag alignment > 64KB as an invalid value.
   // L0 spec says that alignment values that are not powers of 2 are invalid.
-  if (Align > 65536 || (Align & (Align - 1)) != 0)
-    return UR_RESULT_ERROR_INVALID_VALUE;
+  // If alignment == 0, then we are allowing the L0 driver to choose the
+  // alignment so no need to check.
+  if (Align > 0) {
+    if (Align > 65536 || (Align & (Align - 1)) != 0)
+      return UR_RESULT_ERROR_INVALID_VALUE;
+  }
 
   ur_platform_handle_t Plt = Context->getPlatform();
   // If indirect access tracking is enabled then lock the mutex which is
@@ -381,8 +385,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMDeviceAlloc(
   // L0 supports alignment up to 64KB and silently ignores higher values.
   // We flag alignment > 64KB as an invalid value.
   // L0 spec says that alignment values that are not powers of 2 are invalid.
-  if (Alignment > 65536 || (Alignment & (Alignment - 1)) != 0)
-    return UR_RESULT_ERROR_INVALID_VALUE;
+  // If alignment == 0, then we are allowing the L0 driver to choose the
+  // alignment so no need to check.
+  if (Alignment > 0) {
+    if (Alignment > 65536 || (Alignment & (Alignment - 1)) != 0)
+      return UR_RESULT_ERROR_INVALID_VALUE;
+  }
 
   ur_platform_handle_t Plt = Device->Platform;
 
@@ -482,8 +490,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
   // L0 supports alignment up to 64KB and silently ignores higher values.
   // We flag alignment > 64KB as an invalid value.
   // L0 spec says that alignment values that are not powers of 2 are invalid.
-  if (Alignment > 65536 || (Alignment & (Alignment - 1)) != 0)
-    return UR_RESULT_ERROR_INVALID_VALUE;
+  // If alignment == 0, then we are allowing the L0 driver to choose the
+  // alignment so no need to check.
+  if (Alignment > 0) {
+    if (Alignment > 65536 || (Alignment & (Alignment - 1)) != 0)
+      return UR_RESULT_ERROR_INVALID_VALUE;
+  }
 
   ur_platform_handle_t Plt = Device->Platform;
 


### PR DESCRIPTION
- Fixed recast of Queue object vs usage of variable.
- fixed usm alignment check such that == 0 is correctly skipped from buffer overrun checks.
- fixed cast to show no need to check the return from decrement and test in queue finish.
- fixed release of resources for bindless import on error.