### PR TITLE
Index into property array in urDevicePartition for OpenCL

### DIFF
--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -1146,17 +1146,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
     switch (pProperties->pProperties->type) {
     case UR_DEVICE_PARTITION_EQUALLY: {
       CLProperty = static_cast<cl_device_partition_property>(
-          pProperties->pProperties->value.equally);
+          pProperties->pProperties[i].value.equally);
       break;
     }
     case UR_DEVICE_PARTITION_BY_COUNTS: {
       CLProperty = static_cast<cl_device_partition_property>(
-          pProperties->pProperties->value.count);
+          pProperties->pProperties[i].value.count);
       break;
     }
     case UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN: {
       CLProperty = static_cast<cl_device_partition_property>(
-          pProperties->pProperties->value.affinity_domain);
+          pProperties->pProperties[i].value.affinity_domain);
       break;
     }
     default: {


### PR DESCRIPTION
In `urDevicePartition` in the OpenCL adapter we loop through the array of properties but were not actually indexing into the array, only using the first element of the array.

Also added a new CTS test to verify this behaviour.

https://github.com/intel/llvm/pull/16083