### PR TITLE
Revert "update to L0 loader version v1.18.3 and don't scan _deps with Trivy or CodeQL"

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,0 @@
-paths-ignore:
- - '**/_deps/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,6 @@ jobs:
       uses: github/codeql-action/init@f079b8493333aace61c81488f8bd40919487bd9f # v3.25.7
       with:
         languages: cpp, python
-        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Install pip packages
       run: pip install -r third_party/requirements.txt

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -35,7 +35,6 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: 1  # Fail if issue found
-          skip-dirs: '**/_deps/**'
           # file with suppressions: .trivyignore (in root dir)
 
       - name: Print report and trivyignore file

--- a/cmake/FetchLevelZero.cmake
+++ b/cmake/FetchLevelZero.cmake
@@ -40,7 +40,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
         set(UR_LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
     endif()
     if (UR_LEVEL_ZERO_LOADER_TAG STREQUAL "")
-        set(UR_LEVEL_ZERO_LOADER_TAG v1.18.3)
+        set(UR_LEVEL_ZERO_LOADER_TAG v1.17.39)
     endif()
 
     # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104


### PR DESCRIPTION
Reverts oneapi-src/unified-runtime#2208