### PR TITLE
[NFC] Remove "dependencies" on tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ List of options provided by CMake:
 
 ### Additional make targets
 
+To run tests, do the following:
+
+```bash
+$ make
+$ make test
+```
+
 To run automated code formatting, configure CMake with `UR_FORMAT_CPP_STYLE` option
 and then run a custom `cppformat` target:
 

--- a/test/adapters/CMakeLists.txt
+++ b/test/adapters/CMakeLists.txt
@@ -67,7 +67,6 @@ function(add_adapter_memcheck_test name)
                 -D MODE=stderr
                 -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}_memcheck.match
                 -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-                DEPENDS ${TEST_TARGET_NAME}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         )
 

--- a/test/conformance/CMakeLists.txt
+++ b/test/conformance/CMakeLists.txt
@@ -34,7 +34,6 @@ function(add_test_adapter name adapter backend)
             separate_arguments(TEST_COMMAND)
             add_test(NAME ${tname}
                 COMMAND ${TEST_COMMAND}
-                DEPENDS ${TEST_TARGET_NAME}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
         endif()

--- a/test/layers/tracing/CMakeLists.txt
+++ b/test/layers/tracing/CMakeLists.txt
@@ -38,7 +38,6 @@ add_test(NAME example-collected-hello-world
     -D TEST_FILE=$<TARGET_FILE:hello_world>
     -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/hello_world.out.match
     -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-    DEPENDS collector hello_world
 )
 
 set_tracing_test_props(example-collected-hello-world collector)
@@ -49,7 +48,6 @@ add_test(NAME example-logged-hello-world
     -D TEST_FILE=$<TARGET_FILE:hello_world>
     -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/hello_world.out.logged.match
     -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-    DEPENDS hello_world
 )
 set_tests_properties(example-logged-hello-world PROPERTIES LABELS "tracing")
 set_property(TEST example-logged-hello-world PROPERTY ENVIRONMENT
@@ -73,7 +71,6 @@ function(add_tracing_test name)
         -D TEST_FILE=$<TARGET_FILE:${TEST_TARGET_NAME}>
         -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}.out.match
         -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-        DEPENDS test_collector
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     set_tracing_test_props(${name} test_collector)

--- a/test/loader/CMakeLists.txt
+++ b/test/loader/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_test(NAME example-hello-world COMMAND hello_world DEPENDS hello_world)
+add_test(NAME example-hello-world COMMAND hello_world)
 set_tests_properties(example-hello-world PROPERTIES LABELS "loader"
     ENVIRONMENT "UR_ADAPTERS_FORCE_LOAD=\"$<TARGET_FILE:ur_adapter_mock>\""
 )

--- a/test/loader/platforms/CMakeLists.txt
+++ b/test/loader/platforms/CMakeLists.txt
@@ -25,7 +25,6 @@ function(add_loader_platform_test name ENV)
         -D MODE=stdout
         -D MATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/${name}.match
         -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-        DEPENDS test-loader-platforms ur_adapter_mock
     )
     set_tests_properties(${TEST_NAME} PROPERTIES
         LABELS "loader"

--- a/test/tools/urtrace/CMakeLists.txt
+++ b/test/tools/urtrace/CMakeLists.txt
@@ -19,7 +19,6 @@ function(add_trace_test name CLI_ARGS)
         -D MODE=stdout
         -D MATCH_FILE=${CMAKE_CURRENT_BINARY_DIR}/${name}.match
         -P ${PROJECT_SOURCE_DIR}/cmake/match.cmake
-        DEPENDS ur_trace_cli hello_world
     )
     set_tests_properties(${TEST_NAME} PROPERTIES LABELS "urtrace")
 endfunction()


### PR DESCRIPTION
CMake's `add_test` doesn't actually support a `DEPENDS` parameter, so
removed it. Also updated the README with instructionts on running the
tests which explicitly calls out that you should run `make` before the
tests.
