### PR TITLE
Report device fp support via config rather than extension string.

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -437,8 +437,27 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(MemBaseAddrAlign);
   }
   case UR_DEVICE_INFO_HALF_FP_CONFIG: {
-    // TODO: is this config consistent across all NVIDIA GPUs?
-    return ReturnValue(0u);
+    int Major = 0;
+    int Minor = 0;
+
+    UR_CHECK_ERROR(cuDeviceGetAttribute(
+        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
+    UR_CHECK_ERROR(cuDeviceGetAttribute(
+        &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, hDevice->get()));
+
+    if ((Major >= 6) || ((Major == 5) && (Minor >= 3))) {
+      // TODO: is this config consistent across all NVIDIA GPUs?
+      ur_device_fp_capability_flags_t Config =
+          UR_DEVICE_FP_CAPABILITY_FLAG_DENORM |
+          UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_ZERO |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_INF |
+          UR_DEVICE_FP_CAPABILITY_FLAG_FMA;
+      return ReturnValue(Config);
+    } else {
+      return ReturnValue(0u);
+    }
   }
   case UR_DEVICE_INFO_SINGLE_FP_CONFIG: {
     // TODO: is this config consistent across all NVIDIA GPUs?
@@ -616,25 +635,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_EXTENSIONS: {
 
-    std::string SupportedExtensions = "cl_khr_fp64 cl_khr_subgroups ";
+    std::string SupportedExtensions = "cl_khr_subgroups ";
     SupportedExtensions += "cl_intel_devicelib_assert ";
     // Return supported for the UR command-buffer experimental feature
     SupportedExtensions += "ur_exp_command_buffer ";
     SupportedExtensions += "ur_exp_usm_p2p ";
     SupportedExtensions += "ur_exp_launch_properties ";
     SupportedExtensions += " ";
-
-    int Major = 0;
-    int Minor = 0;
-
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, hDevice->get()));
-    UR_CHECK_ERROR(cuDeviceGetAttribute(
-        &Minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, hDevice->get()));
-
-    if ((Major >= 6) || ((Major == 5) && (Minor >= 3))) {
-      SupportedExtensions += "cl_khr_fp16 ";
-    }
 
     return ReturnValue(SupportedExtensions.c_str());
   }

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -370,7 +370,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(MemBaseAddrAlign);
   }
   case UR_DEVICE_INFO_HALF_FP_CONFIG: {
-    return ReturnValue(0u);
+    ur_device_fp_capability_flags_t Config =
+        UR_DEVICE_FP_CAPABILITY_FLAG_DENORM |
+        UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN |
+        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST |
+        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_ZERO |
+        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_INF |
+        UR_DEVICE_FP_CAPABILITY_FLAG_FMA;
+    return ReturnValue(Config);
   }
   case UR_DEVICE_INFO_SINGLE_FP_CONFIG: {
     ur_device_fp_capability_flags_t Config =
@@ -384,14 +391,22 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(Config);
   }
   case UR_DEVICE_INFO_DOUBLE_FP_CONFIG: {
-    ur_device_fp_capability_flags_t Config =
-        UR_DEVICE_FP_CAPABILITY_FLAG_DENORM |
-        UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN |
-        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST |
-        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_ZERO |
-        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_INF |
-        UR_DEVICE_FP_CAPABILITY_FLAG_FMA;
-    return ReturnValue(Config);
+    hipDeviceProp_t Props;
+    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
+                          hipSuccess);
+
+    if (Props.arch.hasDoubles) {
+      ur_device_fp_capability_flags_t Config =
+          UR_DEVICE_FP_CAPABILITY_FLAG_DENORM |
+          UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_ZERO |
+          UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_INF |
+          UR_DEVICE_FP_CAPABILITY_FLAG_FMA;
+      return ReturnValue(Config);
+    } else {
+      return ReturnValue(0u);
+    }
   }
   case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE: {
     return ReturnValue(UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE);
@@ -580,16 +595,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     }
 
     SupportedExtensions += " ";
-
-    hipDeviceProp_t Props;
-    detail::ur::assertion(hipGetDeviceProperties(&Props, hDevice->get()) ==
-                          hipSuccess);
-
-    if (Props.arch.hasDoubles) {
-      SupportedExtensions += "cl_khr_fp64 ";
-    }
-
-    SupportedExtensions += "cl_khr_fp16 ";
 
     return ReturnValue(SupportedExtensions.c_str());
   }

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -260,8 +260,6 @@ ur_result_t urDeviceGetInfo(
     //   for performance.
     // cl_intel_required_subgroup_size - Extension to allow programmers to
     //   optionally specify the required subgroup size for a kernel function.
-    // cl_khr_fp16 - Optional half floating-point support.
-    // cl_khr_fp64 - Support for double floating-point precision.
     // cl_khr_int64_base_atomics, cl_khr_int64_extended_atomics - Optional
     //   extensions that implement atomic operations on 64-bit signed and
     //   unsigned integers to locations in __global and __local memory.
@@ -271,10 +269,6 @@ ur_result_t urDeviceGetInfo(
     // Hardcoding some extensions we know are supported by all Level Zero
     // devices.
     SupportedExtensions += (ZE_SUPPORTED_EXTENSIONS);
-    if (Device->ZeDeviceModuleProperties->flags & ZE_DEVICE_MODULE_FLAG_FP16)
-      SupportedExtensions += ("cl_khr_fp16 ");
-    if (Device->ZeDeviceModuleProperties->flags & ZE_DEVICE_MODULE_FLAG_FP64)
-      SupportedExtensions += ("cl_khr_fp64 ");
     if (Device->ZeDeviceModuleProperties->flags &
         ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS)
       // int64AtomicsSupported indicates support for both.

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -154,10 +154,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
     return ReturnValue(bool{1});
   case UR_DEVICE_INFO_EXTENSIONS:
-    // TODO : Populate return string accordingly - e.g. cl_khr_fp16,
-    // cl_khr_fp64, cl_khr_int64_base_atomics,
-    // cl_khr_int64_extended_atomics
-    return ReturnValue("cl_khr_fp16, cl_khr_fp64 ");
+    return ReturnValue("");
   case UR_DEVICE_INFO_VERSION:
     return ReturnValue("0.1");
   case UR_DEVICE_INFO_COMPILER_AVAILABLE:
@@ -193,19 +190,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH:
     // Default minimum values required by the SYCL specification.
     return ReturnValue(size_t{2048});
-  case UR_DEVICE_INFO_HALF_FP_CONFIG: {
-    // todo:
-    ur_device_fp_capability_flags_t HalfFPValue = 0;
-    return ReturnValue(HalfFPValue);
-  }
-  case UR_DEVICE_INFO_SINGLE_FP_CONFIG: {
-    // todo
-    ur_device_fp_capability_flags_t SingleFPValue = 0;
-    return ReturnValue(SingleFPValue);
-  }
+  case UR_DEVICE_INFO_HALF_FP_CONFIG:
+  case UR_DEVICE_INFO_SINGLE_FP_CONFIG:
   case UR_DEVICE_INFO_DOUBLE_FP_CONFIG: {
-    ur_device_fp_capability_flags_t DoubleFPValue = 0;
-    return ReturnValue(DoubleFPValue);
+    // All fp types are supported, return minimum flags to indicate support.
+    // TODO: look at this in more detail.
+    ur_device_fp_capability_flags_t SupportedFlags =
+        UR_DEVICE_FP_CAPABILITY_FLAG_DENORM |
+        UR_DEVICE_FP_CAPABILITY_FLAG_INF_NAN |
+        UR_DEVICE_FP_CAPABILITY_FLAG_ROUND_TO_NEAREST |
+        UR_DEVICE_FP_CAPABILITY_FLAG_FMA;
+    ;
+    return ReturnValue(SupportedFlags);
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
     return ReturnValue(uint32_t{3});


### PR DESCRIPTION
We're trying to move the UR adapters away from returning hard coded OpenCL
extension strings to report device capabilities, this is the first change
in that direction.

See https://github.com/oneapi-src/unified-runtime/issues/1374