### PR TITLE
[L0] move kernel helper functions to a separate file

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -112,6 +112,7 @@ if(UR_BUILD_ADAPTER_L0)
         ${CMAKE_CURRENT_SOURCE_DIR}/queue_api.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/queue.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/sampler.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/helpers/kernel_helpers.hpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ur_level_zero.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/context.cpp
@@ -130,6 +131,7 @@ if(UR_BUILD_ADAPTER_L0)
         ${CMAKE_CURRENT_SOURCE_DIR}/queue.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/sampler.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/image.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/helpers/kernel_helpers.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../../ur/ur.cpp
     )
 

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "command_buffer.hpp"
+#include "helpers/kernel_helpers.hpp"
 #include "logger/ur_logger.hpp"
 #include "ur_level_zero.hpp"
 
@@ -74,130 +75,6 @@ preferCopyEngineForFill(ur_exp_command_buffer_handle_t CommandBuffer,
   PreferCopyEngine =
       PreferCopyEngine &&
       (UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0));
-
-  return UR_RESULT_SUCCESS;
-}
-
-/**
- * Calculates a work group size for the kernel based on the GlobalWorkSize or
- * the LocalWorkSize if provided.
- * @param[in][optional] Kernel The Kernel. Used when LocalWorkSize is not
- * provided.
- * @param[in][optional] Device The device associated with the kernel. Used when
- * LocalWorkSize is not provided.
- * @param[out] ZeThreadGroupDimensions Number of work groups in each dimension.
- * @param[out] WG The work group size for each dimension.
- * @param[in] WorkDim The number of dimensions in the kernel.
- * @param[in] GlobalWorkSize The global work size.
- * @param[in][optional] LocalWorkSize The local work size.
- * @return UR_RESULT_SUCCESS or an error code on failure.
- */
-ur_result_t calculateKernelWorkDimensions(
-    ur_kernel_handle_t Kernel, ur_device_handle_t Device,
-    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
-    uint32_t WorkDim, const size_t *GlobalWorkSize,
-    const size_t *LocalWorkSize) {
-
-  UR_ASSERT(GlobalWorkSize, UR_RESULT_ERROR_INVALID_VALUE);
-  // If LocalWorkSize is not provided then Kernel must be provided to query
-  // suggested group size.
-  UR_ASSERT(LocalWorkSize || Kernel, UR_RESULT_ERROR_INVALID_VALUE);
-
-  // New variable needed because GlobalWorkSize parameter might not be of size
-  // 3
-  size_t GlobalWorkSize3D[3]{1, 1, 1};
-  std::copy(GlobalWorkSize, GlobalWorkSize + WorkDim, GlobalWorkSize3D);
-
-  if (LocalWorkSize) {
-    WG[0] = ur_cast<uint32_t>(LocalWorkSize[0]);
-    WG[1] = WorkDim >= 2 ? ur_cast<uint32_t>(LocalWorkSize[1]) : 1;
-    WG[2] = WorkDim == 3 ? ur_cast<uint32_t>(LocalWorkSize[2]) : 1;
-  } else {
-    // We can't call to zeKernelSuggestGroupSize if 64-bit GlobalWorkSize3D
-    // values do not fit to 32-bit that the API only supports currently.
-    bool SuggestGroupSize = true;
-    for (int I : {0, 1, 2}) {
-      if (GlobalWorkSize3D[I] > UINT32_MAX) {
-        SuggestGroupSize = false;
-      }
-    }
-    if (SuggestGroupSize) {
-      ZE2UR_CALL(zeKernelSuggestGroupSize,
-                 (Kernel->ZeKernel, GlobalWorkSize3D[0], GlobalWorkSize3D[1],
-                  GlobalWorkSize3D[2], &WG[0], &WG[1], &WG[2]));
-    } else {
-      for (int I : {0, 1, 2}) {
-        // Try to find a I-dimension WG size that the GlobalWorkSize3D[I] is
-        // fully divisable with. Start with the max possible size in
-        // each dimension.
-        uint32_t GroupSize[] = {
-            Device->ZeDeviceComputeProperties->maxGroupSizeX,
-            Device->ZeDeviceComputeProperties->maxGroupSizeY,
-            Device->ZeDeviceComputeProperties->maxGroupSizeZ};
-        GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize3D[I]);
-        while (GlobalWorkSize3D[I] % GroupSize[I]) {
-          --GroupSize[I];
-        }
-        if (GlobalWorkSize[I] / GroupSize[I] > UINT32_MAX) {
-          logger::debug("calculateKernelWorkDimensions: can't find a WG size "
-                        "suitable for global work size > UINT32_MAX");
-          return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-        }
-        WG[I] = GroupSize[I];
-      }
-      logger::debug("calculateKernelWorkDimensions: using computed WG "
-                    "size = {{{}, {}, {}}}",
-                    WG[0], WG[1], WG[2]);
-    }
-  }
-
-  // TODO: assert if sizes do not fit into 32-bit?
-  switch (WorkDim) {
-  case 3:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    ZeThreadGroupDimensions.groupCountZ =
-        ur_cast<uint32_t>(GlobalWorkSize3D[2] / WG[2]);
-    break;
-  case 2:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    WG[2] = 1;
-    break;
-  case 1:
-    ZeThreadGroupDimensions.groupCountX =
-        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    WG[1] = WG[2] = 1;
-    break;
-
-  default:
-    logger::error("calculateKernelWorkDimensions: unsupported work_dim");
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  }
-
-  // Error handling for non-uniform group size case
-  if (GlobalWorkSize3D[0] !=
-      size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 1st dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[1] !=
-      size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 2nd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[2] !=
-      size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 3rd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -880,7 +757,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
   ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
   uint32_t WG[3];
-  UR_CALL(calculateKernelWorkDimensions(Kernel, CommandBuffer->Device,
+  UR_CALL(calculateKernelWorkDimensions(Kernel->ZeKernel, CommandBuffer->Device,
                                         ZeThreadGroupDimensions, WG, WorkDim,
                                         GlobalWorkSize, LocalWorkSize));
 
@@ -1584,8 +1461,8 @@ ur_result_t updateKernelCommand(
 
     uint32_t WG[3];
     UR_CALL(calculateKernelWorkDimensions(
-        Command->Kernel, CommandBuffer->Device, ZeThreadGroupDimensions, WG,
-        Dim, NewGlobalWorkSize, NewLocalWorkSize));
+        Command->Kernel->ZeKernel, CommandBuffer->Device,
+        ZeThreadGroupDimensions, WG, Dim, NewGlobalWorkSize, NewLocalWorkSize));
 
     auto MutableGroupCountDesc =
         std::make_unique<ZeStruct<ze_mutable_group_count_exp_desc_t>>();

--- a/source/adapters/level_zero/helpers/kernel_helpers.cpp
+++ b/source/adapters/level_zero/helpers/kernel_helpers.cpp
@@ -1,0 +1,152 @@
+//===--------- kernel_helpers.cpp - Level Zero Adapter -------------------===//
+//
+// Copyright (C) 2024 Intel Corporation
+//
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "kernel_helpers.hpp"
+#include "logger/ur_logger.hpp"
+
+#include "../common.hpp"
+#include "../context.hpp"
+#include "../device.hpp"
+
+ur_result_t getSuggestedLocalWorkSize(ur_device_handle_t hDevice,
+                                      ze_kernel_handle_t hZeKernel,
+                                      size_t GlobalWorkSize3D[3],
+                                      uint32_t SuggestedLocalWorkSize3D[3]) {
+  uint32_t *WG = SuggestedLocalWorkSize3D;
+
+  // We can't call to zeKernelSuggestGroupSize if 64-bit GlobalWorkSize
+  // values do not fit to 32-bit that the API only supports currently.
+  bool SuggestGroupSize = true;
+  for (int I : {0, 1, 2}) {
+    if (GlobalWorkSize3D[I] > UINT32_MAX) {
+      SuggestGroupSize = false;
+    }
+  }
+  if (SuggestGroupSize) {
+    ZE2UR_CALL(zeKernelSuggestGroupSize,
+               (hZeKernel, GlobalWorkSize3D[0], GlobalWorkSize3D[1],
+                GlobalWorkSize3D[2], &WG[0], &WG[1], &WG[2]));
+  } else {
+    for (int I : {0, 1, 2}) {
+      // Try to find a I-dimension WG size that the GlobalWorkSize[I] is
+      // fully divisable with. Start with the max possible size in
+      // each dimension.
+      uint32_t GroupSize[] = {
+          hDevice->ZeDeviceComputeProperties->maxGroupSizeX,
+          hDevice->ZeDeviceComputeProperties->maxGroupSizeY,
+          hDevice->ZeDeviceComputeProperties->maxGroupSizeZ};
+      GroupSize[I] = (std::min)(size_t(GroupSize[I]), GlobalWorkSize3D[I]);
+      while (GlobalWorkSize3D[I] % GroupSize[I]) {
+        --GroupSize[I];
+      }
+      if (GlobalWorkSize3D[I] / GroupSize[I] > UINT32_MAX) {
+        logger::error("getSuggestedLocalWorkSize: can't find a WG size "
+                      "suitable for global work size > UINT32_MAX");
+        return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+      }
+      WG[I] = GroupSize[I];
+    }
+    logger::debug(
+        "getSuggestedLocalWorkSize: using computed WG size = {{{}, {}, {}}}",
+        WG[0], WG[1], WG[2]);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t setKernelGlobalOffset(ur_context_handle_t Context,
+                                  ze_kernel_handle_t Kernel,
+                                  const size_t *GlobalWorkOffset) {
+  if (!Context->getPlatform()->ZeDriverGlobalOffsetExtensionFound) {
+    logger::debug("No global offset extension found on this driver");
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
+  ZE2UR_CALL(
+      zeKernelSetGlobalOffsetExp,
+      (Kernel, GlobalWorkOffset[0], GlobalWorkOffset[1], GlobalWorkOffset[2]));
+
+  return UR_RESULT_SUCCESS;
+}
+
+ur_result_t calculateKernelWorkDimensions(
+    ze_kernel_handle_t Kernel, ur_device_handle_t Device,
+    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
+    uint32_t WorkDim, const size_t *GlobalWorkSize,
+    const size_t *LocalWorkSize) {
+
+  UR_ASSERT(GlobalWorkSize, UR_RESULT_ERROR_INVALID_VALUE);
+  // If LocalWorkSize is not provided then Kernel must be provided to query
+  // suggested group size.
+  UR_ASSERT(LocalWorkSize || Kernel, UR_RESULT_ERROR_INVALID_VALUE);
+
+  // New variable needed because GlobalWorkSize parameter might not be of size
+  // 3
+  size_t GlobalWorkSize3D[3]{1, 1, 1};
+  std::copy(GlobalWorkSize, GlobalWorkSize + WorkDim, GlobalWorkSize3D);
+
+  if (LocalWorkSize) {
+    WG[0] = ur_cast<uint32_t>(LocalWorkSize[0]);
+    WG[1] = WorkDim >= 2 ? ur_cast<uint32_t>(LocalWorkSize[1]) : 1;
+    WG[2] = WorkDim == 3 ? ur_cast<uint32_t>(LocalWorkSize[2]) : 1;
+  } else {
+    UR_CALL(getSuggestedLocalWorkSize(Device, Kernel, GlobalWorkSize3D, WG));
+  }
+
+  // TODO: assert if sizes do not fit into 32-bit?
+  switch (WorkDim) {
+  case 3:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    ZeThreadGroupDimensions.groupCountY =
+        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
+    ZeThreadGroupDimensions.groupCountZ =
+        ur_cast<uint32_t>(GlobalWorkSize3D[2] / WG[2]);
+    break;
+  case 2:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    ZeThreadGroupDimensions.groupCountY =
+        ur_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
+    WG[2] = 1;
+    break;
+  case 1:
+    ZeThreadGroupDimensions.groupCountX =
+        ur_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
+    WG[1] = WG[2] = 1;
+    break;
+
+  default:
+    logger::error("calculateKernelWorkDimensions: unsupported work_dim");
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
+  // Error handling for non-uniform group size case
+  if (GlobalWorkSize3D[0] !=
+      size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 1st dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+  if (GlobalWorkSize3D[1] !=
+      size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 2nd dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+  if (GlobalWorkSize3D[2] !=
+      size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
+    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
+                  "is not a multiple of the group size in the 3rd dimension");
+    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
+  }
+
+  return UR_RESULT_SUCCESS;
+}

--- a/source/adapters/level_zero/helpers/kernel_helpers.hpp
+++ b/source/adapters/level_zero/helpers/kernel_helpers.hpp
@@ -1,0 +1,57 @@
+//===--------- kernel_helpers.hpp - Level Zero Adapter -------------------===//
+//
+// Copyright (C) 2024 Intel Corporation
+//
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <ur_api.h>
+#include <ze_api.h>
+
+/**
+ * Calculates a work group size for the kernel based on the GlobalWorkSize or
+ * the LocalWorkSize if provided.
+ * @param[in][optional] Kernel The Kernel. Used when LocalWorkSize is not
+ * provided.
+ * @param[in][optional] Device The device associated with the kernel. Used when
+ * LocalWorkSize is not provided.
+ * @param[out] ZeThreadGroupDimensions Number of work groups in each dimension.
+ * @param[out] WG The work group size for each dimension.
+ * @param[in] WorkDim The number of dimensions in the kernel.
+ * @param[in] GlobalWorkSize The global work size.
+ * @param[in][optional] LocalWorkSize The local work size.
+ * @return UR_RESULT_SUCCESS or an error code on failure.
+ */
+ur_result_t calculateKernelWorkDimensions(
+    ze_kernel_handle_t Kernel, ur_device_handle_t Device,
+    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
+    uint32_t WorkDim, const size_t *GlobalWorkSize,
+    const size_t *LocalWorkSize);
+
+/**
+ * Sets the global offset for a kernel command that will be appended to the
+ * command buffer.
+ * @param[in] Context Context associated with the queue.
+ * @param[in] Kernel The handle to the kernel that will be appended.
+ * @param[in] GlobalWorkOffset The global offset value.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t setKernelGlobalOffset(ur_context_handle_t Context,
+                                  ze_kernel_handle_t Kernel,
+                                  const size_t *GlobalWorkOffset);
+
+/**
+ * Get the suggested local work size for a kernel.
+ * @param[in] hDevice The device associated with the kernel.
+ * @param[in] hZeKernel The kernel handle.
+ * @param[in] GlobalWorkSize3D The global work size.
+ * @param[out] SuggestedLocalWorkSize3D The suggested local work size.
+ * @return UR_RESULT_SUCCESS or an error code on failure.
+ */
+ur_result_t getSuggestedLocalWorkSize(ur_device_handle_t hDevice,
+                                      ze_kernel_handle_t hZeKernel,
+                                      size_t GlobalWorkSize3D[3],
+                                      uint32_t SuggestedLocalWorkSize3D[3]);

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -13,6 +13,8 @@
 #include "ur_api.h"
 #include "ur_level_zero.hpp"
 
+#include "helpers/kernel_helpers.hpp"
+
 UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     ur_kernel_handle_t hKernel, ur_queue_handle_t hQueue, uint32_t workDim,
     [[maybe_unused]] const size_t *pGlobalWorkOffset,
@@ -27,7 +29,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
   std::copy(pGlobalWorkSize, pGlobalWorkSize + workDim, GlobalWorkSize3D);
 
   ze_kernel_handle_t ZeKernel{};
-  UR_CALL(getZeKernel(Legacy(hQueue), hKernel, &ZeKernel));
+  UR_CALL(getZeKernel(Legacy(hQueue)->Device->ZeDevice, hKernel, &ZeKernel));
 
   UR_CALL(getSuggestedLocalWorkSize(Legacy(hQueue), ZeKernel, GlobalWorkSize3D,
                                     LocalWorkSize));
@@ -36,15 +38,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
   return UR_RESULT_SUCCESS;
 }
 
-ur_result_t getZeKernel(ur_queue_handle_legacy_t hQueue,
-                        ur_kernel_handle_t hKernel,
+ur_result_t getZeKernel(ze_device_handle_t hDevice, ur_kernel_handle_t hKernel,
                         ze_kernel_handle_t *phZeKernel) {
-  auto ZeDevice = hQueue->Device->ZeDevice;
-
   if (hKernel->ZeKernelMap.empty()) {
     *phZeKernel = hKernel->ZeKernel;
   } else {
-    auto It = hKernel->ZeKernelMap.find(ZeDevice);
+    auto It = hKernel->ZeKernelMap.find(hDevice);
     if (It == hKernel->ZeKernelMap.end()) {
       /* kernel and queue don't match */
       return UR_RESULT_ERROR_INVALID_QUEUE;
@@ -135,7 +134,7 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueKernelLaunch(
 
   auto Queue = this;
   ze_kernel_handle_t ZeKernel{};
-  UR_CALL(getZeKernel(Queue, Kernel, &ZeKernel));
+  UR_CALL(getZeKernel(Queue->Device->ZeDevice, Kernel, &ZeKernel));
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Lock(
@@ -168,68 +167,9 @@ ur_result_t ur_queue_handle_legacy_t_::enqueueKernelLaunch(
   ze_group_count_t ZeThreadGroupDimensions{1, 1, 1};
   uint32_t WG[3]{};
 
-  // New variable needed because GlobalWorkSize parameter might not be of size 3
-  size_t GlobalWorkSize3D[3]{1, 1, 1};
-  std::copy(GlobalWorkSize, GlobalWorkSize + WorkDim, GlobalWorkSize3D);
-
-  if (LocalWorkSize) {
-    for (uint32_t I = 0; I < WorkDim; ++I) {
-      UR_ASSERT(LocalWorkSize[I] < (std::numeric_limits<uint32_t>::max)(),
-                UR_RESULT_ERROR_INVALID_VALUE);
-      WG[I] = static_cast<uint32_t>(LocalWorkSize[I]);
-    }
-  } else {
-    UR_CALL(getSuggestedLocalWorkSize(Queue, ZeKernel, GlobalWorkSize3D, WG));
-  }
-
-  // TODO: assert if sizes do not fit into 32-bit?
-
-  switch (WorkDim) {
-  case 3:
-    ZeThreadGroupDimensions.groupCountX =
-        static_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        static_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    ZeThreadGroupDimensions.groupCountZ =
-        static_cast<uint32_t>(GlobalWorkSize3D[2] / WG[2]);
-    break;
-  case 2:
-    ZeThreadGroupDimensions.groupCountX =
-        static_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    ZeThreadGroupDimensions.groupCountY =
-        static_cast<uint32_t>(GlobalWorkSize3D[1] / WG[1]);
-    WG[2] = 1;
-    break;
-  case 1:
-    ZeThreadGroupDimensions.groupCountX =
-        static_cast<uint32_t>(GlobalWorkSize3D[0] / WG[0]);
-    WG[1] = WG[2] = 1;
-    break;
-
-  default:
-    logger::error("urEnqueueKernelLaunch: unsupported work_dim");
-    return UR_RESULT_ERROR_INVALID_VALUE;
-  }
-
-  // Error handling for non-uniform group size case
-  if (GlobalWorkSize3D[0] !=
-      size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
-    logger::error("urEnqueueKernelLaunch: invalid work_dim. The range is not a "
-                  "multiple of the group size in the 1st dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[1] !=
-      size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
-    logger::error("urEnqueueKernelLaunch: invalid work_dim. The range is not a "
-                  "multiple of the group size in the 2nd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
-  if (GlobalWorkSize3D[2] !=
-      size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
-    logger::debug("urEnqueueKernelLaunch: invalid work_dim. The range is not a "
-                  "multiple of the group size in the 3rd dimension");
-    return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
-  }
+  UR_CALL(calculateKernelWorkDimensions(Kernel->ZeKernel, Queue->Device,
+                                        ZeThreadGroupDimensions, WG, WorkDim,
+                                        GlobalWorkSize, LocalWorkSize));
 
   ZE2UR_CALL(zeKernelSetGroupSize, (ZeKernel, WG[0], WG[1], WG[2]));
 

--- a/source/adapters/level_zero/kernel.hpp
+++ b/source/adapters/level_zero/kernel.hpp
@@ -112,6 +112,37 @@ ur_result_t getSuggestedLocalWorkSize(ur_queue_handle_legacy_t hQueue,
                                       ze_kernel_handle_t hZeKernel,
                                       size_t GlobalWorkSize3D[3],
                                       uint32_t SuggestedLocalWorkSize3D[3]);
-ur_result_t getZeKernel(ur_queue_handle_legacy_t hQueue,
-                        ur_kernel_handle_t hKernel,
+ur_result_t getZeKernel(ze_device_handle_t hDevice, ur_kernel_handle_t hKernel,
                         ze_kernel_handle_t *phZeKernel);
+
+/**
+ * Calculates a work group size for the kernel based on the GlobalWorkSize or
+ * the LocalWorkSize if provided.
+ * @param[in][optional] Kernel The Kernel. Used when LocalWorkSize is not
+ * provided.
+ * @param[in][optional] Device The device associated with the kernel. Used when
+ * LocalWorkSize is not provided.
+ * @param[out] ZeThreadGroupDimensions Number of work groups in each dimension.
+ * @param[out] WG The work group size for each dimension.
+ * @param[in] WorkDim The number of dimensions in the kernel.
+ * @param[in] GlobalWorkSize The global work size.
+ * @param[in][optional] LocalWorkSize The local work size.
+ * @return UR_RESULT_SUCCESS or an error code on failure.
+ */
+ur_result_t calculateKernelWorkDimensions(
+    ur_kernel_handle_t Kernel, ur_device_handle_t Device,
+    ze_group_count_t &ZeThreadGroupDimensions, uint32_t (&WG)[3],
+    uint32_t WorkDim, const size_t *GlobalWorkSize,
+    const size_t *LocalWorkSize);
+
+/**
+ * Sets the global offset for a kernel command that will be appended to the
+ * command buffer.
+ * @param[in] Context Context associated with the queue.
+ * @param[in] Kernel The handle to the kernel that will be appended.
+ * @param[in] GlobalWorkOffset The global offset value.
+ * @return UR_RESULT_SUCCESS or an error code on failure
+ */
+ur_result_t setKernelGlobalOffset(ur_context_handle_t Context,
+                                  ur_kernel_handle_t Kernel,
+                                  const size_t *GlobalWorkOffset);


### PR DESCRIPTION
to avoid code duplication between kernel.cpp and command_buffer.cpp and to enable code reuse with v2 adapter.