### PR TITLE
fix ur_bool_t printing

### DIFF
--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -17403,6 +17403,11 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     return os;
 }
 
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const ur_bool_t value) {
+    os << (value ? "true" : "false");
+    return os;
+}
+
 namespace ur::details {
 ///////////////////////////////////////////////////////////////////////////////
 // @brief Print pointer value

--- a/scripts/templates/print.hpp.mako
+++ b/scripts/templates/print.hpp.mako
@@ -411,6 +411,11 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
 %endfor
 %endfor
 
+inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const ur_bool_t value) {
+    os << (value ? "true" : "false");
+    return os;
+}
+
 namespace ${x}::details {
 ///////////////////////////////////////////////////////////////////////////////
 // @brief Print pointer value

--- a/test/unit/utils/params.cpp
+++ b/test/unit/utils/params.cpp
@@ -27,3 +27,17 @@ TEST(PrintPtr, nested_void_ptrs) {
     ur::details::printPtr(out, pppreal);
     EXPECT_THAT(out.str(), MatchesRegex(".+ \\(.+ \\(.+ \\(.+\\)\\)\\)"));
 }
+
+TEST(PrintBool, False) {
+    ur_bool_t value = false;
+    std::ostringstream out;
+    out << value;
+    EXPECT_STREQ(out.str().data(), "false");
+}
+
+TEST(PrintBool, True) {
+    ur_bool_t value = 1;
+    std::ostringstream out;
+    out << value;
+    EXPECT_STREQ(out.str().data(), "true");
+}


### PR DESCRIPTION
Bool values were printed as ascii characters with code 0 or 1, leading to artifacts. This patch fixes this by printing either 'false' or 'true', depending on the bool's value.

This has been annoying me a while when analyzing logs from SYCL apps.