### PR TITLE
Improvements to align CTS and Spec for Sampler

### DIFF
--- a/test/conformance/sampler/urSamplerCreate.cpp
+++ b/test/conformance/sampler/urSamplerCreate.cpp
@@ -95,6 +95,7 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
     ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
+
 TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
     ur_sampler_desc_t sampler_desc{
         UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
@@ -106,4 +107,20 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
     uur::raii::Sampler hSampler = nullptr;
     ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, hSampler.ptr()),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
+}
+
+TEST_P(urSamplerCreateTest, InvalidNullPointer) {
+    ur_sampler_desc_t sampler_desc{
+        UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
+        nullptr,                             /* pNext */
+        true,                                /* normalizedCoords */
+        UR_SAMPLER_ADDRESSING_MODE_CLAMP,    /* addressing mode */
+        UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */
+    };
+    uur::raii::Sampler hSampler = nullptr;
+    ASSERT_EQ_RESULT(urSamplerCreate(context, nullptr, hSampler.ptr()),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+    ASSERT_EQ_RESULT(urSamplerCreate(context, &sampler_desc, nullptr),
+                     UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -3,6 +3,7 @@
 // See LICENSE.TXT
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "uur/raii.h"
 #include <uur/fixtures.h>
 
 using urSamplerCreateWithNativeHandleTest = uur::urSamplerTest;
@@ -31,4 +32,85 @@ TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
                                     sizeof(addr_mode), &addr_mode, nullptr));
     ASSERT_EQ(addr_mode, sampler_desc.addressingMode);
     ASSERT_SUCCESS(urSamplerRelease(hSampler));
+}
+
+TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullHandle) {
+    ur_native_handle_t native_sampler = 0;
+    {
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urSamplerGetNativeHandle(sampler, &native_sampler));
+    }
+
+    ur_sampler_handle_t hSampler = nullptr;
+    ur_sampler_native_properties_t props{};
+    ASSERT_EQ(urSamplerCreateWithNativeHandle(native_sampler, nullptr, &props,
+                                              &hSampler),
+              UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullPointer) {
+    ur_native_handle_t native_sampler = 0;
+    {
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urSamplerGetNativeHandle(sampler, &native_sampler));
+    }
+
+    ur_sampler_native_properties_t props{};
+    ASSERT_EQ(urSamplerCreateWithNativeHandle(native_sampler, context, &props,
+                                              nullptr),
+              UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}
+
+TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
+
+    ur_native_handle_t native_handle = 0;
+    uur::raii::Sampler hSampler = nullptr;
+    {
+        ur_sampler_desc_t sampler_desc{
+            UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
+            nullptr,                         /* pNext */
+            true,                            /* normalizedCoords */
+            UR_SAMPLER_ADDRESSING_MODE_NONE, /* addressing mode */
+            UR_SAMPLER_FILTER_MODE_NEAREST,  /* filterMode */
+        };
+
+        ASSERT_SUCCESS(urSamplerCreate(context, &sampler_desc, hSampler.ptr()));
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urSamplerGetNativeHandle(hSampler, &native_handle));
+    }
+
+    ur_sampler_native_properties_t props = {
+        UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, nullptr, true};
+    ur_sampler_handle_t sampler = nullptr;
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
+        native_handle, context, &props, &sampler));
+    ASSERT_NE(sampler, nullptr);
+}
+
+TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
+
+    ur_native_handle_t native_handle = 0;
+    uur::raii::Sampler hSampler = nullptr;
+    {
+        ur_sampler_desc_t sampler_desc{
+            UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
+            nullptr,                         /* pNext */
+            true,                            /* normalizedCoords */
+            UR_SAMPLER_ADDRESSING_MODE_NONE, /* addressing mode */
+            UR_SAMPLER_FILTER_MODE_NEAREST,  /* filterMode */
+        };
+
+        ASSERT_SUCCESS(urSamplerCreate(context, &sampler_desc, hSampler.ptr()));
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urSamplerGetNativeHandle(hSampler, &native_handle));
+    }
+
+    ur_sampler_native_properties_t props = {
+        UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, nullptr, false};
+    ur_sampler_handle_t sampler = nullptr;
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
+        native_handle, context, &props, &sampler));
+    ASSERT_NE(sampler, nullptr);
 }


### PR DESCRIPTION
 - Add test for checking UR_RESULT_ERROR_INVALID_NULL_POINTER return conditions for urSamplerCreate
 - Add test for checking UR_RESULT_ERROR_INVALID_NULL_HANDLE/POINTER return conditions for urSamplerCreateWithNativeHandle
 - Add tests for owned/unowned native handles when using urSamplerCreateWithNativeHandle