### PR TITLE
[CI] disable L0 v2 build on clang

### DIFF
--- a/.github/workflows/build-hw-reusable.yml
+++ b/.github/workflows/build-hw-reusable.yml
@@ -44,6 +44,8 @@ jobs:
         exclude:
          - adapter: {name: L0, platform: ""}
            compiler: {c: clang, cxx: clang++}
+         - adapter: {name: L0_V2, platform: ""}
+           compiler: {c: clang, cxx: clang++}
         # Exclude these configurations to avoid overloading the runners.
          - adapter: {static_Loader: ON}
            build_type: Release


### PR DESCRIPTION
When clang is sued no platforms are being found.
This seems to be connected to: https://github.com/oneapi-src/unified-runtime/pull/1516