### PR TITLE
[Common] fix parseDisjointPoolConfig

### DIFF
--- a/source/common/umf_pools/disjoint_pool_config_parser.cpp
+++ b/source/common/umf_pools/disjoint_pool_config_parser.cpp
@@ -215,6 +215,8 @@ DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,
         }
     }
 
+    AllConfigs.EnableBuffers = EnableBuffers;
+
     AllConfigs.limits = std::shared_ptr<umf_disjoint_pool_shared_limits_t>(
         umfDisjointPoolSharedLimitsCreate(MaxSize),
         umfDisjointPoolSharedLimitsDestroy);
@@ -222,10 +224,6 @@ DisjointPoolAllConfigs parseDisjointPoolConfig(const std::string &config,
     for (auto &Config : AllConfigs.Configs) {
         Config.SharedLimits = AllConfigs.limits.get();
         Config.PoolTrace = trace;
-    }
-
-    if (!EnableBuffers) {
-        return {};
     }
 
     if (!trace) {


### PR DESCRIPTION
returning {} when EnableBuffers is false means
returning a defult-constructed DisjointPoolAllConfigs struct which has EnableBuffers set to 1. Fix this by always returning properly constructed DisjointPoolAllConfigs.