### PR TITLE
Set the right HIP device before creating base event counter

### DIFF
--- a/source/adapters/hip/platform.cpp
+++ b/source/adapters/hip/platform.cpp
@@ -77,6 +77,7 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
             for (auto i = 0u; i < static_cast<uint32_t>(NumDevices); ++i) {
               hipDevice_t Device;
               UR_CHECK_ERROR(hipDeviceGet(&Device, i));
+              UR_CHECK_ERROR(hipSetDevice(i));
               hipEvent_t EvBase;
               UR_CHECK_ERROR(hipEventCreate(&EvBase));
 


### PR DESCRIPTION
Without any default device in the current thread, all base events were associated with device 0, causing failures when used on other devices. Fix this by calling `hipSetDevice` before recording the event.

This issue was [reported by a user](https://support.codeplay.com/t/amd-gpu-sycl-plugin-urdevicegetglobaltimestamps-error/743) who was running on a system with two AMD GPUs and tried to do the following:
```cpp
#include <sycl/sycl.hpp>

int main() {
  auto Devs = sycl::device::get_devices(sycl::info::device_type::gpu);
  std::vector<sycl::queue> Queues;
  for (auto D : Devs) {
    Queues.push_back(sycl::queue{D,sycl::property::queue::enable_profiling{}});
  }
}
```
Resulting in
```
UR HIP ERROR:
	Value:           400
	Name:            hipErrorInvalidHandle
	Description:     invalid resource handle
	Function:        getElapsedTime
	Source Location: _deps/unified-runtime-src/source/adapters/hip/device.cpp:31
```
in the constructor of the second queue.

intel/llvm PR: https://github.com/intel/llvm/pull/15964