### PR TITLE
Add device info query to report support for native asserts.

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2194,6 +2194,9 @@ typedef enum ur_device_info_t {
   /// [::ur_bool_t] support the ::urProgramSetSpecializationConstants entry
   /// point
   UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 121,
+  /// [::ur_bool_t] return true if the device has a native assert
+  /// implementation.
+  UR_DEVICE_INFO_USE_NATIVE_ASSERT = 122,
   /// [::ur_bool_t] Returns true if the device supports the use of
   /// command-buffers.
   UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP = 0x1000,

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2876,6 +2876,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
   case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
     os << "UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS";
     break;
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
+    os << "UR_DEVICE_INFO_USE_NATIVE_ASSERT";
+    break;
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
     os << "UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP";
     break;
@@ -4521,6 +4524,19 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << ")";
   } break;
   case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
+    const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+    if (sizeof(ur_bool_t) > size) {
+      os << "invalid size (is: " << size
+         << ", expected: >=" << sizeof(ur_bool_t) << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT: {
     const ur_bool_t *tptr = (const ur_bool_t *)ptr;
     if (sizeof(ur_bool_t) > size) {
       os << "invalid size (is: " << size

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -447,6 +447,8 @@ etors:
       desc: "[uint32_t] the number of compute units for specific backend."
     - name: PROGRAM_SET_SPECIALIZATION_CONSTANTS
       desc: "[$x_bool_t] support the $xProgramSetSpecializationConstants entry point"
+    - name: USE_NATIVE_ASSERT
+      desc: "[$x_bool_t] return true if the device has a native assert implementation."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -617,7 +617,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_EXTENSIONS: {
 
     std::string SupportedExtensions = "cl_khr_fp64 cl_khr_subgroups ";
-    SupportedExtensions += "cl_intel_devicelib_assert ";
     // Return supported for the UR command-buffer experimental feature
     SupportedExtensions += "ur_exp_command_buffer ";
     SupportedExtensions += "ur_exp_usm_p2p ";
@@ -1114,6 +1113,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
+    return ReturnValue(true);
+
   default:
     break;
   }

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -558,12 +558,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue("");
   }
   case UR_DEVICE_INFO_EXTENSIONS: {
-    // TODO: Remove comment when HIP support native asserts.
-    // DEVICELIB_ASSERT extension is set so fallback assert
-    // postprocessing is NOP. HIP 4.3 docs indicate support for
-    // native asserts are in progress
     std::string SupportedExtensions = "";
-    SupportedExtensions += "cl_intel_devicelib_assert ";
     SupportedExtensions += "ur_exp_usm_p2p ";
 
     int RuntimeVersion = 0;
@@ -1107,6 +1102,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP: {
     return ReturnValue(false);
   }
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
+    return ReturnValue(true);
   default:
     break;
   }

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1210,6 +1210,8 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(false);
   case UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
+    return ReturnValue(false);
   default:
     logger::error("Unsupported ParamName in urGetDeviceInfo");
     logger::error("ParamNameParamName={}(0x{})", ParamName,

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -426,6 +426,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_USM_POOL_SUPPORT:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT:
+    return ReturnValue(false);
 
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
     return ReturnValue(false);

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -1227,6 +1227,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(false);
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_USE_NATIVE_ASSERT: {
+    bool Supported = false;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice), {"cl_intel_devicelib_assert"},
+        Supported));
+    return ReturnValue(Supported);
+  }
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -129,7 +129,8 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_ESIMD_SUPPORT, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_IP_VERSION, sizeof(uint32_t)},
     {UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_NUM_COMPUTE_UNITS, sizeof(uint32_t)}};
+    {UR_DEVICE_INFO_NUM_COMPUTE_UNITS, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_USE_NATIVE_ASSERT, sizeof(ur_bool_t)}};
 
 using urDeviceGetInfoTest = uur::urDeviceTestWithParam<ur_device_info_t>;
 
@@ -255,7 +256,8 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
         UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF,            //
         UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT,             //
         UR_DEVICE_INFO_NUM_COMPUTE_UNITS,                      //
-        UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS    //
+        UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS,   //
+        UR_DEVICE_INFO_USE_NATIVE_ASSERT                       //
         ),
     uur::deviceTestWithParamPrinter<ur_device_info_t>);
 

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -332,6 +332,8 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   printDeviceInfo<ur_bool_t>(
       hDevice, UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS);
   std::cout << prefix;
+  printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_USE_NATIVE_ASSERT);
+  std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice,
                              UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP);
   std::cout << prefix;


### PR DESCRIPTION
This allows cuda and hip to stop reporting the opencl extension string, see issue #1374