### PR TITLE
[L0] Refactor to remove default constructor inits

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -147,8 +147,10 @@ ur_result_t createSyncPointAndGetZeEvents(
   UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
                                   SyncPointWaitList, ZeEventList));
   ur_event_handle_t LaunchEvent;
-  UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, HostVisible,
-                      &LaunchEvent, false, !CommandBuffer->IsProfilingEnabled));
+  UR_CALL(EventCreate(CommandBuffer->Context, nullptr /*Queue*/,
+                      false /*IsMultiDevice*/, HostVisible, &LaunchEvent,
+                      false /*CounterBasedEventEnabled*/,
+                      !CommandBuffer->IsProfilingEnabled));
   LaunchEvent->CommandType = CommandType;
   ZeLaunchEvent = LaunchEvent->ZeEvent;
 
@@ -326,22 +328,26 @@ void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
 
   // Release additional signal and wait events used by command_buffer
   if (SignalEvent) {
-    CleanupCompletedEvent(SignalEvent, false);
+    CleanupCompletedEvent(SignalEvent, false /*QueueLocked*/,
+                          false /*SetEventCompleted*/);
     urEventReleaseInternal(SignalEvent);
   }
   if (WaitEvent) {
-    CleanupCompletedEvent(WaitEvent, false);
+    CleanupCompletedEvent(WaitEvent, false /*QueueLocked*/,
+                          false /*SetEventCompleted*/);
     urEventReleaseInternal(WaitEvent);
   }
   if (AllResetEvent) {
-    CleanupCompletedEvent(AllResetEvent, false);
+    CleanupCompletedEvent(AllResetEvent, false /*QueueLocked*/,
+                          false /*SetEventCompleted*/);
     urEventReleaseInternal(AllResetEvent);
   }
 
   // Release events added to the command_buffer
   for (auto &Sync : SyncPoints) {
     auto &Event = Sync.second;
-    CleanupCompletedEvent(Event, false);
+    CleanupCompletedEvent(Event, false /*QueueLocked*/,
+                          false /*SetEventCompleted*/);
     urEventReleaseInternal(Event);
   }
 
@@ -514,12 +520,15 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   ur_event_handle_t WaitEvent;
   ur_event_handle_t AllResetEvent;
 
-  UR_CALL(EventCreate(Context, nullptr, false, false, &SignalEvent, false,
-                      !EnableProfiling));
-  UR_CALL(EventCreate(Context, nullptr, false, false, &WaitEvent, false,
-                      !EnableProfiling));
-  UR_CALL(EventCreate(Context, nullptr, false, false, &AllResetEvent, false,
-                      !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
+                      false /*HostVisible*/, &SignalEvent,
+                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
+                      false /*HostVisible*/, &WaitEvent,
+                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
+                      false /*HostVisible*/, &AllResetEvent,
+                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
   std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
                                                   AllResetEvent->ZeEvent};
 
@@ -1148,14 +1157,15 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
       // when `EventWaitList` dependencies are complete.
       ur_command_list_ptr_t WaitCommandList{};
       UR_CALL(Queue->Context->getAvailableCommandList(
-          Queue, WaitCommandList, false, NumEventsInWaitList, EventWaitList,
-          false));
+          Queue, WaitCommandList, false /*UseCopyEngine*/, NumEventsInWaitList,
+          EventWaitList, false /*AllowBatching*/, nullptr /*ForcedCmdQueue*/));
 
       ZE2UR_CALL(zeCommandListAppendBarrier,
                  (WaitCommandList->first, CommandBuffer->WaitEvent->ZeEvent,
                   CommandBuffer->WaitEvent->WaitList.Length,
                   CommandBuffer->WaitEvent->WaitList.ZeEventList));
-      Queue->executeCommandList(WaitCommandList, false, false);
+      Queue->executeCommandList(WaitCommandList, false /*IsBlocking*/,
+                                false /*OKToBatchCommand*/);
       MustSignalWaitEvent = false;
     }
   }
@@ -1267,9 +1277,9 @@ urCommandBufferEnqueueExp(ur_exp_command_buffer_handle_t CommandBuffer,
 
   // Create a command-list to signal the Event on completion
   ur_command_list_ptr_t SignalCommandList{};
-  UR_CALL(Queue->Context->getAvailableCommandList(Queue, SignalCommandList,
-                                                  false, NumEventsInWaitList,
-                                                  EventWaitList, false));
+  UR_CALL(Queue->Context->getAvailableCommandList(
+      Queue, SignalCommandList, false /*UseCopyEngine*/, NumEventsInWaitList,
+      EventWaitList, false /*AllowBatching*/, nullptr /*ForcedCmdQueue*/));
 
   // Reset the wait-event for the UR command-buffer that is signaled when its
   // submission dependencies have been satisfied.
@@ -1284,7 +1294,8 @@ urCommandBufferEnqueueExp(ur_exp_command_buffer_handle_t CommandBuffer,
   // parameter with signal command-list completing.
   UR_CALL(createUserEvent(CommandBuffer, Queue, SignalCommandList, Event));
 
-  UR_CALL(Queue->executeCommandList(SignalCommandList, false, false));
+  UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
+                                    false /*OKToBatchCommand*/));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -774,7 +774,7 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
                 .emplace(ZeCommandList,
                          ur_command_list_info_t(
                              ZeFence, true, false, ZeCommandQueue, ZeQueueDesc,
-                             Queue->useCompletionBatching(), true,
+                             Queue->useCompletionBatching(), true /*CanReuse */,
                              ZeCommandListIt->second.InOrderList,
                              ZeCommandListIt->second.IsImmediate))
                 .first;

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -302,8 +302,8 @@ struct ur_context_handle_t_ : _ur_object {
   ur_result_t getAvailableCommandList(
       ur_queue_handle_t Queue, ur_command_list_ptr_t &CommandList,
       bool UseCopyEngine, uint32_t NumEventsInWaitList,
-      const ur_event_handle_t *EventWaitList, bool AllowBatching = false,
-      ze_command_queue_handle_t *ForcedCmdQueue = nullptr);
+      const ur_event_handle_t *EventWaitList, bool AllowBatching,
+      ze_command_queue_handle_t *ForcedCmdQueue);
 
   // Checks if Device is covered by this context.
   // For that the Device or its root devices need to be in the context.

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -88,7 +88,8 @@ ur_result_t urEnqueueEventsWait(
     // Get a new command list to be used on this call
     ur_command_list_ptr_t CommandList{};
     UR_CALL(Queue->Context->getAvailableCommandList(
-        Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList));
+        Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
+        false /*AllowBatching*/, nullptr /*ForceCmdQueue*/));
 
     ze_event_handle_t ZeEvent = nullptr;
     ur_event_handle_t InternalEvent;
@@ -109,7 +110,8 @@ ur_result_t urEnqueueEventsWait(
 
     // Execute command list asynchronously as the event will be used
     // to track down its completion.
-    return Queue->executeCommandList(CommandList);
+    return Queue->executeCommandList(CommandList, false /*IsBlocking*/,
+                                     false /*OKToBatchCommand*/);
   }
 
   {
@@ -279,13 +281,14 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
     ur_command_list_ptr_t CmdList;
     UR_CALL(Queue->Context->getAvailableCommandList(
         Queue, CmdList, false /*UseCopyEngine=*/, NumEventsInWaitList,
-        EventWaitList, OkToBatch));
+        EventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
 
     // Insert the barrier into the command-list and execute.
     UR_CALL(insertBarrierIntoCmdList(CmdList, TmpWaitList, ResultEvent,
                                      IsInternal));
 
-    UR_CALL(Queue->executeCommandList(CmdList, false, OkToBatch));
+    UR_CALL(
+        Queue->executeCommandList(CmdList, false /*IsBlocking*/, OkToBatch));
 
     // Because of the dependency between commands in the in-order queue we don't
     // need to keep track of any active barriers if we have in-order queue.
@@ -354,7 +357,7 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
     ur_command_list_ptr_t CmdList;
     UR_CALL(Queue->Context->getAvailableCommandList(
         Queue, CmdList, false /*UseCopyEngine=*/, NumEventsInWaitList,
-        EventWaitList, OkToBatch));
+        EventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
     CmdLists.push_back(CmdList);
   }
 
@@ -404,7 +407,8 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
     // Only batch if the matching CmdList is already open.
     OkToBatch = CommandBatch.OpenCommandList == CmdList;
 
-    UR_CALL(Queue->executeCommandList(CmdList, false, OkToBatch));
+    UR_CALL(
+        Queue->executeCommandList(CmdList, false /*IsBlocking*/, OkToBatch));
   }
 
   UR_CALL(Queue->ActiveBarriers.clear());
@@ -716,7 +720,7 @@ ur_result_t urEnqueueTimestampRecordingExp(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(
       Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
-      /* AllowBatching */ false));
+      /* AllowBatching */ false, nullptr /*ForcedCmdQueue*/));
 
   UR_CALL(createEventAndAssociateQueue(
       Queue, OutEvent, UR_COMMAND_TIMESTAMP_RECORDING_EXP, CommandList,
@@ -740,7 +744,7 @@ ur_result_t urEnqueueTimestampRecordingExp(
               (*OutEvent)->WaitList.ZeEventList));
 
   UR_CALL(
-      Queue->executeCommandList(CommandList, Blocking, /* OkToBatch */ false));
+      Queue->executeCommandList(CommandList, Blocking, false /* OkToBatch */));
 
   return UR_RESULT_SUCCESS;
 }
@@ -816,7 +820,9 @@ urEventWait(uint32_t NumEvents, ///< [in] number of events in the event list
         else {
           // NOTE: we are cleaning up after the event here to free resources
           // sooner in case run-time is not calling urEventRelease soon enough.
-          CleanupCompletedEvent(reinterpret_cast<ur_event_handle_t>(Event));
+          CleanupCompletedEvent(reinterpret_cast<ur_event_handle_t>(Event),
+                                false /*QueueLocked*/,
+                                false /*SetEventCompleted*/);
           // For the case when we have out-of-order queue or regular command
           // lists its more efficient to check fences so put the queue in the
           // set to cleanup later.
@@ -884,7 +890,10 @@ ur_result_t urExtEventCreate(
     ur_event_handle_t
         *Event ///< [out] pointer to the handle of the event object created.
 ) {
-  UR_CALL(EventCreate(Context, nullptr, false, true, Event));
+  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
+                      true /*HostVisible*/, Event,
+                      false /*CounterBasedEventEnabled*/,
+                      false /*ForceDisableProfiling*/));
 
   (*Event)->RefCountExternal++;
   if (!(*Event)->CounterBasedEventsEnabled)
@@ -903,7 +912,10 @@ ur_result_t urEventCreateWithNativeHandle(
   // we dont have urEventCreate, so use this check for now to know that
   // the call comes from urEventCreate()
   if (reinterpret_cast<ze_event_handle_t>(NativeEvent) == nullptr) {
-    UR_CALL(EventCreate(Context, nullptr, false, true, Event));
+    UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
+                        true /*HostVisible*/, Event,
+                        false /*CounterBasedEventEnabled*/,
+                        false /*ForceDisableProfiling*/));
 
     (*Event)->RefCountExternal++;
     if (!(*Event)->CounterBasedEventsEnabled)
@@ -983,7 +995,8 @@ ur_result_t ur_event_handle_t_::getOrCreateHostVisibleEvent(
 
     ur_command_list_ptr_t CommandList{};
     UR_CALL(UrQueue->Context->getAvailableCommandList(
-        UrQueue, CommandList, false /* UseCopyEngine */, 0, nullptr, OkToBatch))
+        UrQueue, CommandList, false /* UseCopyEngine */, 0, nullptr, OkToBatch,
+        nullptr /*ForcedCmdQueue*/))
 
     // Create a "proxy" host-visible event.
     UR_CALL(createEventAndAssociateQueue(
@@ -1529,7 +1542,8 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
           // This prevents a potential deadlock with recursive
           // event locks.
           UR_CALL(Queue->Context->getAvailableCommandList(
-              Queue, CommandList, false, 0, nullptr, true));
+              Queue, CommandList, false /*UseCopyEngine*/, 0, nullptr,
+              true /*AllowBatching*/, nullptr /*ForcedCmdQueue*/));
         }
 
         std::shared_lock<ur_shared_mutex> Lock(EventList[I]->Mutex);

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -32,8 +32,8 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event);
 ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
                         bool IsMultiDevice, bool HostVisible,
                         ur_event_handle_t *RetEvent,
-                        bool CounterBasedEventEnabled = false,
-                        bool ForceDisableProfiling = false);
+                        bool CounterBasedEventEnabled,
+                        bool ForceDisableProfiling);
 } // extern "C"
 
 // This is an experimental option that allows to disable caching of events in
@@ -273,9 +273,8 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle);
 // the event, updates the last command event in the queue and cleans up all dep
 // events of the event.
 // If the caller locks queue mutex then it must pass 'true' to QueueLocked.
-ur_result_t CleanupCompletedEvent(ur_event_handle_t Event,
-                                  bool QueueLocked = false,
-                                  bool SetEventCompleted = false);
+ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
+                                  bool SetEventCompleted);
 
 // Get value of device scope events env var setting or default setting
 static const EventsScope DeviceEventsSetting = [] {

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -852,7 +852,7 @@ ur_result_t urBindlessImagesImageCopyExp(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(hQueue->Context->getAvailableCommandList(
       hQueue, CommandList, UseCopyEngine, numEventsInWaitList, phEventWaitList,
-      OkToBatch));
+      OkToBatch, nullptr /*ForcedCmdQueue*/));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent;

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -138,7 +138,7 @@ ur_result_t urEnqueueKernelLaunch(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(
       Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
-      true /* AllowBatching */));
+      true /* AllowBatching */, nullptr /*ForcedCmdQueue*/));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent{};
@@ -201,7 +201,8 @@ ur_result_t urEnqueueKernelLaunch(
 
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  UR_CALL(Queue->executeCommandList(CommandList, false, true));
+  UR_CALL(Queue->executeCommandList(CommandList, false /*IsBlocking*/,
+                                    true /*OKToBatchCommand*/));
 
   return UR_RESULT_SUCCESS;
 }
@@ -402,7 +403,7 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(
       Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
-      true /* AllowBatching */));
+      true /* AllowBatching */, nullptr /*ForcedCmdQueue*/));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent{};
@@ -465,7 +466,8 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
 
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  UR_CALL(Queue->executeCommandList(CommandList, false, true));
+  UR_CALL(Queue->executeCommandList(CommandList, false /*IsBlocking*/,
+                                    true /*OKToBatchCommand*/));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -150,10 +150,9 @@ private:
 };
 
 ur_result_t resetCommandLists(ur_queue_handle_t Queue);
-ur_result_t
-CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue, bool QueueLocked = false,
-                           bool QueueSynced = false,
-                           ur_event_handle_t CompletedEvent = nullptr);
+ur_result_t CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue,
+                                       bool QueueLocked, bool QueueSynced,
+                                       ur_event_handle_t CompletedEvent);
 
 // Structure describing the specific use of a command-list in a queue.
 // This is because command-lists are re-used across multiple queues
@@ -162,8 +161,8 @@ struct ur_command_list_info_t {
   ur_command_list_info_t(ze_fence_handle_t ZeFence, bool ZeFenceInUse,
                          bool IsClosed, ze_command_queue_handle_t ZeQueue,
                          ZeStruct<ze_command_queue_desc_t> ZeQueueDesc,
-                         bool UseCompletionBatching, bool CanReuse = true,
-                         bool IsInOrderList = false, bool IsImmediate = false)
+                         bool UseCompletionBatching, bool CanReuse,
+                         bool IsInOrderList, bool IsImmediate)
       : ZeFence(ZeFence), ZeFenceInUse(ZeFenceInUse), IsClosed(IsClosed),
         ZeQueue(ZeQueue), ZeQueueDesc(ZeQueueDesc),
         IsInOrderList(IsInOrderList), CanReuse(CanReuse),
@@ -528,8 +527,7 @@ struct ur_queue_handle_t_ : _ur_object {
   //
   // For immediate commandlists, no close and execute is necessary.
   ur_result_t executeCommandList(ur_command_list_ptr_t CommandList,
-                                 bool IsBlocking = false,
-                                 bool OKToBatchCommand = false);
+                                 bool IsBlocking, bool OKToBatchCommand);
 
   // Helper method telling whether we need to reuse discarded event in this
   // queue.


### PR DESCRIPTION
- Remove all the default constructor inits to address error prone code changes and force setting of options and flags individually.