### PR TITLE
Fix unspecified alignment

### DIFF
--- a/source/adapters/native_cpu/usm.cpp
+++ b/source/adapters/native_cpu/usm.cpp
@@ -20,8 +20,8 @@ namespace native_cpu {
 static ur_result_t alloc_helper(ur_context_handle_t hContext,
                                 const ur_usm_desc_t *pUSMDesc, size_t size,
                                 void **ppMem, ur_usm_type_t type) {
-  auto alignment = pUSMDesc ? pUSMDesc->align : 1u;
-  UR_ASSERT((alignment & (alignment - 1)) == 0, UR_RESULT_ERROR_INVALID_VALUE);
+  auto alignment = (pUSMDesc && pUSMDesc->align) ? pUSMDesc->align : 1u;
+  UR_ASSERT(isPowerOf2(alignment), UR_RESULT_ERROR_UNSUPPORTED_ALIGNMENT);
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   // TODO: Check Max size when UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE is implemented
   UR_ASSERT(size > 0, UR_RESULT_ERROR_INVALID_USM_SIZE);


### PR DESCRIPTION
It's plausible that a user will pass a non-null `ur_usm_desc_t` argument that itself has a zero `align` member. We need to gracefully accept such a case.