### PR TITLE
Remove old CMake settings - external adapter source dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,16 +68,6 @@ set(UR_CONFORMANCE_TARGET_TRIPLES "" CACHE STRING
     "List of sycl targets to build CTS device binaries for")
 set(UR_CONFORMANCE_AMD_ARCH "" CACHE STRING "AMD device target ID to build CTS binaries for")
 option(UR_CONFORMANCE_ENABLE_MATCH_FILES "Enable CTS match files" ON)
-set(UR_ADAPTER_LEVEL_ZERO_SOURCE_DIR "" CACHE PATH
-    "Path to external 'level_zero' adapter source dir")
-set(UR_ADAPTER_OPENCL_SOURCE_DIR "" CACHE PATH
-    "Path to external 'opencl' adapter source dir")
-set(UR_ADAPTER_CUDA_SOURCE_DIR "" CACHE PATH
-    "Path to external 'cuda' adapter source dir")
-set(UR_ADAPTER_HIP_SOURCE_DIR "" CACHE PATH
-    "Path to external 'hip' adapter source dir")
-set(UR_ADAPTER_NATIVE_CPU_SOURCE_DIR "" CACHE PATH
-    "Path to external 'native_cpu' adapter source dir")
 
 # There's little reason not to generate the compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
I spotted these CMake settings which I believe were used when adapter sources lived in intel/llvm which is no longer the case so these should be able to be removed.