### PR TITLE
[NATIVECPU] Add lock_guard when stopping threads

### DIFF
--- a/source/adapters/native_cpu/threadpool.hpp
+++ b/source/adapters/native_cpu/threadpool.hpp
@@ -81,8 +81,11 @@ public:
 
   // Waits for all tasks to finish and destroys the worker thread
   inline void stop() {
-    m_isRunning.store(false, std::memory_order_release);
-    m_startWorkCondition.notify_all();
+    {
+      std::lock_guard<std::mutex> lock(m_workMutex);
+      m_isRunning.store(false, std::memory_order_release);
+      m_startWorkCondition.notify_all();
+    }
     if (m_worker.joinable()) {
       // Wait for the worker thread to finish handling the task queue
       m_worker.join();


### PR DESCRIPTION
The lack of synchronization when closing threads in the Native CPU threadpool lead to sporadic hangs in some tests, this PR addresses it.
intel/llvm PR: https://github.com/intel/llvm/pull/15046