### PR TITLE
Split source checks into a seperate workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install apt packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y doxygen ${{matrix.compiler.c}}
+        sudo apt-get install -y ${{matrix.compiler.c}}
 
     - name: Install libhwloc
       run: .github/scripts/install_hwloc.sh
@@ -61,9 +61,6 @@ jobs:
       if: matrix.compiler.cxx == 'g++-7'
       run: |
         sudo apt-get install -y ${{matrix.compiler.cxx}}
-
-    - name: Install pip packages
-      run: pip install -r third_party/requirements.txt
 
     - name: Install libbacktrace
       if: matrix.libbacktrace == '-DVAL_USE_LIBBACKTRACE_BACKTRACE=ON'
@@ -93,7 +90,7 @@ jobs:
         -DUR_ENABLE_TRACING=ON
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DUR_BUILD_TESTS=ON
-        -DUR_FORMAT_CPP_STYLE=ON
+        -DUR_FORMAT_CPP_STYLE=OFF
         -DUR_DPCXX=${{github.workspace}}/dpcpp_compiler/bin/clang++
         ${{matrix.libbacktrace}}
         ${{matrix.pool_tracking}}
@@ -109,17 +106,10 @@ jobs:
         -DUR_ENABLE_TRACING=ON
         -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
         -DUR_BUILD_TESTS=ON
-        -DUR_FORMAT_CPP_STYLE=ON
+        -DUR_FORMAT_CPP_STYLE=OFF
         ${{matrix.libbacktrace}}
         ${{matrix.pool_tracking}}
         ${{matrix.latency_tracking}}
-
-    - name: Generate source from spec, check for uncommitted diff
-      if: matrix.os == 'ubuntu-22.04'
-      run: cmake --build ${{github.workspace}}/build --target check-generated
-
-    - name: Verify that each source file contains a license
-      run: cmake --build ${{github.workspace}}/build --target verify-licenses
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build -j $(nproc)
@@ -284,11 +274,6 @@ jobs:
         -DUR_BUILD_TESTS=ON
         -DUR_FORMAT_CPP_STYLE=ON
         ${{matrix.adapter.var}}
-
-    # TODO: re-enable when check-generated is fixed for windows runners see #888
-    # - name: Generate source from spec, check for uncommitted diff
-    #   if: matrix.os == 'windows-2022'
-    #   run: cmake --build ${{github.workspace}}/build --target check-generated --config ${{matrix.build_type}}
 
     - name: Build all
       run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j $Env:NUMBER_OF_PROCESSORS

--- a/.github/workflows/source-checks.yml
+++ b/.github/workflows/source-checks.yml
@@ -1,0 +1,49 @@
+name: Source Checks
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  source-checks:
+    name: Source Checks
+    # TODO: Make this run on Windows (#888)
+    runs-on: 'ubuntu-22.04'
+
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Install apt packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y doxygen
+
+    - name: Setup PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Install pip packages
+      run: pip install -r third_party/requirements.txt
+
+    # Required for CMake
+    - name: Install libhwloc
+      run: .github/scripts/install_hwloc.sh
+
+    - name: Configure CMake
+      run: >
+        cmake
+        -B${{github.workspace}}/build
+        -DUR_ENABLE_TRACING=OFF
+        -DCMAKE_BUILD_TYPE=Debug
+        -DUR_BUILD_TESTS=OFF
+        -DUR_FORMAT_CPP_STYLE=ON
+
+    - name: Verify that each source file contains a license
+      run: cmake --build ${{github.workspace}}/build --target verify-licenses
+
+    - name: Generate source from spec, check for uncommitted diff
+      run: cmake --build ${{github.workspace}}/build --target check-generated


### PR DESCRIPTION
The "Build - Ubuntu" job has a stage that checks the source generated
from the spec matches the version stored in the repo. This is the
part of the job that takes the longest, and is ran multiple times.

Since it doesn't require a build, it has been brought out into its own
workflow which is only ran once. This should hopefully speed up builds.
