### PR TITLE
Query out and use local size set in program IL in CL adapter.

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_opencl.match
+++ b/test/conformance/enqueue/enqueue_adapter_opencl.match
@@ -1,3 +1,2 @@
 {{NONDETERMINISTIC}}
-urEnqueueKernelLaunchKernelWgSizeTest.Success/Intel_R__OpenCL___{{.*}}_
 {{OPT}}urEnqueueKernelLaunchUSMLinkedList.Success/Intel_R__OpenCL___{{.*}}_UsePoolEnabled


### PR DESCRIPTION
The CL spec wording on this is kind of fuzzy but every CL driver I tested (across intel, amd, nvidia cpu + gpu) returns an error when you have a local size set in the program source/IL and you don't specify any local size in your clEnqueueNDRangeKernel call (i.e. you leave it as NULL).

Our spec does allow you to leave local size as null if you have a size specified in your program, so this change adds some logic to query out the size set in the program and passes it to the enqueue call.

Initially I was concerned this might impact performance of current users but it looks like SYCL always passes a local size when calling urEnqueueKernelLaunch so it won't hit the path with the extra query.