### PR TITLE
[L0] Fix Command List Cache to correctly set In order List property

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -767,9 +767,11 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
         CommandList =
             Queue->CommandListMap
                 .emplace(ZeCommandList,
-                         ur_command_list_info_t(ZeFence, true, false,
-                                                ZeCommandQueue, ZeQueueDesc,
-                                                Queue->useCompletionBatching()))
+                         ur_command_list_info_t(
+                             ZeFence, true, false, ZeCommandQueue, ZeQueueDesc,
+                             Queue->useCompletionBatching(), true,
+                             ZeCommandListIt->second.InOrderList,
+                             ZeCommandListIt->second.IsImmediate))
                 .first;
       }
       ZeCommandListCache.erase(ZeCommandListIt);


### PR DESCRIPTION
- Fix to the emplace call in the context such that the in order list property is not lost from the cache.