### PR TITLE
Compute-benchmarks use already compiled UR

### DIFF
--- a/.github/workflows/benchmarks_compute.yml
+++ b/.github/workflows/benchmarks_compute.yml
@@ -152,20 +152,31 @@ jobs:
       run: cmake --build ${{github.workspace}}/sycl_build -j
 
     - name: Configure UR
-      working-directory: ${{github.workspace}}/ur-repo
       run: >
         cmake -DCMAKE_BUILD_TYPE=Release
-        -B${{github.workspace}}/ur-repo/build
+        -S${{github.workspace}}/ur-repo
+        -B${{github.workspace}}/ur_build
+        -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/ur_install
         -DUR_BUILD_TESTS=OFF
         -DUR_BUILD_ADAPTER_L0=ON
         -DUR_BUILD_ADAPTER_L0_V2=ON
+        -DUMF_DISABLE_HWLOC=ON
 
     - name: Build UR
-      run: cmake --build ${{github.workspace}}/ur-repo/build -j $(nproc)
+      run: cmake --build ${{github.workspace}}/ur_build -j $(nproc)
+
+    - name: Install UR
+      run: cmake --install ${{github.workspace}}/ur_build
 
     - name: Run benchmarks
       id: benchmarks
-      run: numactl -N 0 ${{ github.workspace }}/ur-repo/scripts/benchmarks/main.py ~/bench_workdir ${{github.workspace}}/sycl_build ${{github.workspace}}/ur-repo ${{ matrix.adapter.str_name }} ${{ inputs.bench_script_params }}
+      run: >
+        numactl -N 0 ${{ github.workspace }}/ur-repo/scripts/benchmarks/main.py 
+        ~/bench_workdir 
+        ${{github.workspace}}/sycl_build
+        ${{github.workspace}}/ur_install
+        ${{ matrix.adapter.str_name }}
+        ${{ inputs.bench_script_params }}
 
     - name: Add comment to PR
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/scripts/benchmarks/benches/base.py
+++ b/scripts/benchmarks/benches/base.py
@@ -15,12 +15,27 @@ import tarfile
 class Benchmark:
     def __init__(self, directory):
         self.directory = directory
-        self.adapter_path = os.path.join(options.ur_dir, 'build', 'lib', f"libur_adapter_{options.ur_adapter_name}.so")
+
+    @staticmethod
+    def get_adapter_full_path():
+        for libs_dir_name in ['lib', 'lib64']:
+            adapter_path = os.path.join(
+                options.ur_dir, libs_dir_name, f"libur_adapter_{options.ur_adapter_name}.so")
+            if os.path.isfile(adapter_path):
+                return adapter_path
+        assert False, \
+            f"could not find adapter file {adapter_path} (and in similar lib paths)"
 
     def run_bench(self, command, env_vars):
         env_vars_with_forced_adapter = env_vars.copy()
-        env_vars_with_forced_adapter.update({'UR_ADAPTERS_FORCE_LOAD': self.adapter_path})
-        return run(command=command, env_vars=env_vars_with_forced_adapter, add_sycl=True, cwd=options.benchmark_cwd).stdout.decode()
+        env_vars_with_forced_adapter.update(
+            {'UR_ADAPTERS_FORCE_LOAD': Benchmark.get_adapter_full_path()})
+        return run(
+            command=command,
+            env_vars=env_vars_with_forced_adapter,
+            add_sycl=True,
+            cwd=options.benchmark_cwd
+        ).stdout.decode()
 
     def create_data_path(self, name):
         data_path = os.path.join(self.directory, "data", name)

--- a/scripts/benchmarks/benches/compute.py
+++ b/scripts/benchmarks/benches/compute.py
@@ -15,13 +15,12 @@ class ComputeBench:
     def __init__(self, directory):
         self.directory = directory
         self.built = False
-        return
 
     def setup(self):
         if self.built:
             return
 
-        repo_path = git_clone(self.directory, "compute-benchmarks-repo", "https://github.com/intel/compute-benchmarks.git", "08c41bb8bc1762ad53c6194df6d36bfcceff4aa2")
+        repo_path = git_clone(self.directory, "compute-benchmarks-repo", "https://github.com/intel/compute-benchmarks.git", "f6882552215736f90295244046fcb6e17fe53e83")
         build_path = create_build_path(self.directory, 'compute-benchmarks-build')
 
         configure_command = [
@@ -33,10 +32,7 @@ class ComputeBench:
             f"-DSYCL_COMPILER_ROOT={options.sycl}",
             f"-DALLOW_WARNINGS=ON",
             f"-DBUILD_UR=ON",
-            f"-DUR_BUILD_TESTS=OFF",
-            f"-DUR_BUILD_TESTS=OFF",
-            f"-DUMF_DISABLE_HWLOC=ON",
-            f"-DBENCHMARK_UR_SOURCE_DIR={options.ur_dir}",
+            f"-Dunified-runtime_DIR={options.ur_dir}/lib/cmake/unified-runtime",
         ]
         run(configure_command, add_sycl=True)
 

--- a/scripts/benchmarks/main.py
+++ b/scripts/benchmarks/main.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Unified Runtime Benchmark Runner')
     parser.add_argument('benchmark_directory', type=str, help='Working directory to setup benchmarks.')
     parser.add_argument('sycl', type=str, help='Root directory of the SYCL compiler.')
-    parser.add_argument('ur_dir', type=str, help='Root directory of the UR.')
+    parser.add_argument('ur_dir', type=str, help='UR install prefix path')
     parser.add_argument('ur_adapter_name', type=str, help='Options to build the Unified Runtime as part of the benchmark')
     parser.add_argument("--no-rebuild", help='Rebuild the benchmarks from scratch.', action="store_true")
     parser.add_argument("--env", type=str, help='Use env variable for a benchmark run.', action="append", default=[])

--- a/scripts/benchmarks/utils/utils.py
+++ b/scripts/benchmarks/utils/utils.py
@@ -42,6 +42,7 @@ def git_clone(dir, name, repo, commit):
 
     if os.path.isdir(repo_path) and os.path.isdir(os.path.join(repo_path, '.git')):
         run("git fetch", cwd=repo_path)
+        run("git reset --hard", cwd=repo_path)
         run(f"git checkout {commit}", cwd=repo_path)
     elif not os.path.exists(repo_path):
         run(f"git clone --recursive {repo} {repo_path}")


### PR DESCRIPTION
Utilize support for using UR binary through find_package added in  https://github.com/intel/compute-benchmarks/pull/21

Before this change compute-benchmarks always builds UR from sources which is unnecessary since we already build UR as part of SYCL on UR CI.

Add installing adapters by "cmake --install" which is needed by new benchmarks code.