### PR TITLE
Fix missing include in loader config test

### DIFF
--- a/test/loader/loader_config/urLoaderConfigGetInfo.cpp
+++ b/test/loader/loader_config/urLoaderConfigGetInfo.cpp
@@ -5,6 +5,8 @@
 
 #include "fixtures.hpp"
 
+#include <algorithm>
+
 struct urLoaderConfigGetInfoWithParamTest
     : LoaderConfigTest,
       ::testing::WithParamInterface<ur_loader_config_info_t> {


### PR DESCRIPTION
This file uses `std::find` which is part of `<algorithm>` but it wasn't including it. This causes build failures with gcc 14.