### PR TITLE
don't call xpti if there are no subscribers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if(UR_ENABLE_TRACING)
 
     if (UR_BUILD_XPTI_LIBS)
         # fetch xpti proxy library for the tracing layer
-        FetchContentSparse_Declare(xpti https://github.com/intel/llvm.git "sycl-nightly/20230703" "xpti")
+        FetchContentSparse_Declare(xpti https://github.com/intel/llvm.git "nightly-2024-10-22" "xpti")
         FetchContent_MakeAvailable(xpti)
 
         # set -fPIC for xpti since we are linking it with a shared library
@@ -149,7 +149,7 @@ if(UR_ENABLE_TRACING)
         set(XPTI_DIR ${xpti_SOURCE_DIR})
         set(XPTI_ENABLE_TESTS OFF CACHE INTERNAL "Turn off xptifw tests")
 
-        FetchContentSparse_Declare(xptifw https://github.com/intel/llvm.git "sycl-nightly/20230703" "xptifw")
+        FetchContentSparse_Declare(xptifw https://github.com/intel/llvm.git "nightly-2024-10-22" "xptifw")
 
         FetchContent_MakeAvailable(xptifw)
 

--- a/examples/collector/collector.cpp
+++ b/examples/collector/collector.cpp
@@ -125,8 +125,7 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
         return;
     }
     if (std::string_view(stream_name) != UR_STREAM_NAME) {
-        std::cout << "Invalid stream name: " << stream_name << ". Expected "
-                  << UR_STREAM_NAME << ". Aborting." << std::endl;
+        // we expect ur.call, but this can also be xpti.framework.
         return;
     }
 

--- a/test/layers/tracing/test_collector.cpp
+++ b/test/layers/tracing/test_collector.cpp
@@ -49,8 +49,7 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
         return;
     }
     if (std::string_view(stream_name) != UR_STREAM_NAME) {
-        std::cout << "Invalid stream name: " << stream_name << ". Expected "
-                  << UR_STREAM_NAME << ". Aborting." << std::endl;
+        // we expect ur.call, but this can also be xpti.framework.
         return;
     }
 


### PR DESCRIPTION
This avoids the overhead of preparing data for xpti, and the cost of the xpti call itself, if nothing is subscribed to the ur.call xpti call stream.