### PR TITLE
[L0] Fix urEnqueueEventsWaitWithBarrier for driver in order lists

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -530,6 +530,8 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
         counterBasedExt.flags =
             ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE;
       }
+      logger::debug("ze_event_pool_desc_t counter based flags set to: {}",
+                    counterBasedExt.flags);
       ZeEventPoolDesc.pNext = &counterBasedExt;
     }
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -196,7 +196,9 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
         //
         if (Queue->isInOrderQueue() && InOrderBarrierBySignal &&
             !Queue->isProfilingEnabled()) {
-          if (EventWaitList.Length) {
+          // If we are using driver in order lists, then append wait on events
+          // is unnecessary and we can signal the event created.
+          if (EventWaitList.Length && !CmdList->second.IsInOrderList) {
             ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
                        (CmdList->first, EventWaitList.Length,
                         EventWaitList.ZeEventList));

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -2386,6 +2386,7 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
   ZeCommandQueueDesc.ordinal = QueueOrdinal;
   ZeCommandQueueDesc.index = QueueIndex;
   ZeCommandQueueDesc.mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS;
+  bool isInOrderList = false;
   const char *Priority = "Normal";
   if (Queue->isPriorityLow()) {
     ZeCommandQueueDesc.priority = ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_LOW;
@@ -2401,6 +2402,7 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
   }
 
   if (Queue->Device->useDriverInOrderLists() && Queue->isInOrderQueue()) {
+    isInOrderList = true;
     ZeCommandQueueDesc.flags |= ZE_COMMAND_QUEUE_FLAG_IN_ORDER;
   }
 
@@ -2449,7 +2451,7 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
               ZeCommandList,
               ur_command_list_info_t(
                   nullptr, true, false, nullptr, ZeCommandQueueDesc,
-                  Queue->useCompletionBatching(), true, false, true)})
+                  Queue->useCompletionBatching(), true, isInOrderList, true)})
           .first;
 
   return ImmCmdLists[Index];


### PR DESCRIPTION
- Fix urEnqueueEventsWaitWithBarrier to avoid appending a wait on events given a waitlist, but driver in order lists.
- Driver in order lists gurantees this implicitly and is not needed.