### PR TITLE
[Cuda] Reintroduce catching and reporting of bad_alloc for event object creation

### DIFF
--- a/source/adapters/cuda/event.cpp
+++ b/source/adapters/cuda/event.cpp
@@ -290,8 +290,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
   std::unique_ptr<ur_event_handle_t_> EventPtr{nullptr};
 
-  *phEvent = ur_event_handle_t_::makeWithNative(
-      hContext, reinterpret_cast<CUevent>(hNativeEvent));
+  try {
+    EventPtr =
+        std::unique_ptr<ur_event_handle_t_>(ur_event_handle_t_::makeWithNative(
+            hContext, reinterpret_cast<CUevent>(hNativeEvent)));
+  } catch (const std::bad_alloc &) {
+    return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+  } catch (...) {
+    return UR_RESULT_ERROR_UNKNOWN;
+  }
+
+  *phEvent = EventPtr.release();
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Reintroduces the changes from commit https://github.com/oneapi-src/unified-runtime/commit/c4ae460f779021aa6840ea47a373f6ac336bc589, which were reverted in related merged commit https://github.com/oneapi-src/unified-runtime/commit/1b4a8b852c6b86545b42a71927f88c4fed107217 due to being mistakenly deleted and omitted on rebasing.

This happened because the former changes got split out from PR https://github.com/oneapi-src/unified-runtime/pull/1399 to independent changes in PR https://github.com/oneapi-src/unified-runtime/pull/1397.