### PR TITLE
Revert "[L0] Refactor to remove default constructor inits"

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -147,10 +147,8 @@ ur_result_t createSyncPointAndGetZeEvents(
   UR_CALL(getEventsFromSyncPoints(CommandBuffer, NumSyncPointsInWaitList,
                                   SyncPointWaitList, ZeEventList));
   ur_event_handle_t LaunchEvent;
-  UR_CALL(EventCreate(CommandBuffer->Context, nullptr /*Queue*/,
-                      false /*IsMultiDevice*/, HostVisible, &LaunchEvent,
-                      false /*CounterBasedEventEnabled*/,
-                      !CommandBuffer->IsProfilingEnabled));
+  UR_CALL(EventCreate(CommandBuffer->Context, nullptr, false, HostVisible,
+                      &LaunchEvent, false, !CommandBuffer->IsProfilingEnabled));
   LaunchEvent->CommandType = CommandType;
   ZeLaunchEvent = LaunchEvent->ZeEvent;
 
@@ -328,26 +326,22 @@ void ur_exp_command_buffer_handle_t_::cleanupCommandBufferResources() {
 
   // Release additional signal and wait events used by command_buffer
   if (SignalEvent) {
-    CleanupCompletedEvent(SignalEvent, false /*QueueLocked*/,
-                          false /*SetEventCompleted*/);
+    CleanupCompletedEvent(SignalEvent, false);
     urEventReleaseInternal(SignalEvent);
   }
   if (WaitEvent) {
-    CleanupCompletedEvent(WaitEvent, false /*QueueLocked*/,
-                          false /*SetEventCompleted*/);
+    CleanupCompletedEvent(WaitEvent, false);
     urEventReleaseInternal(WaitEvent);
   }
   if (AllResetEvent) {
-    CleanupCompletedEvent(AllResetEvent, false /*QueueLocked*/,
-                          false /*SetEventCompleted*/);
+    CleanupCompletedEvent(AllResetEvent, false);
     urEventReleaseInternal(AllResetEvent);
   }
 
   // Release events added to the command_buffer
   for (auto &Sync : SyncPoints) {
     auto &Event = Sync.second;
-    CleanupCompletedEvent(Event, false /*QueueLocked*/,
-                          false /*SetEventCompleted*/);
+    CleanupCompletedEvent(Event, false);
     urEventReleaseInternal(Event);
   }
 
@@ -520,15 +514,12 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   ur_event_handle_t WaitEvent;
   ur_event_handle_t AllResetEvent;
 
-  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
-                      false /*HostVisible*/, &SignalEvent,
-                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
-  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
-                      false /*HostVisible*/, &WaitEvent,
-                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
-  UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
-                      false /*HostVisible*/, &AllResetEvent,
-                      false /*CounterBasedEventEnabled*/, !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr, false, false, &SignalEvent, false,
+                      !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr, false, false, &WaitEvent, false,
+                      !EnableProfiling));
+  UR_CALL(EventCreate(Context, nullptr, false, false, &AllResetEvent, false,
+                      !EnableProfiling));
   std::vector<ze_event_handle_t> PrecondEvents = {WaitEvent->ZeEvent,
                                                   AllResetEvent->ZeEvent};
 
@@ -1228,15 +1219,14 @@ ur_result_t waitForDependencies(ur_exp_command_buffer_handle_t CommandBuffer,
       // when `EventWaitList` dependencies are complete.
       ur_command_list_ptr_t WaitCommandList{};
       UR_CALL(Queue->Context->getAvailableCommandList(
-          Queue, WaitCommandList, false /*UseCopyEngine*/, NumEventsInWaitList,
-          EventWaitList, false /*AllowBatching*/, nullptr /*ForcedCmdQueue*/));
+          Queue, WaitCommandList, false, NumEventsInWaitList, EventWaitList,
+          false));
 
       ZE2UR_CALL(zeCommandListAppendBarrier,
                  (WaitCommandList->first, CommandBuffer->WaitEvent->ZeEvent,
                   CommandBuffer->WaitEvent->WaitList.Length,
                   CommandBuffer->WaitEvent->WaitList.ZeEventList));
-      Queue->executeCommandList(WaitCommandList, false /*IsBlocking*/,
-                                false /*OKToBatchCommand*/);
+      Queue->executeCommandList(WaitCommandList, false, false);
       MustSignalWaitEvent = false;
     }
   }
@@ -1348,9 +1338,9 @@ urCommandBufferEnqueueExp(ur_exp_command_buffer_handle_t CommandBuffer,
 
   // Create a command-list to signal the Event on completion
   ur_command_list_ptr_t SignalCommandList{};
-  UR_CALL(Queue->Context->getAvailableCommandList(
-      Queue, SignalCommandList, false /*UseCopyEngine*/, NumEventsInWaitList,
-      EventWaitList, false /*AllowBatching*/, nullptr /*ForcedCmdQueue*/));
+  UR_CALL(Queue->Context->getAvailableCommandList(Queue, SignalCommandList,
+                                                  false, NumEventsInWaitList,
+                                                  EventWaitList, false));
 
   // Reset the wait-event for the UR command-buffer that is signaled when its
   // submission dependencies have been satisfied.
@@ -1365,8 +1355,7 @@ urCommandBufferEnqueueExp(ur_exp_command_buffer_handle_t CommandBuffer,
   // parameter with signal command-list completing.
   UR_CALL(createUserEvent(CommandBuffer, Queue, SignalCommandList, Event));
 
-  UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
-                                    false /*OKToBatchCommand*/));
+  UR_CALL(Queue->executeCommandList(SignalCommandList, false, false));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -774,7 +774,7 @@ ur_result_t ur_context_handle_t_::getAvailableCommandList(
                 .emplace(ZeCommandList,
                          ur_command_list_info_t(
                              ZeFence, true, false, ZeCommandQueue, ZeQueueDesc,
-                             Queue->useCompletionBatching(), true /*CanReuse */,
+                             Queue->useCompletionBatching(), true,
                              ZeCommandListIt->second.InOrderList,
                              ZeCommandListIt->second.IsImmediate))
                 .first;

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -302,8 +302,8 @@ struct ur_context_handle_t_ : _ur_object {
   ur_result_t getAvailableCommandList(
       ur_queue_handle_t Queue, ur_command_list_ptr_t &CommandList,
       bool UseCopyEngine, uint32_t NumEventsInWaitList,
-      const ur_event_handle_t *EventWaitList, bool AllowBatching,
-      ze_command_queue_handle_t *ForcedCmdQueue);
+      const ur_event_handle_t *EventWaitList, bool AllowBatching = false,
+      ze_command_queue_handle_t *ForcedCmdQueue = nullptr);
 
   // Checks if Device is covered by this context.
   // For that the Device or its root devices need to be in the context.

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -32,8 +32,8 @@ ur_result_t urEventReleaseInternal(ur_event_handle_t Event);
 ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
                         bool IsMultiDevice, bool HostVisible,
                         ur_event_handle_t *RetEvent,
-                        bool CounterBasedEventEnabled,
-                        bool ForceDisableProfiling);
+                        bool CounterBasedEventEnabled = false,
+                        bool ForceDisableProfiling = false);
 } // extern "C"
 
 // This is an experimental option that allows to disable caching of events in
@@ -273,8 +273,9 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle);
 // the event, updates the last command event in the queue and cleans up all dep
 // events of the event.
 // If the caller locks queue mutex then it must pass 'true' to QueueLocked.
-ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
-                                  bool SetEventCompleted);
+ur_result_t CleanupCompletedEvent(ur_event_handle_t Event,
+                                  bool QueueLocked = false,
+                                  bool SetEventCompleted = false);
 
 // Get value of device scope events env var setting or default setting
 static const EventsScope DeviceEventsSetting = [] {

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -856,7 +856,7 @@ ur_result_t urBindlessImagesImageCopyExp(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(hQueue->Context->getAvailableCommandList(
       hQueue, CommandList, UseCopyEngine, numEventsInWaitList, phEventWaitList,
-      OkToBatch, nullptr /*ForcedCmdQueue*/));
+      OkToBatch));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent;

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -139,7 +139,7 @@ ur_result_t urEnqueueKernelLaunch(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(
       Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
-      true /* AllowBatching */, nullptr /*ForcedCmdQueue*/));
+      true /* AllowBatching */));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent{};
@@ -202,8 +202,7 @@ ur_result_t urEnqueueKernelLaunch(
 
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  UR_CALL(Queue->executeCommandList(CommandList, false /*IsBlocking*/,
-                                    true /*OKToBatchCommand*/));
+  UR_CALL(Queue->executeCommandList(CommandList, false, true));
 
   return UR_RESULT_SUCCESS;
 }
@@ -405,7 +404,7 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
   ur_command_list_ptr_t CommandList{};
   UR_CALL(Queue->Context->getAvailableCommandList(
       Queue, CommandList, UseCopyEngine, NumEventsInWaitList, EventWaitList,
-      true /* AllowBatching */, nullptr /*ForcedCmdQueue*/));
+      true /* AllowBatching */));
 
   ze_event_handle_t ZeEvent = nullptr;
   ur_event_handle_t InternalEvent{};
@@ -468,8 +467,7 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
 
   // Execute command list asynchronously, as the event will be used
   // to track down its completion.
-  UR_CALL(Queue->executeCommandList(CommandList, false /*IsBlocking*/,
-                                    true /*OKToBatchCommand*/));
+  UR_CALL(Queue->executeCommandList(CommandList, false, true));
 
   return UR_RESULT_SUCCESS;
 }

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -150,9 +150,10 @@ private:
 };
 
 ur_result_t resetCommandLists(ur_queue_handle_t Queue);
-ur_result_t CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue,
-                                       bool QueueLocked, bool QueueSynced,
-                                       ur_event_handle_t CompletedEvent);
+ur_result_t
+CleanupEventsInImmCmdLists(ur_queue_handle_t UrQueue, bool QueueLocked = false,
+                           bool QueueSynced = false,
+                           ur_event_handle_t CompletedEvent = nullptr);
 
 // Structure describing the specific use of a command-list in a queue.
 // This is because command-lists are re-used across multiple queues
@@ -161,8 +162,8 @@ struct ur_command_list_info_t {
   ur_command_list_info_t(ze_fence_handle_t ZeFence, bool ZeFenceInUse,
                          bool IsClosed, ze_command_queue_handle_t ZeQueue,
                          ZeStruct<ze_command_queue_desc_t> ZeQueueDesc,
-                         bool UseCompletionBatching, bool CanReuse,
-                         bool IsInOrderList, bool IsImmediate)
+                         bool UseCompletionBatching, bool CanReuse = true,
+                         bool IsInOrderList = false, bool IsImmediate = false)
       : ZeFence(ZeFence), ZeFenceInUse(ZeFenceInUse), IsClosed(IsClosed),
         ZeQueue(ZeQueue), ZeQueueDesc(ZeQueueDesc),
         IsInOrderList(IsInOrderList), CanReuse(CanReuse),
@@ -527,7 +528,8 @@ struct ur_queue_handle_t_ : _ur_object {
   //
   // For immediate commandlists, no close and execute is necessary.
   ur_result_t executeCommandList(ur_command_list_ptr_t CommandList,
-                                 bool IsBlocking, bool OKToBatchCommand);
+                                 bool IsBlocking = false,
+                                 bool OKToBatchCommand = false);
 
   // Helper method telling whether we need to reuse discarded event in this
   // queue.


### PR DESCRIPTION
Reverts oneapi-src/unified-runtime#2063 due to [this issue](https://github.com/intel/llvm/pull/15309#issuecomment-2422204809).