### PR TITLE
Check if compiler supports -fstack-clash-protection

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -58,7 +58,10 @@ macro(add_sanitizer_flag flag)
     set(CMAKE_REQUIRED_LIBRARIES ${SAVED_CMAKE_REQUIRED_LIBRARIES})
 endmacro()
 
-check_cxx_compiler_flag("-fcf-protection=full" CXX_HAS_FCF_PROTECTION_FULL)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    check_cxx_compiler_flag("-fcf-protection=full" CXX_HAS_FCF_PROTECTION_FULL)
+    check_cxx_compiler_flag("-fstack-clash-protection" CXX_HAS_FSTACK_CLASH_PROTECTION)
+endif()
 
 function(add_ur_target_compile_options name)
     if(NOT MSVC)
@@ -81,9 +84,7 @@ function(add_ur_target_compile_options name)
             # -flto
             # $<$<CXX_COMPILER_ID:Clang,AppleClang>:-fsanitize=cfi>
             $<$<BOOL:${CXX_HAS_FCF_PROTECTION_FULL}>:-fcf-protection=full>
-            # -fstack-clash-protection is not supported in apple clang or GCC < 8
-            $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8>>:-fstack-clash-protection>
-            $<$<CXX_COMPILER_ID:Clang>:-fstack-clash-protection>
+            $<$<BOOL:${CXX_HAS_FSTACK_CLASH_PROTECTION}>:-fstack-clash-protection>
 
             # Colored output
             $<$<CXX_COMPILER_ID:GNU>:-fdiagnostics-color=always>


### PR DESCRIPTION
Similar to #2202, check if the host compiler supports the `-fstack-clash-protection` flag rather than using version ranges.
