### PR TITLE
[L0] Pass and track event dependencies required before executing Memory Copy buffer inits

### DIFF
--- a/.github/workflows/multi_device.yml
+++ b/.github/workflows/multi_device.yml
@@ -30,12 +30,11 @@ jobs:
     - name: Install pip packages
       run: pip install -r third_party/requirements.txt
 
-    # TODO: enable once test failure are fixed/ignored
-    # - name: Download DPC++
-    #   run: |
-    #     wget -O ${{github.workspace}}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/nightly-2024-09-27/sycl_linux.tar.gz
-    #     mkdir dpcpp_compiler
-    #     tar -xvf ${{github.workspace}}/dpcpp_compiler.tar.gz -C dpcpp_compiler
+    - name: Download DPC++
+      run: |
+        wget -O ${{github.workspace}}/dpcpp_compiler.tar.gz https://github.com/intel/llvm/releases/download/nightly-2024-01-29/sycl_linux.tar.gz
+        mkdir dpcpp_compiler
+        tar -xvf ${{github.workspace}}/dpcpp_compiler.tar.gz -C dpcpp_compiler
 
     - name: Configure CMake
       shell: bash -el {0}
@@ -49,6 +48,8 @@ jobs:
         -DUR_BUILD_TESTS=ON
         -DUR_BUILD_ADAPTER_${{matrix.adapter.name}}=ON
         -DUR_TEST_DEVICES_COUNT=2
+        -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
+        -DUR_SYCL_LIBRARY_DIR=${{github.workspace}}/dpcpp_compiler/lib
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build -j $(nproc)
@@ -60,4 +61,4 @@ jobs:
 
     - name: Test adapters
       working-directory: ${{github.workspace}}/build
-      run: env UR_CTS_ADAPTER_PLATFORM="${{matrix.adapter.platform}}" ctest -C ${{matrix.build_type}} --output-on-failure -L "conformance" --timeout 180
+      run: env UR_CTS_ADAPTER_PLATFORM="${{matrix.adapter.platform}}" ctest -C ${{matrix.build_type}} --output-on-failure -L "conformance" -E "enqueue|kernel|program|integration|exp_command_buffer|exp_enqueue_native|exp_launch_properties|exp_usm_p2p" --timeout 180

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -672,7 +672,7 @@ setKernelPendingArguments(ur_exp_command_buffer_handle_t CommandBuffer,
     char **ZeHandlePtr = nullptr;
     if (Arg.Value) {
       UR_CALL(Arg.Value->getZeHandlePtr(ZeHandlePtr, Arg.AccessMode,
-                                        CommandBuffer->Device));
+                                        CommandBuffer->Device, nullptr, 0u));
     }
     ZE2UR_CALL(zeKernelSetArgumentValue,
                (Kernel->ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));
@@ -826,10 +826,10 @@ ur_result_t urCommandBufferAppendMemBufferCopyExp(
 
   char *ZeHandleSrc;
   UR_CALL(SrcBuffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                 CommandBuffer->Device));
+                                 CommandBuffer->Device, nullptr, 0u));
   char *ZeHandleDst;
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                 CommandBuffer->Device));
+                                 CommandBuffer->Device, nullptr, 0u));
 
   bool PreferCopyEngine = (SrcBuffer->OnHost || DstBuffer->OnHost);
 
@@ -858,10 +858,10 @@ ur_result_t urCommandBufferAppendMemBufferCopyRectExp(
 
   char *ZeHandleSrc;
   UR_CALL(SrcBuffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                 CommandBuffer->Device));
+                                 CommandBuffer->Device, nullptr, 0u));
   char *ZeHandleDst;
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                 CommandBuffer->Device));
+                                 CommandBuffer->Device, nullptr, 0u));
 
   bool PreferCopyEngine = (SrcBuffer->OnHost || DstBuffer->OnHost);
 
@@ -884,7 +884,7 @@ ur_result_t urCommandBufferAppendMemBufferWriteExp(
 
   char *ZeHandleDst = nullptr;
   UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                              CommandBuffer->Device));
+                              CommandBuffer->Device, nullptr, 0u));
   // Always prefer copy engine for writes
   bool PreferCopyEngine = true;
 
@@ -908,7 +908,7 @@ ur_result_t urCommandBufferAppendMemBufferWriteRectExp(
 
   char *ZeHandleDst = nullptr;
   UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                              CommandBuffer->Device));
+                              CommandBuffer->Device, nullptr, 0u));
 
   // Always prefer copy engine for writes
   bool PreferCopyEngine = true;
@@ -930,7 +930,7 @@ ur_result_t urCommandBufferAppendMemBufferReadExp(
 
   char *ZeHandleSrc = nullptr;
   UR_CALL(Buffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                              CommandBuffer->Device));
+                              CommandBuffer->Device, nullptr, 0u));
 
   // Always prefer copy engine for reads
   bool PreferCopyEngine = true;
@@ -953,7 +953,7 @@ ur_result_t urCommandBufferAppendMemBufferReadRectExp(
 
   char *ZeHandleSrc;
   UR_CALL(Buffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                              CommandBuffer->Device));
+                              CommandBuffer->Device, nullptr, 0u));
 
   // Always prefer copy engine for reads
   bool PreferCopyEngine = true;
@@ -1078,7 +1078,7 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
   char *ZeHandleDst = nullptr;
   _ur_buffer *UrBuffer = reinterpret_cast<_ur_buffer *>(Buffer);
   UR_CALL(UrBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                CommandBuffer->Device));
+                                CommandBuffer->Device, nullptr, 0u));
 
   return enqueueCommandBufferFillHelper(
       UR_COMMAND_MEM_BUFFER_FILL, CommandBuffer, ZeHandleDst + Offset,
@@ -1512,7 +1512,7 @@ ur_result_t updateKernelCommand(
     char **ZeHandlePtr = nullptr;
     if (NewMemObjArg) {
       UR_CALL(NewMemObjArg->getZeHandlePtr(ZeHandlePtr, UrAccessMode,
-                                           CommandBuffer->Device));
+                                           CommandBuffer->Device, nullptr, 0u));
     }
 
     auto ZeMutableArgDesc =

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -113,7 +113,8 @@ ur_result_t urEnqueueKernelLaunch(
     char **ZeHandlePtr = nullptr;
     if (Arg.Value) {
       UR_CALL(Arg.Value->getZeHandlePtr(ZeHandlePtr, Arg.AccessMode,
-                                        Queue->Device));
+                                        Queue->Device, EventWaitList,
+                                        NumEventsInWaitList));
     }
     ZE2UR_CALL(zeKernelSetArgumentValue,
                (ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));
@@ -273,7 +274,8 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
     char **ZeHandlePtr = nullptr;
     if (Arg.Value) {
       UR_CALL(Arg.Value->getZeHandlePtr(ZeHandlePtr, Arg.AccessMode,
-                                        Queue->Device));
+                                        Queue->Device, EventWaitList,
+                                        NumEventsInWaitList));
     }
     ZE2UR_CALL(zeKernelSetArgumentValue,
                (ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -407,7 +407,8 @@ static ur_result_t enqueueMemImageCommandHelper(
 
     char *ZeHandleSrc = nullptr;
     UR_CALL(SrcMem->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                Queue->Device));
+                                Queue->Device, EventWaitList,
+                                NumEventsInWaitList));
     ZE2UR_CALL(zeCommandListAppendImageCopyToMemory,
                (ZeCommandList, Dst, ur_cast<ze_image_handle_t>(ZeHandleSrc),
                 &ZeSrcRegion, ZeEvent, WaitList.Length, WaitList.ZeEventList));
@@ -440,7 +441,8 @@ static ur_result_t enqueueMemImageCommandHelper(
 
     char *ZeHandleDst = nullptr;
     UR_CALL(DstMem->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                Queue->Device));
+                                Queue->Device, EventWaitList,
+                                NumEventsInWaitList));
     ZE2UR_CALL(zeCommandListAppendImageCopyFromMemory,
                (ZeCommandList, ur_cast<ze_image_handle_t>(ZeHandleDst), Src,
                 &ZeDstRegion, ZeEvent, WaitList.Length, WaitList.ZeEventList));
@@ -458,9 +460,11 @@ static ur_result_t enqueueMemImageCommandHelper(
     char *ZeHandleSrc = nullptr;
     char *ZeHandleDst = nullptr;
     UR_CALL(SrcImage->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                  Queue->Device));
+                                  Queue->Device, EventWaitList,
+                                  NumEventsInWaitList));
     UR_CALL(DstImage->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                  Queue->Device));
+                                  Queue->Device, EventWaitList,
+                                  NumEventsInWaitList));
     ZE2UR_CALL(zeCommandListAppendImageCopyRegion,
                (ZeCommandList, ur_cast<ze_image_handle_t>(ZeHandleDst),
                 ur_cast<ze_image_handle_t>(ZeHandleSrc), &ZeDstRegion,
@@ -504,7 +508,8 @@ ur_result_t urEnqueueMemBufferRead(
 
   char *ZeHandleSrc = nullptr;
   UR_CALL(Src->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                           Queue->Device));
+                           Queue->Device, phEventWaitList,
+                           numEventsInWaitList));
   return enqueueMemCopyHelper(UR_COMMAND_MEM_BUFFER_READ, Queue, pDst,
                               blockingRead, size, ZeHandleSrc + offset,
                               numEventsInWaitList, phEventWaitList, phEvent,
@@ -539,7 +544,8 @@ ur_result_t urEnqueueMemBufferWrite(
 
   char *ZeHandleDst = nullptr;
   UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                              Queue->Device));
+                              Queue->Device, phEventWaitList,
+                              numEventsInWaitList));
   return enqueueMemCopyHelper(UR_COMMAND_MEM_BUFFER_WRITE, Queue,
                               ZeHandleDst + offset, // dst
                               blockingWrite, size,
@@ -585,7 +591,8 @@ ur_result_t urEnqueueMemBufferReadRect(
 
   char *ZeHandleSrc;
   UR_CALL(Buffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                              Queue->Device));
+                              Queue->Device, phEventWaitList,
+                              numEventsInWaitList));
   return enqueueMemCopyRectHelper(
       UR_COMMAND_MEM_BUFFER_READ_RECT, Queue, ZeHandleSrc, pDst, bufferOffset,
       hostOffset, region, bufferRowPitch, hostRowPitch, bufferSlicePitch,
@@ -631,7 +638,8 @@ ur_result_t urEnqueueMemBufferWriteRect(
 
   char *ZeHandleDst = nullptr;
   UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                              Queue->Device));
+                              Queue->Device, phEventWaitList,
+                              numEventsInWaitList));
   return enqueueMemCopyRectHelper(
       UR_COMMAND_MEM_BUFFER_WRITE_RECT, Queue,
       const_cast<char *>(static_cast<const char *>(pSrc)), ZeHandleDst,
@@ -679,10 +687,12 @@ ur_result_t urEnqueueMemBufferCopy(
 
   char *ZeHandleSrc = nullptr;
   UR_CALL(SrcBuffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                 Queue->Device));
+                                 Queue->Device, EventWaitList,
+                                 NumEventsInWaitList));
   char *ZeHandleDst = nullptr;
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                 Queue->Device));
+                                 Queue->Device, EventWaitList,
+                                 NumEventsInWaitList));
 
   return enqueueMemCopyHelper(
       UR_COMMAND_MEM_BUFFER_COPY, Queue, ZeHandleDst + DstOffset,
@@ -736,10 +746,12 @@ ur_result_t urEnqueueMemBufferCopyRect(
 
   char *ZeHandleSrc = nullptr;
   UR_CALL(SrcBuffer->getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                                 Queue->Device));
+                                 Queue->Device, EventWaitList,
+                                 NumEventsInWaitList));
   char *ZeHandleDst = nullptr;
   UR_CALL(DstBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                 Queue->Device));
+                                 Queue->Device, EventWaitList,
+                                 NumEventsInWaitList));
 
   return enqueueMemCopyRectHelper(
       UR_COMMAND_MEM_BUFFER_COPY_RECT, Queue, ZeHandleSrc, ZeHandleDst,
@@ -774,7 +786,8 @@ ur_result_t urEnqueueMemBufferFill(
   char *ZeHandleDst = nullptr;
   _ur_buffer *UrBuffer = reinterpret_cast<_ur_buffer *>(Buffer);
   UR_CALL(UrBuffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                Queue->Device));
+                                Queue->Device, EventWaitList,
+                                NumEventsInWaitList));
   return enqueueMemFillHelper(
       UR_COMMAND_MEM_BUFFER_FILL, Queue, ZeHandleDst + Offset,
       Pattern,     // It will be interpreted as an 8-bit value,
@@ -972,7 +985,8 @@ ur_result_t urEnqueueMemBufferMap(
     std::scoped_lock<ur_shared_mutex> Guard(Buffer->Mutex);
 
     char *ZeHandleSrc;
-    UR_CALL(Buffer->getZeHandle(ZeHandleSrc, AccessMode, Queue->Device));
+    UR_CALL(Buffer->getZeHandle(ZeHandleSrc, AccessMode, Queue->Device,
+                                EventWaitList, NumEventsInWaitList));
 
     if (Buffer->MapHostPtr) {
       *RetMap = Buffer->MapHostPtr + Offset;
@@ -1029,7 +1043,8 @@ ur_result_t urEnqueueMemBufferMap(
     const auto &WaitList = (*Event)->WaitList;
 
     char *ZeHandleSrc;
-    UR_CALL(Buffer->getZeHandle(ZeHandleSrc, AccessMode, Queue->Device));
+    UR_CALL(Buffer->getZeHandle(ZeHandleSrc, AccessMode, Queue->Device,
+                                EventWaitList, NumEventsInWaitList));
 
     UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
                            NumEventsInWaitList, EventWaitList,
@@ -1126,7 +1141,8 @@ ur_result_t urEnqueueMemUnmap(
 
     char *ZeHandleDst;
     UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                Queue->Device));
+                                Queue->Device, EventWaitList,
+                                NumEventsInWaitList));
 
     std::scoped_lock<ur_shared_mutex> Guard(Buffer->Mutex);
     if (Buffer->MapHostPtr)
@@ -1161,7 +1177,8 @@ ur_result_t urEnqueueMemUnmap(
 
   char *ZeHandleDst;
   UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                              Queue->Device));
+                              Queue->Device, EventWaitList,
+                              NumEventsInWaitList));
 
   UR_CALL(setSignalEvent(Queue, UseCopyEngine, &ZeEvent, Event,
                          NumEventsInWaitList, EventWaitList,
@@ -1628,7 +1645,7 @@ ur_result_t urMemBufferCreate(
       // allocation.
       char *ZeHandleDst;
       UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
-                                  Context->Devices[0]));
+                                  Context->Devices[0], nullptr, 0u));
       if (Buffer->OnHost) {
         // Do a host to host copy.
         // For an imported HostPtr the copy is unneeded.
@@ -1670,7 +1687,8 @@ ur_result_t urMemRelease(
     char *ZeHandleImage;
     auto Image = static_cast<_ur_image *>(Mem);
     if (Image->OwnNativeHandle) {
-      UR_CALL(Mem->getZeHandle(ZeHandleImage, ur_mem_handle_t_::write_only));
+      UR_CALL(Mem->getZeHandle(ZeHandleImage, ur_mem_handle_t_::write_only,
+                               nullptr, nullptr, 0u));
       auto ZeResult = ZE_CALL_NOCHECK(
           zeImageDestroy, (ur_cast<ze_image_handle_t>(ZeHandleImage)));
       // Gracefully handle the case that L0 was already unloaded.
@@ -1730,7 +1748,8 @@ ur_result_t urMemGetNativeHandle(
 ) {
   std::shared_lock<ur_shared_mutex> Guard(Mem->Mutex);
   char *ZeHandle = nullptr;
-  UR_CALL(Mem->getZeHandle(ZeHandle, ur_mem_handle_t_::read_write));
+  UR_CALL(Mem->getZeHandle(ZeHandle, ur_mem_handle_t_::read_write, nullptr,
+                           nullptr, 0u));
   *NativeMem = ur_cast<ur_native_handle_t>(ZeHandle);
 
   return UR_RESULT_SUCCESS;
@@ -1821,8 +1840,8 @@ ur_result_t urMemBufferCreateWithNativeHandle(
     // represent the buffer in this context) copy the data to a newly
     // created device allocation.
     char *ZeHandleDst;
-    UR_CALL(
-        Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only, Device));
+    UR_CALL(Buffer->getZeHandle(ZeHandleDst, ur_mem_handle_t_::write_only,
+                                Device, nullptr, 0u));
 
     // Indicate that this buffer has the device buffer mapped to a native buffer
     // and track the native pointer such that the memory is synced later at
@@ -2009,7 +2028,9 @@ static ur_result_t ZeDeviceMemAllocHelper(void **ResultPtr,
 }
 
 ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
-                                    ur_device_handle_t Device) {
+                                    ur_device_handle_t Device,
+                                    const ur_event_handle_t *phWaitEvents,
+                                    uint32_t numWaitEvents) {
 
   // NOTE: There might be no valid allocation at all yet and we get
   // here from piEnqueueKernelLaunch that would be doing the buffer
@@ -2026,7 +2047,8 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
 
   // Sub-buffers don't maintain own allocations but rely on parent buffer.
   if (SubBuffer) {
-    UR_CALL(SubBuffer->Parent->getZeHandle(ZeHandle, AccessMode, Device));
+    UR_CALL(SubBuffer->Parent->getZeHandle(ZeHandle, AccessMode, Device,
+                                           phWaitEvents, numWaitEvents));
     ZeHandle += SubBuffer->Origin;
     // Still store the allocation info in the PI sub-buffer for
     // getZeHandlePtr to work. At least zeKernelSetArgumentValue needs to
@@ -2099,7 +2121,8 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
       // TODO: we can probably generalize this and share root-device
       //       allocations by its own sub-devices even if not all other
       //       devices in the context have the same root.
-      UR_CALL(getZeHandle(ZeHandle, AccessMode, UrContext->SingleRootDevice));
+      UR_CALL(getZeHandle(ZeHandle, AccessMode, UrContext->SingleRootDevice,
+                          phWaitEvents, numWaitEvents));
       Allocation.ReleaseAction = allocation_t::keep;
       Allocation.ZeHandle = ZeHandle;
       Allocation.Valid = true;
@@ -2142,7 +2165,8 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
     char *ZeHandleSrc = nullptr;
     if (NeedCopy) {
       UR_CALL(getZeHandle(ZeHandleSrc, ur_mem_handle_t_::read_only,
-                          LastDeviceWithValidAllocation));
+                          LastDeviceWithValidAllocation, phWaitEvents,
+                          numWaitEvents));
       // It's possible with the single root-device contexts that
       // the buffer is represented by the single root-device
       // allocation and then skip the copy to itself.
@@ -2151,6 +2175,19 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
     }
 
     if (NeedCopy) {
+
+      // Generate the waitlist for the Copy calls based on the passed in
+      // dependencies, if they exist.
+      _ur_ze_event_list_t waitlist;
+      waitlist.ZeEventList = nullptr;
+      waitlist.Length = numWaitEvents;
+      if (numWaitEvents != 0) {
+        waitlist.ZeEventList = new ze_event_handle_t[numWaitEvents];
+        for (uint32_t i = 0; i < numWaitEvents; i++) {
+          waitlist.ZeEventList[i] = phWaitEvents[i]->ZeEvent;
+        }
+      }
+
       // Copy valid buffer data to this allocation.
       // TODO: see if we should better use peer's device allocation used
       // directly, if that capability is reported with zeDeviceCanAccessPeer,
@@ -2188,7 +2225,8 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
         if (!HostAllocation.Valid) {
           ZE2UR_CALL(zeCommandListAppendMemoryCopy,
                      (UrContext->ZeCommandListInit, HostAllocation.ZeHandle,
-                      ZeHandleSrc, Size, nullptr, 0, nullptr));
+                      ZeHandleSrc, Size, nullptr, waitlist.Length,
+                      waitlist.ZeEventList));
           // Mark the host allocation data  as valid so it can be reused.
           // It will be invalidated below if the current access is not
           // read-only.
@@ -2196,14 +2234,17 @@ ur_result_t _ur_buffer::getZeHandle(char *&ZeHandle, access_mode_t AccessMode,
         }
         ZE2UR_CALL(zeCommandListAppendMemoryCopy,
                    (UrContext->ZeCommandListInit, ZeHandle,
-                    HostAllocation.ZeHandle, Size, nullptr, 0, nullptr));
+                    HostAllocation.ZeHandle, Size, nullptr, waitlist.Length,
+                    waitlist.ZeEventList));
       } else {
         // Perform P2P copy.
         std::scoped_lock<ur_mutex> Lock(UrContext->ImmediateCommandListMutex);
         ZE2UR_CALL(zeCommandListAppendMemoryCopy,
                    (UrContext->ZeCommandListInit, ZeHandle, ZeHandleSrc, Size,
-                    nullptr, 0, nullptr));
+                    nullptr, waitlist.Length, waitlist.ZeEventList));
       }
+      if (waitlist.ZeEventList)
+        delete waitlist.ZeEventList;
     }
     Allocation.Valid = true;
     LastDeviceWithValidAllocation = Device;
@@ -2331,9 +2372,12 @@ _ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size,
 
 ur_result_t _ur_buffer::getZeHandlePtr(char **&ZeHandlePtr,
                                        access_mode_t AccessMode,
-                                       ur_device_handle_t Device) {
+                                       ur_device_handle_t Device,
+                                       const ur_event_handle_t *phWaitEvents,
+                                       uint32_t numWaitEvents) {
   char *ZeHandle;
-  UR_CALL(getZeHandle(ZeHandle, AccessMode, Device));
+  UR_CALL(
+      getZeHandle(ZeHandle, AccessMode, Device, phWaitEvents, numWaitEvents));
   ZeHandlePtr = &Allocations[Device].ZeHandle;
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -74,11 +74,15 @@ struct ur_mem_handle_t_ : _ur_object {
 
   // Get the Level Zero handle of the current memory object
   virtual ur_result_t getZeHandle(char *&ZeHandle, access_mode_t,
-                                  ur_device_handle_t Device = nullptr) = 0;
+                                  ur_device_handle_t Device,
+                                  const ur_event_handle_t *phWaitEvents,
+                                  uint32_t numWaitEvents) = 0;
 
   // Get a pointer to the Level Zero handle of the current memory object
   virtual ur_result_t getZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
-                                     ur_device_handle_t Device = nullptr) = 0;
+                                     ur_device_handle_t Device,
+                                     const ur_event_handle_t *phWaitEvents,
+                                     uint32_t numWaitEvents) = 0;
 
   // Method to get type of the derived object (image or buffer)
   virtual bool isImage() const = 0;
@@ -118,10 +122,13 @@ struct _ur_buffer final : ur_mem_handle_t_ {
   // the hood.
   //
   virtual ur_result_t getZeHandle(char *&ZeHandle, access_mode_t,
-                                  ur_device_handle_t Device = nullptr) override;
-  virtual ur_result_t
-  getZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
-                 ur_device_handle_t Device = nullptr) override;
+                                  ur_device_handle_t Device,
+                                  const ur_event_handle_t *phWaitEvents,
+                                  uint32_t numWaitEvents) override;
+  virtual ur_result_t getZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
+                                     ur_device_handle_t Device,
+                                     const ur_event_handle_t *phWaitEvents,
+                                     uint32_t numWaitEvents) override;
 
   bool isImage() const override { return false; }
   bool isSubBuffer() const { return SubBuffer != std::nullopt; }
@@ -199,12 +206,20 @@ struct _ur_image final : ur_mem_handle_t_ {
   }
 
   virtual ur_result_t getZeHandle(char *&ZeHandle, access_mode_t,
-                                  ur_device_handle_t = nullptr) override {
+                                  ur_device_handle_t,
+                                  const ur_event_handle_t *phWaitEvents,
+                                  uint32_t numWaitEvents) override {
+    std::ignore = phWaitEvents;
+    std::ignore = numWaitEvents;
     ZeHandle = reinterpret_cast<char *>(ZeImage);
     return UR_RESULT_SUCCESS;
   }
   virtual ur_result_t getZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
-                                     ur_device_handle_t = nullptr) override {
+                                     ur_device_handle_t,
+                                     const ur_event_handle_t *phWaitEvents,
+                                     uint32_t numWaitEvents) override {
+    std::ignore = phWaitEvents;
+    std::ignore = numWaitEvents;
     ZeHandlePtr = reinterpret_cast<char **>(&ZeImage);
     return UR_RESULT_SUCCESS;
   }

--- a/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -165,6 +165,9 @@ TEST_F(urMultiDeviceContextMemBufferTest, WriteRead) {
     ASSERT_SUCCESS(urEnqueueMemBufferRead(queues[1], buffer, false, 0,
                                           buffer_size_bytes, out_vec.data(), 1,
                                           &e1, nullptr));
+
+    ASSERT_SUCCESS(urQueueFinish(queues[1]));
+
     for (auto &a : out_vec) {
         ASSERT_EQ(a, fill_val);
     }
@@ -186,6 +189,9 @@ TEST_F(urMultiDeviceContextMemBufferTest, FillRead) {
     ASSERT_SUCCESS(urEnqueueMemBufferRead(queues[1], buffer, false, 0,
                                           buffer_size_bytes, out_vec.data(), 1,
                                           &e1, nullptr));
+
+    ASSERT_SUCCESS(urQueueFinish(queues[1]));
+
     for (auto &a : out_vec) {
         ASSERT_EQ(a, fill_val);
     }
@@ -219,6 +225,9 @@ TEST_F(urMultiDeviceContextMemBufferTest, WriteKernelRead) {
     ASSERT_SUCCESS(urEnqueueMemBufferRead(queues[0], buffer, false, 0,
                                           buffer_size_bytes, out_vec.data(), 1,
                                           &e2, nullptr));
+
+    ASSERT_SUCCESS(urQueueFinish(queues[0]));
+
     for (auto &a : out_vec) {
         ASSERT_EQ(a, fill_val + 1);
     }
@@ -257,6 +266,9 @@ TEST_F(urMultiDeviceContextMemBufferTest, WriteKernelKernelRead) {
     ASSERT_SUCCESS(urEnqueueMemBufferRead(queues[1], buffer, false, 0,
                                           buffer_size_bytes, out_vec.data(), 1,
                                           &e3, nullptr));
+
+    ASSERT_SUCCESS(urQueueFinish(queues[1]));
+
     for (auto &a : out_vec) {
         ASSERT_EQ(a, fill_val + 2);
     }


### PR DESCRIPTION


- To ensure buffers are always updated with the correct buffer values, track the dependencies as a prerequisite before performing the memory copy.