### PR TITLE
Fix XPTI initialization bug

### DIFF
--- a/source/loader/layers/tracing/ur_tracing_layer.cpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.cpp
@@ -34,14 +34,15 @@ struct XptiContextManager {
     ~XptiContextManager() { xptiFrameworkFinalize(); }
 };
 
-static std::shared_ptr<XptiContextManager> xptiContextManagerGlobal = [] {
-    return std::make_shared<XptiContextManager>();
-}();
+static std::shared_ptr<XptiContextManager> xptiContextManagerGet() {
+    static auto contextManager = std::make_shared<XptiContextManager>();
+    return contextManager;
+};
 static thread_local xpti_td *activeEvent;
 
 ///////////////////////////////////////////////////////////////////////////////
 context_t::context_t() : logger(logger::create_logger("tracing", true, true)) {
-    this->xptiContextManager = xptiContextManagerGlobal;
+    this->xptiContextManager = xptiContextManagerGet();
 
     call_stream_id = xptiRegisterStream(CALL_STREAM_NAME);
     std::ostringstream streamv;


### PR DESCRIPTION
Due to a possible race between constructor and a global variable initialization, the ur.call XPTI stream would not be visible to components linking with UR.