### PR TITLE
[DeviceSanitizer] Fix a heap use-after-free problem.

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.cpp
@@ -313,7 +313,8 @@ ur_result_t SanitizerInterceptor::releaseMemory(ur_context_handle_t Context,
     }
 
     auto AllocInfoIt = *AllocInfoItOp;
-    auto &AllocInfo = AllocInfoIt->second;
+    // AllocInfo is a shared_ptr and we need to keep a copy to avoid early release
+    auto AllocInfo = AllocInfoIt->second;
 
     if (AllocInfo->Context != Context) {
         if (AllocInfo->UserBegin == Addr) {


### PR DESCRIPTION
`AllocInfo` is a shared_ptr, and we need to keep a copy of it to avoid possible early release of objects that cause heap use-aftre-free problem. 

SYCLOS PR: https://github.com/intel/llvm/pull/15222