### PR TITLE
[Cuda] Save the Cuda native error code on adapter-specific errors

### DIFF
--- a/source/adapters/cuda/adapter.cpp
+++ b/source/adapters/cuda/adapter.cpp
@@ -91,7 +91,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
-  std::ignore = pError;
+  *pError = ErrorAdapterNativeCode;
   *ppMessage = ErrorMessage;
   return ErrorMessageCode;
 }

--- a/source/adapters/cuda/common.hpp
+++ b/source/adapters/cuda/common.hpp
@@ -35,12 +35,13 @@ std::string getCudaVersionString();
 constexpr size_t MaxMessageSize = 256;
 extern thread_local ur_result_t ErrorMessageCode;
 extern thread_local char ErrorMessage[MaxMessageSize];
+extern thread_local int32_t ErrorAdapterNativeCode;
 
 // Utility function for setting a message and warning
 [[maybe_unused]] void setErrorMessage(const char *pMessage,
                                       ur_result_t ErrorCode);
 
-void setPluginSpecificMessage(CUresult cu_res);
+void setAdapterSpecificMessage(CUresult cu_res);
 
 /// ------ Error handling, matching OpenCL plugin semantics.
 namespace detail {


### PR DESCRIPTION
This `ErrorAdapterNativeCode` can be used to propage the native error code values up the stack from unified-runtime when calling `urAdapterGetLastError`, if needed. This can be helpful in DPC++ sycl runtime exception handling, similarly to how the already handily setup `setAdapterSpecificMessage` also preserves the native error code by appending it to an error message buffer.