### PR TITLE
[CL] Make device queries more robust

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1569,8 +1569,7 @@ typedef enum ur_device_info_t {
                                                                      ///< ::urDevicePartition
     UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,                          ///< [uint32_t] max number of sub groups
     UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS = 81,      ///< [::ur_bool_t] support sub group independent forward progress
-    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                       ///< [uint32_t[]] return an array of sub group sizes supported on Intel
-                                                                     ///< device
+    UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL = 82,                       ///< [uint32_t[]] return an array of supported sub group sizes
     UR_DEVICE_INFO_USM_HOST_SUPPORT = 83,                            ///< [::ur_device_usm_access_capability_flags_t] support USM host memory
                                                                      ///< access
     UR_DEVICE_INFO_USM_DEVICE_SUPPORT = 84,                          ///< [::ur_device_usm_access_capability_flags_t] support USM device memory

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -365,7 +365,7 @@ etors:
     - name: SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS
       desc: "[$x_bool_t] support sub group independent forward progress"
     - name: SUB_GROUP_SIZES_INTEL
-      desc: "[uint32_t[]] return an array of sub group sizes supported on Intel device"
+      desc: "[uint32_t[]] return an array of supported sub group sizes"
     - name: USM_HOST_SUPPORT
       desc: "[$x_device_usm_access_capability_flags_t] support USM host memory access"
     - name: USM_DEVICE_SUPPORT


### PR DESCRIPTION
Previously, non-standard device queries (e.g., USM) were submitted to OpenCL devices without checking whether the device supports the extension. As a result, an exception was thrown from sycl::get_info.

Now, we more gracefully handle the case when OpenCL device does not have the extension needed:

- `UR_DEVICE_INFO_USM_*_SUPPORT`: Return all-false when the device does not support USM at all.
- `UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL`: Return `{1}`, like for the host device which also has no sub-groups.
- `UR_DEVICE_INFO_IP_VERSION`: Return `UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION` instead of `UR_RESULT_ERROR_INVALID_VALUE`.

Also, fix the description of `SUB_GROUP_SIZES_INTEL` info query, since UR supports it on NVIDIA and AMD GPUs too.