### PR TITLE
In build jobs, properly disable UR downloads

### DIFF
--- a/.github/workflows/benchmarks_compute.yml
+++ b/.github/workflows/benchmarks_compute.yml
@@ -143,8 +143,8 @@ jobs:
         --ci-defaults ${{matrix.adapter.sycl_config}}
         --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
         --cmake-opt="-DSYCL_PI_TESTS=OFF"
-        --cmake-opt="-DSYCL_PI_UR_USE_FETCH_CONTENT=OFF"
-        --cmake-opt="-DSYCL_PI_UR_SOURCE_DIR=${{github.workspace}}/ur-repo/"
+        --cmake-opt="-DSYCL_UR_USE_FETCH_CONTENT=OFF"
+        --cmake-opt="-DSYCL_UR_SOURCE_DIR=${{github.workspace}}/ur-repo/"
         --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache
         --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -130,8 +130,8 @@ jobs:
         --ci-defaults ${{matrix.adapter.config}}
         --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
         --cmake-opt="-DSYCL_PI_TESTS=OFF"
-        --cmake-opt="-DSYCL_PI_UR_USE_FETCH_CONTENT=OFF"
-        --cmake-opt="-DSYCL_PI_UR_SOURCE_DIR=${{github.workspace}}/ur-repo/"
+        --cmake-opt="-DSYCL_UR_USE_FETCH_CONTENT=OFF"
+        --cmake-opt="-DSYCL_UR_SOURCE_DIR=${{github.workspace}}/ur-repo/"
         --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache
         --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 


### PR DESCRIPTION
These jobs were not properly setting `SYCL_UR_USE_FETCH_CONTENT`, and so were fetching UR when they should have been using the UR under test.