### PR TITLE
[Common] Add total count and sum of latency measurements

### DIFF
--- a/source/common/latency_tracker.hpp
+++ b/source/common/latency_tracker.hpp
@@ -94,14 +94,16 @@ class latency_printer {
 
         for (auto &[name, histogram] : values) {
             auto value = getValues(histogram.get());
-            logger.log(logger::Level::INFO,
-                       "{},{},{},{},{},{},{},{},{},{},{},{},{},{},ns", name,
-                       value.mean, value.percentileValues[0],
-                       value.percentileValues[1], value.percentileValues[2],
-                       value.percentileValues[3], value.percentileValues[4],
-                       value.percentileValues[5], value.percentileValues[6],
-                       value.count, value.count * value.mean, value.min,
-                       value.max, value.stddev);
+            auto f = groupDigits<int64_t>;
+            logger.log(
+                logger::Level::INFO,
+                "{},{},{},{},{},{},{},{},{},{},{},{},{},{},ns", name,
+                f(value.mean), f(value.percentileValues[0]),
+                f(value.percentileValues[1]), f(value.percentileValues[2]),
+                f(value.percentileValues[3]), f(value.percentileValues[4]),
+                f(value.percentileValues[5]), f(value.percentileValues[6]),
+                f(value.count), f(value.count * value.mean), f(value.min),
+                f(value.max), value.stddev);
         }
     }
 

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -478,6 +478,25 @@ template <typename T> class AtomicSingleton {
     }
 };
 
+template <typename Numeric>
+static inline std::string groupDigits(Numeric numeric) {
+    auto number = std::to_string(numeric);
+    std::string sign = numeric >= 0 ? "" : "-";
+    auto digits = number.substr(sign.size(), number.size() - sign.size());
+
+    std::string separated;
+
+    for (size_t i = 0; i < digits.size(); i++) {
+        separated.push_back(digits[i]);
+
+        if (i != digits.size() - 1 && (digits.size() - i - 1) % 3 == 0) {
+            separated.push_back('\'');
+        }
+    }
+
+    return sign + separated;
+}
+
 template <typename T> Spinlock<Rc<T>> AtomicSingleton<T>::instance;
 
 #endif /* UR_UTIL_H */

--- a/test/unit/utils/CMakeLists.txt
+++ b/test/unit/utils/CMakeLists.txt
@@ -13,3 +13,6 @@ add_unit_test(params
 
 add_unit_test(print
     print.cpp)
+
+add_unit_test(helpers
+    helpers.cpp)

--- a/test/unit/utils/helpers.cpp
+++ b/test/unit/utils/helpers.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "ur_util.hpp"
+
+TEST(groupDigits, Success) {
+    EXPECT_EQ(groupDigits(-1), "-1");
+    EXPECT_EQ(groupDigits(-12), "-12");
+    EXPECT_EQ(groupDigits(-123), "-123");
+    EXPECT_EQ(groupDigits(-1234), "-1'234");
+    EXPECT_EQ(groupDigits(-12345), "-12'345");
+    EXPECT_EQ(groupDigits(-123456), "-123'456");
+    EXPECT_EQ(groupDigits(-1234567), "-1'234'567");
+    EXPECT_EQ(groupDigits(-12345678), "-12'345'678");
+
+    EXPECT_EQ(groupDigits(0), "0");
+    EXPECT_EQ(groupDigits(1), "1");
+    EXPECT_EQ(groupDigits(12), "12");
+    EXPECT_EQ(groupDigits(123), "123");
+    EXPECT_EQ(groupDigits(1234), "1'234");
+    EXPECT_EQ(groupDigits(12345), "12'345");
+    EXPECT_EQ(groupDigits(123456), "123'456");
+    EXPECT_EQ(groupDigits(1234567), "1'234'567");
+    EXPECT_EQ(groupDigits(12345678), "12'345'678");
+}


### PR DESCRIPTION
to the latency tracker.

Also show min, max and stdev value at the end - it makes it easier to quickly compare different outputs.