### PR TITLE
Handle INVALID_VALUE in OCL urPlatformGet

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1054,6 +1054,8 @@ typedef enum ur_adapter_backend_t {
 ///         + `NULL == phAdapters`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phPlatforms != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pNumPlatforms == NULL && phPlatforms == NULL`
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGet(
     ur_adapter_handle_t *phAdapters,   ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -48,6 +48,8 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`NumEntries == 0 && phPlatforms != NULL`"
+    - $X_RESULT_ERROR_INVALID_VALUE:
+        - "`pNumPlatforms == NULL && phPlatforms == NULL`"
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Supported platform info"

--- a/source/adapters/opencl/platform.cpp
+++ b/source/adapters/opencl/platform.cpp
@@ -96,6 +96,11 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
     }
   }
 
+  /* INVALID_VALUE is returned when the size is invalid, special case it here */
+  if (Result == CL_INVALID_VALUE && phPlatforms != nullptr && NumEntries == 0) {
+    return UR_RESULT_ERROR_INVALID_SIZE;
+  }
+
   return mapCLErrorToUR(Result);
 }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -234,6 +234,10 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
         if (NumEntries == 0 && phPlatforms != NULL) {
             return UR_RESULT_ERROR_INVALID_SIZE;
         }
+
+        if (pNumPlatforms == NULL && phPlatforms == NULL) {
+            return UR_RESULT_ERROR_INVALID_VALUE;
+        }
     }
 
     ur_result_t result =

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -509,6 +509,8 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///         + `NULL == phAdapters`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phPlatforms != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pNumPlatforms == NULL && phPlatforms == NULL`
 ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -460,6 +460,8 @@ ur_result_t UR_APICALL urAdapterGetInfo(
 ///         + `NULL == phAdapters`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `NumEntries == 0 && phPlatforms != NULL`
+///     - ::UR_RESULT_ERROR_INVALID_VALUE
+///         + `pNumPlatforms == NULL && phPlatforms == NULL`
 ur_result_t UR_APICALL urPlatformGet(
     ur_adapter_handle_t *
         phAdapters, ///< [in][range(0, NumAdapters)] array of adapters to query for platforms.

--- a/test/conformance/platform/urPlatformGet.cpp
+++ b/test/conformance/platform/urPlatformGet.cpp
@@ -41,3 +41,10 @@ TEST_F(urPlatformGetTest, InvalidNullPointer) {
                                    static_cast<uint32_t>(adapters.size()), 0,
                                    nullptr, &count));
 }
+
+TEST_F(urPlatformGetTest, NullArgs) {
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_VALUE,
+                     urPlatformGet(adapters.data(),
+                                   static_cast<uint32_t>(adapters.size()), 0,
+                                   nullptr, nullptr));
+}


### PR DESCRIPTION
The OpenCL function clGetPlatformIDs may return CL_INVALID_VALUE, which
needs to be converted into appropriate UR returns as follows:

* If a non-null platforms list is provided, but the number of elements
  in it is 0, then return UR_RESULT_ERROR_INVALID_SIZE.
* If neither platform or sizes outputs are provided, then return
  UR_RESULT_ERROR_INVALID_VALUE.

This required a spec change.

This fixes a bug Intel are tracking internally as URT-831.
