### PR TITLE
Bump to zlib version 1.3.1 used in examples

### DIFF
--- a/third_party/deps.yml
+++ b/third_party/deps.yml
@@ -25,7 +25,7 @@ dependencies:
   - libssh2=1.11.0
   - libstdcxx-ng=13.1.0
   - libuv=1.44.2
-  - libzlib=1.2.13
+  - libzlib=1.3.1
   - llvm-spirv=14.0.0
   - llvm-tools=14.0.6
   - llvmdev=14.0.6
@@ -35,5 +35,5 @@ dependencies:
   - rhash=1.4.3
   # don't upgrade xz utils due to CVE-2024-3094
   - xz=5.2.6
-  - zlib=1.2.13
+  - zlib=1.3.1
   - zstd=1.5.2


### PR DESCRIPTION
While zlib is not linked into UR libraries, only one of the example applications, we should still avoid using versions with known CVEs.
