### PR TITLE
[L0] Fix Counter Based Event Default signal given placeholder

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1546,8 +1546,13 @@ ur_result_t _ur_ze_event_list_t::createAndRetainUrZeEventList(
 
           ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
                      (ZeCommandList, 1u, &EventList[I]->ZeEvent));
-          if (!MultiDeviceEvent->CounterBasedEventsEnabled)
+          if (!MultiDeviceEvent->CounterBasedEventsEnabled) {
             ZE2UR_CALL(zeEventHostSignal, (MultiDeviceZeEvent));
+          } else {
+            ZE2UR_CALL(zeCommandListAppendSignalEvent,
+                       (ZeCommandList, MultiDeviceZeEvent));
+          }
+          MultiDeviceEvent->Completed = true;
 
           UR_CALL(Queue->executeCommandList(CommandList, /* IsBlocking */ false,
                                             /* OkToBatchCommand */ true));


### PR DESCRIPTION
- When a counter based event is created and is expected to be already signalled, then those events either need to be labelled as Completed==true or they need to be signalled on the device vs the host.
- Now, all places where host signal was skipped, those events are marked "Completed" such that those events will be skipped in the waitlist and in the case of the multi device, the event will be signalled on the device as part of the execute with the previous waitlist.