### PR TITLE
Fix integration tests for CL.

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -1,5 +1,4 @@
 {{NONDETERMINISTIC}}
-{{OPT}}urEnqueueDeviceGetGlobalVariableReadTest.Success/Intel_R__OpenCL___{{.*}}_
 urEnqueueKernelLaunchKernelWgSizeTest.Success/Intel_R__OpenCL___{{.*}}_
 urEnqueueKernelLaunchKernelSubGroupTest.Success/Intel_R__OpenCL___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchUSMLinkedList.Success/Intel_R__OpenCL___{{.*}}_UsePoolEnabled

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -230,7 +230,7 @@ inline std::string printKernelLaunchTestString(
 }
 
 struct urEnqueueKernelLaunchTestWithParam
-    : uur::urBaseKernelExecutionTestWithParam<testParametersEnqueueKernel> {
+    : uur::urKernelExecutionTestWithParam<testParametersEnqueueKernel> {
     void SetUp() override {
         global_range[0] = std::get<1>(GetParam()).X;
         global_range[1] = std::get<1>(GetParam()).Y;
@@ -247,12 +247,11 @@ struct urEnqueueKernelLaunchTestWithParam
             program_name = "fill_3d";
             buffer_size *= global_range[1] * global_range[2];
         }
-        UUR_RETURN_ON_FATAL_FAILURE(
-            urBaseKernelExecutionTestWithParam::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(urKernelExecutionTestWithParam::SetUp());
     }
 
     void TearDown() override {
-        UUR_RETURN_ON_FATAL_FAILURE(uur::urBaseKernelExecutionTestWithParam<
+        UUR_RETURN_ON_FATAL_FAILURE(uur::urKernelExecutionTestWithParam<
                                     testParametersEnqueueKernel>::TearDown());
     }
 

--- a/test/conformance/integration/integration_adapter_opencl.match
+++ b/test/conformance/integration/integration_adapter_opencl.match
@@ -1,7 +1,0 @@
-{{NONDETERMINISTIC}}
-QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__OpenCL___{{.*}}___IN_ORDER_QUEUE
-QueueEmptyStatusTestWithParam.QueueEmptyStatusTest/Intel_R__OpenCL___{{.*}}___OUT_OF_ORDER_QUEUE
-QueueUSMTestWithParam.QueueUSMTest/Intel_R__OpenCL___{{.*}}___IN_ORDER_QUEUE
-QueueUSMTestWithParam.QueueUSMTest/Intel_R__OpenCL___{{.*}}___OUT_OF_ORDER_QUEUE
-QueueBufferTestWithParam.QueueBufferTest/Intel_R__OpenCL___{{.*}}___IN_ORDER_QUEUE
-QueueBufferTestWithParam.QueueBufferTest/Intel_R__OpenCL___{{.*}}___OUT_OF_ORDER_QUEUE

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1220,6 +1220,13 @@ template <class T> struct urProgramTestWithParam : urQueueTestWithParam<T> {
     ur_program_handle_t program = nullptr;
 };
 
+// This fixture can provide a kernel, but it doesn't build the kernel at SetUp,
+// instead Build() must be invoked separately. This is for tests that wish to
+// check device capabilities to determine whether the test should run before
+// trying to load any device code.
+//
+// For a fixture that provides the kernel at SetUp, inherit from urKernelTest
+// instead.
 struct urBaseKernelTest : urProgramTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urProgramTest::SetUp());
@@ -1252,6 +1259,8 @@ struct urKernelTest : urBaseKernelTest {
     }
 };
 
+// Parameterized version of urBaseKernelTest, the comments on that fixture
+// clarify why you'd want to use this instead of urKernelTestWithParam.
 template <class T>
 struct urBaseKernelTestWithParam : urProgramTestWithParam<T> {
     void SetUp() override {
@@ -1386,11 +1395,13 @@ struct KernelLaunchHelper {
     uint32_t current_arg_index = 0;
 };
 
+// Parameterized kernel fixture with execution helpers, for the difference
+// between this and urKernelExecutionTestWithParam see the comment on
+// urBaseKernelTest.
 template <typename T>
 struct urBaseKernelExecutionTestWithParam : urBaseKernelTestWithParam<T> {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelTestWithParam<T>::SetUp());
-        UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelTestWithParam<T>::Build());
     }
 
     void TearDown() override {
@@ -1429,6 +1440,8 @@ struct urBaseKernelExecutionTestWithParam : urBaseKernelTestWithParam<T> {
     std::vector<ur_mem_handle_t> buffer_args;
 };
 
+// Kernel fixture with execution helpers, for the difference between this and
+// urKernelExecutionTest see the comment on urBaseKernelTest.
 struct urBaseKernelExecutionTest : urBaseKernelTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelTest::SetUp());


### PR DESCRIPTION
Turns out this was just a minor error in fixture usage and not allowing for an optional query to be unsupported.

Also remove an unneeded entry in the enqueue match file.