### PR TITLE
Fix Windows CTS with kernels build

### DIFF
--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -450,15 +450,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       URValue[i].type = static_cast<ur_device_partition_t>(CLValue[0]);
       switch (URValue[i].type) {
       case UR_DEVICE_PARTITION_EQUALLY: {
-        URValue[i].value.equally = CLValue[i + 1];
+        URValue[i].value.equally = static_cast<uint32_t>(CLValue[i + 1]);
         break;
       }
       case UR_DEVICE_PARTITION_BY_COUNTS: {
-        URValue[i].value.count = CLValue[i + 1];
+        URValue[i].value.count = static_cast<uint32_t>(CLValue[i + 1]);
         break;
       }
       case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN: {
-        URValue[i].value.affinity_domain = CLValue[i + 1];
+        URValue[i].value.affinity_domain =
+            static_cast<uint32_t>(CLValue[i + 1]);
         break;
       }
       default: {

--- a/source/adapters/opencl/kernel.cpp
+++ b/source/adapters/opencl/kernel.cpp
@@ -302,7 +302,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
 
   switch (propName) {
   case UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS: {
-    if (*(static_cast<const ur_bool_t *>(pPropValue)) == true) {
+    if (*(static_cast<const ur_bool_t *>(pPropValue))) {
       UR_RETURN_ON_FAILURE(usmSetIndirectAccess(hKernel));
     }
     return UR_RESULT_SUCCESS;

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -3,6 +3,7 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <array>
 #include <uur/fixtures.h>
 
 struct urEnqueueKernelLaunchTest : uur::urKernelExecutionTest {

--- a/test/conformance/exp_command_buffer/buffer_saxpy_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/buffer_saxpy_kernel_update.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include <array>
 
 // Test that updating a command-buffer with a single kernel command
 // taking buffer & scalar arguments works correctly.

--- a/test/conformance/exp_command_buffer/commands.cpp
+++ b/test/conformance/exp_command_buffer/commands.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include <array>
 
 struct urCommandBufferCommandsTest
     : uur::command_buffer::urCommandBufferExpTest {

--- a/test/conformance/exp_command_buffer/ndrange_update.cpp
+++ b/test/conformance/exp_command_buffer/ndrange_update.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include <array>
 #include <cstring>
 
 // Test that updating a command-buffer with a single kernel command

--- a/test/conformance/exp_command_buffer/usm_fill_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/usm_fill_kernel_update.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include <array>
 #include <cstring>
 
 // Test that updating a command-buffer with a single kernel command

--- a/test/conformance/exp_command_buffer/usm_saxpy_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/usm_saxpy_kernel_update.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "fixtures.h"
+#include <array>
 #include <cstring>
 
 // Test that updating a command-buffer with a single kernel command

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -3,6 +3,7 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <array>
 #include <uur/fixtures.h>
 
 using urKernelGetGroupInfoTest =


### PR DESCRIPTION
- Include array header when using std::array
- Make potentially lossy implicit conversions explicit
