### PR TITLE
[Command-Buffer] Fix update validation for L0 and OpenCL

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1372,7 +1372,7 @@ ur_result_t validateCommandDesc(
   logger::debug("Mutable features supported by device {}", SupportedFeatures);
 
   // Kernel handle updates are not yet supported.
-  if (CommandDesc->hNewKernel != Command->Kernel) {
+  if (CommandDesc->hNewKernel && CommandDesc->hNewKernel != Command->Kernel) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 

--- a/source/adapters/opencl/command_buffer.cpp
+++ b/source/adapters/opencl/command_buffer.cpp
@@ -547,7 +547,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
         *pUpdateKernelLaunch) {
 
   // Kernel handle updates are not yet supported.
-  if (pUpdateKernelLaunch->hNewKernel != hCommand->Kernel) {
+  if (pUpdateKernelLaunch->hNewKernel &&
+      pUpdateKernelLaunch->hNewKernel != hCommand->Kernel) {
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_native_cpu.match
@@ -21,6 +21,7 @@
 {{OPT}}USMSaxpyKernelTest.UpdateParameters/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}USMMultiSaxpyKernelTest.UpdateParameters/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}USMMultiSaxpyKernelTest.UpdateWithoutBlocking/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
+{{OPT}}USMMultiSaxpyKernelTest.UpdateNullptrKernel/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}NDRangeUpdateTest.Update3D/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}NDRangeUpdateTest.Update2D/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}
 {{OPT}}NDRangeUpdateTest.Update1D/SYCL_NATIVE_CPU___SYCL_Native_CPU__{{.*}}


### PR DESCRIPTION
Fixes bug where passing nullptr to hNewKernel results on UR_RESULT_ERROR_UNSUPPORTED_FEATURE being returned.

intel/llvm: https://github.com/intel/llvm/pull/15998/files