### PR TITLE
[Benchmark] use UR_ADAPTERS_FORCE_LOAD in benchmarks

### DIFF
--- a/.github/workflows/benchmarks_compute.yml
+++ b/.github/workflows/benchmarks_compute.yml
@@ -151,9 +151,17 @@ jobs:
     - name: Build SYCL
       run: cmake --build ${{github.workspace}}/sycl_build -j
 
-    - name: Set oneAPI Device Selector
-      run: |
-        echo "ONEAPI_DEVICE_SELECTOR=${{ matrix.adapter.str_name }}:${{ matrix.adapter.unit }}" >> $GITHUB_ENV
+    - name: Configure UR
+      working-directory: ${{github.workspace}}/ur-repo
+      run: >
+        cmake -DCMAKE_BUILD_TYPE=Release
+        -B${{github.workspace}}/ur-repo/build
+        -DUR_BUILD_TESTS=OFF
+        -DUR_BUILD_ADAPTER_L0=ON
+        -DUR_BUILD_ADAPTER_L0_V2=ON
+
+    - name: Build UR
+      run: cmake --build ${{github.workspace}}/ur-repo/build -j $(nproc)
 
     - name: Run benchmarks
       id: benchmarks

--- a/scripts/benchmarks/benches/base.py
+++ b/scripts/benchmarks/benches/base.py
@@ -16,9 +16,12 @@ import tarfile
 class Benchmark:
     def __init__(self, directory):
         self.directory = directory
+        self.adapter_path = os.path.join(options.ur_dir, 'build', 'lib', f"libur_adapter_{options.ur_adapter_name}.so")
 
     def run_bench(self, command, env_vars):
-        return run(command=command, env_vars=env_vars, add_sycl=True, cwd=options.benchmark_cwd).stdout.decode()
+        env_vars_with_forced_adapter = env_vars.copy()
+        env_vars_with_forced_adapter.update({'UR_ADAPTERS_FORCE_LOAD': self.adapter_path})
+        return run(command=command, env_vars=env_vars_with_forced_adapter, add_sycl=True, cwd=options.benchmark_cwd).stdout.decode()
 
     def create_data_path(self, name):
         data_path = os.path.join(self.directory, "data", name)

--- a/scripts/benchmarks/benches/compute.py
+++ b/scripts/benchmarks/benches/compute.py
@@ -15,7 +15,6 @@ class ComputeBench:
     def __init__(self, directory):
         self.directory = directory
         self.built = False
-        self.adapter_short_name = {'level_zero' : 'L0', "level_zero_v2" : 'L0_V2'}
         return
 
     def setup(self):
@@ -35,11 +34,9 @@ class ComputeBench:
             f"-DALLOW_WARNINGS=ON",
             f"-DBUILD_UR=ON",
             f"-DUR_BUILD_TESTS=OFF",
-            f"-DUR_BUILD_ADAPTER_L0=ON",
             f"-DUR_BUILD_TESTS=OFF",
             f"-DUMF_DISABLE_HWLOC=ON",
             f"-DBENCHMARK_UR_SOURCE_DIR={options.ur_dir}",
-            f"-DUR_BUILD_ADAPTER_{self.adapter_short_name[options.ur_adapter_name]}=ON"
         ]
         run(configure_command, add_sycl=True)
 
@@ -47,7 +44,6 @@ class ComputeBench:
 
         self.built = True
         self.bins = os.path.join(build_path, 'bin')
-        self.libs = os.path.join(build_path, 'lib')
 
 class ComputeBenchmark(Benchmark):
     def __init__(self, bench, name, test):
@@ -129,9 +125,6 @@ class SubmitKernelUR(ComputeBenchmark):
     def name(self):
         order = "in order" if self.ioq else "out of order"
         return f"api_overhead_benchmark_ur SubmitKernel {order}"
-
-    def extra_env_vars(self) -> dict:
-        return {"UR_ADAPTERS_FORCE_LOAD" : os.path.join(self.bench.libs, f"libur_adapter_{options.ur_adapter_name}.so")}
 
     def bin_args(self) -> list[str]:
         return [


### PR DESCRIPTION
to enable testing L0 v2 adapter which cannot be selected by ONEAPI_SELECTOR