### PR TITLE
Avoid potential ambiguity in UrReturnHelper

### DIFF
--- a/source/ur/ur.hpp
+++ b/source/ur/ur.hpp
@@ -304,7 +304,8 @@ public:
 
   // Array return value where element type is differrent from T
   template <class RetType, class T>
-  ur_result_t operator()(const T *t, size_t s) {
+  std::enable_if_t<!std::is_same_v<RetType, T>, ur_result_t>
+  operator()(const T *t, size_t s) {
     return ur::getInfoArray<T, RetType>(s, param_value_size, param_value,
                                         param_value_size_ret, t);
   }


### PR DESCRIPTION
If UrReturnHelper's `operator()` is explicitly called as `operator()<T>(...)`, there is a potential for ambiguity when the specified `RetType` and the inferred `T` are the same: this is ambiguous with the version of `operator()` where only `T` is a template parameter, and `T` is specified explicitly. We already have code that explicitly calls `operator()<T>(...)`, so prevent this from becoming a problem.

I saw this in an unsupported DPC++ build configuration, 32-bit x86, but expect it to come up in future supported DPC++ build configurations as well.

Note: IMHO, the fact that this is so awkward to call suggests to me that this possibly should not be an overload of `operator()` in the first place, but changing that does have the potential to break things, so I just left that as it is now.