### PR TITLE
[CUDA][Bindless] Address USM normalized type image creation failure and functionality

### DIFF
--- a/source/adapters/cuda/image.hpp
+++ b/source/adapters/cuda/image.hpp
@@ -21,14 +21,15 @@ ur_result_t
 urToCudaImageChannelFormat(ur_image_channel_type_t image_channel_type,
                            ur_image_channel_order_t image_channel_order,
                            CUarray_format *return_cuda_format,
-                           size_t *return_pixel_types_size_bytes);
+                           size_t *return_pixel_types_size_bytes,
+                           unsigned int *return_normalized_dtype_flag);
 
 ur_result_t
 cudaToUrImageChannelFormat(CUarray_format cuda_format,
                            ur_image_channel_type_t *return_image_channel_type);
 
-ur_result_t urTextureCreate(ur_context_handle_t hContext,
-                            ur_sampler_desc_t SamplerDesc,
+ur_result_t urTextureCreate(ur_sampler_handle_t hSampler,
                             const ur_image_desc_t *pImageDesc,
-                            CUDA_RESOURCE_DESC ResourceDesc,
+                            const CUDA_RESOURCE_DESC &ResourceDesc,
+                            const unsigned int normalized_dtype_flag,
                             ur_exp_image_native_handle_t *phRetImage);


### PR DESCRIPTION
The specialised formats, CU_AD_FORMAT_{U|S}NORM_INT{8|16}X{1|2|4}, used to specify a format that is normalized, cannot be applied to images backed by USM memory, causing a failure. This commit addresses that issue by using the standard integer formats and making sure the CU_TRSF_READ_AS_INTEGER flag is set appropriately.

Another issue fixed here is that users with CUDA toolkits pre 11.5 are unable to enable normalized types due to the specialised formats being introduced in CUDA 11.5.

Associated DPC++ PR which tests for this: https://github.com/intel/llvm/pull/15299