### PR TITLE
Improved wording of setKernelArgValue

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -4785,6 +4785,7 @@ urKernelSetArgValue(
     size_t argSize,                                      ///< [in] size of argument type
     const ur_kernel_arg_value_properties_t *pProperties, ///< [in][optional] pointer to value properties.
     const void *pArgValue                                ///< [in] argument value represented as matching arg type.
+                                                         ///< The data pointed to will be copied and therefore can be reused on return.
 );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -64,7 +64,9 @@ params:
       desc: "[in][optional] pointer to value properties."
     - type: "const void*"
       name: pArgValue
-      desc: "[in] argument value represented as matching arg type."
+      desc: |
+         [in] argument value represented as matching arg type.
+         The data pointed to will be copied and therefore can be reused on return.
 returns:
     - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX
     - $X_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -3864,6 +3864,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -2943,6 +2943,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
 ) {
     auto pfnSetArgValue = getContext()->urDdiTable.Kernel.pfnSetArgValue;
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3350,6 +3350,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
 ) {
     auto pfnSetArgValue = getContext()->urDdiTable.Kernel.pfnSetArgValue;
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3138,6 +3138,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3646,6 +3646,7 @@ ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
     ) try {
     auto pfnSetArgValue =
         ur_lib::getContext()->urDdiTable.Kernel.pfnSetArgValue;

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3113,6 +3113,7 @@ ur_result_t UR_APICALL urKernelSetArgValue(
         *pProperties, ///< [in][optional] pointer to value properties.
     const void
         *pArgValue ///< [in] argument value represented as matching arg type.
+    ///< The data pointed to will be copied and therefore can be reused on return.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;


### PR DESCRIPTION
This identifies that the data pointed to needs to be copied, similar to clSetKerneLArg when it is by value.
