### PR TITLE
Add dlerror output to loader logs

### DIFF
--- a/source/common/linux/ur_lib_loader.cpp
+++ b/source/common/linux/ur_lib_loader.cpp
@@ -45,7 +45,13 @@ LibLoader::loadAdapterLibrary(const char *name) {
     }
 #endif
     HMODULE handle = dlopen(name, mode);
-    logger::info("loaded adapter 0x{} ({})", handle, name);
+    if (!handle) {
+        char *err = dlerror();
+        logger::info("failed to load adapter '{}' with error: {}", name,
+                     err ? err : "unknown error");
+    } else {
+        logger::info("loaded adapter 0x{} ({})", handle, name);
+    }
     return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(handle);
 }
 


### PR DESCRIPTION
Failing to load an adapter is not an error in most cases the adapter is just not present.

However there's a lot of other reasons why an adapter may fail to load, such as a missing driver library or an unsupported driver. In these cases `dlerror` output is crucial to troubleshoot the issue.