### PR TITLE
[common] fixed some compilation warnings

### DIFF
--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -56,11 +56,11 @@ using provider_unique_handle_t =
         return UMF_RESULT_ERROR_NOT_SUPPORTED;                                 \
     }
 
-DEFINE_CHECK_OP(get_ipc_handle_size);
-DEFINE_CHECK_OP(get_ipc_handle);
-DEFINE_CHECK_OP(put_ipc_handle);
-DEFINE_CHECK_OP(open_ipc_handle);
-DEFINE_CHECK_OP(close_ipc_handle);
+DEFINE_CHECK_OP(get_ipc_handle_size)
+DEFINE_CHECK_OP(get_ipc_handle)
+DEFINE_CHECK_OP(put_ipc_handle)
+DEFINE_CHECK_OP(open_ipc_handle)
+DEFINE_CHECK_OP(close_ipc_handle)
 
 #define UMF_ASSIGN_OP(ops, type, func, default_return)                         \
     ops.func = [](void *obj, auto... args) {                                   \

--- a/test/conformance/cts_exe.py
+++ b/test/conformance/cts_exe.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     result = subprocess.Popen([args.test_command, '--gtest_brief=1',        # nosec B603
                                f'--devices_count={args.devices_count}',
                                f'--platforms_count={args.platforms_count}'],
-                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
 
     pat = re.compile(r'\[( )*FAILED( )*\]')
     output_list = []

--- a/test/layers/validation/fixtures.hpp
+++ b/test/layers/validation/fixtures.hpp
@@ -128,7 +128,7 @@ struct valAllDevicesTest : valPlatformTest {
 
 // We use this to avoid segfaults in the mock adapter when we're doing stuff
 // like double releases in the leak detection tests.
-inline ur_result_t genericSuccessCallback(void *) { return UR_RESULT_SUCCESS; };
+inline ur_result_t genericSuccessCallback(void *) { return UR_RESULT_SUCCESS; }
 
 // This returns valid (non-null) handles that we can safely leak.
 inline ur_result_t fakeContext_urContextCreate(void *pParams) {


### PR DESCRIPTION
- excessive semicolons
- unused variables
- use python3.6 friendly "universal_newlines" alias instead of "text" param