### PR TITLE
[DeviceSanitizer] Fix libstdc++ and libc++ mismatch problem

### DIFF
--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -167,6 +167,26 @@ if(UR_ENABLE_SANITIZER)
         )
         target_include_directories(ur_loader PRIVATE ${LLVM_INCLUDE_DIRS})
         target_link_libraries(ur_loader PRIVATE LLVMSupport LLVMSymbolize)
+        # In in-tree build, if LLVM is built with libc++, we also need to build
+        # symbolizer.cpp with libc++ abi and link libc++ in.
+        if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND LLVM_LIBCXX_USED)
+            execute_process(
+                COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libc++.a
+                OUTPUT_VARIABLE LIBCXX_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+            execute_process(
+                COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libc++abi.a
+                OUTPUT_VARIABLE LIBCXX_ABI_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set_property(SOURCE
+                ${CMAKE_CURRENT_SOURCE_DIR}/layers/sanitizer/linux/symbolizer.cpp
+                APPEND_STRING PROPERTY COMPILE_FLAGS
+                " -stdlib=libc++ ")
+            if(NOT EXISTS ${LIBCXX_PATH} OR NOT EXISTS ${LIBCXX_ABI_PATH})
+                message(FATAL_ERROR "libc++ is required but can't find the libraries")
+            endif()
+            target_link_libraries(ur_loader PRIVATE ${LIBCXX_PATH} ${LIBCXX_ABI_PATH})
+        endif()
     endif()
 
     target_include_directories(ur_loader PRIVATE

--- a/source/loader/CMakeLists.txt
+++ b/source/loader/CMakeLists.txt
@@ -169,7 +169,7 @@ if(UR_ENABLE_SANITIZER)
         target_link_libraries(ur_loader PRIVATE LLVMSupport LLVMSymbolize)
         # In in-tree build, if LLVM is built with libc++, we also need to build
         # symbolizer.cpp with libc++ abi and link libc++ in.
-        if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR AND LLVM_LIBCXX_USED)
+        if(NOT UR_STANDALONE_BUILD AND LLVM_LIBCXX_USED)
             execute_process(
                 COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libc++.a
                 OUTPUT_VARIABLE LIBCXX_PATH

--- a/source/loader/layers/sanitizer/stacktrace.cpp
+++ b/source/loader/layers/sanitizer/stacktrace.cpp
@@ -15,9 +15,10 @@
 
 extern "C" {
 
-__attribute__((weak)) bool SymbolizeCode(const std::string ModuleName,
+__attribute__((weak)) void SymbolizeCode(const char *ModuleName,
                                          uint64_t ModuleOffset,
-                                         std::string &Result);
+                                         char *ResultString, size_t ResultSize,
+                                         size_t *RetSize);
 }
 
 namespace ur_sanitizer_layer {
@@ -49,7 +50,7 @@ void ParseBacktraceInfo(BacktraceInfo BI, std::string &ModuleName,
 // Parse symbolizer output in the following formats:
 //   <function_name>
 //   <file_name>:<line_number>[:<column_number>]
-SourceInfo ParseSymbolizerOutput(std::string Output) {
+SourceInfo ParseSymbolizerOutput(const std::string &Output) {
     SourceInfo Info;
     // Parse function name
     size_t End = Output.find_first_of('\n');
@@ -98,8 +99,14 @@ void StackTrace::print() const {
             std::string ModuleName;
             uptr Offset;
             ParseBacktraceInfo(BI, ModuleName, Offset);
-            if (SymbolizeCode(ModuleName, Offset, Result)) {
-                SourceInfo SrcInfo = ParseSymbolizerOutput(std::move(Result));
+            size_t ResultSize = 0;
+            SymbolizeCode(ModuleName.c_str(), Offset, nullptr, 0, &ResultSize);
+            if (ResultSize) {
+                std::vector<char> ResultVector(ResultSize);
+                SymbolizeCode(ModuleName.c_str(), Offset, ResultVector.data(),
+                              ResultSize, nullptr);
+                std::string Result((char *)ResultVector.data());
+                SourceInfo SrcInfo = ParseSymbolizerOutput(Result);
                 if (SrcInfo.file != "??") {
                     getContext()->logger.always(" #{} in {} {}:{}:{}", index,
                                                 SrcInfo.function, SrcInfo.file,
@@ -109,10 +116,10 @@ void StackTrace::print() const {
                                                 SrcInfo.function, ModuleName,
                                                 (void *)Offset);
                 }
-                continue;
             }
+        } else {
+            getContext()->logger.always("  #{} {}", index, BI);
         }
-        getContext()->logger.always("  #{} {}", index, BI);
         ++index;
     }
     getContext()->logger.always("");


### PR DESCRIPTION
UR will force link with libstdc++, but in in-tree build, if LLVM is built with libc++, this will cause mismatch problem. So, in such case, we need to build symbolizer.cpp with libc++ abi and link libc++ in.