### PR TITLE
[EXP][CMDBUF] Make command handle behaviour consistent

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8233,6 +8233,10 @@ typedef enum ur_exp_command_buffer_info_t {
                                                     ///< The reference count returned should be considered immediately stale.
                                                     ///< It is unsuitable for general use in applications. This feature is
                                                     ///< provided for identifying memory leaks.
+    UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR = 1,      ///< [::ur_exp_command_buffer_desc_t] Returns a ::ur_exp_command_buffer_desc_t
+                                                    ///< with the properties of the command-buffer. Returned values may differ
+                                                    ///< from those passed on construction if the property was ignored by the
+                                                    ///< adapter.
     /// @cond
     UR_EXP_COMMAND_BUFFER_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond
@@ -8489,6 +8493,7 @@ urCommandBufferFinalizeExp(
 ///         + If the device associated with `hCommandBuffer` does not support UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP and either `phEvent` or `phEventWaitList` are not NULL.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION - "phCommand is not NULL and hCommandBuffer is not updatable."
 UR_APIEXPORT ur_result_t UR_APICALL
 urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t hCommandBuffer,                ///< [in] Handle of the command-buffer object.
@@ -8517,7 +8522,8 @@ urCommandBufferAppendKernelLaunchExp(
     ur_event_handle_t *phEvent,                                   ///< [out][optional] return an event object that will be signaled by the
                                                                   ///< completion of this command in the next execution of the
                                                                   ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t *phCommand             ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *phCommand             ///< [out][optional] Handle to this command. Only available if the
+                                                                  ///< command-buffer is updatable.
 );
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9289,7 +9295,7 @@ urCommandBufferUpdateWaitEventsExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT < propName`
+///         + `::UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -9847,6 +9847,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_exp_command_buffer_inf
     case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
         os << "UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT";
         break;
+    case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR:
+        os << "UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR";
+        break;
     default:
         os << "unknown enumerator";
         break;
@@ -9867,6 +9870,18 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_exp_command
         const uint32_t *tptr = (const uint32_t *)ptr;
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+    case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
+        const ur_exp_command_buffer_desc_t *tptr = (const ur_exp_command_buffer_desc_t *)ptr;
+        if (sizeof(ur_exp_command_buffer_desc_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(ur_exp_command_buffer_desc_t) << ")";
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
         os << (const void *)(tptr) << " (";

--- a/scripts/core/EXP-COMMAND-BUFFER.rst
+++ b/scripts/core/EXP-COMMAND-BUFFER.rst
@@ -447,6 +447,7 @@ Enums
     * ${X}_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP
 * ${x}_exp_command_buffer_info_t
     * ${X}_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT
+    * ${X}_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR
 * ${x}_exp_command_buffer_command_info_t
     * ${X}_EXP_COMMAND_BUFFER_COMMAND_INFO_REFERENCE_COUNT
 

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -111,6 +111,12 @@ etors:
             [uint32_t] Reference count of the command-buffer object.
             The reference count returned should be considered immediately stale.
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
+    - name: DESCRIPTOR
+      desc: |
+            [$x_exp_command_buffer_desc_t] Returns a $x_exp_command_buffer_desc_t
+            with the properties of the command-buffer. Returned values may differ
+            from those passed on construction if the property was ignored by the
+            adapter.
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Command-buffer command query information type"
@@ -380,7 +386,8 @@ params:
       desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional] Handle to this command. Only available if the
+      command-buffer is updatable."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -403,6 +410,8 @@ returns:
         - "If the device associated with `hCommandBuffer` does not support UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP and either `phEvent` or `phEventWaitList` are not NULL."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
+    - $X_RESULT_ERROR_INVALID_OPERATION
+        - "phCommand is not NULL and hCommandBuffer is not updatable."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Append a USM memcpy command to a command-buffer object."

--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -432,6 +432,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
     ur_exp_command_buffer_command_handle_t *phCommand) {
   // Preconditions
+  // Command handles can only be obtained from updatable command-buffers
+  UR_ASSERT(!(phCommand && !hCommandBuffer->IsUpdatable),
+            UR_RESULT_ERROR_INVALID_OPERATION);
   UR_ASSERT(hCommandBuffer->Context == hKernel->getContext(),
             UR_RESULT_ERROR_INVALID_KERNEL);
   UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
@@ -1479,6 +1482,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
     return ReturnValue(hCommandBuffer->getExternalReferenceCount());
+  case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
+    ur_exp_command_buffer_desc_t Descriptor{};
+    Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
+    Descriptor.pNext = nullptr;
+    Descriptor.isUpdatable = hCommandBuffer->IsUpdatable;
+    Descriptor.isInOrder = false;
+    Descriptor.enableProfiling = false;
+
+    return ReturnValue(Descriptor);
+  }
   default:
     assert(!"Command-buffer info request not implemented");
   }

--- a/source/adapters/hip/command_buffer.cpp
+++ b/source/adapters/hip/command_buffer.cpp
@@ -330,6 +330,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
   // Preconditions
+  // Command handles can only be obtained from updatable command-buffers
+  UR_ASSERT(!(phCommand && !hCommandBuffer->IsUpdatable),
+            UR_RESULT_ERROR_INVALID_OPERATION);
   UR_ASSERT(hCommandBuffer->Context == hKernel->getContext(),
             UR_RESULT_ERROR_INVALID_KERNEL);
   UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
@@ -1128,6 +1131,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
     return ReturnValue(hCommandBuffer->getExternalReferenceCount());
+  case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
+    ur_exp_command_buffer_desc_t Descriptor{};
+    Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
+    Descriptor.pNext = nullptr;
+    Descriptor.isUpdatable = hCommandBuffer->IsUpdatable;
+    Descriptor.isInOrder = false, Descriptor.enableProfiling = false;
+
+    return ReturnValue(Descriptor);
+  }
   default:
     assert(!"Command-buffer info request not implemented");
   }

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -8399,8 +8399,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/adapters/opencl/command_buffer.cpp
+++ b/source/adapters/opencl/command_buffer.cpp
@@ -152,6 +152,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
   (void)phEventWaitList;
   (void)phEvent;
 
+  // Command handles can only be obtained from updatable command-buffers
+  UR_ASSERT(!(phCommandHandle && !hCommandBuffer->IsUpdatable),
+            UR_RESULT_ERROR_INVALID_OPERATION);
+
   cl_context CLContext = cl_adapter::cast<cl_context>(hCommandBuffer->hContext);
   cl_ext::clCommandNDRangeKernelKHR_fn clCommandNDRangeKernelKHR = nullptr;
   UR_RETURN_ON_FAILURE(
@@ -646,6 +650,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferGetInfoExp(
   switch (propName) {
   case UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT:
     return ReturnValue(hCommandBuffer->getExternalReferenceCount());
+  case UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR: {
+    ur_exp_command_buffer_desc_t Descriptor{};
+    Descriptor.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
+    Descriptor.pNext = nullptr;
+    Descriptor.isUpdatable = hCommandBuffer->IsUpdatable;
+    Descriptor.isInOrder = false;
+    Descriptor.enableProfiling = false;
+
+    return ReturnValue(Descriptor);
+  }
   default:
     assert(!"Command-buffer info request not implemented");
   }

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -7185,8 +7185,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
 ) {
     auto pfnAppendKernelLaunchExp =
         getContext()->urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -8108,8 +8108,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
 ) {
     auto pfnAppendKernelLaunchExp =
         getContext()->urDdiTable.CommandBufferExp.pfnAppendKernelLaunchExp;
@@ -9437,7 +9438,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }
 
-        if (UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT < propName) {
+        if (UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR < propName) {
             return UR_RESULT_ERROR_INVALID_ENUMERATION;
         }
 

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -7155,8 +7155,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -7573,6 +7573,7 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///         + If the device associated with `hCommandBuffer` does not support UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP and either `phEvent` or `phEventWaitList` are not NULL.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION - "phCommand is not NULL and hCommandBuffer is not updatable."
 ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
@@ -7611,8 +7612,9 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
     ) try {
     auto pfnAppendKernelLaunchExp =
         ur_lib::getContext()
@@ -8706,7 +8708,7 @@ ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT < propName`
+///         + `::UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -6429,6 +6429,7 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 ///         + If the device associated with `hCommandBuffer` does not support UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP and either `phEvent` or `phEventWaitList` are not NULL.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
+///     - ::UR_RESULT_ERROR_INVALID_OPERATION - "phCommand is not NULL and hCommandBuffer is not updatable."
 ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
@@ -6467,8 +6468,9 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         phEvent, ///< [out][optional] return an event object that will be signaled by the
                  ///< completion of this command in the next execution of the
                  ///< command-buffer.
-    ur_exp_command_buffer_command_handle_t
-        *phCommand ///< [out][optional] Handle to this command.
+    ur_exp_command_buffer_command_handle_t *
+        phCommand ///< [out][optional] Handle to this command. Only available if the
+                  ///< command-buffer is updatable.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
     return result;
@@ -7382,7 +7384,7 @@ ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hCommandBuffer`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_EXP_COMMAND_BUFFER_INFO_REFERENCE_COUNT < propName`
+///         + `::UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/test/conformance/exp_command_buffer/update/invalid_update.cpp
+++ b/test/conformance/exp_command_buffer/update/invalid_update.cpp
@@ -119,12 +119,16 @@ TEST_P(InvalidUpdateTest, NotUpdatableCommandBuffer) {
     EXPECT_NE(test_cmd_buf_handle, nullptr);
 
     // Append a kernel commands to command-buffer and close command-buffer
+    // Should be an error because we are trying to get command handle but
+    // command buffer is not updatable.
     ur_exp_command_buffer_command_handle_t test_command_handle = nullptr;
-    EXPECT_SUCCESS(urCommandBufferAppendKernelLaunchExp(
-        test_cmd_buf_handle, kernel, n_dimensions, &global_offset, &global_size,
-        &local_size, 0, nullptr, 0, nullptr, 0, nullptr, nullptr, nullptr,
-        &test_command_handle));
-    EXPECT_NE(test_command_handle, nullptr);
+    ASSERT_EQ_RESULT(urCommandBufferAppendKernelLaunchExp(
+                         test_cmd_buf_handle, kernel, n_dimensions,
+                         &global_offset, &global_size, &local_size, 0, nullptr,
+                         0, nullptr, 0, nullptr, nullptr, nullptr,
+                         &test_command_handle),
+                     UR_RESULT_ERROR_INVALID_OPERATION);
+    ASSERT_EQ(test_command_handle, nullptr);
 
     EXPECT_SUCCESS(urCommandBufferFinalizeExp(test_cmd_buf_handle));
     finalized = true;
@@ -156,11 +160,11 @@ TEST_P(InvalidUpdateTest, NotUpdatableCommandBuffer) {
         nullptr,         // pNewLocalWorkSize
     };
 
-    // Update command to command-buffer that doesn't have updatable set should
-    // be an error
+    // Since no command handle was returned Update command to command-buffer
+    // should also be an error.
     ur_result_t result =
         urCommandBufferUpdateKernelLaunchExp(test_command_handle, &update_desc);
-    EXPECT_EQ(UR_RESULT_ERROR_INVALID_OPERATION, result);
+    EXPECT_EQ(UR_RESULT_ERROR_INVALID_NULL_HANDLE, result);
 
     if (test_command_handle) {
         EXPECT_SUCCESS(urCommandBufferReleaseCommandExp(test_command_handle));


### PR DESCRIPTION
- Attempting to obtain a command handle when the command buffer is not updatable is now an error across all adapters
- command-buffer spec and adapter code updated to reflect this
- invalid_update CTS test updated to reflect new behaviour