### PR TITLE
[UR] Don't allow the loader to catch exceptions

### DIFF
--- a/scripts/templates/libapi.cpp.mako
+++ b/scripts/templates/libapi.cpp.mako
@@ -65,7 +65,7 @@ try {
 
     return ${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
 %endif
-} catch(...) { return exceptionToResult(std::current_exception()); }
+} catch(...) { std::abort(); }
 %if 'condition' in obj:
 #endif // ${th.subt(n, tags, obj['condition'])}
 %endif

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -31,7 +31,7 @@ ur_result_t UR_APICALL urLoaderConfigCreate(
     ) try {
     return ur_lib::urLoaderConfigCreate(phLoaderConfig);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,7 +56,7 @@ ur_result_t UR_APICALL urLoaderConfigRetain(
     ) try {
     return ur_lib::urLoaderConfigRetain(hLoaderConfig);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -81,7 +81,7 @@ ur_result_t UR_APICALL urLoaderConfigRelease(
     ) try {
     return ur_lib::urLoaderConfigRelease(hLoaderConfig);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -129,7 +129,7 @@ ur_result_t UR_APICALL urLoaderConfigGetInfo(
     return ur_lib::urLoaderConfigGetInfo(hLoaderConfig, propName, propSize,
                                          pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -155,7 +155,7 @@ ur_result_t UR_APICALL urLoaderConfigEnableLayer(
     ) try {
     return ur_lib::urLoaderConfigEnableLayer(hLoaderConfig, pLayerName);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -189,7 +189,7 @@ ur_result_t UR_APICALL urLoaderConfigSetCodeLocationCallback(
     return ur_lib::urLoaderConfigSetCodeLocationCallback(hLoaderConfig,
                                                          pfnCodeloc, pUserData);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -217,7 +217,7 @@ ur_result_t UR_APICALL urLoaderConfigSetMockingEnabled(
     ) try {
     return ur_lib::urLoaderConfigSetMockingEnabled(hLoaderConfig, enable);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -253,7 +253,7 @@ ur_result_t UR_APICALL urLoaderInit(
     ) try {
     return ur_lib::urLoaderInit(device_flags, hLoaderConfig);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -268,7 +268,7 @@ ur_result_t UR_APICALL urLoaderInit(
 ur_result_t UR_APICALL urLoaderTearDown(void) try {
     return ur_lib::urLoaderTearDown();
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -313,7 +313,7 @@ ur_result_t UR_APICALL urAdapterGet(
 
     return pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -343,7 +343,7 @@ ur_result_t UR_APICALL urAdapterRelease(
 
     return pfnAdapterRelease(hAdapter);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -370,7 +370,7 @@ ur_result_t UR_APICALL urAdapterRetain(
 
     return pfnAdapterRetain(hAdapter);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -433,7 +433,7 @@ ur_result_t UR_APICALL urAdapterGetLastError(
 
     return pfnAdapterGetLastError(hAdapter, ppMessage, pError);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -484,7 +484,7 @@ ur_result_t UR_APICALL urAdapterGetInfo(
     return pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue,
                              pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -533,7 +533,7 @@ ur_result_t UR_APICALL urPlatformGet(
     return pfnGet(phAdapters, NumAdapters, NumEntries, phPlatforms,
                   pNumPlatforms);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -587,7 +587,7 @@ ur_result_t UR_APICALL urPlatformGetInfo(
 
     return pfnGetInfo(hPlatform, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -618,7 +618,7 @@ ur_result_t UR_APICALL urPlatformGetApiVersion(
 
     return pfnGetApiVersion(hPlatform, pVersion);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -657,7 +657,7 @@ ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
     return pfnGetNativeHandle(hPlatform, phNativePlatform);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -699,7 +699,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativePlatform, hAdapter, pProperties,
                                      phPlatform);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -743,7 +743,7 @@ ur_result_t UR_APICALL urPlatformGetBackendOption(
 
     return pfnGetBackendOption(hPlatform, pFrontendOption, ppPlatformOption);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -800,7 +800,7 @@ ur_result_t UR_APICALL urDeviceGet(
 
     return pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -846,7 +846,7 @@ ur_result_t UR_APICALL urDeviceGetSelected(
     return ur_lib::urDeviceGetSelected(hPlatform, DeviceType, NumEntries,
                                        phDevices, pNumDevices);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -901,7 +901,7 @@ ur_result_t UR_APICALL urDeviceGetInfo(
 
     return pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -941,7 +941,7 @@ ur_result_t UR_APICALL urDeviceRetain(
 
     return pfnRetain(hDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -978,7 +978,7 @@ ur_result_t UR_APICALL urDeviceRelease(
 
     return pfnRelease(hDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1030,7 +1030,7 @@ ur_result_t UR_APICALL urDevicePartition(
     return pfnPartition(hDevice, pProperties, NumDevices, phSubDevices,
                         pNumDevicesRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1079,7 +1079,7 @@ ur_result_t UR_APICALL urDeviceSelectBinary(
 
     return pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1118,7 +1118,7 @@ ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
     return pfnGetNativeHandle(hDevice, phNativeDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1160,7 +1160,7 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeDevice, hAdapter, pProperties,
                                      phDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1199,7 +1199,7 @@ ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
     return pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1248,7 +1248,7 @@ ur_result_t UR_APICALL urContextCreate(
 
     return pfnCreate(DeviceCount, phDevices, pProperties, phContext);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1284,7 +1284,7 @@ ur_result_t UR_APICALL urContextRetain(
 
     return pfnRetain(hContext);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1317,7 +1317,7 @@ ur_result_t UR_APICALL urContextRelease(
 
     return pfnRelease(hContext);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1373,7 +1373,7 @@ ur_result_t UR_APICALL urContextGetInfo(
 
     return pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1412,7 +1412,7 @@ ur_result_t UR_APICALL urContextGetNativeHandle(
 
     return pfnGetNativeHandle(hContext, phNativeContext);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1458,7 +1458,7 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeContext, hAdapter, numDevices,
                                      phDevices, pProperties, phContext);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1498,7 +1498,7 @@ ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
     return pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1570,7 +1570,7 @@ ur_result_t UR_APICALL urMemImageCreate(
     return pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost,
                           phMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1621,7 +1621,7 @@ ur_result_t UR_APICALL urMemBufferCreate(
 
     return pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1657,7 +1657,7 @@ ur_result_t UR_APICALL urMemRetain(
 
     return pfnRetain(hMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1688,7 +1688,7 @@ ur_result_t UR_APICALL urMemRelease(
 
     return pfnRelease(hMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1738,7 +1738,7 @@ ur_result_t UR_APICALL urMemBufferPartition(
 
     return pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1783,7 +1783,7 @@ ur_result_t UR_APICALL urMemGetNativeHandle(
 
     return pfnGetNativeHandle(hMem, hDevice, phNativeMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1823,7 +1823,7 @@ ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     return pfnBufferCreateWithNativeHandle(hNativeMem, hContext, pProperties,
                                            phMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1868,7 +1868,7 @@ ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     return pfnImageCreateWithNativeHandle(hNativeMem, hContext, pImageFormat,
                                           pImageDesc, pProperties, phMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1923,7 +1923,7 @@ ur_result_t UR_APICALL urMemGetInfo(
 
     return pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1978,7 +1978,7 @@ ur_result_t UR_APICALL urMemImageGetInfo(
     return pfnImageGetInfo(hMemory, propName, propSize, pPropValue,
                            pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2025,7 +2025,7 @@ ur_result_t UR_APICALL urSamplerCreate(
 
     return pfnCreate(hContext, pDesc, phSampler);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2057,7 +2057,7 @@ ur_result_t UR_APICALL urSamplerRetain(
 
     return pfnRetain(hSampler);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2089,7 +2089,7 @@ ur_result_t UR_APICALL urSamplerRelease(
 
     return pfnRelease(hSampler);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2137,7 +2137,7 @@ ur_result_t UR_APICALL urSamplerGetInfo(
 
     return pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2176,7 +2176,7 @@ ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
     return pfnGetNativeHandle(hSampler, phNativeSampler);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2217,7 +2217,7 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeSampler, hContext, pProperties,
                                      phSampler);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2274,7 +2274,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
 
     return pfnHostAlloc(hContext, pUSMDesc, pool, size, ppMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2333,7 +2333,7 @@ ur_result_t UR_APICALL urUSMDeviceAlloc(
 
     return pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, ppMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2393,7 +2393,7 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
 
     return pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, ppMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2421,7 +2421,7 @@ ur_result_t UR_APICALL urUSMFree(
 
     return pfnFree(hContext, pMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2464,7 +2464,7 @@ ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     return pfnGetMemAllocInfo(hContext, pMem, propName, propSize, pPropValue,
                               pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2503,7 +2503,7 @@ ur_result_t UR_APICALL urUSMPoolCreate(
 
     return pfnPoolCreate(hContext, pPoolDesc, ppPool);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2526,7 +2526,7 @@ ur_result_t UR_APICALL urUSMPoolRetain(
 
     return pfnPoolRetain(pPool);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2556,7 +2556,7 @@ ur_result_t UR_APICALL urUSMPoolRelease(
 
     return pfnPoolRelease(pPool);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2598,7 +2598,7 @@ ur_result_t UR_APICALL urUSMPoolGetInfo(
 
     return pfnPoolGetInfo(hPool, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2652,7 +2652,7 @@ ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     return pfnGranularityGetInfo(hContext, hDevice, propName, propSize,
                                  pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2686,7 +2686,7 @@ ur_result_t UR_APICALL urVirtualMemReserve(
 
     return pfnReserve(hContext, pStart, size, ppStart);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2714,7 +2714,7 @@ ur_result_t UR_APICALL urVirtualMemFree(
 
     return pfnFree(hContext, pStart, size);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2751,7 +2751,7 @@ ur_result_t UR_APICALL urVirtualMemMap(
 
     return pfnMap(hContext, pStart, size, hPhysicalMem, offset, flags);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2783,7 +2783,7 @@ ur_result_t UR_APICALL urVirtualMemUnmap(
 
     return pfnUnmap(hContext, pStart, size);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2816,7 +2816,7 @@ ur_result_t UR_APICALL urVirtualMemSetAccess(
 
     return pfnSetAccess(hContext, pStart, size, flags);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2857,7 +2857,7 @@ ur_result_t UR_APICALL urVirtualMemGetInfo(
     return pfnGetInfo(hContext, pStart, size, propName, propSize, pPropValue,
                       pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2895,7 +2895,7 @@ ur_result_t UR_APICALL urPhysicalMemCreate(
 
     return pfnCreate(hContext, hDevice, size, pProperties, phPhysicalMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2919,7 +2919,7 @@ ur_result_t UR_APICALL urPhysicalMemRetain(
 
     return pfnRetain(hPhysicalMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2943,7 +2943,7 @@ ur_result_t UR_APICALL urPhysicalMemRelease(
 
     return pfnRelease(hPhysicalMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2993,7 +2993,7 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
 
     return pfnCreateWithIL(hContext, pIL, length, pProperties, phProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3049,7 +3049,7 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
     return pfnCreateWithBinary(hContext, hDevice, size, pBinary, pProperties,
                                phProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3091,7 +3091,7 @@ ur_result_t UR_APICALL urProgramBuild(
 
     return pfnBuild(hContext, hProgram, pOptions);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3133,7 +3133,7 @@ ur_result_t UR_APICALL urProgramCompile(
 
     return pfnCompile(hContext, hProgram, pOptions);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3191,7 +3191,7 @@ ur_result_t UR_APICALL urProgramLink(
 
     return pfnLink(hContext, count, phPrograms, pOptions, phProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3225,7 +3225,7 @@ ur_result_t UR_APICALL urProgramRetain(
 
     return pfnRetain(hProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3259,7 +3259,7 @@ ur_result_t UR_APICALL urProgramRelease(
 
     return pfnRelease(hProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3314,7 +3314,7 @@ ur_result_t UR_APICALL urProgramGetFunctionPointer(
     return pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
                                  ppFunctionPointer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3366,7 +3366,7 @@ ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
                                        pGlobalVariableSizeRet,
                                        ppGlobalVariablePointerRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3417,7 +3417,7 @@ ur_result_t UR_APICALL urProgramGetInfo(
 
     return pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3462,7 +3462,7 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
     return pfnGetBuildInfo(hProgram, hDevice, propName, propSize, pPropValue,
                            pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3503,7 +3503,7 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
     return pfnSetSpecializationConstants(hProgram, count, pSpecConstants);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3542,7 +3542,7 @@ ur_result_t UR_APICALL urProgramGetNativeHandle(
 
     return pfnGetNativeHandle(hProgram, phNativeProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3583,7 +3583,7 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeProgram, hContext, pProperties,
                                      phProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3618,7 +3618,7 @@ ur_result_t UR_APICALL urKernelCreate(
 
     return pfnCreate(hProgram, pKernelName, phKernel);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3658,7 +3658,7 @@ ur_result_t UR_APICALL urKernelSetArgValue(
 
     return pfnSetArgValue(hKernel, argIndex, argSize, pProperties, pArgValue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3694,7 +3694,7 @@ ur_result_t UR_APICALL urKernelSetArgLocal(
 
     return pfnSetArgLocal(hKernel, argIndex, argSize, pProperties);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3746,7 +3746,7 @@ ur_result_t UR_APICALL urKernelGetInfo(
 
     return pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3788,7 +3788,7 @@ ur_result_t UR_APICALL urKernelGetGroupInfo(
     return pfnGetGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
                            pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3826,7 +3826,7 @@ ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     return pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize, pPropValue,
                               pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3859,7 +3859,7 @@ ur_result_t UR_APICALL urKernelRetain(
 
     return pfnRetain(hKernel);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3893,7 +3893,7 @@ ur_result_t UR_APICALL urKernelRelease(
 
     return pfnRelease(hKernel);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3934,7 +3934,7 @@ ur_result_t UR_APICALL urKernelSetArgPointer(
 
     return pfnSetArgPointer(hKernel, argIndex, pProperties, pArgValue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3978,7 +3978,7 @@ ur_result_t UR_APICALL urKernelSetExecInfo(
 
     return pfnSetExecInfo(hKernel, propName, propSize, pProperties, pPropValue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4013,7 +4013,7 @@ ur_result_t UR_APICALL urKernelSetArgSampler(
 
     return pfnSetArgSampler(hKernel, argIndex, pProperties, hArgValue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4049,7 +4049,7 @@ ur_result_t UR_APICALL urKernelSetArgMemObj(
 
     return pfnSetArgMemObj(hKernel, argIndex, pProperties, hArgValue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4096,7 +4096,7 @@ ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
     return pfnSetSpecializationConstants(hKernel, count, pSpecConstants);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4135,7 +4135,7 @@ ur_result_t UR_APICALL urKernelGetNativeHandle(
 
     return pfnGetNativeHandle(hKernel, phNativeKernel);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4181,7 +4181,7 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeKernel, hContext, hProgram,
                                      pProperties, phKernel);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4233,7 +4233,7 @@ ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
                                         pGlobalWorkOffset, pGlobalWorkSize,
                                         pSuggestedLocalWorkSize);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4281,7 +4281,7 @@ ur_result_t UR_APICALL urQueueGetInfo(
 
     return pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4328,7 +4328,7 @@ ur_result_t UR_APICALL urQueueCreate(
 
     return pfnCreate(hContext, hDevice, pProperties, phQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4364,7 +4364,7 @@ ur_result_t UR_APICALL urQueueRetain(
 
     return pfnRetain(hQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4402,7 +4402,7 @@ ur_result_t UR_APICALL urQueueRelease(
 
     return pfnRelease(hQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4443,7 +4443,7 @@ ur_result_t UR_APICALL urQueueGetNativeHandle(
 
     return pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4485,7 +4485,7 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeQueue, hContext, hDevice,
                                      pProperties, phQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4522,7 +4522,7 @@ ur_result_t UR_APICALL urQueueFinish(
 
     return pfnFinish(hQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4558,7 +4558,7 @@ ur_result_t UR_APICALL urQueueFlush(
 
     return pfnFlush(hQueue);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4604,7 +4604,7 @@ ur_result_t UR_APICALL urEventGetInfo(
 
     return pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4652,7 +4652,7 @@ ur_result_t UR_APICALL urEventGetProfilingInfo(
     return pfnGetProfilingInfo(hEvent, propName, propSize, pPropValue,
                                pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4690,7 +4690,7 @@ ur_result_t UR_APICALL urEventWait(
 
     return pfnWait(numEvents, phEventWaitList);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4721,7 +4721,7 @@ ur_result_t UR_APICALL urEventRetain(
 
     return pfnRetain(hEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4752,7 +4752,7 @@ ur_result_t UR_APICALL urEventRelease(
 
     return pfnRelease(hEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4791,7 +4791,7 @@ ur_result_t UR_APICALL urEventGetNativeHandle(
 
     return pfnGetNativeHandle(hEvent, phNativeEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4832,7 +4832,7 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     return pfnCreateWithNativeHandle(hNativeEvent, hContext, pProperties,
                                      phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4876,7 +4876,7 @@ ur_result_t UR_APICALL urEventSetCallback(
 
     return pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4951,7 +4951,7 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
                            pGlobalWorkSize, pLocalWorkSize, numEventsInWaitList,
                            phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5005,7 +5005,7 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
 
     return pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5063,7 +5063,7 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     return pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
                                     phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5127,7 +5127,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     return pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
                             numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5193,7 +5193,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     return pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
                              numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5281,7 +5281,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5372,7 +5372,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
         numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5434,7 +5434,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
                             dstOffset, size, numEventsInWaitList,
                             phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5514,7 +5514,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                                 dstRowPitch, dstSlicePitch, numEventsInWaitList,
                                 phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5581,7 +5581,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
                             size, numEventsInWaitList, phEventWaitList,
                             phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5652,7 +5652,7 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
                            rowPitch, slicePitch, pDst, numEventsInWaitList,
                            phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5724,7 +5724,7 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
                             rowPitch, slicePitch, pSrc, numEventsInWaitList,
                             phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5791,7 +5791,7 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
                            region, numEventsInWaitList, phEventWaitList,
                            phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5864,7 +5864,7 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
                            numEventsInWaitList, phEventWaitList, phEvent,
                            ppRetMap);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5919,7 +5919,7 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
     return pfnMemUnmap(hQueue, hMem, pMappedPtr, numEventsInWaitList,
                        phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5979,7 +5979,7 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     return pfnUSMFill(hQueue, pMem, patternSize, pPattern, size,
                       numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6035,7 +6035,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     return pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
                         phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6096,7 +6096,7 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     return pfnUSMPrefetch(hQueue, pMem, size, flags, numEventsInWaitList,
                           phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6143,7 +6143,7 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
     return pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6212,7 +6212,7 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     return pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width,
                         height, numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6280,7 +6280,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
                           width, height, numEventsInWaitList, phEventWaitList,
                           phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6335,7 +6335,7 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
         hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
         numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6390,7 +6390,7 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
                                        count, offset, pDst, numEventsInWaitList,
                                        phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6447,7 +6447,7 @@ ur_result_t UR_APICALL urEnqueueReadHostPipe(
     return pfnReadHostPipe(hQueue, hProgram, pipe_symbol, blocking, pDst, size,
                            numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6504,7 +6504,7 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     return pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
                             numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6574,7 +6574,7 @@ ur_result_t UR_APICALL urUSMPitchedAllocExp(
     return pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
                               height, elementSizeBytes, ppMem, pResultPitch);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6609,7 +6609,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageHandleDestroyExp(
 
     return pfnUnsampledImageHandleDestroyExp(hContext, hDevice, hImage);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6644,7 +6644,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageHandleDestroyExp(
 
     return pfnSampledImageHandleDestroyExp(hContext, hDevice, hImage);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6691,7 +6691,7 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     return pfnImageAllocateExp(hContext, hDevice, pImageFormat, pImageDesc,
                                phImageMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6725,7 +6725,7 @@ ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
     return pfnImageFreeExp(hContext, hDevice, hImageMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6775,7 +6775,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     return pfnUnsampledImageCreateExp(hContext, hDevice, hImageMem,
                                       pImageFormat, pImageDesc, phImage);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6828,7 +6828,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     return pfnSampledImageCreateExp(hContext, hDevice, hImageMem, pImageFormat,
                                     pImageDesc, hSampler, phImage);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6902,7 +6902,7 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                            imageCopyFlags, numEventsInWaitList, phEventWaitList,
                            phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6943,7 +6943,7 @@ ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     return pfnImageGetInfoExp(hContext, hImageMem, propName, pPropValue,
                               pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6983,7 +6983,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     return pfnMipmapGetLevelExp(hContext, hDevice, hImageMem, mipmapLevel,
                                 phImageMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7017,7 +7017,7 @@ ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
     return pfnMipmapFreeExp(hContext, hDevice, hMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7064,7 +7064,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     return pfnImportExternalMemoryExp(hContext, hDevice, size, memHandleType,
                                       pExternalMemDesc, phExternalMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7111,7 +7111,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     return pfnMapExternalArrayExp(hContext, hDevice, pImageFormat, pImageDesc,
                                   hExternalMem, phImageMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7153,7 +7153,7 @@ ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     return pfnMapExternalLinearMemoryExp(hContext, hDevice, offset, size,
                                          hExternalMem, ppRetMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7189,7 +7189,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
     return pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7235,7 +7235,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
                                          pExternalSemaphoreDesc,
                                          phExternalSemaphore);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7272,7 +7272,7 @@ ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     return pfnReleaseExternalSemaphoreExp(hContext, hDevice,
                                           hExternalSemaphore);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7324,7 +7324,7 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
                                        waitValue, numEventsInWaitList,
                                        phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7377,7 +7377,7 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
                                          signalValue, numEventsInWaitList,
                                          phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7418,7 +7418,7 @@ ur_result_t UR_APICALL urCommandBufferCreateExp(
 
     return pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7446,7 +7446,7 @@ ur_result_t UR_APICALL urCommandBufferRetainExp(
 
     return pfnRetainExp(hCommandBuffer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7475,7 +7475,7 @@ ur_result_t UR_APICALL urCommandBufferReleaseExp(
 
     return pfnReleaseExp(hCommandBuffer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7504,7 +7504,7 @@ ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 
     return pfnFinalizeExp(hCommandBuffer);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7579,7 +7579,7 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
         pLocalWorkSize, numKernelAlternatives, phKernelAlternatives,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint, phCommand);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7630,7 +7630,7 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
                                  numSyncPointsInWaitList, pSyncPointWaitList,
                                  pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7685,7 +7685,7 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
                                size, numSyncPointsInWaitList,
                                pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7735,7 +7735,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
         hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7786,7 +7786,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
                                       pSrc, numSyncPointsInWaitList,
                                       pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7836,7 +7836,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
                                      pDst, numSyncPointsInWaitList,
                                      pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7894,7 +7894,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
         srcRowPitch, srcSlicePitch, dstRowPitch, dstSlicePitch,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7959,7 +7959,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pSrc,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8022,7 +8022,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
         bufferRowPitch, bufferSlicePitch, hostRowPitch, hostSlicePitch, pDst,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8076,7 +8076,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
         hCommandBuffer, hBuffer, pPattern, patternSize, offset, size,
         numSyncPointsInWaitList, pSyncPointWaitList, pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8134,7 +8134,7 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
                                    numSyncPointsInWaitList, pSyncPointWaitList,
                                    pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8191,7 +8191,7 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
                                  numSyncPointsInWaitList, pSyncPointWaitList,
                                  pSyncPoint);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8237,7 +8237,7 @@ ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     return pfnEnqueueExp(hCommandBuffer, hQueue, numEventsInWaitList,
                          phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8265,7 +8265,7 @@ ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
 
     return pfnRetainCommandExp(hCommand);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8294,7 +8294,7 @@ ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 
     return pfnReleaseCommandExp(hCommand);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8344,7 +8344,7 @@ ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 
     return pfnUpdateKernelLaunchExp(hCommand, pUpdateKernelLaunch);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8392,7 +8392,7 @@ ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     return pfnGetInfoExp(hCommandBuffer, propName, propSize, pPropValue,
                          pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8440,7 +8440,7 @@ ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
     return pfnCommandGetInfoExp(hCommand, propName, propSize, pPropValue,
                                 pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8509,7 +8509,7 @@ ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
         hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
         pLocalWorkSize, numEventsInWaitList, phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8545,7 +8545,7 @@ ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     return pfnSuggestMaxCooperativeGroupCountExp(
         hKernel, localWorkSize, dynamicSharedMemorySize, pGroupCountRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8593,7 +8593,7 @@ ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     return pfnTimestampRecordingExp(hQueue, blocking, numEventsInWaitList,
                                     phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8682,7 +8682,7 @@ ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
                                     launchPropList, numEventsInWaitList,
                                     phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8727,7 +8727,7 @@ ur_result_t UR_APICALL urProgramBuildExp(
 
     return pfnBuildExp(hProgram, numDevices, phDevices, pOptions);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8773,7 +8773,7 @@ ur_result_t UR_APICALL urProgramCompileExp(
 
     return pfnCompileExp(hProgram, numDevices, phDevices, pOptions);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8836,7 +8836,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
     return pfnLinkExp(hContext, numDevices, phDevices, count, phPrograms,
                       pOptions, phProgram);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8868,7 +8868,7 @@ ur_result_t UR_APICALL urUSMImportExp(
 
     return pfnImportExp(hContext, pMem, size);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8898,7 +8898,7 @@ ur_result_t UR_APICALL urUSMReleaseExp(
 
     return pfnReleaseExp(hContext, pMem);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8949,7 +8949,7 @@ ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
     return pfnEnablePeerAccessExp(commandDevice, peerDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9001,7 +9001,7 @@ ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
     return pfnDisablePeerAccessExp(commandDevice, peerDevice);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9060,7 +9060,7 @@ ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     return pfnPeerAccessGetInfoExp(commandDevice, peerDevice, propName,
                                    propSize, pPropValue, pPropSizeRet);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9111,7 +9111,7 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
                                phMemList, pProperties, numEventsInWaitList,
                                phEventWaitList, phEvent);
 } catch (...) {
-    return exceptionToResult(std::current_exception());
+    std::abort();
 }
 
 } // extern "C"


### PR DESCRIPTION
Call std::abort if an exception is thrown to the loader. Since UR is a C interface, no exceptions should be thrown between different UR layers.