### PR TITLE
Remove superfluous namespace

### DIFF
--- a/source/adapters/native_cpu/usm.cpp
+++ b/source/adapters/native_cpu/usm.cpp
@@ -21,8 +21,6 @@ ur_result_t getProviderNativeError(const char *, int32_t) {
 }
 } // namespace umf
 
-namespace native_cpu {
-
 static ur_result_t alloc_helper(ur_context_handle_t hContext,
                                 const ur_usm_desc_t *pUSMDesc, size_t size,
                                 void **ppMem, ur_usm_type_t type) {
@@ -39,15 +37,12 @@ static ur_result_t alloc_helper(ur_context_handle_t hContext,
   return UR_RESULT_SUCCESS;
 }
 
-} // namespace native_cpu
-
 UR_APIEXPORT ur_result_t UR_APICALL
 urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
                ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
   std::ignore = pool;
 
-  return native_cpu::alloc_helper(hContext, pUSMDesc, size, ppMem,
-                                  UR_USM_TYPE_HOST);
+  return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_HOST);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -57,8 +52,7 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   std::ignore = hDevice;
   std::ignore = pool;
 
-  return native_cpu::alloc_helper(hContext, pUSMDesc, size, ppMem,
-                                  UR_USM_TYPE_DEVICE);
+  return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_DEVICE);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -68,8 +62,7 @@ urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
   std::ignore = hDevice;
   std::ignore = pool;
 
-  return native_cpu::alloc_helper(hContext, pUSMDesc, size, ppMem,
-                                  UR_USM_TYPE_SHARED);
+  return alloc_helper(hContext, pUSMDesc, size, ppMem, UR_USM_TYPE_SHARED);
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t hContext,


### PR DESCRIPTION
It only contained `static` functions so it just made uses within the same TU more cumbersome.