### PR TITLE
Don't double-space captured output in test wrapper

### DIFF
--- a/test/conformance/cts_exe.py
+++ b/test/conformance/cts_exe.py
@@ -54,6 +54,5 @@ if __name__ == '__main__':
         print(signal.strsignal(abs(rc)))
 
     print("#### GTEST_OUTPUT ####", file=sys.stderr)
-    for output in output_list:
-        print(output, file=sys.stderr)
+    print(''.join(output_list), file=sys.stderr)
     print("#### GTEST_OUTPUT_END ####", file=sys.stderr)


### PR DESCRIPTION
Lines read already have newlines, so don't need the implicit newline added by calling `print` in a loop over the lines. One call to print with one newline is cheaper and doesn't add the double newlines.