### PR TITLE
[L0 v2] Remove ur_shared_handle

### DIFF
--- a/source/adapters/level_zero/v2/common.hpp
+++ b/source/adapters/level_zero/v2/common.hpp
@@ -85,70 +85,6 @@ private:
   bool ownZeHandle;
 };
 
-template <typename URHandle, ur_result_t (*retain)(URHandle),
-          ur_result_t (*release)(URHandle)>
-struct ur_shared_handle {
-  using handle_t = URHandle;
-
-  ur_shared_handle() : handle(nullptr) {}
-  explicit ur_shared_handle(handle_t handle) : handle(handle) {}
-  ~ur_shared_handle() {
-    try {
-      reset();
-    } catch (...) {
-    }
-  }
-
-  ur_shared_handle(const ur_shared_handle &other) : handle(other.handle) {
-    retain(handle);
-  }
-  ur_shared_handle(ur_shared_handle &&other) : handle(other.handle) {
-    other.handle = nullptr;
-  }
-  ur_shared_handle(std::nullptr_t) : handle(nullptr) {}
-
-  void reset() {
-    if (!handle) {
-      return;
-    }
-
-    UR_CALL_THROWS(release(handle));
-    handle = nullptr;
-  }
-
-  ur_shared_handle &operator=(const ur_shared_handle &other) {
-    if (handle) {
-      release(handle);
-    }
-    handle = other.handle;
-    retain(handle);
-    return *this;
-  }
-  ur_shared_handle &operator=(ur_shared_handle &&other) {
-    if (handle) {
-      release(handle);
-    }
-    handle = other.handle;
-    other.handle = nullptr;
-    return *this;
-  }
-  ur_shared_handle &operator=(std::nullptr_t) {
-    if (handle) {
-      release(handle);
-    }
-    new (this) ur_shared_handle(nullptr);
-    return *this;
-  }
-
-  handle_t *ptr() { return &handle; }
-  handle_t get() const { return handle; }
-  handle_t operator->() { return handle; }
-  operator handle_t() { return handle; }
-
-private:
-  handle_t handle;
-};
-
 using ze_kernel_handle_t =
     ze_handle_wrapper<::ze_kernel_handle_t, zeKernelDestroy>;
 
@@ -157,12 +93,6 @@ using ze_event_handle_t =
 
 using ze_event_pool_handle_t =
     ze_handle_wrapper<::ze_event_pool_handle_t, zeEventPoolDestroy>;
-
-using ur_queue_shared_handle_t =
-    ur_shared_handle<ur_queue_handle_t, urQueueRetain, urQueueRelease>;
-
-using ur_kernel_shared_handle_t =
-    ur_shared_handle<ur_kernel_handle_t, urKernelRetain, urKernelRelease>;
 
 } // namespace raii
 } // namespace v2

--- a/source/adapters/level_zero/v2/kernel.hpp
+++ b/source/adapters/level_zero/v2/kernel.hpp
@@ -26,21 +26,8 @@ struct ur_single_device_kernel_t {
 
 struct ur_kernel_handle_t_ : _ur_object {
 private:
-  static inline ur_result_t
-  internalProgramRelease(ur_program_handle_t hProgram) {
-    // do a release on the program this kernel was part of without delete of the
-    // program handle.
-    hProgram->ur_release_program_resources(false);
-    return UR_RESULT_SUCCESS;
-  }
-
 public:
-  using ur_program_shared_handle_t =
-      v2::raii::ur_shared_handle<ur_program_handle_t, urProgramRetain,
-                                 internalProgramRelease>;
-
-  ur_kernel_handle_t_(ur_program_shared_handle_t hProgram,
-                      const char *kernelName);
+  ur_kernel_handle_t_(ur_program_handle_t hProgram, const char *kernelName);
 
   // From native handle
   ur_kernel_handle_t_(ur_native_handle_t hNativeKernel,
@@ -75,7 +62,7 @@ public:
 
 private:
   // Keep the program of the kernel.
-  ur_program_shared_handle_t hProgram;
+  ur_program_handle_t hProgram;
 
   // Vector of ur_single_device_kernel_t indexed by device->Id
   std::vector<std::optional<ur_single_device_kernel_t>> deviceKernels;

--- a/test/conformance/kernel/kernel_adapter_native_cpu.match
+++ b/test/conformance/kernel/kernel_adapter_native_cpu.match
@@ -104,6 +104,7 @@ urKernelGetSubGroupInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU
 urKernelGetSubGroupInfoTest.InvalidEnumeration/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL
 urKernelGetSubGroupInfoSingleTest.CompileNumSubgroupsIsZero/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelReleaseTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+urKernelReleaseTest.KernelReleaseAfterProgramRelease/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelReleaseTest.InvalidNullHandleKernel/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelRetainTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelRetainTest.InvalidNullHandleKernel/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/kernel/urKernelRelease.cpp
+++ b/test/conformance/kernel/urKernelRelease.cpp
@@ -13,6 +13,13 @@ TEST_P(urKernelReleaseTest, Success) {
     ASSERT_SUCCESS(urKernelRelease(kernel));
 }
 
+TEST_P(urKernelReleaseTest, KernelReleaseAfterProgramRelease) {
+    ASSERT_SUCCESS(urKernelRetain(kernel));
+    ASSERT_SUCCESS(urProgramRelease(program));
+    program = nullptr;
+    ASSERT_SUCCESS(urKernelRelease(kernel));
+}
+
 TEST_P(urKernelReleaseTest, InvalidNullHandleKernel) {
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                      urKernelRelease(nullptr));


### PR DESCRIPTION
as it's error prone to use - similarly to shared_ptr we should not create multiple instances of shared_handle from a single raw pointer.

Also, fix error in kernel.cpp: program handle was not being retained, leading to segfaults.