### PR TITLE
[L0] remove unused capture from lambda

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1169,7 +1169,7 @@ ur_queue_handle_legacy_t_::ur_queue_handle_legacy_t_(
       ZeCommandListBatchComputeConfig.startSize();
   CopyCommandBatch.QueueBatchSize = ZeCommandListBatchCopyConfig.startSize();
 
-  static const bool useDriverCounterBasedEvents = [Device] {
+  static const bool useDriverCounterBasedEvents = [] {
     const char *UrRet = std::getenv("UR_L0_USE_DRIVER_COUNTER_BASED_EVENTS");
     if (!UrRet) {
       return true;


### PR DESCRIPTION
this generates warning on clang