### PR TITLE
Add guards to InvalidNullPointerPlatform

### DIFF
--- a/test/conformance/platform/platform_adapter_cuda.match
+++ b/test/conformance/platform/platform_adapter_cuda.match
@@ -1,2 +1,0 @@
-{{NONDETERMINISTIC}}
-urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/platform/platform_adapter_hip.match
+++ b/test/conformance/platform/platform_adapter_hip.match
@@ -1,2 +1,0 @@
-{{NONDETERMINISTIC}}
-urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/platform/platform_adapter_native_cpu.match
+++ b/test/conformance/platform/platform_adapter_native_cpu.match
@@ -1,2 +1,0 @@
-{{NONDETERMINISTIC}}
-urPlatformCreateWithNativeHandleTest.InvalidNullPointerPlatform

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -83,7 +83,8 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
 TEST_F(urPlatformCreateWithNativeHandleTest, InvalidNullPointerPlatform) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = 0;
-        ASSERT_SUCCESS(urPlatformGetNativeHandle(platform, &native_handle));
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urPlatformGetNativeHandle(platform, &native_handle));
         ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                          urPlatformCreateWithNativeHandle(
                              native_handle, adapters[0], nullptr, nullptr));


### PR DESCRIPTION
This test calls `urPlatformGetNativeHandle`, which may report that the
feature is unsupported. Skip this test if the feature is unavailable.
