### PR TITLE
Improvements to align CTS and Spec for Loader

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -707,7 +707,7 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urLoaderConfigEnableLayer(
     ur_loader_config_handle_t hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
     const char *pLayerName                   ///< [in] Null terminated string containing the name of the layer to
-                                             ///< enable.
+                                             ///< enable. Empty if none are enabled.
 );
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/scripts/core/INTRO.rst
+++ b/scripts/core/INTRO.rst
@@ -286,7 +286,7 @@ for these parameter structs can be found in the main API header.
 Layers
 ---------------------
 UR comes with a mechanism that allows various API intercept layers to be enabled, either through the API or with an environment variable (see `Environment Variables`_).
-Layers currently included with the runtime are as follows:
+By default, no layers are enabled. Layers currently included with the runtime are as follows:
 
 .. list-table::
    :header-rows: 1

--- a/scripts/core/loader.yml
+++ b/scripts/core/loader.yml
@@ -135,7 +135,7 @@ params:
       desc: "[in] Handle to config object the layer will be enabled for."
     - type: const char*
       name: pLayerName
-      desc: "[in] Null terminated string containing the name of the layer to enable."
+      desc: "[in] Null terminated string containing the name of the layer to enable. Empty if none are enabled."
 returns:
     - $X_RESULT_ERROR_LAYER_NOT_PRESENT:
         - "If layer specified with `pLayerName` can't be found by the loader."

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -151,7 +151,7 @@ ur_result_t UR_APICALL urLoaderConfigEnableLayer(
         hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
     const char *
         pLayerName ///< [in] Null terminated string containing the name of the layer to
-                   ///< enable.
+                   ///< enable. Empty if none are enabled.
     ) try {
     return ur_lib::urLoaderConfigEnableLayer(hLoaderConfig, pLayerName);
 } catch (...) {

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -143,7 +143,7 @@ ur_result_t UR_APICALL urLoaderConfigEnableLayer(
         hLoaderConfig, ///< [in] Handle to config object the layer will be enabled for.
     const char *
         pLayerName ///< [in] Null terminated string containing the name of the layer to
-                   ///< enable.
+                   ///< enable. Empty if none are enabled.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;

--- a/test/loader/loader_config/CMakeLists.txt
+++ b/test/loader/loader_config/CMakeLists.txt
@@ -9,6 +9,7 @@ add_ur_executable(test-loader-config
     urLoaderConfigEnableLayer.cpp
     urLoaderConfigRelease.cpp
     urLoaderConfigRetain.cpp
+    urLoaderConfigSetCodeLocationCallback.cpp
 )
 
 target_link_libraries(test-loader-config

--- a/test/loader/loader_config/urLoaderConfigCreate.cpp
+++ b/test/loader/loader_config/urLoaderConfigCreate.cpp
@@ -17,6 +17,7 @@ struct LoaderConfigCreateTest : ::testing::Test {
 
 TEST_F(LoaderConfigCreateTest, Success) {
     ASSERT_SUCCESS(urLoaderConfigCreate(&loaderConfig));
+    ASSERT_TRUE(loaderConfig != nullptr);
 }
 
 TEST_F(LoaderConfigCreateTest, InvalidNullPointerLoaderConfig) {

--- a/test/loader/loader_config/urLoaderConfigGetInfo.cpp
+++ b/test/loader/loader_config/urLoaderConfigGetInfo.cpp
@@ -5,7 +5,7 @@
 
 #include "fixtures.hpp"
 
-struct urLoaderConfigGetInfoTest
+struct urLoaderConfigGetInfoWithParamTest
     : LoaderConfigTest,
       ::testing::WithParamInterface<ur_loader_config_info_t> {
     void SetUp() override {
@@ -23,30 +23,111 @@ struct urLoaderConfigGetInfoTest
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    , urLoaderConfigGetInfoTest,
+    , urLoaderConfigGetInfoWithParamTest,
     ::testing::Values(UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS,
                       UR_LOADER_CONFIG_INFO_REFERENCE_COUNT));
 
-TEST_P(urLoaderConfigGetInfoTest, Success) {
+TEST_P(urLoaderConfigGetInfoWithParamTest, Success) {
     ASSERT_SUCCESS(urLoaderConfigGetInfo(loaderConfig, infoType, infoSize,
                                          infoAllocation.data(), nullptr));
 }
 
-TEST_P(urLoaderConfigGetInfoTest, InvalidNullHandleLoaderConfig) {
+TEST_P(urLoaderConfigGetInfoWithParamTest, InvalidNullHandleLoaderConfig) {
     ASSERT_EQ(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
               urLoaderConfigGetInfo(nullptr, infoType, infoSize,
                                     infoAllocation.data(), nullptr));
 }
 
-TEST_P(urLoaderConfigGetInfoTest, InvalidNullPointer) {
+TEST_P(urLoaderConfigGetInfoWithParamTest, InvalidNullPointer) {
+    ASSERT_EQ(
+        UR_RESULT_ERROR_INVALID_NULL_POINTER,
+        urLoaderConfigGetInfo(loaderConfig, infoType, 1, nullptr, nullptr));
+
     ASSERT_EQ(
         UR_RESULT_ERROR_INVALID_NULL_POINTER,
         urLoaderConfigGetInfo(loaderConfig, infoType, 0, nullptr, nullptr));
 }
 
-TEST_P(urLoaderConfigGetInfoTest, InvalidEnumerationInfoType) {
+TEST_P(urLoaderConfigGetInfoWithParamTest, InvalidEnumerationInfoType) {
     ASSERT_EQ(UR_RESULT_ERROR_INVALID_ENUMERATION,
               urLoaderConfigGetInfo(loaderConfig,
                                     UR_LOADER_CONFIG_INFO_FORCE_UINT32, 0,
                                     nullptr, &infoSize));
+}
+
+TEST_P(urLoaderConfigGetInfoWithParamTest, InvalidSize) {
+    ASSERT_EQ(UR_RESULT_ERROR_INVALID_SIZE,
+              urLoaderConfigGetInfo(loaderConfig, infoType, 0,
+                                    infoAllocation.data(), &infoSize));
+
+    ASSERT_EQ(UR_RESULT_ERROR_INVALID_SIZE,
+              urLoaderConfigGetInfo(loaderConfig, infoType, infoSize - 1,
+                                    infoAllocation.data(), &infoSize));
+}
+
+using urLoaderConfigGetInfoTest = LoaderConfigTest;
+
+TEST_F(urLoaderConfigGetInfoTest, ReferenceCountNonZero) {
+    uint32_t referenceCount = 0;
+    ASSERT_SUCCESS(urLoaderConfigGetInfo(
+        loaderConfig, UR_LOADER_CONFIG_INFO_REFERENCE_COUNT,
+        sizeof(referenceCount), &referenceCount, nullptr));
+    ASSERT_GT(referenceCount, 0);
+}
+
+std::vector<std::string> splitString(const std::string &str, char delimiter) {
+    std::vector<std::string> tokens;
+    std::stringstream ss(str);
+    std::string token;
+    while (std::getline(ss, token, delimiter)) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+bool isLayerStringValid(std::string &layersString,
+                        const std::vector<std::string> &validLayers) {
+    if (layersString.empty()) {
+        return true;
+    }
+
+    layersString.pop_back(); // remove null terminator before comparing
+    std::vector<std::string> layers = splitString(layersString, ';');
+
+    for (const std::string &layer : layers) {
+        if (std::find(validLayers.begin(), validLayers.end(), layer) ==
+            validLayers.end()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+TEST_F(urLoaderConfigGetInfoTest, ValidLayersList) {
+    std::vector<std::string> layerNames{
+        "UR_LAYER_PARAMETER_VALIDATION",
+        "UR_LAYER_BOUNDS_CHECKING",
+        "UR_LAYER_LEAK_CHECKING",
+        "UR_LAYER_LIFETIME_VALIDATION",
+        "UR_LAYER_FULL_VALIDATION",
+        "UR_LAYER_TRACING",
+        "UR_LAYER_ASAN",
+        "UR_LAYER_MSAN",
+        "UR_LAYER_TSAN",
+    };
+
+    std::string availableLayers;
+    size_t availableLayersLength = 0;
+
+    ASSERT_SUCCESS(urLoaderConfigGetInfo(loaderConfig,
+                                         UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS,
+                                         0, nullptr, &availableLayersLength));
+
+    availableLayers.resize(availableLayersLength);
+    ASSERT_SUCCESS(urLoaderConfigGetInfo(
+        loaderConfig, UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS,
+        availableLayersLength, availableLayers.data(), nullptr));
+
+    ASSERT_TRUE(isLayerStringValid(availableLayers, layerNames));
 }

--- a/test/loader/loader_config/urLoaderConfigSetCodeLocationCallback.cpp
+++ b/test/loader/loader_config/urLoaderConfigSetCodeLocationCallback.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Intel Corporation
+// Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "fixtures.hpp"
+
+ur_code_location_t codeLocationCallback([[maybe_unused]] void *userData) {
+    ur_code_location_t codeloc;
+    codeloc.columnNumber = 1;
+    codeloc.lineNumber = 2;
+    codeloc.functionName = "fname";
+    codeloc.sourceFile = "sfile";
+
+    return codeloc;
+}
+
+struct urLoaderConfigSetCodeLocationCallbackTest : LoaderConfigTest {};
+
+TEST_F(urLoaderConfigSetCodeLocationCallbackTest, Success) {
+    ASSERT_SUCCESS(urLoaderConfigSetCodeLocationCallback(
+        loaderConfig, codeLocationCallback, nullptr));
+}
+
+TEST_F(urLoaderConfigSetCodeLocationCallbackTest, InvalidNullHandle) {
+    ASSERT_EQ(urLoaderConfigSetCodeLocationCallback(
+                  nullptr, codeLocationCallback, nullptr),
+              UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_F(urLoaderConfigSetCodeLocationCallbackTest, InvalidNullPointer) {
+    ASSERT_EQ(
+        urLoaderConfigSetCodeLocationCallback(loaderConfig, nullptr, nullptr),
+        UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}


### PR DESCRIPTION
- Add a null pointer check for urLoaderConfigCreate
- Add a null pointer and invalid size check for urLoaderConfigGetinfo
- Add invalid size test for urLoaderConfigGetInfo
- Add reference count test for urLoaderConfigGetInfo
- Add new test for urLoaderConfigSetCodeLocationCallback
- Add new test for UR_LOADER_CONFIG_INFO_AVAILABLE_LAYERS to test the list is valid (empty or valid values)
- Updated doc wording to say no layers are enabled by default