### PR TITLE
Ensure UR will clear contexts before unloading on windows

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -140,6 +140,11 @@ if(UR_BUILD_ADAPTER_L0)
             PRIVATE
                 ${CMAKE_CURRENT_SOURCE_DIR}/adapter_lib_init_linux.cpp
         )
+    else()
+        target_sources(ur_adapter_level_zero
+            PRIVATE
+                ${CMAKE_CURRENT_SOURCE_DIR}/adapter_lib_init_windows.cpp
+        )
     endif()
 
     # TODO: fix level_zero adapter conversion warnings

--- a/source/adapters/level_zero/adapter_lib_init_windows.cpp
+++ b/source/adapters/level_zero/adapter_lib_init_windows.cpp
@@ -1,0 +1,43 @@
+//===--------- adapter_lib_init_linux.cpp - Level Zero Adapter ------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
+// Exceptions. See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "adapter.hpp"
+#include "ur_level_zero.hpp"
+
+#include <windows.h>
+
+BOOL WINAPI DllMain(HINSTANCE hinstDLL, // handle to DLL module
+                    DWORD fdwReason,    // reason for calling function
+                    LPVOID lpReserved)  // reserved
+{
+  switch (fdwReason) {
+  case DLL_PROCESS_ATTACH:
+    break;
+  case DLL_PROCESS_DETACH: {
+    std::lock_guard<std::mutex> Lock{GlobalAdapter->Mutex};
+    const auto *platforms = GlobalAdapter->PlatformCache->get_value();
+    for (const auto &p : *platforms) {
+      std::scoped_lock<ur_shared_mutex> ContextsLock(p->ContextsMutex);
+      while (!p->Contexts.empty()) {
+        ur_context_handle_t &ctx = p->Contexts.front();
+        ctx->deleteCachedObjectsOnDestruction();
+        UR_CALL(urContextRelease(ctx));
+        deleteFromCachedList<ur_context_handle_t>(ctx, p->Contexts);
+      }
+    }
+    break;
+  }
+  case DLL_THREAD_ATTACH:
+    break;
+  case DLL_THREAD_DETACH:
+    break;
+  }
+  return TRUE;
+}

--- a/source/adapters/level_zero/adapter_lib_init_windows.cpp
+++ b/source/adapters/level_zero/adapter_lib_init_windows.cpp
@@ -27,6 +27,8 @@ ur_result_t deleteCacheOnDestruction() {
       while (RefCount--) {
         UR_CALL(urContextRelease(ctx));
       }
+      // context object should be deleted at this point, but this is a guard
+      // call to protect from infinite loop on case of error.
       deleteFromCachedList<ur_context_handle_t>(ctx, p->Contexts);
     }
   }

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -450,6 +450,9 @@ extern const bool UseUSMAllocator;
 
 // Controls support of the indirect access kernels and deferred memory release.
 const bool IndirectAccessTrackingEnabled = [] {
+#ifdef _WIN32
+  return false;
+#endif
   char *UrRet = std::getenv("UR_L0_TRACK_INDIRECT_ACCESS_MEMORY");
   char *PiRet = std::getenv("SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY");
   const bool RetVal = UrRet ? std::stoi(UrRet) : (PiRet ? std::stoi(PiRet) : 0);
@@ -529,5 +532,20 @@ extern thread_local int32_t ErrorAdapterNativeCode;
 [[maybe_unused]] void setErrorMessage(const char *pMessage,
                                       ur_result_t ErrorCode,
                                       int32_t AdapterErrorCode);
+
+template <class T>
+void addToCachedList(T &CachedObject, std::list<T> &CachedList) {
+  auto It = std::find(CachedList.begin(), CachedList.end(), CachedObject);
+  if (It == CachedList.end()) {
+    CachedList.push_back(CachedObject);
+  }
+}
+
+template <class T>
+void deleteFromCachedList(T &CachedObject, std::list<T> &CachedList) {
+  auto It = std::find(CachedList.begin(), CachedList.end(), CachedObject);
+  if (It != CachedList.end())
+    CachedList.erase(It);
+}
 
 #define L0_DRIVER_INORDER_MIN_VERSION 29534

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -175,6 +175,8 @@ struct ur_context_handle_t_ : _ur_object {
   std::vector<std::unordered_map<ur_device_handle_t, size_t>>
       EventCachesDeviceMap{4};
 
+  std::list<ur_kernel_handle_t> KernelsCache;
+
   // Initialize the PI context.
   ur_result_t initialize();
 
@@ -308,6 +310,14 @@ struct ur_context_handle_t_ : _ur_object {
 
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
+
+  void deleteCachedObjectsOnDestruction() {
+    while (!KernelsCache.empty()) {
+      ur_kernel_handle_t &kernel = KernelsCache.front();
+      UR_CALL_THROWS(urKernelRelease(kernel));
+      deleteFromCachedList(kernel, KernelsCache);
+    }
+  }
 
 private:
   // Get the cache of events for a provided scope and profiling mode.

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -23,6 +23,7 @@
 #include <zes_api.h>
 
 #include "common.hpp"
+#include "kernel.hpp"
 #include "queue.hpp"
 
 #include <umf_helpers.hpp>
@@ -311,13 +312,7 @@ struct ur_context_handle_t_ : _ur_object {
   // Get handle to the L0 context
   ze_context_handle_t getZeHandle() const;
 
-  void deleteCachedObjectsOnDestruction() {
-    while (!KernelsCache.empty()) {
-      ur_kernel_handle_t &kernel = KernelsCache.front();
-      UR_CALL_THROWS(urKernelRelease(kernel));
-      deleteFromCachedList(kernel, KernelsCache);
-    }
-  }
+  void deleteCachedObjectsOnDestruction();
 
 private:
   // Get the cache of events for a provided scope and profiling mode.

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -594,11 +594,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreate(
 
 #ifdef _WIN32
     auto &Context = Program->Context;
-    auto It = std::find(Context->KernelsCache.begin(),
-                        Context->KernelsCache.end(), *RetKernel);
-    if (It == Context->KernelsCache.end()) {
-      Context->KernelsCache.push_back(*RetKernel);
-    }
+    addToCachedList(*RetKernel, Context->KernelsCache);
 #endif
 
   } catch (const std::bad_alloc &) {
@@ -912,13 +908,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelRelease(
         return ze2urResult(ZeResult);
     }
   }
-
   Kernel->ZeKernelMap.clear();
-
   if (IndirectAccessTrackingEnabled) {
     UR_CALL(urContextRelease(KernelProgram->Context));
   }
-
   // do a release on the program this kernel was part of without delete of the
   // program handle
   KernelProgram->ur_release_program_resources(false);
@@ -1098,6 +1091,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     }
 
     *RetKernel = reinterpret_cast<ur_kernel_handle_t>(Kernel);
+#ifdef _WIN32
+    auto &Context = Program->Context;
+    addToCachedList(*RetKernel, Context->KernelsCache);
+#endif
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {


### PR DESCRIPTION
UR adapter is unloaded before clearing all intel/llvm side objects, this is because sycl-rt will only start the destruction on a call to destruct sycl.dll on DllMain [here](https://github.com/intel/llvm/blob/9fbf6b2d07123930c21e5069ee9bd2d1b7a7348d/sycl/source/detail/global_handler.cpp#L355). windows unload the dependencies first before calling DllMain process unloading. So, UR adapter dll will be unloaded before even sycl DllMain destruction is called. So, if we tried at sycl-rt side to clean the default context, this will result in access violation problems.

The proposed solution here is to use DllMain in UR L0 adapter, cache any created contexts/kernels and let it clean any context/kernels left before it unloads. I choosed this context object as it holds the usm pools so it is important to clean that, and kernels needed to fix some tests so also need to be cleaned.