### PR TITLE
[L0] Fix urEnqueueDeviceGlobalVariableWrite to use device specific mo…

### DIFF
--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -494,11 +494,19 @@ ur_result_t urEnqueueDeviceGlobalVariableWrite(
 ) {
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
+  ze_module_handle_t ZeModule{};
+  auto It = Program->ZeModuleMap.find(Queue->Device->ZeDevice);
+  if (It != Program->ZeModuleMap.end()) {
+    ZeModule = It->second;
+  } else {
+    ZeModule = Program->ZeModule;
+  }
+
   // Find global variable pointer
   size_t GlobalVarSize = 0;
   void *GlobalVarPtr = nullptr;
   ZE2UR_CALL(zeModuleGetGlobalPointer,
-             (Program->ZeModule, Name, &GlobalVarSize, &GlobalVarPtr));
+             (ZeModule, Name, &GlobalVarSize, &GlobalVarPtr));
   if (GlobalVarSize < Offset + Count) {
     setErrorMessage("Write device global variable is out of range.",
                     UR_RESULT_ERROR_INVALID_VALUE,


### PR DESCRIPTION
…dules

- Fixed urEnqueueDeviceGlobalVariableWrite to check the map for a device specific module for the device used by the queue if it exists, otherwise use the ZeModule in the Program handle.