### PR TITLE
Deterministic mode and improvements for match.py

### DIFF
--- a/cmake/match.py
+++ b/cmake/match.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2023 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -12,6 +12,8 @@
 # List of available special tags:
 # {{OPT}}    - makes content in the same line as the tag optional
 # {{IGNORE}} - ignores all content until the next successfully matched line or the end of the input
+# {{NONDETERMINISTIC}} - order of match rules isn't important - each (non OPT) input line is paired with a match line
+# in any order
 # Special tags are mutually exclusive and are expected to be located at the start of a line.
 #
 
@@ -20,15 +22,25 @@ import sys
 import re
 from enum import Enum
 
+## @brief print a sequence of lines
+def print_lines(lines, hint = None):
+    counter = 1
+    for l in lines:
+        hint_char = " "
+        if hint == counter - 1:
+            hint_char = ">"
+        print("{}{:4d}| {}".format(hint_char, counter, l.strip()))
+        counter += 1
+
 
 ## @brief print the whole content of input and match files
-def print_content(input_lines, match_lines, ignored_lines):
-    print("--- Input Lines " + "-" * 64)
-    print("".join(input_lines).strip())
-    print("--- Match Lines " + "-" * 64)
-    print("".join(match_lines).strip())
-    print("--- Ignored Lines " + "-" * 62)
-    print("".join(ignored_lines).strip())
+def print_content(input_lines, match_lines, ignored_lines, hint_input = None, hint_match = None):
+    print("------ Input Lines " + "-" * 61)
+    print_lines(input_lines, hint_input)
+    print("------ Match Lines " + "-" * 61)
+    print_lines(match_lines, hint_match)
+    print("------ Ignored Lines " + "-" * 59)
+    print_lines(ignored_lines)
     print("-" * 80)
 
 
@@ -37,6 +49,24 @@ def print_incorrect_match(match_line, present, expected):
     print("Line " + str(match_line) + " does not match")
     print("is:       " + present)
     print("expected: " + expected)
+
+
+## @brief print missing match line
+def print_input_not_found(input_line, input):
+    print("Input line " + str(input_line) + " has no match line")
+    print("is:       " + input)
+
+
+## @brief print missing input line
+def print_match_not_found(match_line, input):
+    print("Match line " + str(match_line) + " has no input line")
+    print("is:       " + input)
+
+
+## @brief print general syntax error
+def print_error(text, match_line):
+    print("Line " + str(match_line) + " encountered an error")
+    print(text)
 
 
 ## @brief pattern matching script status values
@@ -63,6 +93,7 @@ def check_status(input_lines, match_lines):
 class Tag(Enum):
     OPT = "{{OPT}}"         # makes the line optional
     IGNORE = "{{IGNORE}}"   # ignores all input until next match or end of input file
+    NONDETERMINISTIC = "{{NONDETERMINISTIC}}" # switches on "deterministic mode"
     COMMENT = "#"           # comment - line ignored
 
 
@@ -88,32 +119,53 @@ def main():
         )
 
     ignored_lines = []
+    matched_lines = set()
 
     input_idx = 0
     match_idx = 0
     tags_in_effect = []
+    deterministic_mode = False
     while True:
         # check file status
         status = check_status(input_lines[input_idx:], match_lines[match_idx:])
-        if (status == Status.INPUT_AND_MATCH_END) or (status == Status.MATCH_END and Tag.IGNORE in tags_in_effect):
-            # all lines matched or the last line in match file is an ignore tag
-            sys.exit(0)
-        elif status == Status.MATCH_END:
-            print_incorrect_match(match_idx + 1, input_lines[input_idx].strip(), "");
-            print_content(input_lines, match_lines, ignored_lines)
-            sys.exit(1)
-        elif status == Status.INPUT_END:
-        # If we get to the end of the input, but still have pending matches,
-        # then that's a failure unless all pending matches are optional -
-        # otherwise we're done
-            while match_idx < len(match_lines):
-                if not (match_lines[match_idx].startswith(Tag.OPT.value) or
-                        match_lines[match_idx].startswith(Tag.IGNORE.value)):
-                    print_incorrect_match(match_idx + 1, "", match_lines[match_idx]);
-                    print_content(input_lines, match_lines, ignored_lines)
+        if deterministic_mode:
+            if status == Status.INPUT_END:
+                # Convert the list of seen matches to the list of unseen matches
+                remaining_matches = set(range(len(match_lines))) - matched_lines
+                for m in remaining_matches:
+                    line = match_lines[m]
+                    if line.startswith(Tag.OPT.value) or line.startswith(Tag.NONDETERMINISTIC.value):
+                        continue
+                    print_match_not_found(m + 1, match_lines[m])
+                    print_content(input_lines, match_lines, ignored_lines, hint_match=m)
                     sys.exit(1)
-                match_idx += 1
-            sys.exit(0)
+
+                sys.exit(0)
+            elif status == Status.MATCH_END:
+                print_input_not_found(input_idx + 1, input_lines[input_idx])
+                print_content(input_lines, match_lines, ignored_lines, hint_input=input_idx)
+                sys.exit(1)
+        else:
+            if (status == Status.INPUT_AND_MATCH_END) or (status == Status.MATCH_END and Tag.IGNORE in tags_in_effect):
+                # all lines matched or the last line in match file is an ignore tag
+                sys.exit(0)
+            elif status == Status.MATCH_END:
+                print_incorrect_match(input_idx + 1, input_lines[input_idx].strip(), "")
+                print_content(input_lines, match_lines, ignored_lines, hint_input=input_idx)
+                sys.exit(1)
+            elif status == Status.INPUT_END:
+            # If we get to the end of the input, but still have pending matches,
+            # then that's a failure unless all pending matches are optional -
+            # otherwise we're done
+                while match_idx < len(match_lines):
+                    if not (match_lines[match_idx].startswith(Tag.OPT.value) or
+                            match_lines[match_idx].startswith(Tag.IGNORE.value) or
+                            match_lines[match_idx].startswith(Tag.NONDETERMINISTIC.value)):
+                        print_incorrect_match(match_idx + 1, "", match_lines[match_idx])
+                        print_content(input_lines, match_lines, ignored_lines, hint_match=match_idx)
+                        sys.exit(1)
+                    match_idx += 1
+                sys.exit(0)
 
         input_line = input_lines[input_idx].strip() if input_idx < len(input_lines) else ""
         match_line = match_lines[match_idx]
@@ -122,7 +174,15 @@ def main():
         if match_line.startswith(Tag.OPT.value):
             tags_in_effect.append(Tag.OPT)
             match_line = match_line[len(Tag.OPT.value):]
+        elif match_line.startswith(Tag.NONDETERMINISTIC.value) and not deterministic_mode:
+            deterministic_mode = True
+            match_idx = 0
+            input_idx = 0
+            continue
         elif match_line.startswith(Tag.IGNORE.value):
+            if deterministic_mode:
+                print_error(r"Can't use \{{IGNORE\}} in deterministic mode")
+                sys.exit(2)
             tags_in_effect.append(Tag.IGNORE)
             match_idx += 1
             continue # line with ignore tag should be skipped
@@ -137,20 +197,29 @@ def main():
                 pattern += part
 
         # match or process tags
-        if re.fullmatch(pattern, input_line):
-            input_idx += 1
-            match_idx += 1
-            tags_in_effect = []
-        elif Tag.OPT in tags_in_effect:
-            match_idx += 1
-            tags_in_effect.remove(Tag.OPT)
-        elif Tag.IGNORE in tags_in_effect:
-            ignored_lines.append(input_line + os.linesep)
-            input_idx += 1
+        if deterministic_mode:
+            if re.fullmatch(pattern, input_line) and match_idx not in matched_lines:
+                input_idx += 1
+                matched_lines.add(match_idx)
+                match_idx = 0
+                tags_in_effect = []
+            else:
+                match_idx += 1
         else:
-            print_incorrect_match(match_idx + 1, input_line, match_line.strip())
-            print_content(input_lines, match_lines, ignored_lines)
-            sys.exit(1)
+            if re.fullmatch(pattern, input_line):
+                input_idx += 1
+                match_idx += 1
+                tags_in_effect = []
+            elif Tag.OPT in tags_in_effect:
+                match_idx += 1
+                tags_in_effect.remove(Tag.OPT)
+            elif Tag.IGNORE in tags_in_effect:
+                ignored_lines.append(input_line + os.linesep)
+                input_idx += 1
+            else:
+                print_incorrect_match(match_idx + 1, input_line, match_line.strip())
+                print_content(input_lines, match_lines, ignored_lines, hint_match=match_idx, hint_input=input_idx)
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/test/conformance/adapter/adapter_adapter_native_cpu.match
+++ b/test/conformance/adapter/adapter_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urAdapterGetLastErrorTest.Success
 urAdapterGetLastErrorTest.InvalidHandle
 urAdapterGetLastErrorTest.InvalidMessagePtr

--- a/test/conformance/context/context_adapter_level_zero.match
+++ b/test/conformance/context/context_adapter_level_zero.match
@@ -1,2 +1,3 @@
+{{NONDETERMINISTIC}}
 urContextCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urContextSetExtendedDeleterTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/context/context_adapter_level_zero_v2.match
+++ b/test/conformance/context/context_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urContextCreateWithNativeHandleTest.InvalidNullHandleAdapter/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}__
 urContextCreateWithNativeHandleTest.InvalidNullPointerContext/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}__
 urContextSetExtendedDeleterTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}__

--- a/test/conformance/context/context_adapter_native_cpu.match
+++ b/test/conformance/context/context_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urContextCreateWithNativeHandleTest.InvalidNullHandleAdapter/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urContextCreateWithNativeHandleTest.InvalidNullPointerContext/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urContextSetExtendedDeleterTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/device/device_adapter_cuda.match
+++ b/test/conformance/device/device_adapter_cuda.match
@@ -1,2 +1,3 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime

--- a/test/conformance/device/device_adapter_hip.match
+++ b/test/conformance/device/device_adapter_hip.match
@@ -1,2 +1,3 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime

--- a/test/conformance/device/device_adapter_level_zero.match
+++ b/test/conformance/device/device_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_GLOBAL_MEM_FREE

--- a/test/conformance/device/device_adapter_level_zero_v2.match
+++ b/test/conformance/device/device_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime
 {{OPT}}urDeviceGetInfoTest.Success/UR_DEVICE_INFO_GLOBAL_MEM_FREE

--- a/test/conformance/device/device_adapter_native_cpu.match
+++ b/test/conformance/device/device_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.InvalidNullHandlePlatform
 urDeviceCreateWithNativeHandleTest.InvalidNullPointerDevice
 {{OPT}}urDeviceGetGlobalTimestampTest.SuccessSynchronizedTime

--- a/test/conformance/device/device_adapter_opencl.match
+++ b/test/conformance/device/device_adapter_opencl.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urDeviceCreateWithNativeHandleTest.SuccessWithUnOwnedNativeHandle

--- a/test/conformance/enqueue/enqueue_adapter_cuda.match
+++ b/test/conformance/enqueue/enqueue_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEnqueueKernelLaunchTest.InvalidKernelArgs/NVIDIA_CUDA_BACKEND___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.NonMatchingLocalSize/NVIDIA_CUDA_BACKEND___{{.*}}_
 urEnqueueKernelLaunchKernelSubGroupTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}_

--- a/test/conformance/enqueue/enqueue_adapter_hip.match
+++ b/test/conformance/enqueue/enqueue_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 # HIP can't check kernel arguments
 urEnqueueKernelLaunchTest.InvalidKernelArgs/AMD_HIP_BACKEND___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.NonMatchingLocalSize/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/enqueue/enqueue_adapter_level_zero.match
+++ b/test/conformance/enqueue/enqueue_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urEnqueueEventsWaitTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchTest.InvalidKernelArgs/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchKernelWgSizeTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/enqueue/enqueue_adapter_level_zero_v2.match
+++ b/test/conformance/enqueue/enqueue_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urEnqueueKernelLaunchTest.InvalidKernelArgs/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/enqueue/enqueue_adapter_native_cpu.match
+++ b/test/conformance/enqueue/enqueue_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.InvalidNullHandleQueue/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__OpenCL___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.Success/Intel_R__OpenCL___{{.*}}_
 urEnqueueKernelLaunchKernelSubGroupTest.Success/Intel_R__OpenCL___{{.*}}_

--- a/test/conformance/event/event_adapter_cuda.match
+++ b/test/conformance/event/event_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEventGetProfilingInfoTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_PROFILING_INFO_COMMAND_COMPLETE
 urEventGetProfilingInfoWithTimingComparisonTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}_
 urEventSetCallbackTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}_

--- a/test/conformance/event/event_adapter_hip.match
+++ b/test/conformance/event/event_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEventGetProfilingInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_PROFILING_INFO_COMMAND_COMPLETE
 urEventGetProfilingInfoWithTimingComparisonTest.Success/AMD_HIP_BACKEND___{{.*}}_
 urEventSetCallbackTest.Success/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/event/event_adapter_level_zero.match
+++ b/test/conformance/event/event_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urEventGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_EVENT_INFO_COMMAND_TYPE
 {{OPT}}urEventGetProfilingInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_PROFILING_INFO_COMMAND_QUEUED
 {{OPT}}urEventGetProfilingInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_PROFILING_INFO_COMMAND_SUBMIT

--- a/test/conformance/event/event_adapter_level_zero_v2.match
+++ b/test/conformance/event/event_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEventGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_EVENT_INFO_COMMAND_QUEUE
 urEventGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_EVENT_INFO_CONTEXT
 urEventGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_EVENT_INFO_COMMAND_TYPE

--- a/test/conformance/event/event_adapter_native_cpu.match
+++ b/test/conformance/event/event_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urEventGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_EVENT_INFO_COMMAND_QUEUE
 urEventGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_EVENT_INFO_CONTEXT
 urEventGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_EVENT_INFO_COMMAND_TYPE

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_level_zero_v2.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 BufferFillCommandTest.UpdateParameters/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 BufferFillCommandTest.UpdateGlobalSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 BufferFillCommandTest.SeparateUpdateCalls/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}BufferFillCommandTest.UpdateParameters/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}BufferFillCommandTest.UpdateGlobalSize/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}BufferFillCommandTest.SeparateUpdateCalls/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/exp_enqueue_native/exp_enqueue_native_adapter_level_zero_v2.match
+++ b/test/conformance/exp_enqueue_native/exp_enqueue_native_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urLevelZeroEnqueueNativeCommandTest.Success{{.*}}
 urLevelZeroEnqueueNativeCommandTest.Dependencies{{.*}}
 urLevelZeroEnqueueNativeCommandTest.DependenciesURBefore{{.*}}

--- a/test/conformance/exp_launch_properties/exp_launch_properties_adapter_native_cpu.match
+++ b/test/conformance/exp_launch_properties/exp_launch_properties_adapter_native_cpu.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urEnqueueKernelLaunchCustomTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/integration/integration_adapter_level_zero.match
+++ b/test/conformance/integration/integration_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___IN_ORDER_QUEUE
 {{OPT}}QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___OUT_OF_ORDER_QUEUE
 {{OPT}}QueueUSMTestWithParam.QueueUSMTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___IN_ORDER_QUEUE

--- a/test/conformance/integration/integration_adapter_level_zero_v2.match
+++ b/test/conformance/integration/integration_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___IN_ORDER_QUEUE
 {{OPT}}QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___OUT_OF_ORDER_QUEUE
 {{OPT}}QueueUSMTestWithParam.QueueUSMTest/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___IN_ORDER_QUEUE

--- a/test/conformance/integration/integration_adapter_native_cpu.match
+++ b/test/conformance/integration/integration_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__IN_ORDER_QUEUE
 QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__OUT_OF_ORDER_QUEUE
 QueueUSMTestWithParam.QueueUSMTest/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__IN_ORDER_QUEUE

--- a/test/conformance/integration/integration_adapter_opencl.match
+++ b/test/conformance/integration/integration_adapter_opencl.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__OpenCL___{{.*}}___IN_ORDER_QUEUE
 QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__OpenCL___{{.*}}___OUT_OF_ORDER_QUEUE
 QueueUSMTestWithParam.QueueUSMTest/Intel_R__OpenCL___{{.*}}___IN_ORDER_QUEUE

--- a/test/conformance/kernel/kernel_adapter_cuda.match
+++ b/test/conformance/kernel/kernel_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urKernelGetGroupInfoWgSizeTest.CompileWorkGroupSize/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urKernelSetArgLocalTest.InvalidKernelArgumentIndex/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urKernelSetArgMemObjTest.InvalidKernelArgumentIndex/NVIDIA_CUDA_BACKEND___{{.*}}_

--- a/test/conformance/kernel/kernel_adapter_hip.match
+++ b/test/conformance/kernel/kernel_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urKernelGetGroupInfoWgSizeTest.CompileWorkGroupSize/AMD_HIP_BACKEND___{{.*}}_
 urKernelGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}___UR_KERNEL_INFO_NUM_REGS
 urKernelSetArgLocalTest.InvalidKernelArgumentIndex/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/kernel/kernel_adapter_level_zero.match
+++ b/test/conformance/kernel/kernel_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urKernelSetExecInfoTest.SuccessIndirectAccess/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urKernelSetExecInfoUSMPointersTest.SuccessHost/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urKernelSetExecInfoUSMPointersTest.SuccessDevice/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/kernel/kernel_adapter_level_zero_v2.match
+++ b/test/conformance/kernel/kernel_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urKernelGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_KERNEL_INFO_FUNCTION_NAME
 urKernelGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_KERNEL_INFO_NUM_ARGS
 urKernelGetInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_KERNEL_INFO_REFERENCE_COUNT

--- a/test/conformance/kernel/kernel_adapter_native_cpu.match
+++ b/test/conformance/kernel/kernel_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urKernelCreateTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelCreateTest.InvalidNullHandleProgram/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urKernelCreateTest.InvalidNullPointerName/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/kernel/kernel_adapter_opencl.match
+++ b/test/conformance/kernel/kernel_adapter_opencl.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urKernelGetInfoTest.Success/Intel_R__OpenCL_{{.*}}_UR_KERNEL_INFO_NUM_REGS

--- a/test/conformance/memory/memory_adapter_cuda.match
+++ b/test/conformance/memory/memory_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urMemImageCreateTest.InvalidSize/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urMemImageCremBufferCrateTestWith1DMemoryTypeParam.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_TYPE_IMAGE1D_ARRAY
 {{OPT}}urMemImageCreateTestWith2DMemoryTypeParam.Success/NVIDIA_CUDA_BACKEND___{{.*}}___UR_MEM_TYPE_IMAGE2D_ARRAY

--- a/test/conformance/memory/memory_adapter_hip.match
+++ b/test/conformance/memory/memory_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urMemImageCreateTest.InvalidSize/AMD_HIP_BACKEND___{{.*}}
 urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}
 urMemImageGetInfoTest.Success/AMD_HIP_BACKEND___{{.*}}

--- a/test/conformance/memory/memory_adapter_level_zero.match
+++ b/test/conformance/memory/memory_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urMemBufferPartitionTest.InvalidValueCreateType/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 {{OPT}}urMemGetInfoImageTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_MEM_INFO_SIZE

--- a/test/conformance/memory/memory_adapter_level_zero_v2.match
+++ b/test/conformance/memory/memory_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urMemBufferPartitionTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urMemBufferPartitionTest.InvalidValueCreateType/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/memory/memory_adapter_native_cpu.match
+++ b/test/conformance/memory/memory_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urMemBufferPartitionTest.InvalidValueCreateType/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urMemGetInfoTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_MEM_INFO_SIZE

--- a/test/conformance/memory/memory_adapter_opencl.match
+++ b/test/conformance/memory/memory_adapter_opencl.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urMemImageCreateTest.InvalidImageDescStype/Intel_R__OpenCL___{{.*}}

--- a/test/conformance/platform/platform_adapter_cuda.match
+++ b/test/conformance/platform/platform_adapter_cuda.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/platform/platform_adapter_hip.match
+++ b/test/conformance/platform/platform_adapter_hip.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/platform/platform_adapter_native_cpu.match
+++ b/test/conformance/platform/platform_adapter_native_cpu.match
@@ -1,1 +1,2 @@
+{{NONDETERMINISTIC}}
 urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/program/program_adapter_cuda.match
+++ b/test/conformance/program/program_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urProgramBuildTest.BuildFailure/NVIDIA_CUDA_BACKEND___{{.*}}_
 {{OPT}}urProgramCreateWithILTest.Success/NVIDIA_CUDA_BACKEND___{{.*}}
 {{OPT}}urProgramCreateWithILTest.SuccessWithProperties/NVIDIA_CUDA_BACKEND___{{.*}}

--- a/test/conformance/program/program_adapter_hip.match
+++ b/test/conformance/program/program_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urProgramBuildTest.BuildFailure/AMD_HIP_BACKEND___{{.*}}_
 # HIP hasn't implemented urProgramCreateWithNativeHandleTest
 {{OPT}}urProgramCreateWithNativeHandleTest.Success/AMD_HIP_BACKEND___{{.*}}_

--- a/test/conformance/program/program_adapter_level_zero.match
+++ b/test/conformance/program/program_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urProgramCreateWithNativeHandleTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urProgramCreateWithNativeHandleTest.InvalidNullHandleContext/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urProgramCreateWithNativeHandleTest.InvalidNullPointerProgram/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/program/program_adapter_level_zero_v2.match
+++ b/test/conformance/program/program_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urProgramCreateWithNativeHandleTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urProgramCreateWithNativeHandleTest.InvalidNullHandleContext/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_
 urProgramCreateWithNativeHandleTest.InvalidNullPointerProgram/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}_

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urProgramBuildTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramBuildTest.SuccessWithOptions/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}urProgramBuildTest.InvalidNullHandleContext/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}

--- a/test/conformance/program/program_adapter_opencl.match
+++ b/test/conformance/program/program_adapter_opencl.match
@@ -1,2 +1,3 @@
+{{NONDETERMINISTIC}}
 urProgramCreateWithILTest.BuildInvalidProgram/Intel_R__OpenCL___{{.*}}_
 urProgramGetInfoTest.Success/Intel_R__OpenCL___{{.*}}___UR_PROGRAM_INFO_SOURCE

--- a/test/conformance/queue/queue_adapter_native_cpu.match
+++ b/test/conformance/queue/queue_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urQueueCreateTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urQueueCreateTest.CheckContext/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 urQueueCreateWithParamTest.SuccessWithProperties/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE

--- a/test/conformance/sampler/sampler_adapter_level_zero.match
+++ b/test/conformance/sampler/sampler_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_REFERENCE_COUNT
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_CONTEXT
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_NORMALIZED_COORDS

--- a/test/conformance/sampler/sampler_adapter_level_zero_v2.match
+++ b/test/conformance/sampler/sampler_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_REFERENCE_COUNT
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_CONTEXT
 {{OPT}}urSamplerGetInfoTestWithParam.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UR_SAMPLER_INFO_NORMALIZED_COORDS

--- a/test/conformance/usm/usm_adapter_cuda.match
+++ b/test/conformance/usm/usm_adapter_cuda.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urUSMDeviceAllocTest.InvalidUSMSize/NVIDIA_CUDA_BACKEND___{{.*}}___UsePoolEnabled
 {{OPT}}urUSMDeviceAllocTest.InvalidUSMSize/NVIDIA_CUDA_BACKEND___{{.*}}___UsePoolDisabled
 {{OPT}}urUSMHostAllocTest.InvalidUSMSize/NVIDIA_CUDA_BACKEND___{{.*}}___UsePoolEnabled

--- a/test/conformance/usm/usm_adapter_hip.match
+++ b/test/conformance/usm/usm_adapter_hip.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urUSMDeviceAllocTest.Success/AMD_HIP_BACKEND___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.SuccessWithDescriptors/AMD_HIP_BACKEND___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.InvalidNullHandleContext/AMD_HIP_BACKEND___{{.*}}___UsePoolEnabled

--- a/test/conformance/usm/usm_adapter_level_zero.match
+++ b/test/conformance/usm/usm_adapter_level_zero.match
@@ -1,2 +1,3 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urUSMDeviceAllocTest.InvalidUSMSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UsePoolEnabled
 {{OPT}}urUSMDeviceAllocTest.InvalidUSMSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___UsePoolDisabled

--- a/test/conformance/usm/usm_adapter_level_zero_v2.match
+++ b/test/conformance/usm/usm_adapter_level_zero_v2.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urUSMDeviceAllocTest.InvalidUSMSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}____UsePoolEnabled
 urUSMDeviceAllocTest.InvalidUSMSize/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}____UsePoolDisabled
 urUSMGetMemAllocInfoTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}____UR_USM_ALLOC_INFO_POOL

--- a/test/conformance/usm/usm_adapter_native_cpu.match
+++ b/test/conformance/usm/usm_adapter_native_cpu.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urUSMDeviceAllocTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UsePoolEnabled
 urUSMDeviceAllocTest.Success/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UsePoolDisabled
 urUSMDeviceAllocTest.SuccessWithDescriptors/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}__UsePoolEnabled

--- a/test/conformance/usm/usm_adapter_opencl.match
+++ b/test/conformance/usm/usm_adapter_opencl.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 urUSMDeviceAllocTest.Success/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.SuccessWithDescriptors/Intel_R__OpenCL___{{.*}}___UsePoolEnabled
 urUSMDeviceAllocTest.InvalidNullHandleContext/Intel_R__OpenCL___{{.*}}___UsePoolEnabled

--- a/test/conformance/virtual_memory/virtual_memory_adapter_level_zero.match
+++ b/test/conformance/virtual_memory/virtual_memory_adapter_level_zero.match
@@ -1,3 +1,4 @@
+{{NONDETERMINISTIC}}
 {{OPT}}urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___3
 {{OPT}}urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___7
 {{OPT}}urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___12

--- a/test/conformance/virtual_memory/virtual_memory_adapter_level_zero_v2.match
+++ b/test/conformance/virtual_memory/virtual_memory_adapter_level_zero_v2.match
@@ -1,4 +1,4 @@
-
+{{NONDETERMINISTIC}}
 urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___1
 urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___2
 urPhysicalMemCreateTest.Success/Intel_R__oneAPI_Unified_Runtime_over_Level_Zero___{{.*}}___3


### PR DESCRIPTION
Some improvements for match.py:
* Added a {{NONDETERMINISTIC}} tag, which indicates that the match file results need not be in order.
* When printing output, line numbers and the "interesting line" are provided.
* Fix incorrect index being used when no lines matching a "match" line are found.

In addition, all the conformance test match files are marked as "{{NONDETERMINISTIC}}", as they may be ran in different orders depending on compile flags.