### PR TITLE
Report correct extension string for devicelib assert in cuda + hip.

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -621,7 +621,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_EXTENSIONS: {
 
     std::string SupportedExtensions = "cl_khr_fp64 cl_khr_subgroups ";
-    SupportedExtensions += "pi_ext_intel_devicelib_assert ";
+    SupportedExtensions += "cl_intel_devicelib_assert ";
     // Return supported for the UR command-buffer experimental feature
     SupportedExtensions += "ur_exp_command_buffer ";
     SupportedExtensions += "ur_exp_usm_p2p ";

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -548,7 +548,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // postprocessing is NOP. HIP 4.3 docs indicate support for
     // native asserts are in progress
     std::string SupportedExtensions = "";
-    SupportedExtensions += "pi_ext_intel_devicelib_assert ";
+    SupportedExtensions += "cl_intel_devicelib_assert ";
     SupportedExtensions += "ur_exp_usm_p2p ";
 
     int RuntimeVersion = 0;


### PR DESCRIPTION
It seems that the extension string SYCL RT checks for was changed by this commit https://github.com/intel/llvm/commit/0939f39818225ce3e469e08f6a45711b449a8ad4 in PI, but the change never made it to the UR adapters.