### PR TITLE
[DeviceSanitizer] Unmap/Release virtual memory when there is no dependency

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.hpp
@@ -47,6 +47,10 @@ struct DeviceInfo {
 
     ur_mutex Mutex;
     std::queue<std::shared_ptr<AllocInfo>> Quarantine;
+    std::unordered_map<
+        uptr, std::pair<ur_physical_mem_handle_t,
+                        std::unordered_set<std::shared_ptr<AllocInfo>>>>
+        VirtualMemMaps;
     size_t QuarantineSize = 0;
 
     // Device handles are special and alive in the whole process lifetime,
@@ -173,8 +177,16 @@ class SanitizerInterceptor {
                                AllocType Type, void **ResultPtr);
     ur_result_t releaseMemory(ur_context_handle_t Context, void *Ptr);
 
+    ur_result_t
+    releasePhysicalMem(ur_context_handle_t Context,
+                       const std::vector<ur_device_handle_t> &Devices,
+                       std::shared_ptr<struct AllocInfo> AI);
+
     ur_result_t registerDeviceGlobals(ur_context_handle_t Context,
                                       ur_program_handle_t Program);
+
+    ur_result_t unregisterDeviceGlobals(ur_context_handle_t Context,
+                                        ur_program_handle_t Program);
 
     ur_result_t preLaunchKernel(ur_kernel_handle_t Kernel,
                                 ur_queue_handle_t Queue,

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -285,9 +285,9 @@ ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-ur_result_t UR_APICALL
-urProgramRelease(
-    ur_program_handle_t hProgram ///< [in][release] handle for the Program to release
+ur_result_t UR_APICALL urProgramRelease(
+    ur_program_handle_t
+        hProgram ///< [in][release] handle for the Program to release
 ) {
     auto pfnProgramRelease = getContext()->urDdiTable.Program.pfnRelease;
 

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -284,6 +284,28 @@ ur_result_t UR_APICALL urProgramLinkExp(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+/// @brief Intercept function for urProgramRelease
+ur_result_t UR_APICALL
+urProgramRelease(
+    ur_program_handle_t hProgram ///< [in][release] handle for the Program to release
+) {
+    auto pfnProgramRelease = getContext()->urDdiTable.Program.pfnRelease;
+
+    if (nullptr == pfnProgramRelease) {
+        return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+    }
+
+    UR_CALL(getContext()->interceptor->unregisterDeviceGlobals(
+        GetContext(hProgram), hProgram));
+
+    UR_CALL(pfnProgramRelease(hProgram));
+
+    getContext()->logger.debug("==== urProgramRelease");
+
+    return UR_RESULT_SUCCESS;
+}
+
+///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
 __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object


### PR DESCRIPTION
Now, we don't unmap/release virtual memory even if the corresponding USM is freed. This will cause device out of memory issue if a program runs for a long time.