### PR TITLE
[NFC] Warning squishing

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -512,7 +512,7 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
   // Create one event ZePool per MaxNumEventsPerPool events
   if (*ZePool == nullptr) {
     ze_event_pool_counter_based_exp_desc_t counterBasedExt = {
-        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC};
+        ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC, nullptr, 0};
     ZeStruct<ze_event_pool_desc_t> ZeEventPoolDesc;
     ZeEventPoolDesc.count = MaxNumEventsPerPool;
     ZeEventPoolDesc.flags = 0;

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1517,8 +1517,8 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
 
         std::shared_lock<ur_shared_mutex> Lock(EventList[I]->Mutex);
 
-        ur_device_handle_t QueueRootDevice;
-        ur_device_handle_t CurrentQueueRootDevice;
+        ur_device_handle_t QueueRootDevice = nullptr;
+        ur_device_handle_t CurrentQueueRootDevice = nullptr;
         if (Queue) {
           QueueRootDevice = Queue->Device;
           CurrentQueueRootDevice = CurQueueDevice;

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -16,6 +16,7 @@
 #include "sampler.hpp"
 #include "ur_interface_loader.hpp"
 #include "ur_level_zero.hpp"
+#include "ze_api.h"
 
 typedef ze_result_t(ZE_APICALL *zeImageGetDeviceOffsetExp_pfn)(
     ze_image_handle_t hImage, uint64_t *pDeviceOffset);
@@ -445,7 +446,8 @@ ur_result_t bindlessImagesCreateImpl(ur_context_handle_t hContext,
   ze_image_handle_t ZeImage;
 
   ze_memory_allocation_properties_t MemAllocProperties{
-      ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES};
+      ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES, nullptr,
+      ZE_MEMORY_TYPE_UNKNOWN, 0, 0};
   ZE2UR_CALL(zeMemGetAllocProperties,
              (hContext->ZeContext, reinterpret_cast<const void *>(hImageMem),
               &MemAllocProperties, nullptr));

--- a/source/adapters/level_zero/v2/event_provider_normal.cpp
+++ b/source/adapters/level_zero/v2/event_provider_normal.cpp
@@ -32,7 +32,7 @@ provider_pool::provider_pool(ur_context_handle_t context,
   desc.flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE;
 
   ze_event_pool_counter_based_exp_desc_t counterBasedExt = {
-      ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC, nullptr};
+      ZE_STRUCTURE_TYPE_COUNTER_BASED_EVENT_POOL_EXP_DESC, nullptr, 0};
 
   if (events == event_type::EVENT_COUNTER) {
     counterBasedExt.flags =

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -147,6 +147,7 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
     // We can exit early if we have in-order queue.
     if (!lastHandler)
       return ReturnValue(true);
+    [[fallthrough]];
   }
   default:
     logger::error(

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -560,19 +560,20 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                     const auto thirdDeviceId = getDeviceId(thirdPart);
                     deviceList.push_back(DeviceSpec{
                         DevicePartLevel::SUBSUB, hardwareType, firstDeviceId,
-                        secondDeviceId, thirdDeviceId});
+                        secondDeviceId, thirdDeviceId, nullptr});
                 } else {
                     // second dot not found, this is a subdevice
-                    deviceList.push_back(DeviceSpec{DevicePartLevel::SUB,
-                                                    hardwareType, firstDeviceId,
-                                                    secondDeviceId});
+                    deviceList.push_back(
+                        DeviceSpec{DevicePartLevel::SUB, hardwareType,
+                                   firstDeviceId, secondDeviceId, 0, nullptr});
                 }
             } else {
                 // first dot not found, this is a root device
                 const auto hardwareType = getRootHardwareType(filterString);
                 const auto firstDeviceId = getDeviceId(filterString);
                 deviceList.push_back(DeviceSpec{DevicePartLevel::ROOT,
-                                                hardwareType, firstDeviceId});
+                                                hardwareType, firstDeviceId, 0,
+                                                0, nullptr});
             }
         }
     }
@@ -587,8 +588,9 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
         // for example, we pretend that "garbage:0;!cuda:*" was just "!cuda:*"
         // so we add an implicit accept-all term (equivalent to prepending "*:*;")
         // as we would have done if the user had given us the corrected string
-        acceptDeviceList.push_back(DeviceSpec{
-            DevicePartLevel::ROOT, ::UR_DEVICE_TYPE_ALL, DeviceIdTypeALL});
+        acceptDeviceList.push_back(DeviceSpec{DevicePartLevel::ROOT,
+                                              ::UR_DEVICE_TYPE_ALL,
+                                              DeviceIdTypeALL, 0, 0, nullptr});
     }
 
     logger::debug("DEBUG: size of acceptDeviceList = {}",

--- a/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
+++ b/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
@@ -24,7 +24,8 @@ TEST_P(urLevelZeroKernelNativeHandleTest, OwnedHandleRelease) {
     auto kernel_name =
         uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
 
-    ze_module_desc_t moduleDesc = {ZE_STRUCTURE_TYPE_MODULE_DESC};
+    ze_module_desc_t moduleDesc{};
+    moduleDesc.stype = ZE_STRUCTURE_TYPE_MODULE_DESC;
     moduleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
     moduleDesc.inputSize = il_binary->size();
     moduleDesc.pInputModule =
@@ -36,7 +37,8 @@ TEST_P(urLevelZeroKernelNativeHandleTest, OwnedHandleRelease) {
                              &module, NULL),
               ZE_RESULT_SUCCESS);
 
-    ze_kernel_desc_t kernelDesc = {ZE_STRUCTURE_TYPE_KERNEL_DESC};
+    ze_kernel_desc_t kernelDesc{};
+    kernelDesc.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
     kernelDesc.pKernelName = kernel_name.c_str();
 
     ze_kernel_handle_t native_kernel;
@@ -75,7 +77,8 @@ TEST_P(urLevelZeroKernelNativeHandleTest, NullProgram) {
     auto kernel_name =
         uur::KernelsEnvironment::instance->GetEntryPointNames("foo")[0];
 
-    ze_module_desc_t moduleDesc = {ZE_STRUCTURE_TYPE_MODULE_DESC};
+    ze_module_desc_t moduleDesc{};
+    moduleDesc.stype = ZE_STRUCTURE_TYPE_MODULE_DESC;
     moduleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
     moduleDesc.inputSize = il_binary->size();
     moduleDesc.pInputModule =
@@ -87,7 +90,8 @@ TEST_P(urLevelZeroKernelNativeHandleTest, NullProgram) {
                              &module, NULL),
               ZE_RESULT_SUCCESS);
 
-    ze_kernel_desc_t kernelDesc = {ZE_STRUCTURE_TYPE_KERNEL_DESC};
+    ze_kernel_desc_t kernelDesc{};
+    kernelDesc.stype = ZE_STRUCTURE_TYPE_KERNEL_DESC;
     kernelDesc.pKernelName = kernel_name.c_str();
 
     ze_kernel_handle_t native_kernel;

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -17,7 +17,8 @@ TEST_P(urContextCreateTest, Success) {
 }
 
 TEST_P(urContextCreateTest, SuccessWithProperties) {
-    ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES};
+    ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES,
+                                       nullptr, 0};
     uur::raii::Context context = nullptr;
     ASSERT_SUCCESS(urContextCreate(1, &device, &properties, context.ptr()));
     ASSERT_NE(nullptr, context);

--- a/test/conformance/device_code/indexers_usm.cpp
+++ b/test/conformance/device_code/indexers_usm.cpp
@@ -3,6 +3,9 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+// Offsets are deprecated, but we should still test that they work
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 #include <sycl/sycl.hpp>
 
 int main() {

--- a/test/conformance/device_code/linker_error.cpp
+++ b/test/conformance/device_code/linker_error.cpp
@@ -3,17 +3,17 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 SYCL_EXTERNAL void this_function_does_not_exist();
 
 int main() {
-    cl::sycl::queue deviceQueue;
-    cl::sycl::range<1> numOfItems{1};
+    sycl::queue deviceQueue;
+    sycl::range<1> numOfItems{1};
 
     try {
-        deviceQueue.submit([&](cl::sycl::handler &cgh) {
-            auto kern = [=](cl::sycl::id<1>) {
+        deviceQueue.submit([&](sycl::handler &cgh) {
+            auto kern = [=](sycl::id<1>) {
 #ifdef __SYCL_DEVICE_ONLY__
                 this_function_does_not_exist();
 #endif

--- a/test/conformance/exp_command_buffer/fixtures.h
+++ b/test/conformance/exp_command_buffer/fixtures.h
@@ -154,7 +154,8 @@ struct urUpdatableCommandBufferExpExecutionTest
 
         // Create a command-buffer with update enabled.
         ur_exp_command_buffer_desc_t desc{
-            UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, nullptr, true};
+            UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, nullptr, true, false,
+            false};
 
         ASSERT_SUCCESS(urCommandBufferCreateExp(context, device, &desc,
                                                 &updatable_cmd_buf_handle));

--- a/test/conformance/program/urProgramCreateWithIL.cpp
+++ b/test/conformance/program/urProgramCreateWithIL.cpp
@@ -37,7 +37,8 @@ TEST_P(urProgramCreateWithILTest, Success) {
 }
 
 TEST_P(urProgramCreateWithILTest, SuccessWithProperties) {
-    ur_program_properties_t properties{UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES};
+    ur_program_properties_t properties{UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES,
+                                       nullptr, 0, nullptr};
     ur_program_handle_t program = nullptr;
     ASSERT_SUCCESS(urProgramCreateWithIL(
         context, il_binary->data(), il_binary->size(), &properties, &program));


### PR DESCRIPTION
This fixes some warnings picked up by GCC 11 and Clang 20 when -Wextra is set. Note that -Wextra is not currently set on any command line - I'll do that separately as part of a more general "hardening" commit.