### PR TITLE
Fix missing mutex on get_alloc_info_entry

### DIFF
--- a/source/adapters/native_cpu/context.hpp
+++ b/source/adapters/native_cpu/context.hpp
@@ -111,6 +111,7 @@ struct ur_context_handle_t_ : RefCounted {
 
   const native_cpu::usm_alloc_info &
   get_alloc_info_entry(const void *ptr) const {
+    std::lock_guard<std::mutex> lock(alloc_mutex);
     auto it = allocations.find(ptr);
     if (it == allocations.end()) {
       return native_cpu::usm_alloc_info_null_entry;


### PR DESCRIPTION
Coverity showed up a missing alloc_mutex on get_alloc_info_entry. This fixes this by adding it.
