### PR TITLE
use a relative benchmark cache path

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -199,5 +199,5 @@ jobs:
       if: ${{ always() && inputs.upload_report }}
       uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
       with:
-        path: ${{ github.workspace }}/ur-repo/benchmark_results.html
+        path: ur-repo/benchmark_results.html
         key: benchmark-results-${{ matrix.adapter.str_name }}-${{ github.run_id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,9 +54,8 @@ jobs:
         id: download-bench-html
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
-          path: ${{ github.workspace }}/ur-repo/benchmark_results.html
+          path: ur-repo/benchmark_results.html
           key: benchmark-results-
-          restore-keys: benchmark-results-
 
       - name: Move benchmark HTML
         # exact or partial cache hit


### PR DESCRIPTION
The absolute path may differ between runners, resulting in the cached elements not being found.