### PR TITLE
fix path to markdown results in benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -176,7 +176,7 @@ jobs:
           let markdown = ""
           try {
             const fs = require('fs');
-            markdown = fs.readFileSync('benchmark_results.md', 'utf8');
+            markdown = fs.readFileSync('ur-repo/benchmark_results.md', 'utf8');
           } catch(err) {
           }
 


### PR DESCRIPTION
The benchmarks script is now run with its working directory set to ur-repo so that the scripts can figure out the commit hash. This means that the output markdown is now stored in a different location.