### PR TITLE
[OpenCL] Use older OpenCL-Headers commit to fix build

### DIFF
--- a/source/adapters/opencl/CMakeLists.txt
+++ b/source/adapters/opencl/CMakeLists.txt
@@ -54,7 +54,7 @@ if(UR_OPENCL_INCLUDE_DIR)
 else()
     FetchContent_Declare(OpenCL-Headers
         GIT_REPOSITORY  "https://github.com/KhronosGroup/OpenCL-Headers.git"
-        GIT_TAG         main
+        GIT_TAG         1e193332d02e27e15812d24ff2a3a7a908eb92a3
     )
     FetchContent_MakeAvailable(OpenCL-Headers)
     FetchContent_GetProperties(OpenCL-Headers


### PR DESCRIPTION
Build in DPCPP is broken because of the below error caused by the upstream headers change.

Just use the previous commit from the one that breaks the build until the adapter code can be updated.

```
 In file included from /__w/llvm/llvm/build/_deps/unified-runtime-src/source/adapters/opencl/adapter.cpp:11:
/__w/llvm/llvm/build/_deps/unified-runtime-src/source/adapters/opencl/common.hpp:317:29: error: 'cl_mutable_base_config_khr' does not name a type; did you mean 'cl_mutable_dispatch_config_khr'?
  317 |                       const cl_mutable_base_config_khr *mutable_config);
```