### PR TITLE
Remove soon to be deprecated macos-12 job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -284,7 +284,7 @@ jobs:
     name: Build - MacOS
     strategy:
         matrix:
-          os: ['macos-12', 'macos-13']
+          os: ['macos-13']
     runs-on: ${{matrix.os}}
 
     steps:


### PR DESCRIPTION
I noticed in the Actions page of a PR that the macos-12 build job would be deprecated soon (seen in #2149) and have just seen a further notice (under Annotations in [this PR](https://github.com/oneapi-src/unified-runtime/actions/runs/11365211313/job/31619043571) with a link to a [Github announcement](https://github.com/actions/runner-images/issues/10721) that the job will start to get deprecated from November:

> GitHub Actions is starting the deprecation process for macOS 12. While the image is being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on 10/7/24 and the image will be fully unsupported by 12/3/24
> 
> To raise awareness of the upcoming removal, we will temporarily fail jobs using macOS 12. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
>     November 4, 14:00 UTC - November 5, 00:00 UTC
>     November 11, 14:00 UTC - November 12, 00:00 UTC
>     November 18, 14:00 UTC - November 19, 00:00 UTC
>     November 25, 14:00 UTC - November 26, 00:00 UTC

Given that jobs will temporarily fail during the above dates and they will eventually be unsupported then we may as well remove the job now. Should we add a job for macos-14 or 15?

Closes https://github.com/oneapi-src/unified-runtime/issues/2149