### PR TITLE
Remove command-buffer CTS L0 workaround

### DIFF
--- a/test/conformance/exp_command_buffer/fixtures.h
+++ b/test/conformance/exp_command_buffer/fixtures.h
@@ -159,37 +159,17 @@ struct urUpdatableCommandBufferExpExecutionTest
         ASSERT_SUCCESS(urCommandBufferCreateExp(context, device, &desc,
                                                 &updatable_cmd_buf_handle));
         ASSERT_NE(updatable_cmd_buf_handle, nullptr);
-
-        // Currently there are synchronization issue with immediate submission when used for command buffers.
-        // So, create queue with batched submission for this test suite if the backend is Level Zero.
-        if (backend == UR_PLATFORM_BACKEND_LEVEL_ZERO) {
-            ur_queue_flags_t flags = UR_QUEUE_FLAG_SUBMISSION_BATCHED;
-            ur_queue_properties_t props = {
-                /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
-                /*.pNext =*/nullptr,
-                /*.flags =*/flags,
-            };
-            ASSERT_SUCCESS(urQueueCreate(context, device, &props, &queue));
-            ASSERT_NE(queue, nullptr);
-        } else {
-            queue = urCommandBufferExpExecutionTest::queue;
-        }
     }
 
     void TearDown() override {
         if (updatable_cmd_buf_handle) {
             EXPECT_SUCCESS(urCommandBufferReleaseExp(updatable_cmd_buf_handle));
         }
-        if (backend == UR_PLATFORM_BACKEND_LEVEL_ZERO && queue) {
-            ASSERT_SUCCESS(urQueueRelease(queue));
-        }
-
         UUR_RETURN_ON_FATAL_FAILURE(
             urCommandBufferExpExecutionTest::TearDown());
     }
 
     ur_exp_command_buffer_handle_t updatable_cmd_buf_handle = nullptr;
-    ur_queue_handle_t queue = nullptr;
 };
 
 struct urCommandBufferCommandExpTest


### PR DESCRIPTION
The CTS code for command-buffers on the L0 backend has a workaround that forces batched submission to be used rather than immediate submission.

However, both batch and immediate submission L0 command-lists are now supported, so this workaround is no longer required.

Tested by running on PVC which uses immediate command-lists by default. Also by manually setting env var `UR_L0_USE_IMMEDIATE_COMMANDLISTS` to both `1` and `0` when running the CTS tests.