### PR TITLE
[Cuda] Check for exceeding grid dimension limits (work-group count)

### DIFF
--- a/source/adapters/cuda/enqueue.cpp
+++ b/source/adapters/cuda/enqueue.cpp
@@ -250,9 +250,18 @@ setKernelParams([[maybe_unused]] const ur_context_handle_t Context,
       return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
     }
 
+    size_t MaxGridDim[3] = {0, 0, 0};
+    urDeviceGetInfo(Device, UR_DEVICE_INFO_MAX_WORK_GROUPS_3D,
+                    sizeof(MaxGridDim), &MaxGridDim, nullptr);
     for (size_t i = 0; i < WorkDim; i++) {
       BlocksPerGrid[i] =
           (GlobalWorkSize[i] + ThreadsPerBlock[i] - 1) / ThreadsPerBlock[i];
+
+      if (BlocksPerGrid[i] > MaxGridDim[i]) {
+        // Currently this is handled as an invalid value error. Revisit when a
+        // better alternative result error code is agreed on.
+        return UR_RESULT_ERROR_INVALID_VALUE;
+      }
     }
 
     // Set the implicit global offset parameter if kernel has offset variant


### PR DESCRIPTION
This change does the grid dimensions validation earlier as it was previously deferred to `cuLaunchKernel`. For now it returns `UR_RESULT_ERROR_INVALID_VALUE` as it is also handled this way in the DPC++ sycl runtime, but it allows better control to target this with a more suitable error code in the future.

Related Q&A discussion: https://github.com/intel/llvm/discussions/14160

intel/llvm PR: https://github.com/intel/llvm/pull/15390