### PR TITLE
[CI] Fix coverity workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023 Intel Corporation
+# Copyright (C) 2023-2024 Intel Corporation
 #
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
@@ -37,11 +37,6 @@ jobs:
 
       - name: Install pip packages
         run: pip install -r third_party/requirements.txt
-
-      - name: Install apt packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libhwloc-dev
 
       - name: Configure CMake
         run: >


### PR DESCRIPTION
we can't install anything on the self-hosted runner, it's sudoless.
All required dependencies should be already there.

// Preview of this workflow on my fork - CMake configured properly
https://github.com/lukaszstolarczuk/unified-runtime/actions/runs/10386076621/job/28756560507