### PR TITLE
Don't use leading underscores in names

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -69,6 +69,7 @@ function(add_ur_target_compile_options name)
             -Wformat
             -Wformat-security
             -Wunused-parameter
+            -Wno-error=unknown-pragmas
 
             # Hardening options
             -fPIC
@@ -87,6 +88,7 @@ function(add_ur_target_compile_options name)
             # Colored output
             $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>
             $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fcolor-diagnostics>
+            $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13>>:-Werror=reserved-identifier>
         )
         if (UR_DEVELOPER_MODE)
             target_compile_options(${name} PRIVATE -Werror)

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -29,7 +29,7 @@ namespace ur_loader
     %if 'condition' in obj:
     #if ${th.subt(n, tags, obj['condition'])}
     %endif
-    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${X}_DLL_LOCAL ${x}_result_t ${X}_APICALL
     ${th.make_func_name(n, tags, obj)}(
         %for line in th.make_param_lines(n, tags, obj):
         ${line}

--- a/scripts/templates/libddi.cpp.mako
+++ b/scripts/templates/libddi.cpp.mako
@@ -28,7 +28,7 @@ namespace ${x}_lib
     ///////////////////////////////////////////////////////////////////////////////
 
 
-    __${x}dlllocal ${x}_result_t context_t::ddiInit()
+    ${X}_DLL_LOCAL ${x}_result_t context_t::ddiInit()
     {
         ${x}_result_t result = ${X}_RESULT_SUCCESS;
 

--- a/scripts/templates/mockddi.cpp.mako
+++ b/scripts/templates/mockddi.cpp.mako
@@ -31,7 +31,7 @@ namespace driver
     %if 'condition' in obj:
     #if ${th.subt(n, tags, obj['condition'])}
     %endif
-    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${X}_DLL_LOCAL ${x}_result_t ${X}_APICALL
     ${fname}(
         %for line in th.make_param_lines(n, tags, obj):
         ${line}

--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -30,7 +30,7 @@ namespace ur_tracing_layer
     %if 'condition' in obj:
     #if ${th.subt(n, tags, obj['condition'])}
     %endif
-    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${X}_DLL_LOCAL ${x}_result_t ${X}_APICALL
     ${th.make_func_name(n, tags, obj)}(
         %for line in th.make_param_lines(n, tags, obj):
         ${line}
@@ -75,7 +75,7 @@ namespace ur_tracing_layer
     ///     - ::${X}_RESULT_SUCCESS
     ///     - ::${X}_RESULT_ERROR_INVALID_NULL_POINTER
     ///     - ::${X}_RESULT_ERROR_UNSUPPORTED_VERSION
-    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${X}_DLL_LOCAL ${x}_result_t ${X}_APICALL
     ${tbl['export']['name']}(
         %for line in th.make_param_lines(n, tags, tbl['export']):
         ${line}

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -40,7 +40,7 @@ namespace ur_validation_layer
     %if 'condition' in obj:
     #if ${th.subt(n, tags, obj['condition'])}
     %endif
-    __${x}dlllocal ${x}_result_t ${X}_APICALL
+    ${X}_DLL_LOCAL ${x}_result_t ${X}_APICALL
     ${func_name}(
         %for line in th.make_param_lines(n, tags, obj):
         ${line}

--- a/source/adapters/cuda/program.cpp
+++ b/source/adapters/cuda/program.cpp
@@ -65,8 +65,8 @@ ur_program_handle_t_::setMetadata(const ur_program_metadata_t *Metadata,
 
     auto [Prefix, Tag] = splitMetadataName(MetadataElementName);
 
-    if (Tag == __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE ||
-        Tag == __SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE) {
+    if (Tag == SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE ||
+        Tag == SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE) {
       // If metadata is reqd_work_group_size/max_work_group_size, record it for
       // the corresponding kernel name.
       size_t MDElemsSize = MetadataElement.size - sizeof(std::uint64_t);
@@ -83,20 +83,19 @@ ur_program_handle_t_::setMetadata(const ur_program_metadata_t *Metadata,
       // Read values and pad with 1's for values not present.
       std::array<uint32_t, 3> WorkGroupElements = {1, 1, 1};
       std::memcpy(WorkGroupElements.data(), ValuePtr, MDElemsSize);
-      (Tag == __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE
+      (Tag == SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE
            ? KernelReqdWorkGroupSizeMD
            : KernelMaxWorkGroupSizeMD)[Prefix] =
           std::make_tuple(WorkGroupElements[0], WorkGroupElements[1],
                           WorkGroupElements[2]);
-    } else if (Tag == __SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING) {
+    } else if (Tag == SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING) {
       const char *MetadataValPtr =
           reinterpret_cast<const char *>(MetadataElement.value.pData) +
           sizeof(std::uint64_t);
       const char *MetadataValPtrEnd =
           MetadataValPtr + MetadataElement.size - sizeof(std::uint64_t);
       GlobalIDMD[Prefix] = std::string{MetadataValPtr, MetadataValPtrEnd};
-    } else if (Tag ==
-               __SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE) {
+    } else if (Tag == SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE) {
       KernelMaxLinearWorkGroupSizeMD[Prefix] = MetadataElement.value.data64;
     }
   }

--- a/source/adapters/hip/program.cpp
+++ b/source/adapters/hip/program.cpp
@@ -88,18 +88,17 @@ ur_program_handle_t_::setMetadata(const ur_program_metadata_t *Metadata,
 
     auto [Prefix, Tag] = splitMetadataName(MetadataElementName);
 
-    if (MetadataElementName ==
-        __SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION) {
+    if (MetadataElementName == SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION) {
       assert(MetadataElement.type == UR_PROGRAM_METADATA_TYPE_UINT32);
       IsRelocatable = MetadataElement.value.data32;
-    } else if (Tag == __SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING) {
+    } else if (Tag == SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING) {
       const char *MetadataValPtr =
           reinterpret_cast<const char *>(MetadataElement.value.pData) +
           sizeof(std::uint64_t);
       const char *MetadataValPtrEnd =
           MetadataValPtr + MetadataElement.size - sizeof(std::uint64_t);
       GlobalIDMD[Prefix] = std::string{MetadataValPtr, MetadataValPtrEnd};
-    } else if (Tag == __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE) {
+    } else if (Tag == SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE) {
       // If metadata is reqd_work_group_size, record it for the corresponding
       // kernel name.
       size_t MDElemsSize = MetadataElement.size - sizeof(std::uint64_t);

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -25,7 +25,7 @@ struct command_buffer_profiling_t {
   ze_kernel_timestamp_result_t *Timestamps;
 };
 
-struct ur_exp_command_buffer_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_handle_t_ : public ur_object_ {
   ur_exp_command_buffer_handle_t_(
       ur_context_handle_t Context, ur_device_handle_t Device,
       ze_command_list_handle_t CommandList,
@@ -122,7 +122,7 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   std::vector<ur_kernel_handle_t> KernelsList;
 };
 
-struct ur_exp_command_buffer_command_handle_t_ : public _ur_object {
+struct ur_exp_command_buffer_command_handle_t_ : public ur_object_ {
   ur_exp_command_buffer_command_handle_t_(ur_exp_command_buffer_handle_t,
                                           uint64_t, uint32_t, bool,
                                           ur_kernel_handle_t);

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -404,8 +404,8 @@ private:
 };
 
 // Base class to store common data
-struct _ur_object {
-  _ur_object() : RefCount{} {}
+struct ur_object_ {
+  ur_object_() : RefCount{} {}
 
   // Must be atomic to prevent data race when incrementing/decrementing.
   ReferenceCounter RefCount;
@@ -432,7 +432,7 @@ struct _ur_object {
 
 // Record for a memory allocation. This structure is used to keep information
 // for each memory allocation.
-struct MemAllocRecord : _ur_object {
+struct MemAllocRecord : ur_object_ {
   MemAllocRecord(ur_context_handle_t Context, bool OwnZeMemHandle = true)
       : Context(Context) {
     OwnNativeHandle = OwnZeMemHandle;

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -33,7 +33,7 @@ struct l0_command_list_cache_info {
   bool IsImmediate = false;
 };
 
-struct ur_context_handle_t_ : _ur_object {
+struct ur_context_handle_t_ : ur_object_ {
   ur_context_handle_t_(ze_context_handle_t ZeContext, uint32_t NumDevices,
                        const ur_device_handle_t *Devs, bool OwnZeContext)
       : ZeContext{ZeContext}, Devices{Devs, Devs + NumDevices},

--- a/source/adapters/level_zero/device.hpp
+++ b/source/adapters/level_zero/device.hpp
@@ -57,7 +57,7 @@ struct ur_ze_external_memory_data {
   size_t size;
 };
 
-struct ur_device_handle_t_ : _ur_object {
+struct ur_device_handle_t_ : ur_object_ {
   ur_device_handle_t_(ze_device_handle_t Device, ur_platform_handle_t Plt,
                       ur_device_handle_t ParentDevice = nullptr)
       : ZeDevice{Device}, Platform{Plt}, RootDevice{ParentDevice},

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -122,7 +122,7 @@ struct _ur_ze_event_list_t {
 
 void printZeEventList(const _ur_ze_event_list_t &PiZeEventList);
 
-struct ur_event_handle_t_ : _ur_object {
+struct ur_event_handle_t_ : ur_object_ {
   ur_event_handle_t_(ze_event_handle_t ZeEvent,
                      ze_event_pool_handle_t ZeEventPool,
                      ur_context_handle_t Context, ur_command_t CommandType,
@@ -216,7 +216,7 @@ struct ur_event_handle_t_ : _ur_object {
   uint64_t RecordEventEndTimestamp = 0;
 
   // Besides each PI object keeping a total reference count in
-  // _ur_object::RefCount we keep special track of the event *external*
+  // ur_object_::RefCount we keep special track of the event *external*
   // references. This way we are able to tell when the event is not referenced
   // externally anymore, i.e. it can't be passed as a dependency event to
   // piEnqueue* functions and explicitly waited meaning that we can do some

--- a/source/adapters/level_zero/kernel.hpp
+++ b/source/adapters/level_zero/kernel.hpp
@@ -13,7 +13,7 @@
 #include "memory.hpp"
 #include <unordered_set>
 
-struct ur_kernel_handle_t_ : _ur_object {
+struct ur_kernel_handle_t_ : ur_object_ {
   ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
       : Context{nullptr}, Program{Program}, ZeKernel{nullptr},
         SubmissionsCount{0}, MemAllocs{} {

--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -60,7 +60,7 @@ ur_result_t enqueueMemCopyRectHelper(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *EventWaitList,
     ur_event_handle_t *OutEvent, bool PreferCopyEngine = false);
 
-struct ur_mem_handle_t_ : _ur_object {
+struct ur_mem_handle_t_ : ur_object_ {
   // Keeps the PI context of this memory handle.
   ur_context_handle_t UrContext;
 

--- a/source/adapters/level_zero/physical_mem.hpp
+++ b/source/adapters/level_zero/physical_mem.hpp
@@ -11,7 +11,7 @@
 
 #include "common.hpp"
 
-struct ur_physical_mem_handle_t_ : _ur_object {
+struct ur_physical_mem_handle_t_ : ur_object_ {
   ur_physical_mem_handle_t_(ze_physical_mem_handle_t ZePhysicalMem,
                             ur_context_handle_t Context)
       : ZePhysicalMem{ZePhysicalMem}, Context{Context} {}

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -24,7 +24,7 @@ struct ur_zes_device_handle_data_t {
   ze_bool_t SubDevice = false;
 };
 
-struct ur_platform_handle_t_ : public _ur_platform {
+struct ur_platform_handle_t_ : public ur_platform {
   ur_platform_handle_t_(ze_driver_handle_t Driver)
       : ZeDriver{Driver}, ZeApiVersion{ZE_API_VERSION_CURRENT} {}
   // Performs initialization of a newly constructed PI platform.

--- a/source/adapters/level_zero/program.hpp
+++ b/source/adapters/level_zero/program.hpp
@@ -11,7 +11,7 @@
 
 #include "common.hpp"
 
-struct ur_program_handle_t_ : _ur_object {
+struct ur_program_handle_t_ : ur_object_ {
   // ur_program_handle_t_() {}
 
   typedef enum {

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -225,7 +225,7 @@ using ur_command_list_map_t =
 // The iterator pointing to a specific command-list in use.
 using ur_command_list_ptr_t = ur_command_list_map_t::iterator;
 
-struct ur_queue_handle_t_ : _ur_object {
+struct ur_queue_handle_t_ : ur_object_ {
   ur_queue_handle_t_(std::vector<ze_command_queue_handle_t> &ComputeQueues,
                      std::vector<ze_command_queue_handle_t> &CopyQueues,
                      ur_context_handle_t Context, ur_device_handle_t Device,
@@ -419,7 +419,7 @@ struct ur_queue_handle_t_ : _ur_object {
   active_barriers ActiveBarriers;
 
   // Besides each PI object keeping a total reference count in
-  // _ur_object::RefCount we keep special track of the queue *external*
+  // ur_object_::RefCount we keep special track of the queue *external*
   // references. This way we are able to tell when the queue is being finished
   // externally, and can wait for internal references to complete, and do proper
   // cleanup of the queue.

--- a/source/adapters/level_zero/sampler.hpp
+++ b/source/adapters/level_zero/sampler.hpp
@@ -11,7 +11,7 @@
 
 #include "common.hpp"
 
-struct ur_sampler_handle_t_ : _ur_object {
+struct ur_sampler_handle_t_ : ur_object_ {
   ur_sampler_handle_t_(ze_sampler_handle_t Sampler) : ZeSampler{Sampler} {}
 
   // Level Zero sampler handle.

--- a/source/adapters/level_zero/usm.hpp
+++ b/source/adapters/level_zero/usm.hpp
@@ -15,7 +15,7 @@
 
 usm::DisjointPoolAllConfigs InitializeDisjointPoolConfig();
 
-struct ur_usm_pool_handle_t_ : _ur_object {
+struct ur_usm_pool_handle_t_ : ur_object_ {
   bool zeroInit;
 
   usm::DisjointPoolAllConfigs DisjointPoolConfigs =

--- a/source/adapters/level_zero/v2/context.hpp
+++ b/source/adapters/level_zero/v2/context.hpp
@@ -17,7 +17,7 @@
 #include "event_pool_cache.hpp"
 #include "usm.hpp"
 
-struct ur_context_handle_t_ : _ur_object {
+struct ur_context_handle_t_ : ur_object_ {
   ur_context_handle_t_(ze_context_handle_t hContext, uint32_t numDevices,
                        const ur_device_handle_t *phDevices, bool ownZeContext);
 

--- a/source/adapters/level_zero/v2/event.hpp
+++ b/source/adapters/level_zero/v2/event.hpp
@@ -22,7 +22,7 @@ namespace v2 {
 class event_pool;
 }
 
-struct ur_event_handle_t_ : _ur_object {
+struct ur_event_handle_t_ : ur_object_ {
 public:
   ur_event_handle_t_(v2::event_allocation eventAllocation,
                      v2::event_pool *pool);

--- a/source/adapters/level_zero/v2/kernel.hpp
+++ b/source/adapters/level_zero/v2/kernel.hpp
@@ -24,7 +24,7 @@ struct ur_single_device_kernel_t {
   mutable ZeCache<ZeStruct<ze_kernel_properties_t>> zeKernelProperties;
 };
 
-struct ur_kernel_handle_t_ : _ur_object {
+struct ur_kernel_handle_t_ : ur_object_ {
 private:
 public:
   ur_kernel_handle_t_(ur_program_handle_t hProgram, const char *kernelName);

--- a/source/adapters/level_zero/v2/memory.hpp
+++ b/source/adapters/level_zero/v2/memory.hpp
@@ -15,7 +15,7 @@
 #include "../device.hpp"
 #include "common.hpp"
 
-struct ur_mem_handle_t_ : _ur_object {
+struct ur_mem_handle_t_ : ur_object_ {
   ur_mem_handle_t_(ur_context_handle_t hContext, size_t size);
   virtual ~ur_mem_handle_t_() = default;
 

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -38,7 +38,7 @@ struct ur_command_list_handler_t {
   ze_event_handle_t lastEvent = nullptr;
 };
 
-struct ur_queue_immediate_in_order_t : _ur_object, public ur_queue_handle_t_ {
+struct ur_queue_immediate_in_order_t : ur_object_, public ur_queue_handle_t_ {
 private:
   ur_context_handle_t hContext;
   ur_device_handle_t hDevice;

--- a/source/adapters/level_zero/v2/usm.hpp
+++ b/source/adapters/level_zero/v2/usm.hpp
@@ -15,7 +15,7 @@
 #include "common.hpp"
 #include "ur_pool_manager.hpp"
 
-struct ur_usm_pool_handle_t_ : _ur_object {
+struct ur_usm_pool_handle_t_ : ur_object_ {
   ur_usm_pool_handle_t_(ur_context_handle_t hContext,
                         ur_usm_pool_desc_t *pPoolDes);
 

--- a/source/adapters/mock/ur_mock.hpp
+++ b/source/adapters/mock/ur_mock.hpp
@@ -18,7 +18,7 @@
 
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal context_t {
+class UR_DLL_LOCAL context_t {
   public:
     ur_api_version_t version = UR_API_VERSION_CURRENT;
 

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -15,7 +15,7 @@
 namespace driver {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
-__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGet(
     uint32_t
         NumEntries, ///< [in] the number of adapters to be added to phAdapters.
     ///< If phAdapters is not NULL, then NumEntries should be greater than
@@ -73,7 +73,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRelease
-__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRelease(
     ur_adapter_handle_t hAdapter ///< [in][release] Adapter handle to release
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -115,7 +115,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRetain
-__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRetain(
     ur_adapter_handle_t hAdapter ///< [in][retain] Adapter handle to retain
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -157,7 +157,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetLastError
-__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
         ppMessage, ///< [out] pointer to a C string where the adapter specific error message
@@ -206,7 +206,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetInfo
-__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetInfo(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
     ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -259,7 +259,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
@@ -321,7 +321,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
@@ -374,7 +374,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_api_version_t *pVersion      ///< [out] api version
     ) try {
@@ -417,7 +417,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetNativeHandle(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
     ur_native_handle_t *
         phNativePlatform ///< [out] a pointer to the native handle of the platform.
@@ -463,7 +463,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
     ur_adapter_handle_t
@@ -518,7 +518,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetBackendOption
-__urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetBackendOption(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance.
     const char
         *pFrontendOption, ///< [in] string containing the frontend option.
@@ -567,7 +567,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
     uint32_t
@@ -628,7 +628,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -682,7 +682,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRetain(
     ur_device_handle_t
         hDevice ///< [in][retain] handle of the device to get a reference of.
     ) try {
@@ -725,7 +725,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t
         hDevice ///< [in][release] handle of the device to release.
     ) try {
@@ -768,7 +768,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
     const ur_device_partition_properties_t
         *pProperties,    ///< [in] Device partition properties.
@@ -821,7 +821,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
     const ur_device_binary_t
@@ -873,7 +873,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetNativeHandle(
     ur_device_handle_t hDevice, ///< [in] handle of the device.
     ur_native_handle_t
         *phNativeDevice ///< [out] a pointer to the native handle of the device.
@@ -918,7 +918,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t
         hNativeDevice, ///< [in][nocheck] the native handle of the device.
     ur_adapter_handle_t
@@ -973,7 +973,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     uint64_t *
         pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
@@ -1024,7 +1024,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreate(
     uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
     const ur_device_handle_t
         *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
@@ -1074,7 +1074,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRetain(
     ur_context_handle_t
         hContext ///< [in][retain] handle of the context to get a reference of.
     ) try {
@@ -1118,7 +1118,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t
         hContext ///< [in][release] handle of the context to release.
     ) try {
@@ -1162,7 +1162,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
@@ -1217,7 +1217,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_native_handle_t *
         phNativeContext ///< [out] a pointer to the native handle of the context.
@@ -1263,7 +1263,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
         hNativeContext, ///< [in][nocheck] the native handle of the context.
     ur_adapter_handle_t
@@ -1323,7 +1323,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
@@ -1372,7 +1372,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     const ur_image_format_t
@@ -1422,7 +1422,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
@@ -1478,7 +1478,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t
         hMem ///< [in][retain] handle of the memory object to get access
     ) try {
@@ -1522,7 +1522,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t
         hMem ///< [in][release] handle of the memory object to release
     ) try {
@@ -1566,7 +1566,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
@@ -1617,7 +1617,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetNativeHandle(
     ur_mem_handle_t hMem, ///< [in] handle of the mem.
     ur_device_handle_t
         hDevice, ///< [in][optional] handle of the device that the native handle will be
@@ -1665,7 +1665,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1719,7 +1719,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1777,7 +1777,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory,            ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
@@ -1832,7 +1832,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
@@ -1886,7 +1886,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,   ///< [in] handle of the context object
     const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
@@ -1932,7 +1932,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRetain(
     ur_sampler_handle_t
         hSampler ///< [in][retain] handle of the sampler object to get access
     ) try {
@@ -1976,7 +1976,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRelease(
     ur_sampler_handle_t
         hSampler ///< [in][release] handle of the sampler object to release
     ) try {
@@ -2020,7 +2020,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
@@ -2071,7 +2071,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetNativeHandle(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
     ur_native_handle_t *
         phNativeSampler ///< [out] a pointer to the native handle of the sampler.
@@ -2117,7 +2117,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler, ///< [in][nocheck] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -2171,7 +2171,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const ur_usm_desc_t
         *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
@@ -2222,7 +2222,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t
@@ -2274,7 +2274,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -2326,7 +2326,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
     ) try {
@@ -2370,7 +2370,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
@@ -2423,7 +2423,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_desc_t *
         pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
@@ -2470,7 +2470,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRetain
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRetain(
     ur_usm_pool_handle_t pPool ///< [in][retain] pointer to USM memory pool
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2513,7 +2513,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRelease
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRelease(
     ur_usm_pool_handle_t pPool ///< [in][release] pointer to USM memory pool
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2556,7 +2556,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolGetInfo
-__urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolGetInfo(
     ur_usm_pool_handle_t hPool,  ///< [in] handle of the USM memory pool
     ur_usm_pool_info_t propName, ///< [in] name of the pool property to query
     size_t propSize, ///< [in] size in bytes of the pool property value provided
@@ -2606,7 +2606,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGranularityGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t
         hDevice, ///< [in][optional] is the device to get the granularity from, if the
@@ -2666,7 +2666,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemReserve
-__urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemReserve(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in][optional] pointer to the start of the virtual memory region to
@@ -2718,7 +2718,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemFree
-__urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in] pointer to the start of the virtual memory range to free.
@@ -2763,7 +2763,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemMap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemMap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2815,7 +2815,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemUnmap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemUnmap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void *
         pStart, ///< [in] pointer to the start of the mapped virtual memory range
@@ -2860,7 +2860,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemSetAccess
-__urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemSetAccess(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2908,7 +2908,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGetInfo(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2965,7 +2965,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemCreate
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] handle of the device object.
     size_t
@@ -3017,7 +3017,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRetain
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRetain(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][retain] handle of the physical memory object to retain.
     ) try {
@@ -3061,7 +3061,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRelease
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRelease(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][release] handle of the physical memory object to release.
     ) try {
@@ -3105,7 +3105,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithIL(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     const void *pIL,              ///< [in] pointer to IL binary.
     size_t length,                ///< [in] length of `pIL` in bytes.
@@ -3155,7 +3155,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithBinary(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     ur_device_handle_t
         hDevice,            ///< [in] handle to device associated with binary.
@@ -3207,7 +3207,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL urProgramBuild(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     const char *
@@ -3252,7 +3252,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL urProgramCompile(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t
         hProgram, ///< [in][out] handle of the program to compile.
@@ -3298,7 +3298,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL urProgramLink(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLink(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t count, ///< [in] number of program handles in `phPrograms`.
     const ur_program_handle_t *
@@ -3352,7 +3352,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t
         hProgram ///< [in][retain] handle for the Program to retain
     ) try {
@@ -3396,7 +3396,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t
         hProgram ///< [in][release] handle for the Program to release
     ) try {
@@ -3440,7 +3440,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetFunctionPointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
@@ -3494,7 +3494,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetGlobalVariablePointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve the pointer for.
     ur_program_handle_t
@@ -3551,7 +3551,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
@@ -3605,7 +3605,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
@@ -3661,7 +3661,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3711,7 +3711,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetNativeHandle(
     ur_program_handle_t hProgram, ///< [in] handle of the program.
     ur_native_handle_t *
         phNativeProgram ///< [out] a pointer to the native handle of the program.
@@ -3757,7 +3757,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram, ///< [in][nocheck] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
@@ -3811,7 +3811,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
     ur_kernel_handle_t
@@ -3857,7 +3857,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t argSize,    ///< [in] size of argument type
@@ -3907,7 +3907,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t
@@ -3955,7 +3955,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
@@ -4010,7 +4010,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
@@ -4063,7 +4063,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
@@ -4116,7 +4116,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in][retain] handle for the Kernel to retain
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4159,7 +4159,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t
         hKernel ///< [in][release] handle for the Kernel to release
     ) try {
@@ -4203,7 +4203,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_pointer_properties_t
@@ -4252,7 +4252,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
@@ -4302,7 +4302,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgSampler(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_sampler_properties_t
@@ -4349,7 +4349,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_mem_obj_properties_t
@@ -4396,7 +4396,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -4445,7 +4445,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetNativeHandle(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
@@ -4490,7 +4490,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4546,7 +4546,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSuggestedLocalWorkSize
-__urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     uint32_t
@@ -4607,7 +4607,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
@@ -4658,7 +4658,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_queue_properties_t
@@ -4707,7 +4707,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t
         hQueue ///< [in][retain] handle of the queue object to get access
     ) try {
@@ -4751,7 +4751,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t
         hQueue ///< [in][release] handle of the queue object to release
     ) try {
@@ -4795,7 +4795,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
     ur_queue_native_desc_t
         *pDesc, ///< [in][optional] pointer to native descriptor
@@ -4843,7 +4843,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t
         hNativeQueue, ///< [in][nocheck] the native handle of the queue.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4898,7 +4898,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4940,7 +4940,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4982,7 +4982,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
@@ -5031,7 +5031,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
         propName,    ///< [in] the name of the profiling property to query
@@ -5083,7 +5083,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
     const ur_event_handle_t *
         phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
@@ -5128,7 +5128,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in][retain] handle of the event object
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5171,7 +5171,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in][release] handle of the event object
     ) try {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -5214,7 +5214,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetNativeHandle(
     ur_event_handle_t hEvent, ///< [in] handle of the event.
     ur_native_handle_t
         *phNativeEvent ///< [out] a pointer to the native handle of the event.
@@ -5259,7 +5259,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t
         hNativeEvent, ///< [in][nocheck] the native handle of the event.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -5313,7 +5313,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
@@ -5360,7 +5360,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -5439,7 +5439,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -5497,7 +5497,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -5558,7 +5558,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5623,7 +5623,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5690,7 +5690,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -5778,7 +5778,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -5870,7 +5870,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOffset, size)] handle of the src buffer object
@@ -5935,7 +5935,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOrigin, region)] handle of the source buffer object
@@ -6012,7 +6012,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -6082,7 +6082,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -6153,7 +6153,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -6225,7 +6225,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImageSrc, ///< [in][bounds(srcOrigin, region)] handle of the src image object
@@ -6296,7 +6296,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -6366,7 +6366,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemUnmap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hMem,         ///< [in] handle of the memory (buffer or image) object
@@ -6427,7 +6427,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pMem, ///< [in][bounds(0, size)] pointer to USM memory object
     size_t
@@ -6494,7 +6494,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool blocking,            ///< [in] blocking or non-blocking copy
     void *
@@ -6558,7 +6558,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -6620,7 +6620,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMAdvise(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -6674,7 +6674,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *
         pMem, ///< [in][bounds(0, pitch * height)] pointer to memory to be filled.
@@ -6745,7 +6745,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *
@@ -6816,7 +6816,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -6886,7 +6886,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -6956,7 +6956,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueReadHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueReadHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the read command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -7028,7 +7028,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueWriteHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the write command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -7101,7 +7101,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPitchedAllocExp
-__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -7158,7 +7158,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -7209,7 +7209,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -7260,7 +7260,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageAllocateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -7314,7 +7314,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7364,7 +7364,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7419,7 +7419,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7476,7 +7476,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageCopyExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void *pSrc,         ///< [in] location the data will be copied from
     void *pDst,               ///< [in] location the data will be copied to
@@ -7560,7 +7560,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_exp_image_mem_native_handle_t
         hImageMem,            ///< [in] handle to the image memory
@@ -7611,7 +7611,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7665,7 +7665,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7715,7 +7715,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
@@ -7772,7 +7772,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalArrayExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -7829,7 +7829,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalLinearMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     uint64_t offset,              ///< [in] offset into memory region to map
@@ -7881,7 +7881,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_mem_handle_t
@@ -7931,7 +7931,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
@@ -7987,7 +7987,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_handle_t
@@ -8037,7 +8037,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -8108,7 +8108,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -8179,7 +8179,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] Handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] Handle of the device object.
     const ur_exp_command_buffer_desc_t
@@ -8229,7 +8229,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][retain] Handle of the command-buffer object.
     ) try {
@@ -8273,7 +8273,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][release] Handle of the command-buffer object.
     ) try {
@@ -8317,7 +8317,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] Handle of the command-buffer object.
     ) try {
@@ -8361,7 +8361,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
     ur_kernel_handle_t hKernel, ///< [in] Kernel to append.
@@ -8468,7 +8468,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMMemcpyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -8555,7 +8555,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,   ///< [in] handle of the command-buffer object.
     void *pMemory,        ///< [in] pointer to USM allocated memory to fill.
@@ -8645,7 +8645,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -8736,7 +8736,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8826,7 +8826,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8915,7 +8915,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -9017,7 +9017,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -9125,7 +9125,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -9231,7 +9231,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
@@ -9323,7 +9323,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMPrefetchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,  ///< [in] handle of the command-buffer object.
     const void *pMemory, ///< [in] pointer to USM allocated memory to prefetch.
@@ -9410,7 +9410,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMAdviseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,           ///< [in] handle of the command-buffer object.
     const void *pMemory,          ///< [in] pointer to the USM memory object.
@@ -9497,7 +9497,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     ur_queue_handle_t
@@ -9557,7 +9557,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][retain] Handle of the command-buffer command.
     ) try {
@@ -9604,7 +9604,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][release] Handle of the command-buffer command.
     ) try {
@@ -9651,7 +9651,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer kernel command to update.
     const ur_exp_command_buffer_update_kernel_launch_desc_t *
@@ -9700,7 +9700,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateSignalEventExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     ur_event_handle_t *phSignalEvent ///< [out] Event to be signaled.
@@ -9749,7 +9749,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateWaitEventsExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     uint32_t numEventsInWaitList, ///< [in] Size of the event wait list.
@@ -9801,7 +9801,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object
     ur_exp_command_buffer_info_t
@@ -9854,7 +9854,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCommandGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] handle of the command-buffer command object
     ur_exp_command_buffer_command_info_t
@@ -9910,7 +9910,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueCooperativeKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -9993,7 +9993,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSuggestMaxCooperativeGroupCountExp
-__urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     size_t
         localWorkSize, ///< [in] number of local work-items that will form a work-group when the
@@ -10046,7 +10046,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool
         blocking, ///< [in] indicates whether the call to this function should block until
@@ -10112,7 +10112,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunchCustomExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -10189,7 +10189,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
-__urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -10237,7 +10237,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompileExp
-__urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompileExp(
     ur_program_handle_t
         hProgram,        ///< [in][out] handle of the program to compile.
     uint32_t numDevices, ///< [in] number of devices
@@ -10286,7 +10286,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLinkExp
-__urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLinkExp(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -10344,7 +10344,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
@@ -10388,7 +10388,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
     ) try {
@@ -10431,7 +10431,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PEnablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -10478,7 +10478,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PDisablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -10526,7 +10526,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PPeerAccessGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     ur_device_handle_t
         commandDevice,             ///< [in] handle of the command device object
     ur_device_handle_t peerDevice, ///< [in] handle of the peer device object
@@ -10586,7 +10586,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueNativeCommandExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_enqueue_native_command_function_t
         pfnNativeEnqueue, ///< [in] function calling the native underlying API, to be executed

--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -53,7 +53,7 @@ namespace ur {
 } // namespace detail
 
 // Base class to store common data
-struct _ur_object {
+struct ur_object_ {
   ur_shared_mutex Mutex;
 };
 

--- a/source/adapters/native_cpu/context.cpp
+++ b/source/adapters/native_cpu/context.cpp
@@ -51,7 +51,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return returnValue(1);
   case UR_CONTEXT_INFO_DEVICES:
-    return returnValue(hContext->_device);
+    return returnValue(hContext->device);
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
     return returnValue(uint32_t{hContext->getReferenceCount()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:

--- a/source/adapters/native_cpu/context.hpp
+++ b/source/adapters/native_cpu/context.hpp
@@ -91,9 +91,9 @@ static usm_alloc_info get_alloc_info(void *ptr) {
 } // namespace native_cpu
 
 struct ur_context_handle_t_ : RefCounted {
-  ur_context_handle_t_(ur_device_handle_t_ *phDevices) : _device{phDevices} {}
+  ur_context_handle_t_(ur_device_handle_t_ *phDevices) : device{phDevices} {}
 
-  ur_device_handle_t _device;
+  ur_device_handle_t device;
 
   ur_result_t remove_alloc(void *ptr) {
     std::lock_guard<std::mutex> lock(alloc_mutex);
@@ -138,7 +138,7 @@ struct ur_context_handle_t_ : RefCounted {
       return nullptr;
     // Do a placement new of the alloc_info to avoid allocation and copy
     auto info = new (info_addr)
-        native_cpu::usm_alloc_info(type, ptr, size, this->_device, pool, alloc);
+        native_cpu::usm_alloc_info(type, ptr, size, this->device, pool, alloc);
     if (!info)
       return nullptr;
     allocations.insert(ptr);

--- a/source/adapters/native_cpu/kernel.cpp
+++ b/source/adapters/native_cpu/kernel.cpp
@@ -22,8 +22,8 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
   UR_ASSERT(hProgram, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(pKernelName, UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-  auto kernelEntry = hProgram->_kernels.find(pKernelName);
-  if (kernelEntry == hProgram->_kernels.end())
+  auto kernelEntry = hProgram->kernels.find(pKernelName);
+  if (kernelEntry == hProgram->kernels.end())
     return UR_RESULT_ERROR_INVALID_KERNEL;
 
   auto f = reinterpret_cast<nativecpu_ptr_t>(
@@ -70,7 +70,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
 
-  hKernel->_args.emplace_back(const_cast<void *>(pArgValue));
+  hKernel->args.emplace_back(const_cast<void *>(pArgValue));
 
   return UR_RESULT_SUCCESS;
 }
@@ -81,8 +81,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
   std::ignore = pProperties;
   // emplace a placeholder kernel arg, gets replaced with a pointer to the
   // memory pool before enqueueing the kernel.
-  hKernel->_args.emplace_back(nullptr);
-  hKernel->_localArgInfo.emplace_back(argIndex, argSize);
+  hKernel->args.emplace_back(nullptr);
+  hKernel->localArgInfo.emplace_back(argIndex, argSize);
   return UR_RESULT_SUCCESS;
 }
 
@@ -104,7 +104,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
     //  case UR_KERNEL_INFO_PROGRAM:
     //    return ReturnValue(ur_program_handle_t{ Kernel->Program });
   case UR_KERNEL_INFO_FUNCTION_NAME:
-    return ReturnValue(hKernel->_name);
+    return ReturnValue(hKernel->name);
   case UR_KERNEL_INFO_REFERENCE_COUNT:
     return ReturnValue(uint32_t{hKernel->getReferenceCount()});
   case UR_KERNEL_INFO_ATTRIBUTES:
@@ -137,7 +137,7 @@ urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
   case UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE: {
     size_t GroupSize[3] = {0, 0, 0};
     const auto &ReqdWGSizeMDMap = hKernel->hProgram->KernelReqdWorkGroupSizeMD;
-    const auto ReqdWGSizeMD = ReqdWGSizeMDMap.find(hKernel->_name);
+    const auto ReqdWGSizeMD = ReqdWGSizeMDMap.find(hKernel->name);
     if (ReqdWGSizeMD != ReqdWGSizeMDMap.end()) {
       const auto ReqdWGSize = ReqdWGSizeMD->second;
       GroupSize[0] = std::get<0>(ReqdWGSize);
@@ -228,7 +228,7 @@ urKernelSetArgPointer(ur_kernel_handle_t hKernel, uint32_t argIndex,
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(pArgValue, UR_RESULT_ERROR_INVALID_NULL_POINTER);
 
-  hKernel->_args.push_back(const_cast<void *>(pArgValue));
+  hKernel->args.push_back(const_cast<void *>(pArgValue));
 
   return UR_RESULT_SUCCESS;
 }
@@ -271,11 +271,11 @@ urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
   // Taken from ur/adapters/cuda/kernel.cpp
   // zero-sized buffers are expected to be null.
   if (hArgValue == nullptr) {
-    hKernel->_args.emplace_back(nullptr);
+    hKernel->args.emplace_back(nullptr);
     return UR_RESULT_SUCCESS;
   }
 
-  hKernel->_args.emplace_back(hArgValue->_mem);
+  hKernel->args.emplace_back(hArgValue->mem);
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/native_cpu/memory.cpp
+++ b/source/adapters/native_cpu/memory.cpp
@@ -51,11 +51,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
   ur_mem_handle_t_ *retMem;
 
   if (useHostPtr) {
-    retMem = new _ur_buffer(hContext, pProperties->pHost);
+    retMem = new ur_buffer(hContext, pProperties->pHost);
   } else if (copyHostPtr) {
-    retMem = new _ur_buffer(hContext, pProperties->pHost, size);
+    retMem = new ur_buffer(hContext, pProperties->pHost, size);
   } else {
-    retMem = new _ur_buffer(hContext, size);
+    retMem = new ur_buffer(hContext, size);
   }
 
   *phBuffer = retMem;
@@ -87,7 +87,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
 
   std::ignore = bufferCreateType;
   UR_ASSERT(hBuffer && !hBuffer->isImage() &&
-                !(static_cast<_ur_buffer *>(hBuffer))->isSubBuffer(),
+                !(static_cast<ur_buffer *>(hBuffer))->isSubBuffer(),
             UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   std::shared_lock<ur_shared_mutex> Guard(hBuffer->Mutex);
@@ -98,8 +98,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
   }
 
   try {
-    auto partitionedBuffer = new _ur_buffer(static_cast<_ur_buffer *>(hBuffer),
-                                            pRegion->origin, pRegion->size);
+    auto partitionedBuffer = new ur_buffer(static_cast<ur_buffer *>(hBuffer),
+                                           pRegion->origin, pRegion->size);
     *phMem = reinterpret_cast<ur_mem_handle_t>(partitionedBuffer);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;

--- a/source/adapters/native_cpu/program.cpp
+++ b/source/adapters/native_cpu/program.cpp
@@ -72,10 +72,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
       const auto &mdNode = pProperties->pMetadatas[i];
       std::string mdName(mdNode.pName);
       auto [Prefix, Tag] = splitMetadataName(mdName);
-      if (Tag == __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE ||
-          Tag == __SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE) {
-        bool isReqd =
-            Tag == __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE;
+      if (Tag == SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE ||
+          Tag == SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE) {
+        bool isReqd = Tag == SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE;
         native_cpu::WGSize_t wgSizeProp;
         auto res = deserializeWGMetadata(
             mdNode, wgSizeProp,
@@ -87,7 +86,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
                 : hProgram->KernelMaxWorkGroupSizeMD)[Prefix] =
             std::move(wgSizeProp);
       } else if (Tag ==
-                 __SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE) {
+                 SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE) {
         hProgram->KernelMaxLinearWorkGroupSizeMD[Prefix] = mdNode.value.data64;
       }
     }
@@ -96,7 +95,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
   const nativecpu_entry *nativecpu_it =
       reinterpret_cast<const nativecpu_entry *>(pBinary);
   while (nativecpu_it->kernel_ptr != nullptr) {
-    hProgram->_kernels.insert(
+    hProgram->kernels.insert(
         std::make_pair(nativecpu_it->kernelname, nativecpu_it->kernel_ptr));
     nativecpu_it++;
   }
@@ -214,7 +213,7 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
   case UR_PROGRAM_INFO_NUM_DEVICES:
     return returnValue(1u);
   case UR_PROGRAM_INFO_DEVICES:
-    return returnValue(hProgram->_ctx->_device);
+    return returnValue(hProgram->ctx->device);
   case UR_PROGRAM_INFO_BINARY_SIZES:
     return returnValue("foo");
   case UR_PROGRAM_INFO_BINARIES:

--- a/source/adapters/native_cpu/program.hpp
+++ b/source/adapters/native_cpu/program.hpp
@@ -23,19 +23,19 @@ using WGSize_t = std::array<uint32_t, 3>;
 
 struct ur_program_handle_t_ : RefCounted {
   ur_program_handle_t_(ur_context_handle_t ctx, const unsigned char *pBinary)
-      : _ctx{ctx}, _ptr{pBinary} {}
+      : ctx{ctx}, ptr{pBinary} {}
 
   uint32_t getReferenceCount() const noexcept { return _refCount; }
 
-  ur_context_handle_t _ctx;
-  const unsigned char *_ptr;
+  ur_context_handle_t ctx;
+  const unsigned char *ptr;
   struct _compare {
     bool operator()(char const *a, char const *b) const {
       return std::strcmp(a, b) < 0;
     }
   };
 
-  std::map<const char *, const unsigned char *, _compare> _kernels;
+  std::map<const char *, const unsigned char *, _compare> kernels;
   std::unordered_map<std::string, native_cpu::WGSize_t>
       KernelReqdWorkGroupSizeMD;
   std::unordered_map<std::string, native_cpu::WGSize_t>

--- a/source/common/ur_util.hpp
+++ b/source/common/ur_util.hpp
@@ -88,9 +88,9 @@ inline std::string create_library_path(const char *name, const char *path) {
 
 //////////////////////////////////////////////////////////////////////////
 #if !defined(_WIN32) && (__GNUC__ >= 4)
-#define __urdlllocal __attribute__((visibility("hidden")))
+#define UR_DLL_LOCAL __attribute__((visibility("hidden")))
 #else
-#define __urdlllocal
+#define UR_DLL_LOCAL
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/source/loader/layers/sanitizer/linux/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/linux/sanitizer_utils.cpp
@@ -21,7 +21,16 @@
 #include <string>
 #include <sys/mman.h>
 
+#ifdef __clang__
+// The ifdef __clang__ is necessary to avoid unknown pragma warnings on other
+// implementations.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
 extern "C" __attribute__((weak)) void __asan_init(void);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 namespace ur_sanitizer_layer {
 

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -54,7 +54,7 @@ ur_result_t setupContext(ur_context_handle_t Context, uint32_t numDevices,
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
-__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGet(
     uint32_t
         NumEntries, ///< [in] the number of adapters to be added to phAdapters.
     ///< If phAdapters is not NULL, then NumEntries should be greater than
@@ -86,7 +86,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const ur_usm_desc_t
         *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
@@ -110,7 +110,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t
@@ -135,7 +135,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -160,7 +160,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -177,7 +177,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL urProgramBuild(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_program_handle_t hProgram, ///< [in] handle of the program object
     const char *pOptions          ///< [in] string of build options
@@ -200,7 +200,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
-__urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -225,7 +225,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL urProgramLink(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLink(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t count, ///< [in] number of program handles in `phPrograms`.
     const ur_program_handle_t *
@@ -285,7 +285,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -350,7 +350,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreate(
     uint32_t numDevices, ///< [in] the number of devices given in phDevices
     const ur_device_handle_t
         *phDevices, ///< [in][range(0, numDevices)] array of handle of devices.
@@ -379,7 +379,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
         hNativeContext, ///< [in][nocheck] the native handle of the getContext()->
     ur_adapter_handle_t hAdapter,
@@ -413,7 +413,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRetain(
     ur_context_handle_t
         hContext ///< [in] handle of the context to get a reference of.
 ) {
@@ -436,7 +436,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t hContext ///< [in] handle of the context to release.
 ) {
     auto pfnRelease = getContext()->urDdiTable.Context.pfnRelease;
@@ -460,7 +460,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
@@ -513,7 +513,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory,            ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
@@ -559,7 +559,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to get access
 ) {
     auto pfnRetain = getContext()->urDdiTable.Mem.pfnRetain;
@@ -581,7 +581,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t hMem ///< [in] handle of the memory object to release
 ) {
     auto pfnRelease = getContext()->urDdiTable.Mem.pfnRelease;
@@ -607,7 +607,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
@@ -643,7 +643,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetNativeHandle(
     ur_mem_handle_t hMem, ///< [in] handle of the mem.
     ur_device_handle_t hDevice,
     ur_native_handle_t
@@ -670,7 +670,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -714,7 +714,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -760,7 +760,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -821,7 +821,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -885,7 +885,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOffset, size)] handle of the src buffer object
@@ -940,7 +940,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOrigin, region)] handle of the source buffer object
@@ -1007,7 +1007,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -1051,7 +1051,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -1141,7 +1141,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemUnmap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hMem,         ///< [in] handle of the memory (buffer or image) object
@@ -1200,7 +1200,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
     ur_kernel_handle_t
@@ -1222,7 +1222,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to retain
 ) {
     auto pfnRetain = getContext()->urDdiTable.Kernel.pfnRetain;
@@ -1244,7 +1244,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t urKernelRelease(
+UR_DLL_LOCAL ur_result_t urKernelRelease(
     ur_kernel_handle_t hKernel ///< [in] handle for the Kernel to release
 ) {
     auto pfnRelease = getContext()->urDdiTable.Kernel.pfnRelease;
@@ -1267,7 +1267,7 @@ __urdlllocal ur_result_t urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t argSize,    ///< [in] size of argument type
@@ -1301,7 +1301,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_mem_obj_properties_t
@@ -1329,7 +1329,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t
@@ -1365,7 +1365,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_pointer_properties_t
@@ -1404,7 +1404,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_global_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1434,7 +1434,7 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetContextProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetContextProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_context_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1469,7 +1469,7 @@ __urdlllocal ur_result_t UR_APICALL urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetProgramProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetProgramProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_program_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1499,7 +1499,7 @@ __urdlllocal ur_result_t UR_APICALL urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetKernelProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetKernelProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_kernel_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1535,7 +1535,7 @@ __urdlllocal ur_result_t UR_APICALL urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetMemProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetMemProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_mem_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1569,7 +1569,7 @@ __urdlllocal ur_result_t UR_APICALL urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_program_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1600,7 +1600,7 @@ __urdlllocal ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_enqueue_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -1642,7 +1642,7 @@ __urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetUSMProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetUSMProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_usm_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers

--- a/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
+++ b/source/loader/layers/sanitizer/ur_sanitizer_layer.hpp
@@ -30,7 +30,7 @@ enum class SanitizerType {
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal context_t : public proxy_layer_context_t,
+class UR_DLL_LOCAL context_t : public proxy_layer_context_t,
                                public AtomicSingleton<context_t> {
   public:
     ur_dditable_t urDdiTable = {};

--- a/source/loader/layers/tracing/ur_tracing_layer.hpp
+++ b/source/loader/layers/tracing/ur_tracing_layer.hpp
@@ -24,7 +24,7 @@ namespace ur_tracing_layer {
 struct XptiContextManager;
 
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal context_t : public proxy_layer_context_t,
+class UR_DLL_LOCAL context_t : public proxy_layer_context_t,
                                public AtomicSingleton<context_t> {
   public:
     ur_dditable_t urDdiTable = {};

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -17,7 +17,7 @@
 namespace ur_tracing_layer {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
-__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGet(
     uint32_t
         NumEntries, ///< [in] the number of adapters to be added to phAdapters.
     ///< If phAdapters is not NULL, then NumEntries should be greater than
@@ -61,7 +61,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRelease
-__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRelease(
     ur_adapter_handle_t hAdapter ///< [in][release] Adapter handle to release
 ) {
     auto pfnAdapterRelease = getContext()->urDdiTable.Global.pfnAdapterRelease;
@@ -95,7 +95,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRetain
-__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRetain(
     ur_adapter_handle_t hAdapter ///< [in][retain] Adapter handle to retain
 ) {
     auto pfnAdapterRetain = getContext()->urDdiTable.Global.pfnAdapterRetain;
@@ -129,7 +129,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetLastError
-__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
         ppMessage, ///< [out] pointer to a C string where the adapter specific error message
@@ -172,7 +172,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetInfo
-__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetInfo(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
     ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -218,7 +218,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
@@ -267,7 +267,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
@@ -313,7 +313,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_api_version_t *pVersion      ///< [out] api version
 ) {
@@ -350,7 +350,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetNativeHandle(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
     ur_native_handle_t *
         phNativePlatform ///< [out] a pointer to the native handle of the platform.
@@ -390,7 +390,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
     ur_adapter_handle_t
@@ -436,7 +436,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetBackendOption
-__urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetBackendOption(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance.
     const char
         *pFrontendOption, ///< [in] string containing the frontend option.
@@ -480,7 +480,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
     uint32_t
@@ -527,7 +527,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -574,7 +574,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRetain(
     ur_device_handle_t
         hDevice ///< [in][retain] handle of the device to get a reference of.
 ) {
@@ -609,7 +609,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t
         hDevice ///< [in][release] handle of the device to release.
 ) {
@@ -644,7 +644,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
     const ur_device_partition_properties_t
         *pProperties,    ///< [in] Device partition properties.
@@ -690,7 +690,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
     const ur_device_binary_t
@@ -736,7 +736,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetNativeHandle(
     ur_device_handle_t hDevice, ///< [in] handle of the device.
     ur_native_handle_t
         *phNativeDevice ///< [out] a pointer to the native handle of the device.
@@ -775,7 +775,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t
         hNativeDevice, ///< [in][nocheck] the native handle of the device.
     ur_adapter_handle_t
@@ -821,7 +821,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     uint64_t *
         pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
@@ -866,7 +866,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreate(
     uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
     const ur_device_handle_t
         *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
@@ -908,7 +908,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRetain(
     ur_context_handle_t
         hContext ///< [in][retain] handle of the context to get a reference of.
 ) {
@@ -943,7 +943,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t
         hContext ///< [in][release] handle of the context to release.
 ) {
@@ -978,7 +978,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
@@ -1026,7 +1026,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_native_handle_t *
         phNativeContext ///< [out] a pointer to the native handle of the context.
@@ -1066,7 +1066,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
         hNativeContext, ///< [in][nocheck] the native handle of the context.
     ur_adapter_handle_t
@@ -1118,7 +1118,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
@@ -1160,7 +1160,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     const ur_image_format_t
@@ -1202,7 +1202,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
@@ -1244,7 +1244,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t
         hMem ///< [in][retain] handle of the memory object to get access
 ) {
@@ -1278,7 +1278,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t
         hMem ///< [in][release] handle of the memory object to release
 ) {
@@ -1313,7 +1313,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
@@ -1357,7 +1357,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetNativeHandle(
     ur_mem_handle_t hMem, ///< [in] handle of the mem.
     ur_device_handle_t
         hDevice, ///< [in][optional] handle of the device that the native handle will be
@@ -1397,7 +1397,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1443,7 +1443,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1492,7 +1492,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory,            ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
@@ -1540,7 +1540,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
@@ -1587,7 +1587,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,   ///< [in] handle of the context object
     const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
@@ -1624,7 +1624,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRetain(
     ur_sampler_handle_t
         hSampler ///< [in][retain] handle of the sampler object to get access
 ) {
@@ -1659,7 +1659,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRelease(
     ur_sampler_handle_t
         hSampler ///< [in][release] handle of the sampler object to release
 ) {
@@ -1694,7 +1694,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
@@ -1738,7 +1738,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetNativeHandle(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
     ur_native_handle_t *
         phNativeSampler ///< [out] a pointer to the native handle of the sampler.
@@ -1778,7 +1778,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler, ///< [in][nocheck] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -1823,7 +1823,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const ur_usm_desc_t
         *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
@@ -1865,7 +1865,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t
@@ -1909,7 +1909,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -1953,7 +1953,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1987,7 +1987,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
@@ -2034,7 +2034,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_desc_t *
         pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
@@ -2072,7 +2072,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRetain
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRetain(
     ur_usm_pool_handle_t pPool ///< [in][retain] pointer to USM memory pool
 ) {
     auto pfnPoolRetain = getContext()->urDdiTable.USM.pfnPoolRetain;
@@ -2106,7 +2106,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRelease
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRelease(
     ur_usm_pool_handle_t pPool ///< [in][release] pointer to USM memory pool
 ) {
     auto pfnPoolRelease = getContext()->urDdiTable.USM.pfnPoolRelease;
@@ -2140,7 +2140,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolGetInfo
-__urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolGetInfo(
     ur_usm_pool_handle_t hPool,  ///< [in] handle of the USM memory pool
     ur_usm_pool_info_t propName, ///< [in] name of the pool property to query
     size_t propSize, ///< [in] size in bytes of the pool property value provided
@@ -2183,7 +2183,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGranularityGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t
         hDevice, ///< [in][optional] is the device to get the granularity from, if the
@@ -2236,7 +2236,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemReserve
-__urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemReserve(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in][optional] pointer to the start of the virtual memory region to
@@ -2280,7 +2280,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemFree
-__urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in] pointer to the start of the virtual memory range to free.
@@ -2317,7 +2317,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemMap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemMap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2362,7 +2362,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemUnmap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemUnmap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void *
         pStart, ///< [in] pointer to the start of the mapped virtual memory range
@@ -2399,7 +2399,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemSetAccess
-__urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemSetAccess(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2440,7 +2440,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGetInfo(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2490,7 +2490,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemCreate
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] handle of the device object.
     size_t
@@ -2534,7 +2534,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRetain
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRetain(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][retain] handle of the physical memory object to retain.
 ) {
@@ -2569,7 +2569,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRelease
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRelease(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][release] handle of the physical memory object to release.
 ) {
@@ -2605,7 +2605,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithIL(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     const void *pIL,              ///< [in] pointer to IL binary.
     size_t length,                ///< [in] length of `pIL` in bytes.
@@ -2648,7 +2648,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithBinary(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     ur_device_handle_t
         hDevice,            ///< [in] handle to device associated with binary.
@@ -2695,7 +2695,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL urProgramBuild(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     const char *
@@ -2732,7 +2732,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL urProgramCompile(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t
         hProgram, ///< [in][out] handle of the program to compile.
@@ -2770,7 +2770,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL urProgramLink(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLink(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t count, ///< [in] number of program handles in `phPrograms`.
     const ur_program_handle_t *
@@ -2816,7 +2816,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t
         hProgram ///< [in][retain] handle for the Program to retain
 ) {
@@ -2851,7 +2851,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t
         hProgram ///< [in][release] handle for the Program to release
 ) {
@@ -2886,7 +2886,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetFunctionPointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
@@ -2934,7 +2934,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetGlobalVariablePointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve the pointer for.
     ur_program_handle_t
@@ -2985,7 +2985,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
@@ -3032,7 +3032,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
@@ -3082,7 +3082,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3126,7 +3126,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetNativeHandle(
     ur_program_handle_t hProgram, ///< [in] handle of the program.
     ur_native_handle_t *
         phNativeProgram ///< [out] a pointer to the native handle of the program.
@@ -3166,7 +3166,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram, ///< [in][nocheck] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
@@ -3211,7 +3211,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
     ur_kernel_handle_t
@@ -3248,7 +3248,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t argSize,    ///< [in] size of argument type
@@ -3291,7 +3291,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t
@@ -3332,7 +3332,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
@@ -3380,7 +3380,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
@@ -3427,7 +3427,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
@@ -3476,7 +3476,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in][retain] handle for the Kernel to retain
 ) {
     auto pfnRetain = getContext()->urDdiTable.Kernel.pfnRetain;
@@ -3510,7 +3510,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t
         hKernel ///< [in][release] handle for the Kernel to release
 ) {
@@ -3545,7 +3545,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_pointer_properties_t
@@ -3588,7 +3588,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
@@ -3631,7 +3631,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgSampler(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_sampler_properties_t
@@ -3672,7 +3672,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_mem_obj_properties_t
@@ -3713,7 +3713,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3755,7 +3755,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetNativeHandle(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
@@ -3794,7 +3794,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -3841,7 +3841,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSuggestedLocalWorkSize
-__urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     uint32_t
@@ -3897,7 +3897,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
@@ -3941,7 +3941,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_queue_properties_t
@@ -3981,7 +3981,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t
         hQueue ///< [in][retain] handle of the queue object to get access
 ) {
@@ -4016,7 +4016,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t
         hQueue ///< [in][release] handle of the queue object to release
 ) {
@@ -4051,7 +4051,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
     ur_queue_native_desc_t
         *pDesc, ///< [in][optional] pointer to native descriptor
@@ -4091,7 +4091,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t
         hNativeQueue, ///< [in][nocheck] the native handle of the queue.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4137,7 +4137,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = getContext()->urDdiTable.Queue.pfnFinish;
@@ -4171,7 +4171,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = getContext()->urDdiTable.Queue.pfnFlush;
@@ -4205,7 +4205,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
@@ -4247,7 +4247,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
         propName,    ///< [in] the name of the profiling property to query
@@ -4295,7 +4295,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
     const ur_event_handle_t *
         phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
@@ -4331,7 +4331,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in][retain] handle of the event object
 ) {
     auto pfnRetain = getContext()->urDdiTable.Event.pfnRetain;
@@ -4365,7 +4365,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in][release] handle of the event object
 ) {
     auto pfnRelease = getContext()->urDdiTable.Event.pfnRelease;
@@ -4399,7 +4399,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetNativeHandle(
     ur_event_handle_t hEvent, ///< [in] handle of the event.
     ur_native_handle_t
         *phNativeEvent ///< [out] a pointer to the native handle of the event.
@@ -4436,7 +4436,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t
         hNativeEvent, ///< [in][nocheck] the native handle of the event.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4481,7 +4481,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
@@ -4521,7 +4521,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -4591,7 +4591,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4638,7 +4638,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4688,7 +4688,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4744,7 +4744,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4803,7 +4803,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -4884,7 +4884,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -4968,7 +4968,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOffset, size)] handle of the src buffer object
@@ -5024,7 +5024,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOrigin, region)] handle of the source buffer object
@@ -5094,7 +5094,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5155,7 +5155,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5217,7 +5217,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5280,7 +5280,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImageSrc, ///< [in][bounds(srcOrigin, region)] handle of the src image object
@@ -5342,7 +5342,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5400,7 +5400,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemUnmap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hMem,         ///< [in] handle of the memory (buffer or image) object
@@ -5451,7 +5451,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pMem, ///< [in][bounds(0, size)] pointer to USM memory object
     size_t
@@ -5508,7 +5508,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool blocking,            ///< [in] blocking or non-blocking copy
     void *
@@ -5562,7 +5562,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -5615,7 +5615,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMAdvise(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -5657,7 +5657,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *
         pMem, ///< [in][bounds(0, pitch * height)] pointer to memory to be filled.
@@ -5718,7 +5718,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *
@@ -5780,7 +5780,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -5841,7 +5841,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -5901,7 +5901,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueReadHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueReadHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the read command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -5964,7 +5964,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueWriteHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the write command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -6028,7 +6028,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPitchedAllocExp
-__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -6080,7 +6080,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -6129,7 +6129,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -6177,7 +6177,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageAllocateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -6222,7 +6222,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6263,7 +6263,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6312,7 +6312,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6364,7 +6364,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageCopyExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void *pSrc,         ///< [in] location the data will be copied from
     void *pDst,               ///< [in] location the data will be copied to
@@ -6439,7 +6439,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_exp_image_mem_native_handle_t
         hImageMem,            ///< [in] handle to the image memory
@@ -6483,7 +6483,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6529,7 +6529,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6570,7 +6570,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
@@ -6621,7 +6621,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalArrayExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -6670,7 +6670,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalLinearMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     uint64_t offset,              ///< [in] offset into memory region to map
@@ -6720,7 +6720,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_mem_handle_t
@@ -6764,7 +6764,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
@@ -6816,7 +6816,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_handle_t
@@ -6863,7 +6863,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -6926,7 +6926,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -6991,7 +6991,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] Handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] Handle of the device object.
     const ur_exp_command_buffer_desc_t
@@ -7034,7 +7034,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][retain] Handle of the command-buffer object.
 ) {
@@ -7071,7 +7071,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
@@ -7109,7 +7109,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] Handle of the command-buffer object.
 ) {
@@ -7147,7 +7147,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
     ur_kernel_handle_t hKernel, ///< [in] Kernel to append.
@@ -7242,7 +7242,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMMemcpyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -7316,7 +7316,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,   ///< [in] handle of the command-buffer object.
     void *pMemory,        ///< [in] pointer to USM allocated memory to fill.
@@ -7392,7 +7392,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -7471,7 +7471,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7549,7 +7549,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7626,7 +7626,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -7719,7 +7719,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7819,7 +7819,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7916,7 +7916,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
@@ -7996,7 +7996,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMPrefetchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,  ///< [in] handle of the command-buffer object.
     const void *pMemory, ///< [in] pointer to USM allocated memory to prefetch.
@@ -8070,7 +8070,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMAdviseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,           ///< [in] handle of the command-buffer object.
     const void *pMemory,          ///< [in] pointer to the USM memory object.
@@ -8144,7 +8144,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     ur_queue_handle_t
@@ -8196,7 +8196,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][retain] Handle of the command-buffer command.
 ) {
@@ -8234,7 +8234,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][release] Handle of the command-buffer command.
 ) {
@@ -8272,7 +8272,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer kernel command to update.
     const ur_exp_command_buffer_update_kernel_launch_desc_t *
@@ -8315,7 +8315,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateSignalEventExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     ur_event_handle_t *phSignalEvent ///< [out] Event to be signaled.
@@ -8356,7 +8356,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateWaitEventsExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     uint32_t numEventsInWaitList, ///< [in] Size of the event wait list.
@@ -8402,7 +8402,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object
     ur_exp_command_buffer_info_t
@@ -8451,7 +8451,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCommandGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] handle of the command-buffer command object
     ur_exp_command_buffer_command_info_t
@@ -8500,7 +8500,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueCooperativeKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -8574,7 +8574,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSuggestMaxCooperativeGroupCountExp
-__urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     size_t
         localWorkSize, ///< [in] number of local work-items that will form a work-group when the
@@ -8625,7 +8625,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool
         blocking, ///< [in] indicates whether the call to this function should block until
@@ -8683,7 +8683,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunchCustomExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -8755,7 +8755,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
-__urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -8795,7 +8795,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompileExp
-__urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompileExp(
     ur_program_handle_t
         hProgram,        ///< [in][out] handle of the program to compile.
     uint32_t numDevices, ///< [in] number of devices
@@ -8837,7 +8837,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLinkExp
-__urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLinkExp(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -8887,7 +8887,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
@@ -8923,7 +8923,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
 ) {
@@ -8958,7 +8958,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PEnablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -8998,7 +8998,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PDisablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -9038,7 +9038,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PPeerAccessGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     ur_device_handle_t
         commandDevice,             ///< [in] handle of the command device object
     ur_device_handle_t peerDevice, ///< [in] handle of the peer device object
@@ -9092,7 +9092,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueNativeCommandExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_enqueue_native_command_function_t
         pfnNativeEnqueue, ///< [in] function calling the native underlying API, to be executed
@@ -9166,7 +9166,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetGlobalProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_global_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9211,7 +9211,7 @@ __urdlllocal ur_result_t UR_APICALL urGetGlobalProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_bindless_images_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9320,7 +9320,7 @@ __urdlllocal ur_result_t UR_APICALL urGetBindlessImagesExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_command_buffer_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9444,7 +9444,7 @@ __urdlllocal ur_result_t UR_APICALL urGetCommandBufferExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetContextProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetContextProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_context_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9497,7 +9497,7 @@ __urdlllocal ur_result_t UR_APICALL urGetContextProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_enqueue_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9610,7 +9610,7 @@ __urdlllocal ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_enqueue_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9657,7 +9657,7 @@ __urdlllocal ur_result_t UR_APICALL urGetEnqueueExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetEventProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetEventProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_event_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9712,7 +9712,7 @@ __urdlllocal ur_result_t UR_APICALL urGetEventProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetKernelProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetKernelProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_kernel_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9795,7 +9795,7 @@ __urdlllocal ur_result_t UR_APICALL urGetKernelProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetKernelExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetKernelExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_kernel_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9830,7 +9830,7 @@ __urdlllocal ur_result_t UR_APICALL urGetKernelExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetMemProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetMemProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_mem_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9894,7 +9894,7 @@ __urdlllocal ur_result_t UR_APICALL urGetMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetPhysicalMemProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetPhysicalMemProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_physical_mem_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9933,7 +9933,7 @@ __urdlllocal ur_result_t UR_APICALL urGetPhysicalMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_platform_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -9983,7 +9983,7 @@ __urdlllocal ur_result_t UR_APICALL urGetPlatformProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetProgramProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetProgramProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_program_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10062,7 +10062,7 @@ __urdlllocal ur_result_t UR_APICALL urGetProgramProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_program_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10101,7 +10101,7 @@ __urdlllocal ur_result_t UR_APICALL urGetProgramExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetQueueProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetQueueProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_queue_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10156,7 +10156,7 @@ __urdlllocal ur_result_t UR_APICALL urGetQueueProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetSamplerProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_sampler_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10205,7 +10205,7 @@ __urdlllocal ur_result_t UR_APICALL urGetSamplerProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetUSMProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetUSMProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_usm_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10262,7 +10262,7 @@ __urdlllocal ur_result_t UR_APICALL urGetUSMProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_usm_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10301,7 +10301,7 @@ __urdlllocal ur_result_t UR_APICALL urGetUSMExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_usm_p2p_exp_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10343,7 +10343,7 @@ __urdlllocal ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_virtual_mem_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers
@@ -10395,7 +10395,7 @@ __urdlllocal ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
 ///     - ::UR_RESULT_SUCCESS
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_VERSION
-__urdlllocal ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+UR_DLL_LOCAL ur_result_t UR_APICALL urGetDeviceProcAddrTable(
     ur_api_version_t version, ///< [in] API version requested
     ur_device_dditable_t
         *pDdiTable ///< [in,out] pointer to table of DDI function pointers

--- a/source/loader/layers/ur_proxy_layer.hpp
+++ b/source/loader/layers/ur_proxy_layer.hpp
@@ -19,7 +19,7 @@
 #include <set>
 
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal proxy_layer_context_t {
+class UR_DLL_LOCAL proxy_layer_context_t {
   public:
     virtual ~proxy_layer_context_t(){};
     ur_api_version_t version = UR_API_VERSION_CURRENT;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -16,7 +16,7 @@ namespace ur_validation_layer {
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
-__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGet(
     uint32_t
         NumEntries, ///< [in] the number of adapters to be added to phAdapters.
     ///< If phAdapters is not NULL, then NumEntries should be greater than
@@ -56,7 +56,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRelease
-__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRelease(
     ur_adapter_handle_t hAdapter ///< [in][release] Adapter handle to release
 ) {
     auto pfnAdapterRelease = getContext()->urDdiTable.Global.pfnAdapterRelease;
@@ -82,7 +82,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRetain
-__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRetain(
     ur_adapter_handle_t hAdapter ///< [in][retain] Adapter handle to retain
 ) {
     auto pfnAdapterRetain = getContext()->urDdiTable.Global.pfnAdapterRetain;
@@ -108,7 +108,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetLastError
-__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
         ppMessage, ///< [out] pointer to a C string where the adapter specific error message
@@ -150,7 +150,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetInfo
-__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetInfo(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
     ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -204,7 +204,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
@@ -244,7 +244,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
@@ -293,7 +293,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_api_version_t *pVersion      ///< [out] api version
 ) {
@@ -320,7 +320,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetNativeHandle(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
     ur_native_handle_t *
         phNativePlatform ///< [out] a pointer to the native handle of the platform.
@@ -349,7 +349,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
     ur_adapter_handle_t
@@ -389,7 +389,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetBackendOption
-__urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetBackendOption(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance.
     const char
         *pFrontendOption, ///< [in] string containing the frontend option.
@@ -426,7 +426,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
     uint32_t
@@ -481,7 +481,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -536,7 +536,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRetain(
     ur_device_handle_t
         hDevice ///< [in][retain] handle of the device to get a reference of.
 ) {
@@ -563,7 +563,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t
         hDevice ///< [in][release] handle of the device to release.
 ) {
@@ -590,7 +590,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
     const ur_device_partition_properties_t
         *pProperties,    ///< [in] Device partition properties.
@@ -636,7 +636,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
     const ur_device_binary_t
@@ -685,7 +685,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetNativeHandle(
     ur_device_handle_t hDevice, ///< [in] handle of the device.
     ur_native_handle_t
         *phNativeDevice ///< [out] a pointer to the native handle of the device.
@@ -719,7 +719,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t
         hNativeDevice, ///< [in][nocheck] the native handle of the device.
     ur_adapter_handle_t
@@ -763,7 +763,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     uint64_t *
         pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
@@ -798,7 +798,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreate(
     uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
     const ur_device_handle_t
         *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
@@ -839,7 +839,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRetain(
     ur_context_handle_t
         hContext ///< [in][retain] handle of the context to get a reference of.
 ) {
@@ -866,7 +866,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t
         hContext ///< [in][release] handle of the context to release.
 ) {
@@ -893,7 +893,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
@@ -949,7 +949,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_native_handle_t *
         phNativeContext ///< [out] a pointer to the native handle of the context.
@@ -983,7 +983,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
         hNativeContext, ///< [in][nocheck] the native handle of the context.
     ur_adapter_handle_t
@@ -1032,7 +1032,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
@@ -1068,7 +1068,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     const ur_image_format_t
@@ -1154,7 +1154,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
@@ -1222,7 +1222,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t
         hMem ///< [in][retain] handle of the memory object to get access
 ) {
@@ -1249,7 +1249,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t
         hMem ///< [in][release] handle of the memory object to release
 ) {
@@ -1276,7 +1276,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
@@ -1331,7 +1331,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetNativeHandle(
     ur_mem_handle_t hMem, ///< [in] handle of the mem.
     ur_device_handle_t
         hDevice, ///< [in][optional] handle of the device that the native handle will be
@@ -1372,7 +1372,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1415,7 +1415,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1469,7 +1469,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory,            ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
@@ -1525,7 +1525,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
@@ -1580,7 +1580,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,   ///< [in] handle of the context object
     const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
@@ -1631,7 +1631,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRetain(
     ur_sampler_handle_t
         hSampler ///< [in][retain] handle of the sampler object to get access
 ) {
@@ -1658,7 +1658,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRelease(
     ur_sampler_handle_t
         hSampler ///< [in][release] handle of the sampler object to release
 ) {
@@ -1685,7 +1685,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
@@ -1737,7 +1737,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetNativeHandle(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
     ur_native_handle_t *
         phNativeSampler ///< [out] a pointer to the native handle of the sampler.
@@ -1771,7 +1771,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler, ///< [in][nocheck] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -1814,7 +1814,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const ur_usm_desc_t
         *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
@@ -1870,7 +1870,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t
@@ -1937,7 +1937,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -2004,7 +2004,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -2036,7 +2036,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
@@ -2082,7 +2082,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_desc_t *
         pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
@@ -2129,7 +2129,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRetain
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRetain(
     ur_usm_pool_handle_t pPool ///< [in][retain] pointer to USM memory pool
 ) {
     auto pfnPoolRetain = getContext()->urDdiTable.USM.pfnPoolRetain;
@@ -2155,7 +2155,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRelease
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRelease(
     ur_usm_pool_handle_t pPool ///< [in][release] pointer to USM memory pool
 ) {
     auto pfnPoolRelease = getContext()->urDdiTable.USM.pfnPoolRelease;
@@ -2181,7 +2181,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolGetInfo
-__urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolGetInfo(
     ur_usm_pool_handle_t hPool,  ///< [in] handle of the USM memory pool
     ur_usm_pool_info_t propName, ///< [in] name of the pool property to query
     size_t propSize, ///< [in] size in bytes of the pool property value provided
@@ -2232,7 +2232,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGranularityGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t
         hDevice, ///< [in][optional] is the device to get the granularity from, if the
@@ -2296,7 +2296,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemReserve
-__urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemReserve(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in][optional] pointer to the start of the virtual memory region to
@@ -2336,7 +2336,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemFree
-__urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in] pointer to the start of the virtual memory range to free.
@@ -2370,7 +2370,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemMap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemMap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2424,7 +2424,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemUnmap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemUnmap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void *
         pStart, ///< [in] pointer to the start of the mapped virtual memory range
@@ -2458,7 +2458,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemSetAccess
-__urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemSetAccess(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2498,7 +2498,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGetInfo(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2547,7 +2547,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemCreate
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] handle of the device object.
     size_t
@@ -2605,7 +2605,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRetain
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRetain(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][retain] handle of the physical memory object to retain.
 ) {
@@ -2632,7 +2632,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRelease
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRelease(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][release] handle of the physical memory object to release.
 ) {
@@ -2659,7 +2659,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithIL(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     const void *pIL,              ///< [in] pointer to IL binary.
     size_t length,                ///< [in] length of `pIL` in bytes.
@@ -2719,7 +2719,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithBinary(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     ur_device_handle_t
         hDevice,            ///< [in] handle to device associated with binary.
@@ -2787,7 +2787,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL urProgramBuild(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     const char *
@@ -2826,7 +2826,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL urProgramCompile(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t
         hProgram, ///< [in][out] handle of the program to compile.
@@ -2866,7 +2866,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL urProgramLink(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLink(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t count, ///< [in] number of program handles in `phPrograms`.
     const ur_program_handle_t *
@@ -2916,7 +2916,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t
         hProgram ///< [in][retain] handle for the Program to retain
 ) {
@@ -2943,7 +2943,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t
         hProgram ///< [in][release] handle for the Program to release
 ) {
@@ -2970,7 +2970,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetFunctionPointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
@@ -3025,7 +3025,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetGlobalVariablePointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve the pointer for.
     ur_program_handle_t
@@ -3082,7 +3082,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
@@ -3137,7 +3137,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
@@ -3191,7 +3191,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3232,7 +3232,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetNativeHandle(
     ur_program_handle_t hProgram, ///< [in] handle of the program.
     ur_native_handle_t *
         phNativeProgram ///< [out] a pointer to the native handle of the program.
@@ -3266,7 +3266,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram, ///< [in][nocheck] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
@@ -3309,7 +3309,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
     ur_kernel_handle_t
@@ -3351,7 +3351,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t argSize,    ///< [in] size of argument type
@@ -3390,7 +3390,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t
@@ -3423,7 +3423,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
@@ -3479,7 +3479,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
@@ -3531,7 +3531,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
@@ -3583,7 +3583,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in][retain] handle for the Kernel to retain
 ) {
     auto pfnRetain = getContext()->urDdiTable.Kernel.pfnRetain;
@@ -3609,7 +3609,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t
         hKernel ///< [in][release] handle for the Kernel to release
 ) {
@@ -3636,7 +3636,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_pointer_properties_t
@@ -3670,7 +3670,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
@@ -3713,7 +3713,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgSampler(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_sampler_properties_t
@@ -3754,7 +3754,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_mem_obj_properties_t
@@ -3796,7 +3796,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3836,7 +3836,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetNativeHandle(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
@@ -3870,7 +3870,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -3920,7 +3920,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSuggestedLocalWorkSize
-__urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     uint32_t
@@ -3985,7 +3985,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
@@ -4037,7 +4037,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_queue_properties_t
@@ -4102,7 +4102,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t
         hQueue ///< [in][retain] handle of the queue object to get access
 ) {
@@ -4129,7 +4129,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t
         hQueue ///< [in][release] handle of the queue object to release
 ) {
@@ -4156,7 +4156,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
     ur_queue_native_desc_t
         *pDesc, ///< [in][optional] pointer to native descriptor
@@ -4191,7 +4191,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t
         hNativeQueue, ///< [in][nocheck] the native handle of the queue.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4240,7 +4240,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     auto pfnFinish = getContext()->urDdiTable.Queue.pfnFinish;
@@ -4267,7 +4267,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     auto pfnFlush = getContext()->urDdiTable.Queue.pfnFlush;
@@ -4294,7 +4294,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
@@ -4344,7 +4344,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
         propName,    ///< [in] the name of the profiling property to query
@@ -4390,7 +4390,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
     const ur_event_handle_t *
         phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
@@ -4419,7 +4419,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in][retain] handle of the event object
 ) {
     auto pfnRetain = getContext()->urDdiTable.Event.pfnRetain;
@@ -4445,7 +4445,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in][release] handle of the event object
 ) {
     auto pfnRelease = getContext()->urDdiTable.Event.pfnRelease;
@@ -4471,7 +4471,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetNativeHandle(
     ur_event_handle_t hEvent, ///< [in] handle of the event.
     ur_native_handle_t
         *phNativeEvent ///< [out] a pointer to the native handle of the event.
@@ -4504,7 +4504,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t
         hNativeEvent, ///< [in][nocheck] the native handle of the event.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4547,7 +4547,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
@@ -4591,7 +4591,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -4678,7 +4678,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4733,7 +4733,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4789,7 +4789,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4870,7 +4870,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4953,7 +4953,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -5088,7 +5088,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -5226,7 +5226,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOffset, size)] handle of the src buffer object
@@ -5320,7 +5320,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOrigin, region)] handle of the source buffer object
@@ -5461,7 +5461,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5562,7 +5562,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5652,7 +5652,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5743,7 +5743,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImageSrc, ///< [in][bounds(srcOrigin, region)] handle of the src image object
@@ -5847,7 +5847,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5934,7 +5934,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemUnmap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hMem,         ///< [in] handle of the memory (buffer or image) object
@@ -6005,7 +6005,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pMem, ///< [in][bounds(0, size)] pointer to USM memory object
     size_t
@@ -6095,7 +6095,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool blocking,            ///< [in] blocking or non-blocking copy
     void *
@@ -6182,7 +6182,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -6260,7 +6260,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMAdvise(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -6313,7 +6313,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *
         pMem, ///< [in][bounds(0, pitch * height)] pointer to memory to be filled.
@@ -6427,7 +6427,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *
@@ -6535,7 +6535,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -6616,7 +6616,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -6697,7 +6697,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueReadHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueReadHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the read command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -6782,7 +6782,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueWriteHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the write command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -6868,7 +6868,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPitchedAllocExp
-__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -6945,7 +6945,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -6988,7 +6988,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -7031,7 +7031,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageAllocateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -7091,7 +7091,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7131,7 +7131,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7193,7 +7193,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7266,7 +7266,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageCopyExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void *pSrc,         ///< [in] location the data will be copied from
     void *pDst,               ///< [in] location the data will be copied to
@@ -7371,7 +7371,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_exp_image_mem_native_handle_t
         hImageMem,            ///< [in] handle to the image memory
@@ -7413,7 +7413,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7461,7 +7461,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -7501,7 +7501,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
@@ -7560,7 +7560,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalArrayExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -7626,7 +7626,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalLinearMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     uint64_t offset,              ///< [in] offset into memory region to map
@@ -7679,7 +7679,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_mem_handle_t
@@ -7724,7 +7724,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
@@ -7784,7 +7784,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_handle_t
@@ -7830,7 +7830,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -7891,7 +7891,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -7953,7 +7953,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] Handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] Handle of the device object.
     const ur_exp_command_buffer_desc_t
@@ -7999,7 +7999,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][retain] Handle of the command-buffer object.
 ) {
@@ -8022,7 +8022,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
@@ -8046,7 +8046,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] Handle of the command-buffer object.
 ) {
@@ -8070,7 +8070,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
     ur_kernel_handle_t hKernel, ///< [in] Kernel to append.
@@ -8184,7 +8184,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMMemcpyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -8268,7 +8268,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,   ///< [in] handle of the command-buffer object.
     void *pMemory,        ///< [in] pointer to USM allocated memory to fill.
@@ -8362,7 +8362,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -8454,7 +8454,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8541,7 +8541,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8627,7 +8627,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -8727,7 +8727,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8829,7 +8829,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8928,7 +8928,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
@@ -9016,7 +9016,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMPrefetchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,  ///< [in] handle of the command-buffer object.
     const void *pMemory, ///< [in] pointer to USM allocated memory to prefetch.
@@ -9100,7 +9100,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMAdviseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,           ///< [in] handle of the command-buffer object.
     const void *pMemory,          ///< [in] pointer to the USM memory object.
@@ -9184,7 +9184,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     ur_queue_handle_t
@@ -9245,7 +9245,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][retain] Handle of the command-buffer command.
 ) {
@@ -9269,7 +9269,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][release] Handle of the command-buffer command.
 ) {
@@ -9293,7 +9293,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer kernel command to update.
     const ur_exp_command_buffer_update_kernel_launch_desc_t *
@@ -9329,7 +9329,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateSignalEventExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     ur_event_handle_t *phSignalEvent ///< [out] Event to be signaled.
@@ -9358,7 +9358,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateWaitEventsExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     uint32_t numEventsInWaitList, ///< [in] Size of the event wait list.
@@ -9404,7 +9404,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object
     ur_exp_command_buffer_info_t
@@ -9454,7 +9454,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCommandGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] handle of the command-buffer command object
     ur_exp_command_buffer_command_info_t
@@ -9504,7 +9504,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueCooperativeKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -9592,7 +9592,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSuggestMaxCooperativeGroupCountExp
-__urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     size_t
         localWorkSize, ///< [in] number of local work-items that will form a work-group when the
@@ -9633,7 +9633,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool
         blocking, ///< [in] indicates whether the call to this function should block until
@@ -9701,7 +9701,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunchCustomExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -9784,7 +9784,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
-__urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -9820,7 +9820,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompileExp
-__urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompileExp(
     ur_program_handle_t
         hProgram,        ///< [in][out] handle of the program to compile.
     uint32_t numDevices, ///< [in] number of devices
@@ -9858,7 +9858,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLinkExp
-__urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLinkExp(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -9915,7 +9915,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
@@ -9948,7 +9948,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
 ) {
@@ -9980,7 +9980,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PEnablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -10019,7 +10019,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PDisablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -10058,7 +10058,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PPeerAccessGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     ur_device_handle_t
         commandDevice,             ///< [in] handle of the command device object
     ur_device_handle_t peerDevice, ///< [in] handle of the peer device object
@@ -10126,7 +10126,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueNativeCommandExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_enqueue_native_command_function_t
         pfnNativeEnqueue, ///< [in] function calling the native underlying API, to be executed

--- a/source/loader/layers/validation/ur_validation_layer.hpp
+++ b/source/loader/layers/validation/ur_validation_layer.hpp
@@ -20,7 +20,7 @@ namespace ur_validation_layer {
 struct RefCountContext;
 
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal context_t : public proxy_layer_context_t,
+class UR_DLL_LOCAL context_t : public proxy_layer_context_t,
                                public AtomicSingleton<context_t> {
   public:
     bool enableParameterValidation = false;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -15,7 +15,7 @@
 namespace ur_loader {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
-__urdlllocal ur_result_t UR_APICALL urAdapterGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGet(
     uint32_t
         NumEntries, ///< [in] the number of adapters to be added to phAdapters.
     ///< If phAdapters is not NULL, then NumEntries should be greater than
@@ -65,7 +65,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRelease
-__urdlllocal ur_result_t UR_APICALL urAdapterRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRelease(
     ur_adapter_handle_t hAdapter ///< [in][release] Adapter handle to release
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -90,7 +90,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterRetain
-__urdlllocal ur_result_t UR_APICALL urAdapterRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterRetain(
     ur_adapter_handle_t hAdapter ///< [in][retain] Adapter handle to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -115,7 +115,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetLastError
-__urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter instance
     const char **
         ppMessage, ///< [out] pointer to a C string where the adapter specific error message
@@ -146,7 +146,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGetInfo
-__urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urAdapterGetInfo(
     ur_adapter_handle_t hAdapter, ///< [in] handle of the adapter
     ur_adapter_info_t propName,   ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -182,7 +182,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGet
-__urdlllocal ur_result_t UR_APICALL urPlatformGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.
     uint32_t NumAdapters, ///< [in] number of adapters pointed to by phAdapters
@@ -261,7 +261,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetInfo
-__urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetInfo(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_platform_info_t propName,    ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPlatformInfo.
@@ -298,7 +298,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetApiVersion
-__urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetApiVersion(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform
     ur_api_version_t *pVersion      ///< [out] api version
 ) {
@@ -325,7 +325,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetNativeHandle(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform.
     ur_native_handle_t *
         phNativePlatform ///< [out] a pointer to the native handle of the platform.
@@ -357,7 +357,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_native_handle_t
         hNativePlatform, ///< [in][nocheck] the native handle of the platform.
     ur_adapter_handle_t
@@ -404,7 +404,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPlatformGetBackendOption
-__urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPlatformGetBackendOption(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance.
     const char
         *pFrontendOption, ///< [in] string containing the frontend option.
@@ -435,7 +435,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGet
-__urdlllocal ur_result_t UR_APICALL urDeviceGet(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGet(
     ur_platform_handle_t hPlatform, ///< [in] handle of the platform instance
     ur_device_type_t DeviceType,    ///< [in] the type of the devices.
     uint32_t
@@ -488,7 +488,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetInfo
-__urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetInfo(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     ur_device_info_t propName,  ///< [in] type of the info to retrieve
     size_t propSize, ///< [in] the number of bytes pointed to by pPropValue.
@@ -593,7 +593,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRetain
-__urdlllocal ur_result_t UR_APICALL urDeviceRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRetain(
     ur_device_handle_t
         hDevice ///< [in][retain] handle of the device to get a reference of.
 ) {
@@ -619,7 +619,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceRelease
-__urdlllocal ur_result_t UR_APICALL urDeviceRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceRelease(
     ur_device_handle_t
         hDevice ///< [in][release] handle of the device to release.
 ) {
@@ -645,7 +645,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDevicePartition
-__urdlllocal ur_result_t UR_APICALL urDevicePartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice, ///< [in] handle of the device to partition.
     const ur_device_partition_properties_t
         *pProperties,    ///< [in] Device partition properties.
@@ -696,7 +696,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceSelectBinary
-__urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceSelectBinary(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to select binary for.
     const ur_device_binary_t
@@ -730,7 +730,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetNativeHandle(
     ur_device_handle_t hDevice, ///< [in] handle of the device.
     ur_native_handle_t
         *phNativeDevice ///< [out] a pointer to the native handle of the device.
@@ -761,7 +761,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t
         hNativeDevice, ///< [in][nocheck] the native handle of the device.
     ur_adapter_handle_t
@@ -808,7 +808,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urDeviceGetGlobalTimestamps
-__urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+UR_DLL_LOCAL ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, ///< [in] handle of the device instance
     uint64_t *
         pDeviceTimestamp, ///< [out][optional] pointer to the Device's global timestamp that
@@ -839,7 +839,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreate
-__urdlllocal ur_result_t UR_APICALL urContextCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreate(
     uint32_t DeviceCount, ///< [in] the number of devices given in phDevices
     const ur_device_handle_t
         *phDevices, ///< [in][range(0, DeviceCount)] array of handle of devices.
@@ -889,7 +889,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRetain
-__urdlllocal ur_result_t UR_APICALL urContextRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRetain(
     ur_context_handle_t
         hContext ///< [in][retain] handle of the context to get a reference of.
 ) {
@@ -915,7 +915,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextRelease
-__urdlllocal ur_result_t UR_APICALL urContextRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextRelease(
     ur_context_handle_t
         hContext ///< [in][release] handle of the context to release.
 ) {
@@ -941,7 +941,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetInfo
-__urdlllocal ur_result_t UR_APICALL urContextGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context
     ur_context_info_t propName,   ///< [in] type of the info to retrieve
     size_t
@@ -1011,7 +1011,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextGetNativeHandle(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_native_handle_t *
         phNativeContext ///< [out] a pointer to the native handle of the context.
@@ -1042,7 +1042,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     ur_native_handle_t
         hNativeContext, ///< [in][nocheck] the native handle of the context.
     ur_adapter_handle_t
@@ -1101,7 +1101,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urContextSetExtendedDeleter
-__urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
+UR_DLL_LOCAL ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ///< [in] handle of the context.
     ur_context_extended_deleter_t
         pfnDeleter, ///< [in] Function pointer to extended deleter.
@@ -1130,7 +1130,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreate
-__urdlllocal ur_result_t UR_APICALL urMemImageCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     const ur_image_format_t
@@ -1174,7 +1174,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreate
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
     size_t size, ///< [in] size in bytes of the memory object to be allocated
@@ -1217,7 +1217,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRetain
-__urdlllocal ur_result_t UR_APICALL urMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRetain(
     ur_mem_handle_t
         hMem ///< [in][retain] handle of the memory object to get access
 ) {
@@ -1243,7 +1243,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemRelease
-__urdlllocal ur_result_t UR_APICALL urMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemRelease(
     ur_mem_handle_t
         hMem ///< [in][release] handle of the memory object to release
 ) {
@@ -1269,7 +1269,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferPartition
-__urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferPartition(
     ur_mem_handle_t
         hBuffer,          ///< [in] handle of the buffer object to allocate from
     ur_mem_flags_t flags, ///< [in] allocation and usage information flags
@@ -1314,7 +1314,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetNativeHandle(
     ur_mem_handle_t hMem, ///< [in] handle of the mem.
     ur_device_handle_t
         hDevice, ///< [in][optional] handle of the device that the native handle will be
@@ -1353,7 +1353,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemBufferCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1398,7 +1398,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     ur_native_handle_t
         hNativeMem, ///< [in][nocheck] the native handle to the memory.
     ur_context_handle_t hContext, ///< [in] handle of the context object.
@@ -1446,7 +1446,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemGetInfo(
     ur_mem_handle_t
         hMemory,            ///< [in] handle to the memory object being queried.
     ur_mem_info_t propName, ///< [in] type of the info to retrieve.
@@ -1516,7 +1516,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urMemImageGetInfo
-__urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ///< [in] handle to the image object being queried.
     ur_image_info_t propName, ///< [in] type of image info to retrieve.
     size_t
@@ -1553,7 +1553,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreate
-__urdlllocal ur_result_t UR_APICALL urSamplerCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,   ///< [in] handle of the context object
     const ur_sampler_desc_t *pDesc, ///< [in] pointer to the sampler description
     ur_sampler_handle_t
@@ -1594,7 +1594,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRetain
-__urdlllocal ur_result_t UR_APICALL urSamplerRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRetain(
     ur_sampler_handle_t
         hSampler ///< [in][retain] handle of the sampler object to get access
 ) {
@@ -1620,7 +1620,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerRelease
-__urdlllocal ur_result_t UR_APICALL urSamplerRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerRelease(
     ur_sampler_handle_t
         hSampler ///< [in][release] handle of the sampler object to release
 ) {
@@ -1646,7 +1646,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetInfo
-__urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetInfo(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler object
     ur_sampler_info_t propName, ///< [in] name of the sampler property to query
     size_t
@@ -1712,7 +1712,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerGetNativeHandle(
     ur_sampler_handle_t hSampler, ///< [in] handle of the sampler.
     ur_native_handle_t *
         phNativeSampler ///< [out] a pointer to the native handle of the sampler.
@@ -1743,7 +1743,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urSamplerCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_native_handle_t
         hNativeSampler, ///< [in][nocheck] the native handle of the sampler.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -1789,7 +1789,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMHostAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMHostAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const ur_usm_desc_t
         *pUSMDesc, ///< [in][optional] USM memory allocation descriptor
@@ -1825,7 +1825,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMDeviceAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMDeviceAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t
@@ -1865,7 +1865,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMSharedAlloc
-__urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMSharedAlloc(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -1905,7 +1905,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMFree
-__urdlllocal ur_result_t UR_APICALL urUSMFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to USM memory object
 ) {
@@ -1931,7 +1931,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMGetMemAllocInfo
-__urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     const void *pMem,             ///< [in] pointer to USM memory object
     ur_usm_alloc_info_t
@@ -2012,7 +2012,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolCreate
-__urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_usm_pool_desc_t *
         pPoolDesc, ///< [in] pointer to USM pool descriptor. Can be chained with
@@ -2054,7 +2054,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRetain
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRetain(
     ur_usm_pool_handle_t pPool ///< [in][retain] pointer to USM memory pool
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2079,7 +2079,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolRelease
-__urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolRelease(
     ur_usm_pool_handle_t pPool ///< [in][release] pointer to USM memory pool
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -2104,7 +2104,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPoolGetInfo
-__urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPoolGetInfo(
     ur_usm_pool_handle_t hPool,  ///< [in] handle of the USM memory pool
     ur_usm_pool_info_t propName, ///< [in] name of the pool property to query
     size_t propSize, ///< [in] size in bytes of the pool property value provided
@@ -2170,7 +2170,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGranularityGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t
         hDevice, ///< [in][optional] is the device to get the granularity from, if the
@@ -2215,7 +2215,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemReserve
-__urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemReserve(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in][optional] pointer to the start of the virtual memory region to
@@ -2249,7 +2249,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemFree
-__urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemFree(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     const void *
         pStart, ///< [in] pointer to the start of the virtual memory range to free.
@@ -2277,7 +2277,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemMap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemMap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2315,7 +2315,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemUnmap
-__urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemUnmap(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void *
         pStart, ///< [in] pointer to the start of the mapped virtual memory range
@@ -2343,7 +2343,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemSetAccess
-__urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemSetAccess(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2373,7 +2373,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urVirtualMemGetInfo
-__urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urVirtualMemGetInfo(
     ur_context_handle_t hContext, ///< [in] handle to the context object.
     const void
         *pStart, ///< [in] pointer to the start of the virtual memory range.
@@ -2412,7 +2412,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemCreate
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] handle of the device object.
     size_t
@@ -2461,7 +2461,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRetain
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRetain(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][retain] handle of the physical memory object to retain.
 ) {
@@ -2489,7 +2489,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urPhysicalMemRelease
-__urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urPhysicalMemRelease(
     ur_physical_mem_handle_t
         hPhysicalMem ///< [in][release] handle of the physical memory object to release.
 ) {
@@ -2517,7 +2517,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithIL
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithIL(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     const void *pIL,              ///< [in] pointer to IL binary.
     size_t length,                ///< [in] length of `pIL` in bytes.
@@ -2561,7 +2561,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithBinary
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithBinary(
     ur_context_handle_t hContext, ///< [in] handle of the context instance
     ur_device_handle_t
         hDevice,            ///< [in] handle to device associated with binary.
@@ -2611,7 +2611,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuild
-__urdlllocal ur_result_t UR_APICALL urProgramBuild(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuild(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     const char *
@@ -2642,7 +2642,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompile
-__urdlllocal ur_result_t UR_APICALL urProgramCompile(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompile(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     ur_program_handle_t
         hProgram, ///< [in][out] handle of the program to compile.
@@ -2674,7 +2674,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLink
-__urdlllocal ur_result_t UR_APICALL urProgramLink(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLink(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t count, ///< [in] number of program handles in `phPrograms`.
     const ur_program_handle_t *
@@ -2728,7 +2728,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRetain
-__urdlllocal ur_result_t UR_APICALL urProgramRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRetain(
     ur_program_handle_t
         hProgram ///< [in][retain] handle for the Program to retain
 ) {
@@ -2754,7 +2754,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramRelease
-__urdlllocal ur_result_t UR_APICALL urProgramRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramRelease(
     ur_program_handle_t
         hProgram ///< [in][release] handle for the Program to release
 ) {
@@ -2780,7 +2780,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetFunctionPointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetFunctionPointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve pointer for.
     ur_program_handle_t
@@ -2818,7 +2818,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetGlobalVariablePointer
-__urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     ur_device_handle_t
         hDevice, ///< [in] handle of the device to retrieve the pointer for.
     ur_program_handle_t
@@ -2859,7 +2859,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_program_info_t propName, ///< [in] name of the Program property to query
     size_t propSize,            ///< [in] the size of the Program property.
@@ -2940,7 +2940,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetBuildInfo
-__urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     ur_device_handle_t hDevice,   ///< [in] handle of the Device object
     ur_program_build_info_t
@@ -2982,7 +2982,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     ur_program_handle_t hProgram, ///< [in] handle of the Program object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3012,7 +3012,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramGetNativeHandle(
     ur_program_handle_t hProgram, ///< [in] handle of the program.
     ur_native_handle_t *
         phNativeProgram ///< [out] a pointer to the native handle of the program.
@@ -3043,7 +3043,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_native_handle_t
         hNativeProgram, ///< [in][nocheck] the native handle of the program.
     ur_context_handle_t hContext, ///< [in] handle of the context instance
@@ -3089,7 +3089,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreate
-__urdlllocal ur_result_t UR_APICALL urKernelCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram, ///< [in] handle of the program instance
     const char *pKernelName,      ///< [in] pointer to null-terminated string.
     ur_kernel_handle_t
@@ -3130,7 +3130,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgValue
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgValue(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t argSize,    ///< [in] size of argument type
@@ -3162,7 +3162,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgLocal
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgLocal(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     size_t
@@ -3192,7 +3192,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_kernel_info_t propName,  ///< [in] name of the Kernel property to query
     size_t propSize,            ///< [in] the size of the Kernel property value.
@@ -3274,7 +3274,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_group_info_t
@@ -3313,7 +3313,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSubGroupInfo
-__urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     ur_kernel_handle_t hKernel, ///< [in] handle of the Kernel object
     ur_device_handle_t hDevice, ///< [in] handle of the Device object
     ur_kernel_sub_group_info_t
@@ -3352,7 +3352,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRetain
-__urdlllocal ur_result_t UR_APICALL urKernelRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRetain(
     ur_kernel_handle_t hKernel ///< [in][retain] handle for the Kernel to retain
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3377,7 +3377,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelRelease
-__urdlllocal ur_result_t UR_APICALL urKernelRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelRelease(
     ur_kernel_handle_t
         hKernel ///< [in][release] handle for the Kernel to release
 ) {
@@ -3403,7 +3403,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgPointer
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgPointer(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_pointer_properties_t
@@ -3434,7 +3434,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetExecInfo
-__urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetExecInfo(
     ur_kernel_handle_t hKernel,     ///< [in] handle of the kernel object
     ur_kernel_exec_info_t propName, ///< [in] name of the execution attribute
     size_t propSize,                ///< [in] size in byte the attribute value
@@ -3467,7 +3467,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgSampler
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgSampler(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_sampler_properties_t
@@ -3499,7 +3499,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetArgMemObj
-__urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetArgMemObj(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t argIndex, ///< [in] argument index in range [0, num args - 1]
     const ur_kernel_arg_mem_obj_properties_t
@@ -3533,7 +3533,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSetSpecializationConstants
-__urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t count, ///< [in] the number of elements in the pSpecConstants array
     const ur_specialization_constant_info_t *
@@ -3562,7 +3562,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetNativeHandle(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
@@ -3593,7 +3593,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -3646,7 +3646,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetSuggestedLocalWorkSize
-__urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     uint32_t
@@ -3691,7 +3691,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetInfo
-__urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetInfo(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_queue_info_t propName, ///< [in] name of the queue property to query
     size_t
@@ -3781,7 +3781,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreate
-__urdlllocal ur_result_t UR_APICALL urQueueCreate(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreate(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_queue_properties_t
@@ -3827,7 +3827,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRetain
-__urdlllocal ur_result_t UR_APICALL urQueueRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRetain(
     ur_queue_handle_t
         hQueue ///< [in][retain] handle of the queue object to get access
 ) {
@@ -3853,7 +3853,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueRelease
-__urdlllocal ur_result_t UR_APICALL urQueueRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueRelease(
     ur_queue_handle_t
         hQueue ///< [in][release] handle of the queue object to release
 ) {
@@ -3879,7 +3879,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueGetNativeHandle(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue.
     ur_queue_native_desc_t
         *pDesc, ///< [in][optional] pointer to native descriptor
@@ -3912,7 +3912,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_native_handle_t
         hNativeQueue, ///< [in][nocheck] the native handle of the queue.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -3964,7 +3964,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFinish
-__urdlllocal ur_result_t UR_APICALL urQueueFinish(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFinish(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be finished.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -3989,7 +3989,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urQueueFlush
-__urdlllocal ur_result_t UR_APICALL urQueueFlush(
+UR_DLL_LOCAL ur_result_t UR_APICALL urQueueFlush(
     ur_queue_handle_t hQueue ///< [in] handle of the queue to be flushed.
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4014,7 +4014,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_event_info_t propName, ///< [in] the name of the event property to query
     size_t propSize, ///< [in] size in bytes of the event property value
@@ -4090,7 +4090,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetProfilingInfo
-__urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetProfilingInfo(
     ur_event_handle_t hEvent, ///< [in] handle of the event object
     ur_profiling_info_t
         propName,    ///< [in] the name of the profiling property to query
@@ -4125,7 +4125,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventWait
-__urdlllocal ur_result_t UR_APICALL urEventWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventWait(
     uint32_t numEvents, ///< [in] number of events in the event list
     const ur_event_handle_t *
         phEventWaitList ///< [in][range(0, numEvents)] pointer to a list of events to wait for
@@ -4158,7 +4158,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRetain
-__urdlllocal ur_result_t UR_APICALL urEventRetain(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRetain(
     ur_event_handle_t hEvent ///< [in][retain] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4183,7 +4183,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventRelease
-__urdlllocal ur_result_t UR_APICALL urEventRelease(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventRelease(
     ur_event_handle_t hEvent ///< [in][release] handle of the event object
 ) {
     ur_result_t result = UR_RESULT_SUCCESS;
@@ -4208,7 +4208,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventGetNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventGetNativeHandle(
     ur_event_handle_t hEvent, ///< [in] handle of the event.
     ur_native_handle_t
         *phNativeEvent ///< [out] a pointer to the native handle of the event.
@@ -4239,7 +4239,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventCreateWithNativeHandle
-__urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_native_handle_t
         hNativeEvent, ///< [in][nocheck] the native handle of the event.
     ur_context_handle_t hContext, ///< [in] handle of the context object
@@ -4285,7 +4285,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
-__urdlllocal ur_result_t UR_APICALL urEventSetCallback(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEventSetCallback(
     ur_event_handle_t hEvent,       ///< [in] handle of the event object
     ur_execution_info_t execStatus, ///< [in] execution status of the event
     ur_event_callback_t pfnNotify,  ///< [in] execution status of the event
@@ -4314,7 +4314,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunch
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunch(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -4394,7 +4394,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWait
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWait(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4455,7 +4455,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueEventsWaitWithBarrier
-__urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     ur_queue_handle_t hQueue,     ///< [in] handle of the queue object
     uint32_t numEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t *
@@ -4517,7 +4517,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4587,7 +4587,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -4659,7 +4659,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferReadRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -4742,7 +4742,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferWriteRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(bufferOrigin, region)] handle of the buffer object
@@ -4828,7 +4828,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOffset, size)] handle of the src buffer object
@@ -4902,7 +4902,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferCopyRect
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBufferSrc, ///< [in][bounds(srcOrigin, region)] handle of the source buffer object
@@ -4986,7 +4986,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5056,7 +5056,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5131,7 +5131,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImage, ///< [in][bounds(origin, region)] handle of the image object
@@ -5207,7 +5207,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemImageCopy
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemImageCopy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hImageSrc, ///< [in][bounds(srcOrigin, region)] handle of the src image object
@@ -5287,7 +5287,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemBufferMap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemBufferMap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hBuffer, ///< [in][bounds(offset, size)] handle of the buffer object
@@ -5359,7 +5359,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueMemUnmap
-__urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueMemUnmap(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_mem_handle_t
         hMem,         ///< [in] handle of the memory (buffer or image) object
@@ -5425,7 +5425,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     void *pMem, ///< [in][bounds(0, size)] pointer to USM memory object
     size_t
@@ -5494,7 +5494,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool blocking,            ///< [in] blocking or non-blocking copy
     void *
@@ -5561,7 +5561,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMPrefetch
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -5625,7 +5625,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMAdvise
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMAdvise(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void
         *pMem,   ///< [in][bounds(0, size)] pointer to the USM memory object
@@ -5673,7 +5673,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMFill2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMFill2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     void *
         pMem, ///< [in][bounds(0, pitch * height)] pointer to memory to be filled.
@@ -5746,7 +5746,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueUSMMemcpy2D
-__urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     bool blocking, ///< [in] indicates if this operation should block the host.
     void *
@@ -5818,7 +5818,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableWrite
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -5891,7 +5891,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueDeviceGlobalVariableRead
-__urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue to submit to.
     ur_program_handle_t
         hProgram, ///< [in] handle of the program containing the device global variable.
@@ -5964,7 +5964,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueReadHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueReadHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the read command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -6041,7 +6041,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueWriteHostPipe
-__urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     ur_queue_handle_t
         hQueue, ///< [in] a valid host command-queue in which the write command
     ///< will be queued. hQueue and hProgram must be created with the same
@@ -6119,7 +6119,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMPitchedAllocExp
-__urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMPitchedAllocExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_usm_desc_t *
@@ -6164,7 +6164,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -6197,7 +6197,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageHandleDestroyExp
-__urdlllocal ur_result_t UR_APICALL
+UR_DLL_LOCAL ur_result_t UR_APICALL
 urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
@@ -6230,7 +6230,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageAllocateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -6270,7 +6270,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6301,7 +6301,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesUnsampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6343,7 +6343,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSampledImageCreateExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6390,7 +6390,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageCopyExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     const void *pSrc,         ///< [in] location the data will be copied from
     void *pDst,               ///< [in] location the data will be copied to
@@ -6465,7 +6465,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImageGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_exp_image_mem_native_handle_t
         hImageMem,            ///< [in] handle to the image memory
@@ -6496,7 +6496,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapGetLevelExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6536,7 +6536,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMipmapFreeExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_image_mem_native_handle_t
@@ -6567,7 +6567,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     size_t size,                  ///< [in] size of the external memory
@@ -6618,7 +6618,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalArrayExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     const ur_image_format_t
@@ -6664,7 +6664,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesMapExternalLinearMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     uint64_t offset,              ///< [in] offset into memory region to map
@@ -6704,7 +6704,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalMemoryExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_mem_handle_t
@@ -6740,7 +6740,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesImportExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_type_t
@@ -6792,7 +6792,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesReleaseExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     ur_device_handle_t hDevice,   ///< [in] handle of the device object
     ur_exp_external_semaphore_handle_t
@@ -6830,7 +6830,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesWaitExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -6905,7 +6905,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urBindlessImagesSignalExternalSemaphoreExp
-__urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_external_semaphore_handle_t
         hSemaphore, ///< [in] external semaphore handle
@@ -6980,7 +6980,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCreateExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_context_handle_t hContext, ///< [in] Handle of the context object.
     ur_device_handle_t hDevice,   ///< [in] Handle of the device object.
     const ur_exp_command_buffer_desc_t
@@ -7027,7 +7027,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][retain] Handle of the command-buffer object.
 ) {
@@ -7057,7 +7057,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in][release] Handle of the command-buffer object.
 ) {
@@ -7087,7 +7087,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferFinalizeExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer ///< [in] Handle of the command-buffer object.
 ) {
@@ -7117,7 +7117,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,         ///< [in] Handle of the command-buffer object.
     ur_kernel_handle_t hKernel, ///< [in] Kernel to append.
@@ -7236,7 +7236,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMMemcpyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     void *pDst,         ///< [in] Location the data will be copied to.
@@ -7326,7 +7326,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,   ///< [in] handle of the command-buffer object.
     void *pMemory,        ///< [in] pointer to USM allocated memory to fill.
@@ -7418,7 +7418,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -7516,7 +7516,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7611,7 +7611,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7705,7 +7705,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferCopyRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hSrcMem, ///< [in] The data to be copied.
@@ -7811,7 +7811,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferWriteRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -7920,7 +7920,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferReadRectExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] Handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] Handle of the buffer object.
@@ -8027,7 +8027,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendMemBufferFillExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,      ///< [in] handle of the command-buffer object.
     ur_mem_handle_t hBuffer, ///< [in] handle of the buffer object.
@@ -8123,7 +8123,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMPrefetchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,  ///< [in] handle of the command-buffer object.
     const void *pMemory, ///< [in] pointer to USM allocated memory to prefetch.
@@ -8213,7 +8213,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferAppendUSMAdviseExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer,           ///< [in] handle of the command-buffer object.
     const void *pMemory,          ///< [in] pointer to the USM memory object.
@@ -8303,7 +8303,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferEnqueueExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] Handle of the command-buffer object.
     ur_queue_handle_t
@@ -8371,7 +8371,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferRetainCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][retain] Handle of the command-buffer command.
 ) {
@@ -8402,7 +8402,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferReleaseCommandExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
     ur_exp_command_buffer_command_handle_t
         hCommand ///< [in][release] Handle of the command-buffer command.
 ) {
@@ -8433,7 +8433,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseCommandExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer kernel command to update.
     const ur_exp_command_buffer_update_kernel_launch_desc_t *
@@ -8495,7 +8495,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateSignalEventExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     ur_event_handle_t *phSignalEvent ///< [out] Event to be signaled.
@@ -8540,7 +8540,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferUpdateWaitEventsExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] Handle of the command-buffer command to update.
     uint32_t numEventsInWaitList, ///< [in] Size of the event wait list.
@@ -8585,7 +8585,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     ur_exp_command_buffer_handle_t
         hCommandBuffer, ///< [in] handle of the command-buffer object
     ur_exp_command_buffer_info_t
@@ -8625,7 +8625,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urCommandBufferCommandGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
     ur_exp_command_buffer_command_handle_t
         hCommand, ///< [in] handle of the command-buffer command object
     ur_exp_command_buffer_command_info_t
@@ -8666,7 +8666,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCommandGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueCooperativeKernelLaunchExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -8747,7 +8747,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelSuggestMaxCooperativeGroupCountExp
-__urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     size_t
         localWorkSize, ///< [in] number of local work-items that will form a work-group when the
@@ -8781,7 +8781,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueTimestampRecordingExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     bool
         blocking, ///< [in] indicates whether the call to this function should block until
@@ -8849,7 +8849,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueKernelLaunchCustomExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     ur_queue_handle_t hQueue,   ///< [in] handle of the queue object
     ur_kernel_handle_t hKernel, ///< [in] handle of the kernel object
     uint32_t
@@ -8908,7 +8908,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramBuildExp
-__urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramBuildExp(
     ur_program_handle_t hProgram, ///< [in] Handle of the program to build.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -8945,7 +8945,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramCompileExp
-__urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramCompileExp(
     ur_program_handle_t
         hProgram,        ///< [in][out] handle of the program to compile.
     uint32_t numDevices, ///< [in] number of devices
@@ -8984,7 +8984,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urProgramLinkExp
-__urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urProgramLinkExp(
     ur_context_handle_t hContext, ///< [in] handle of the context instance.
     uint32_t numDevices,          ///< [in] number of devices
     ur_device_handle_t *
@@ -9048,7 +9048,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMImportExp
-__urdlllocal ur_result_t UR_APICALL urUSMImportExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMImportExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem,                   ///< [in] pointer to host memory object
     size_t size ///< [in] size in bytes of the host memory object to be imported
@@ -9075,7 +9075,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUSMReleaseExp
-__urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUSMReleaseExp(
     ur_context_handle_t hContext, ///< [in] handle of the context object
     void *pMem                    ///< [in] pointer to host memory object
 ) {
@@ -9101,7 +9101,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PEnablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -9133,7 +9133,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PDisablePeerAccessExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     ur_device_handle_t
         commandDevice,            ///< [in] handle of the command device object
     ur_device_handle_t peerDevice ///< [in] handle of the peer device object
@@ -9166,7 +9166,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urUsmP2PPeerAccessGetInfoExp
-__urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     ur_device_handle_t
         commandDevice,             ///< [in] handle of the command device object
     ur_device_handle_t peerDevice, ///< [in] handle of the peer device object
@@ -9211,7 +9211,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
 
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEnqueueNativeCommandExp
-__urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
+UR_DLL_LOCAL ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     ur_queue_handle_t hQueue, ///< [in] handle of the queue object
     ur_exp_enqueue_native_command_function_t
         pfnNativeEnqueue, ///< [in] function calling the native underlying API, to be executed

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -64,7 +64,7 @@ void context_t::tearDownLayers() const {
 }
 
 //////////////////////////////////////////////////////////////////////////
-__urdlllocal ur_result_t context_t::Init(
+UR_DLL_LOCAL ur_result_t context_t::Init(
     ur_device_init_flags_t, ur_loader_config_handle_t hLoaderConfig) {
     if (hLoaderConfig && hLoaderConfig->enableMock) {
         // This clears default known adapters and replaces them with the mock

--- a/source/loader/ur_lib.hpp
+++ b/source/loader/ur_lib.hpp
@@ -53,7 +53,7 @@ struct ur_loader_config_handle_t_ {
 
 namespace ur_lib {
 ///////////////////////////////////////////////////////////////////////////////
-class __urdlllocal context_t : public AtomicSingleton<context_t> {
+class UR_DLL_LOCAL context_t : public AtomicSingleton<context_t> {
   public:
 #ifdef DYNAMIC_LOAD_LOADER
     HMODULE loader = nullptr;

--- a/source/loader/ur_libddi.cpp
+++ b/source/loader/ur_libddi.cpp
@@ -17,7 +17,7 @@
 namespace ur_lib {
 ///////////////////////////////////////////////////////////////////////////////
 
-__urdlllocal ur_result_t context_t::ddiInit() {
+UR_DLL_LOCAL ur_result_t context_t::ddiInit() {
     ur_result_t result = UR_RESULT_SUCCESS;
 
     if (UR_RESULT_SUCCESS == result) {

--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -50,14 +50,13 @@ const ur_command_t UR_EXT_COMMAND_TYPE_USER =
 
 /// Program metadata tags recognized by the UR adapters. For kernels the tag
 /// must appear after the kernel name.
-#define __SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE                    \
+#define SYCL_UR_PROGRAM_METADATA_TAG_REQD_WORK_GROUP_SIZE                      \
   "@reqd_work_group_size"
-#define __SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING "@global_id_mapping"
-#define __SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE                     \
-  "@max_work_group_size"
-#define __SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE              \
+#define SYCL_UR_PROGRAM_METADATA_GLOBAL_ID_MAPPING "@global_id_mapping"
+#define SYCL_UR_PROGRAM_METADATA_TAG_MAX_WORK_GROUP_SIZE "@max_work_group_size"
+#define SYCL_UR_PROGRAM_METADATA_TAG_MAX_LINEAR_WORK_GROUP_SIZE                \
   "@max_linear_work_group_size"
-#define __SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION "Requires finalization"
+#define SYCL_UR_PROGRAM_METADATA_TAG_NEED_FINALIZATION "Requires finalization"
 
 // Terminates the process with a catastrophic error message.
 [[noreturn]] inline void die(const char *Message) {
@@ -192,7 +191,7 @@ template <class T> struct ZeCache : private T {
     return error;
 
 // TODO: populate with target agnostic handling of UR platforms
-struct _ur_platform {};
+struct ur_platform {};
 
 // Controls tracing UR calls from within the UR itself.
 extern bool PrintTrace;


### PR DESCRIPTION
This is a pretty mechanical transformation, whereby we don't use leading underscores in implementation, nor headers (where there's already the convention of using *trailing* underscores for types, and undecorated names in local and class scopes).