### PR TITLE
[OpenCL] Fix USM alignment error check to occur always and return nulllptr

### DIFF
--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -87,6 +87,11 @@ urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
   void *Ptr = nullptr;
   uint32_t Alignment = pUSMDesc ? pUSMDesc->align : 0;
 
+  if (pUSMDesc && pUSMDesc->align != 0 &&
+      ((pUSMDesc->align & (pUSMDesc->align - 1)) != 0)) {
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {
     UR_RETURN_ON_FAILURE(usmDescToCLMemProperties(
@@ -130,6 +135,11 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   void *Ptr = nullptr;
   uint32_t Alignment = pUSMDesc ? pUSMDesc->align : 0;
 
+  if (pUSMDesc && pUSMDesc->align != 0 &&
+      ((pUSMDesc->align & (pUSMDesc->align - 1)) != 0)) {
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
+
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {
     UR_RETURN_ON_FAILURE(usmDescToCLMemProperties(
@@ -172,6 +182,11 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 
   void *Ptr = nullptr;
   uint32_t Alignment = pUSMDesc ? pUSMDesc->align : 0;
+
+  if (pUSMDesc && pUSMDesc->align != 0 &&
+      ((pUSMDesc->align & (pUSMDesc->align - 1)) != 0)) {
+    return UR_RESULT_ERROR_INVALID_VALUE;
+  }
 
   std::vector<cl_mem_properties_intel> AllocProperties;
   if (pUSMDesc && pUSMDesc->pNext) {


### PR DESCRIPTION
- USM calls to alloc must return a nullptr and error given invalid alignment. This cannot be relied upon in the validation layer.