### PR TITLE
[NFC] Make macro in conf. test no longer leak

### DIFF
--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -11,10 +11,8 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateWithNativeHandleTest);
 
 TEST_P(urContextCreateWithNativeHandleTest, Success) {
     ur_native_handle_t native_context = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urContextGetNativeHandle(context, &native_context));
-    }
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urContextGetNativeHandle(context, &native_context));
 
     // We cannot assume anything about a native_handle, not even if it's
     // `nullptr` since this could be a valid representation within a backend.
@@ -35,10 +33,9 @@ TEST_P(urContextCreateWithNativeHandleTest, Success) {
 
 TEST_P(urContextCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
     ur_native_handle_t native_context = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urContextGetNativeHandle(context, &native_context));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urContextGetNativeHandle(context, &native_context));
 
     ur_context_handle_t ctx = nullptr;
     ur_context_native_properties_t props{
@@ -50,10 +47,9 @@ TEST_P(urContextCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 
 TEST_P(urContextCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
     ur_native_handle_t native_context = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urContextGetNativeHandle(context, &native_context));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urContextGetNativeHandle(context, &native_context));
 
     ur_context_handle_t ctx = nullptr;
     ur_context_native_properties_t props{

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -9,10 +9,9 @@ using urDeviceCreateWithNativeHandleTest = uur::urAllDevicesTest;
 TEST_F(urDeviceCreateWithNativeHandleTest, Success) {
     for (auto device : devices) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urDeviceGetNativeHandle(device, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urDeviceGetNativeHandle(device, &native_handle));
 
         // We cannot assume anything about a native_handle, not even if it's
         // `nullptr` since this could be a valid representation within a backend.
@@ -32,10 +31,9 @@ TEST_F(urDeviceCreateWithNativeHandleTest, Success) {
 TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
     for (auto device : devices) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urDeviceGetNativeHandle(device, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urDeviceGetNativeHandle(device, &native_handle));
 
         ur_device_handle_t dev = nullptr;
         ur_device_native_properties_t props{
@@ -49,10 +47,9 @@ TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 TEST_F(urDeviceCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
     for (auto device : devices) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urDeviceGetNativeHandle(device, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urDeviceGetNativeHandle(device, &native_handle));
 
         ur_device_handle_t dev = nullptr;
         ur_device_native_properties_t props{

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -11,10 +11,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
 
 TEST_P(urEventCreateWithNativeHandleTest, Success) {
     ur_native_handle_t native_event = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urEventGetNativeHandle(event, &native_event));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urEventGetNativeHandle(event, &native_event));
 
     // We cannot assume anything about a native_handle, not even if it's
     // `nullptr` since this could be a valid representation within a backend.

--- a/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -8,10 +8,9 @@
 struct urKernelCreateWithNativeHandleTest : uur::urKernelTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urKernelGetNativeHandle(kernel, &native_kernel_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urKernelGetNativeHandle(kernel, &native_kernel_handle));
     }
 
     void TearDown() override {

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -10,10 +10,9 @@ using urPlatformCreateWithNativeHandleTest = uur::platform::urPlatformTest;
 TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urPlatformGetNativeHandle(platform, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urPlatformGetNativeHandle(platform, &native_handle));
 
         // We cannot assume anything about a native_handle, not even if it's
         // `nullptr` since this could be a valid representation within a backend.
@@ -33,10 +32,9 @@ TEST_F(urPlatformCreateWithNativeHandleTest, Success) {
 TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urPlatformGetNativeHandle(platform, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urPlatformGetNativeHandle(platform, &native_handle));
 
         // We cannot assume anything about a native_handle, not even if it's
         // `nullptr` since this could be a valid representation within a backend.
@@ -58,10 +56,9 @@ TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
 TEST_F(urPlatformCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
     for (auto platform : platforms) {
         ur_native_handle_t native_handle = 0;
-        {
-            UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-                urPlatformGetNativeHandle(platform, &native_handle));
-        }
+
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+            urPlatformGetNativeHandle(platform, &native_handle));
 
         // We cannot assume anything about a native_handle, not even if it's
         // `nullptr` since this could be a valid representation within a backend.

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -9,10 +9,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueCreateWithNativeHandleTest);
 
 TEST_P(urQueueCreateWithNativeHandleTest, Success) {
     ur_native_handle_t native_handle = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urQueueGetNativeHandle(queue, nullptr, &native_handle));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urQueueGetNativeHandle(queue, nullptr, &native_handle));
 
     // We cannot assume anything about a native_handle, not even if it's
     // `nullptr` since this could be a valid representation within a backend.

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -12,10 +12,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerCreateWithNativeHandleTest);
 
 TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
     ur_native_handle_t native_sampler = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urSamplerGetNativeHandle(sampler, &native_sampler));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urSamplerGetNativeHandle(sampler, &native_sampler));
 
     // We cannot assume anything about a native_handle, not even if it's
     // `nullptr` since this could be a valid representation within a backend.
@@ -36,10 +35,9 @@ TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
 
 TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullHandle) {
     ur_native_handle_t native_sampler = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urSamplerGetNativeHandle(sampler, &native_sampler));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urSamplerGetNativeHandle(sampler, &native_sampler));
 
     ur_sampler_handle_t hSampler = nullptr;
     ur_sampler_native_properties_t props{};
@@ -50,10 +48,9 @@ TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullHandle) {
 
 TEST_P(urSamplerCreateWithNativeHandleTest, InvalidNullPointer) {
     ur_native_handle_t native_sampler = 0;
-    {
-        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-            urSamplerGetNativeHandle(sampler, &native_sampler));
-    }
+
+    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+        urSamplerGetNativeHandle(sampler, &native_sampler));
 
     ur_sampler_native_properties_t props{};
     ASSERT_EQ(urSamplerCreateWithNativeHandle(native_sampler, context, &props,

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -23,13 +23,15 @@
     (void)0
 
 #define UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(ret)                                 \
-    auto status = ret;                                                         \
-    if (status == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||                       \
-        status == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {                   \
-        GTEST_SKIP();                                                          \
-    } else {                                                                   \
-        ASSERT_EQ(status, UR_RESULT_SUCCESS);                                  \
-    }
+    do {                                                                       \
+        auto status = ret;                                                     \
+        if (status == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||                   \
+            status == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {               \
+            GTEST_SKIP();                                                      \
+        } else {                                                               \
+            ASSERT_EQ(status, UR_RESULT_SUCCESS);                              \
+        }                                                                      \
+    } while (0)
 
 namespace uur {
 


### PR DESCRIPTION
`UUR_ASSERT_SUCCESS_OR_UNSUPPORTED` previously leaked a `status`
variable to the calling scope. This change makes it no longer do that.
