### PR TITLE
[L0] Bump l0 loader version

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -40,7 +40,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG v1.17.6)
+        set(UR_LEVEL_ZERO_LOADER_TAG v1.17.28)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104


### PR DESCRIPTION
Current version seems to cause compilation error on Windows and L0 v2 adapter fails to find any platforms.