### PR TITLE
[L0] Fix device query of bindless image support

### DIFF
--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1010,20 +1010,28 @@ ur_result_t urDeviceGetInfo(
                        Device->Platform->ZeMutableCmdListExt.Supported);
   }
   case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP: {
-    // On L0 bindless images are supported.
-    return ReturnValue(true);
+    bool DeviceIsDG2OrNewer =
+        Device->ZeDeviceIpVersionExt->ipVersion >= 0x030dc000;
+    return ReturnValue(DeviceIsDG2OrNewer &&
+                       Device->ZeDeviceImageProperties->maxImageDims1D > 0 &&
+                       Device->ZeDeviceImageProperties->maxImageDims2D > 0 &&
+                       Device->ZeDeviceImageProperties->maxImageDims3D > 0);
   }
   case UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP: {
     // On L0 bindless images can not be backed by shared (managed) USM.
     return ReturnValue(false);
   }
   case UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP: {
-    // On L0 1D bindless image USM are supported.
-    return ReturnValue(true);
+    bool DeviceIsDG2OrNewer =
+        Device->ZeDeviceIpVersionExt->ipVersion >= 0x030dc000;
+    return ReturnValue(DeviceIsDG2OrNewer &&
+                       Device->ZeDeviceImageProperties->maxImageDims1D > 0);
   }
   case UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP: {
-    // On L0 2D bindless image USM are supported.
-    return ReturnValue(true);
+    bool DeviceIsDG2OrNewer =
+        Device->ZeDeviceIpVersionExt->ipVersion >= 0x030dc000;
+    return ReturnValue(DeviceIsDG2OrNewer &&
+                       Device->ZeDeviceImageProperties->maxImageDims2D > 0);
   }
   case UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP:
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP:


### PR DESCRIPTION
Bindless image support is only supported on intel DG2 or newer GPU. In addition, it also requires basic image support queried from ZeDeviceImageProperties.

SYCL PR: https://github.com/intel/llvm/pull/15211