### PR TITLE
[DeviceAsan] Minor bug fixes

### DIFF
--- a/source/loader/layers/sanitizer/asan_shadow.cpp
+++ b/source/loader/layers/sanitizer/asan_shadow.cpp
@@ -249,6 +249,7 @@ ur_result_t ShadowMemoryGPU::ReleaseShadow(std::shared_ptr<AllocInfo> AI) {
             getContext()->logger.debug("urVirtualMemUnmap: {} ~ {}",
                                        (void *)MappedPtr,
                                        (void *)(MappedPtr + PageSize - 1));
+            VirtualMemMaps.erase(MappedPtr);
         }
     }
 

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -357,6 +357,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
     UR_CALL(pfnProgramLink(hContext, count, phPrograms, pOptions, phProgram));
 
+    UR_CALL(getContext()->interceptor->insertProgram(*phProgram));
     UR_CALL(getContext()->interceptor->registerProgram(hContext, *phProgram));
 
     return UR_RESULT_SUCCESS;
@@ -388,6 +389,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
     UR_CALL(pfnProgramLinkExp(hContext, numDevices, phDevices, count,
                               phPrograms, pOptions, phProgram));
 
+    UR_CALL(getContext()->interceptor->insertProgram(*phProgram));
     UR_CALL(getContext()->interceptor->registerProgram(hContext, *phProgram));
 
     return UR_RESULT_SUCCESS;


### PR DESCRIPTION
- Wrong Allocation Info is used in `SanitizerInterceptor::releaseMemory()`, leading to double release of the `AllocInfo` and not release the out-of-quarantine allocations.
- Remove virtual memory mapping entry once we release them
- We need to `insertProgram()` before `registerProgram()` if the API creates new program(in this case, urProgramLink[Exp]), or we cannot find this program and will trigger assertion.