### PR TITLE
Make /DEPENDENTLOADFLAG value configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ set(UR_ADAPTER_HIP_SOURCE_DIR "" CACHE PATH
     "Path to external 'hip' adapter source dir")
 set(UR_ADAPTER_NATIVE_CPU_SOURCE_DIR "" CACHE PATH
     "Path to external 'native_cpu' adapter source dir")
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(UR_DEPENDENTLOADFLAG "0x2000" CACHE STRING
+        "Value to use for Windows link.exe /DEPENDENTLOADFLAG option")
+endif()
 
 # There's little reason not to generate the compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -156,9 +156,9 @@ function(add_ur_library name)
     add_library(${name} ${ARGN})
     add_ur_target_compile_options(${name})
     add_ur_target_link_options(${name})
-    if(MSVC)
+    if(CMAKE_LINKER MATCHES link.exe)
         target_link_options(${name} PRIVATE
-            $<$<STREQUAL:$<TARGET_LINKER_FILE_NAME:${name}>,link.exe>:/DEPENDENTLOADFLAG:0x2000>
+            LINKER:/DEPENDENTLOADFLAG:${UR_DEPENDENTLOADFLAG}
         )
     endif()
 endfunction()


### PR DESCRIPTION
In Windows development environments the default value of `0x2000` is too restrictive as it does not allow loading the `OpenCL.dll` built as part
of the project. This patch makes the value passed to the `/DEPENDENTLOADFLAG` option configurable using the `UR_DEPENDENTLOADFLAG` CMake option.
