### PR TITLE
[L0] Refcnt Parent Buffer on Sub Buffer Create and die on use of buffer after free

### DIFF
--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -108,7 +108,10 @@ struct _ur_buffer final : ur_mem_handle_t_ {
   // Sub-buffer constructor
   _ur_buffer(_ur_buffer *Parent, size_t Origin, size_t Size)
       : ur_mem_handle_t_(Parent->UrContext),
-        Size(Size), SubBuffer{{Parent, Origin}} {}
+        Size(Size), SubBuffer{{Parent, Origin}} {
+    // Retain the Parent Buffer due to the Creation of the SubBuffer.
+    Parent->RefCount.increment();
+  }
 
   // Interop-buffer constructor
   _ur_buffer(ur_context_handle_t Context, size_t Size,
@@ -135,6 +138,9 @@ struct _ur_buffer final : ur_mem_handle_t_ {
 
   // Frees all allocations made for the buffer.
   ur_result_t free();
+
+  // Tracks if this buffer is freed already or should be considered valid.
+  bool isFreed{false};
 
   // Information about a single allocation representing this buffer.
   struct allocation_t {


### PR DESCRIPTION
- Refcnt the Parent Buffer on Sub Buffer Creation to avoid free until
  after all sub buffers are released.
- Avoid use after free of buffers by tracking if a buffer has already
  been called with free() and verify that the parent of a sub buffer has
not already been released before attempting to get ze handles from the
parent.
- In either use after free case, die aborts before the memory is accessed.