### PR TITLE
[NFC][CUDA] Include STL headers in program.cpp

### DIFF
--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -11,6 +11,17 @@
 #include "program.hpp"
 #include "ur_util.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
 bool getMaxRegistersJitOptionValue(const std::string &BuildOptions,
                                    unsigned int &Value) {
   using namespace std::string_view_literals;


### PR DESCRIPTION
This patch fixes the following build error on Windows:
```
source\adapters\cuda\program.cpp(73): error C2079: 'WorkGroupElements' uses undefined class 'std::array<uint32_t,3>'
```
Technically only `<array>` was sufficient for resolving it, but it's better to include everything that the file relies on.