### PR TITLE
[L0] Make destructor of the context virtual

### DIFF
--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -43,6 +43,8 @@ struct ur_context_handle_t_ : _ur_object {
 
   ur_context_handle_t_(ze_context_handle_t ZeContext) : ZeContext{ZeContext} {}
 
+  virtual ~ur_context_handle_t_() {}
+
   // A L0 context handle is primarily used during creation and management of
   // resources that may be used by multiple devices.
   // This field is only set at ur_context_handle_t creation time, and cannot


### PR DESCRIPTION
to make sure that v2::context will release all the resources on context destruction.

This patch is not applicable to main branch as we already removed the inheritance there.