### PR TITLE
[L0] Interrupt-based event implementation

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -215,7 +215,7 @@ ur_result_t createSyncPointAndGetZeEvents(
   UR_CALL(EventCreate(CommandBuffer->Context, nullptr /*Queue*/,
                       false /*IsMultiDevice*/, HostVisible, &LaunchEvent,
                       false /*CounterBasedEventEnabled*/,
-                      !CommandBuffer->IsProfilingEnabled));
+                      !CommandBuffer->IsProfilingEnabled, false));
   LaunchEvent->CommandType = CommandType;
   ZeLaunchEvent = LaunchEvent->ZeEvent;
 

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -215,7 +215,8 @@ ur_result_t createSyncPointAndGetZeEvents(
   UR_CALL(EventCreate(CommandBuffer->Context, nullptr /*Queue*/,
                       false /*IsMultiDevice*/, HostVisible, &LaunchEvent,
                       false /*CounterBasedEventEnabled*/,
-                      !CommandBuffer->IsProfilingEnabled, false));
+                      !CommandBuffer->IsProfilingEnabled,
+                      false /*InterruptBasedEventEnabled*/));
   LaunchEvent->CommandType = CommandType;
   ZeLaunchEvent = LaunchEvent->ZeEvent;
 
@@ -680,13 +681,15 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
     if (Device->hasMainCopyEngine()) {
       UR_CALL(EventCreate(Context, nullptr /*Queue*/, false, false,
                           &CopyFinishedEvent, UseCounterBasedEvents,
-                          !EnableProfiling));
+                          !EnableProfiling,
+                          false /*InterruptBasedEventEnabled*/));
     }
 
     if (EnableProfiling) {
       UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
                           false /*HostVisible*/, &ComputeFinishedEvent,
-                          UseCounterBasedEvents, !EnableProfiling));
+                          UseCounterBasedEvents, !EnableProfiling,
+                          false /*InterruptBasedEventEnabled*/));
     }
   }
 
@@ -695,7 +698,8 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   if (WaitEventPath) {
     UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
                         false /*HostVisible*/, &WaitEvent,
-                        false /*CounterBasedEventEnabled*/, !EnableProfiling));
+                        false /*CounterBasedEventEnabled*/, !EnableProfiling,
+                        false /*InterruptBasedEventEnabled*/));
   }
 
   // Create ZeCommandListResetEvents only if counter-based events are not being
@@ -707,7 +711,8 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   if (!UseCounterBasedEvents) {
     UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
                         false /*HostVisible*/, &AllResetEvent,
-                        false /*CounterBasedEventEnabled*/, !EnableProfiling));
+                        false /*CounterBasedEventEnabled*/, !EnableProfiling,
+                        false /*InterruptBasedEventEnabled*/));
 
     UR_CALL(createMainCommandList(Context, Device, false, false, false,
                                   ZeCommandListResetEvents));
@@ -715,7 +720,8 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
     // The ExecutionFinishedEvent is only waited on by ZeCommandListResetEvents.
     UR_CALL(EventCreate(Context, nullptr /*Queue*/, false /*IsMultiDevice*/,
                         false /*HostVisible*/, &ExecutionFinishedEvent,
-                        false /*CounterBasedEventEnabled*/, !EnableProfiling));
+                        false /*CounterBasedEventEnabled*/, !EnableProfiling,
+                        false /*InterruptBased*/));
   }
 
   try {

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -574,8 +574,9 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
     bool HostVisible, bool WithProfiling, ur_device_handle_t Device,
     bool CounterBasedEventEnabled, bool InterruptBasedEventEnabled) {
   std::scoped_lock<ur_mutex> Lock(EventCacheMutex);
-  auto Cache = getEventCache(HostVisible, WithProfiling, Device,
-                             CounterBasedEventEnabled);
+  auto Cache =
+      getEventCache(HostVisible, WithProfiling, Device,
+                    CounterBasedEventEnabled, InterruptBasedEventEnabled);
   if (Cache->empty()) {
     logger::info("Cache empty (Host Visible: {}, Profiling: {}, Counter: {}, "
                  "Device: {})",
@@ -611,9 +612,9 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
     Device = Event->UrQueue->Device;
   }
 
-  auto Cache =
-      getEventCache(Event->isHostVisible(), Event->isProfilingEnabled(), Device,
-                    Event->CounterBasedEventsEnabled);
+  auto Cache = getEventCache(
+      Event->isHostVisible(), Event->isProfilingEnabled(), Device,
+      Event->CounterBasedEventsEnabled, Event->InterruptBasedEventsEnabled);
   logger::info("Inserting {} event (Host Visible: {}, Profiling: {}, Counter: "
                "{}, Device: {}) into cache {}",
                Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -579,27 +579,24 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
                     CounterBasedEventEnabled, InterruptBasedEventEnabled);
   if (Cache->empty()) {
     logger::info("Cache empty (Host Visible: {}, Profiling: {}, Counter: {}, "
-                 "Device: {})",
-                 HostVisible, WithProfiling, CounterBasedEventEnabled, Device);
+                 "Interrupt: {}, Device: {})",
+                 HostVisible, WithProfiling, CounterBasedEventEnabled,
+                 InterruptBasedEventEnabled, Device);
     return nullptr;
   }
 
   auto It = Cache->begin();
   ur_event_handle_t Event = *It;
-  if (Event->CounterBasedEventsEnabled != CounterBasedEventEnabled) {
-    return nullptr;
-  }
-  if (Event->InterruptBasedEventsEnabled != InterruptBasedEventEnabled) {
-    return nullptr;
-  }
+
   Cache->erase(It);
   // We have to reset event before using it.
   Event->reset();
 
   logger::info("Using {} event (Host Visible: {}, Profiling: {}, Counter: {}, "
-               "Device: {}) from cache {}",
+               "Interrupt: {}, Device: {}) from cache {}",
                Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
-               Event->CounterBasedEventsEnabled, Device, Cache);
+               Event->CounterBasedEventsEnabled,
+               Event->InterruptBasedEventsEnabled, Cache);
 
   return Event;
 }

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -596,7 +596,7 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
                "Interrupt: {}, Device: {}) from cache {}",
                Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
                Event->CounterBasedEventsEnabled,
-               Event->InterruptBasedEventsEnabled, Cache);
+               Event->InterruptBasedEventsEnabled, Device, Cache);
 
   return Event;
 }

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -257,7 +257,7 @@ struct ur_context_handle_t_ : _ur_object {
     EventPoolCacheType CacheType;
 
     calculateCacheIndex(HostVisible, CounterBasedEventEnabled,
-                        InterruptBasedEventEnabled, UsingImmediateCmdList,
+                        UsingImmediateCmdList, InterruptBasedEventEnabled,
                         CacheType);
     if (ZeDevice) {
       auto ZeEventPoolCacheMap =

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -374,9 +374,10 @@ private:
     EVENT_FLAG_HOST_VISIBLE = UR_BIT(0),
     EVENT_FLAG_WITH_PROFILING = UR_BIT(1),
     EVENT_FLAG_COUNTER = UR_BIT(2),
-    EVENT_FLAG_DEVICE = UR_BIT(3), // if set, subsequent bits are device id
+    EVENT_FLAG_INTERRUPT = UR_BIT(3),
+    EVENT_FLAG_DEVICE = UR_BIT(5), // if set, subsequent bits are device id
     MAX_EVENT_FLAG_BITS =
-        4, // this is used as an offset for embedding device id
+        6, // this is used as an offset for embedding device id
   };
 
   // Mutex to control operations on event caches.
@@ -388,7 +389,8 @@ private:
 
   // Get the cache of events for a provided scope and profiling mode.
   EventCache *getEventCache(bool HostVisible, bool WithProfiling,
-                            ur_device_handle_t Device, bool Counter) {
+                            ur_device_handle_t Device, bool Counter,
+                            bool Interrupt) {
 
     size_t index = 0;
     if (HostVisible) {
@@ -399,6 +401,9 @@ private:
     }
     if (Counter) {
       index |= EVENT_FLAG_COUNTER;
+    }
+    if (Interrupt) {
+      index |= EVENT_FLAG_INTERRUPT;
     }
     if (Device) {
       index |= EVENT_FLAG_DEVICE | (*Device->Id << MAX_EVENT_FLAG_BITS);

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -33,6 +33,24 @@ struct l0_command_list_cache_info {
   bool IsImmediate = false;
 };
 
+typedef uint32_t ze_intel_event_sync_mode_exp_flags_t;
+typedef enum _ze_intel_event_sync_mode_exp_flag_t {
+  ZE_INTEL_EVENT_SYNC_MODE_EXP_FLAG_LOW_POWER_WAIT = ZE_BIT(0),
+  ZE_INTEL_EVENT_SYNC_MODE_EXP_FLAG_SIGNAL_INTERRUPT = ZE_BIT(1),
+  ZE_INTEL_EVENT_SYNC_MODE_EXP_EXP_FLAG_FORCE_UINT32 = 0x7fffffff
+
+} ze_intel_event_sync_mode_exp_flag_t;
+
+#define ZE_INTEL_STRUCTURE_TYPE_EVENT_SYNC_MODE_EXP_DESC                       \
+  (ze_structure_type_t)0x00030016
+
+typedef struct _ze_intel_event_sync_mode_exp_desc_t {
+  ze_structure_type_t stype;
+  const void *pNext;
+
+  ze_intel_event_sync_mode_exp_flags_t syncModeFlags;
+} ze_intel_event_sync_mode_exp_desc_t;
+
 struct ur_context_handle_t_ : _ur_object {
   ur_context_handle_t_(ze_context_handle_t ZeContext, uint32_t NumDevices,
                        const ur_device_handle_t *Devs, bool OwnZeContext)
@@ -199,7 +217,8 @@ struct ur_context_handle_t_ : _ur_object {
                                              bool ProfilingEnabled,
                                              ur_device_handle_t Device,
                                              bool CounterBasedEventEnabled,
-                                             bool UsingImmCmdList);
+                                             bool UsingImmCmdList,
+                                             bool InterruptBasedEventEnabled);
 
   // Get ur_event_handle_t from cache.
   ur_event_handle_t getEventFromContextCache(bool HostVisible,

--- a/source/adapters/level_zero/context.hpp
+++ b/source/adapters/level_zero/context.hpp
@@ -375,9 +375,9 @@ private:
     EVENT_FLAG_WITH_PROFILING = UR_BIT(1),
     EVENT_FLAG_COUNTER = UR_BIT(2),
     EVENT_FLAG_INTERRUPT = UR_BIT(3),
-    EVENT_FLAG_DEVICE = UR_BIT(5), // if set, subsequent bits are device id
+    EVENT_FLAG_DEVICE = UR_BIT(4), // if set, subsequent bits are device id
     MAX_EVENT_FLAG_BITS =
-        6, // this is used as an offset for embedding device id
+        5, // this is used as an offset for embedding device id
   };
 
   // Mutex to control operations on event caches.

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1157,8 +1157,6 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(true);
   case UR_DEVICE_INFO_USM_POOL_SUPPORT:
     return ReturnValue(true);
-  case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
-    return ReturnValue(false);
   case UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP: {
 #ifdef ZE_INTEL_DEVICE_BLOCK_ARRAY_EXP_NAME
     const auto ZeDeviceBlockArrayFlags =

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -486,7 +486,7 @@ ur_result_t urDeviceGetInfo(
     // TODO: To find out correct value
     return ReturnValue("");
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
-    return ReturnValue(UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP);
+    return ReturnValue(static_cast<ur_bool_t>(true));
   case UR_DEVICE_INFO_QUEUE_PROPERTIES:
     return ReturnValue(
         ur_queue_flag_t(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE |

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -485,6 +485,8 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_BUILT_IN_KERNELS:
     // TODO: To find out correct value
     return ReturnValue("");
+  case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
+    return ReturnValue(UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP);
   case UR_DEVICE_INFO_QUEUE_PROPERTIES:
     return ReturnValue(
         ur_queue_flag_t(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE |

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -457,8 +457,9 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
                   ///< this particular command instance.
 ) {
   bool InterruptBased =
-      EnqueueExtProp &&
-      (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS);
+      EnqueueExtProp
+          ? (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS)
+          : false;
   if (InterruptBased) {
     // Create the event with interrupt-based properties
     return static_cast<ur_result_t (*)(
@@ -470,7 +471,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
         ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
         ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
         Queue, NumEventsInWaitList, EventWaitList, OutEvent,
-        Queue ? Queue->InterruptBasedEventsEnabled : false);
+        Queue->InterruptBasedEventsEnabled || false);
   }
 }
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -438,7 +438,7 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
       ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
       ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
       Queue, NumEventsInWaitList, EventWaitList, OutEvent,
-      Queue->interruptBasedEventsEnabled());
+      Queue == nullptr ? false : Queue->InterruptBasedEventsEnabled);
 }
 
 ur_result_t urEnqueueEventsWaitWithBarrierExt(
@@ -470,7 +470,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
         ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
         ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
         Queue, NumEventsInWaitList, EventWaitList, OutEvent,
-        Queue->interruptBasedEventsEnabled());
+        Queue ? Queue->InterruptBasedEventsEnabled : false);
   }
 }
 
@@ -1342,7 +1342,8 @@ ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
   }
 
   if (auto CachedEvent = Context->getEventFromContextCache(
-          HostVisible, ProfilingEnabled, Device, CounterBasedEventEnabled)) {
+          HostVisible, ProfilingEnabled, Device, CounterBasedEventEnabled,
+          InterruptBasedEventEnabled)) {
     *RetEvent = CachedEvent;
     return UR_RESULT_SUCCESS;
   }
@@ -1355,7 +1356,7 @@ ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
   if (auto Res = Context->getFreeSlotInExistingOrNewPool(
           ZeEventPool, Index, HostVisible, ProfilingEnabled, Device,
           CounterBasedEventEnabled, UsingImmediateCommandlists,
-          Queue->interruptBasedEventsEnabled()))
+          InterruptBasedEventEnabled))
     return Res;
 
   ZeStruct<ze_event_desc_t> ZeEventDesc;

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -156,7 +156,7 @@ static const bool InOrderBarrierBySignal = [] {
   return (UrRet ? std::atoi(UrRet) : true);
 }();
 
-ur_result_t urEnqueueEventsWaitWithBarrier(
+ur_result_t EnqueueEventsWaitWithBarrier(
     ur_queue_handle_t Queue,      ///< [in] handle of the queue object
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
@@ -166,69 +166,69 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
                         ///< the numEventsInWaitList must be 0, indicating that
                         ///< all previously enqueued commands must be complete.
     ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
-) {
+        *OutEvent, ///< [in,out][optional] return an event object that
+                   ///< identifies this particular command instance.
+    bool InterruptBasedEventsEnabled) {
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 
   // Helper function for appending a barrier to a command list.
-  auto insertBarrierIntoCmdList = [&Queue](ur_command_list_ptr_t CmdList,
-                                           _ur_ze_event_list_t &EventWaitList,
-                                           ur_event_handle_t &Event,
-                                           bool IsInternal) {
-    UR_CALL(createEventAndAssociateQueue(Queue, &Event,
-                                         UR_COMMAND_EVENTS_WAIT_WITH_BARRIER,
-                                         CmdList, IsInternal, false));
+  auto insertBarrierIntoCmdList =
+      [&Queue](ur_command_list_ptr_t CmdList,
+               _ur_ze_event_list_t &EventWaitList, ur_event_handle_t &Event,
+               bool IsInternal, bool InterruptBasedEventsEnabled) {
+        UR_CALL(createEventAndAssociateQueue(
+            Queue, &Event, UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, CmdList,
+            IsInternal, InterruptBasedEventsEnabled));
 
-    Event->WaitList = EventWaitList;
+        Event->WaitList = EventWaitList;
 
-    // For in-order queue we don't need a real barrier, just wait for
-    // requested events in potentially different queues and add a "barrier"
-    // event signal because it is already guaranteed that previous commands
-    // in this queue are completed when the signal is started.
-    //
-    // Only consideration here is that when profiling is used, signalEvent
-    // cannot be used if EventWaitList.Lenght == 0. In those cases, we need
-    // to fallback directly to barrier to have correct timestamps. See here:
-    // https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=appendsignalevent#_CPPv430zeCommandListAppendSignalEvent24ze_command_list_handle_t17ze_event_handle_t
-    //
-    // TODO: this and other special handling of in-order queues to be
-    // updated when/if Level Zero adds native support for in-order queues.
-    //
-    if (Queue->isInOrderQueue() && InOrderBarrierBySignal &&
-        !Queue->isProfilingEnabled()) {
-      if (EventWaitList.Length) {
-        if (CmdList->second.IsInOrderList) {
-          for (unsigned i = EventWaitList.Length; i-- > 0;) {
-            // If the event is a multidevice event, then given driver in order
-            // lists, we cannot include this into the wait event list due to
-            // driver limitations.
-            if (EventWaitList.UrEventList[i]->IsMultiDevice) {
-              EventWaitList.Length--;
-              if (EventWaitList.Length != i) {
-                std::swap(EventWaitList.UrEventList[i],
-                          EventWaitList.UrEventList[EventWaitList.Length]);
-                std::swap(EventWaitList.ZeEventList[i],
-                          EventWaitList.ZeEventList[EventWaitList.Length]);
+        // For in-order queue we don't need a real barrier, just wait for
+        // requested events in potentially different queues and add a "barrier"
+        // event signal because it is already guaranteed that previous commands
+        // in this queue are completed when the signal is started.
+        //
+        // Only consideration here is that when profiling is used, signalEvent
+        // cannot be used if EventWaitList.Lenght == 0. In those cases, we need
+        // to fallback directly to barrier to have correct timestamps. See here:
+        // https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=appendsignalevent#_CPPv430zeCommandListAppendSignalEvent24ze_command_list_handle_t17ze_event_handle_t
+        //
+        // TODO: this and other special handling of in-order queues to be
+        // updated when/if Level Zero adds native support for in-order queues.
+        //
+        if (Queue->isInOrderQueue() && InOrderBarrierBySignal &&
+            !Queue->isProfilingEnabled()) {
+          if (EventWaitList.Length) {
+            if (CmdList->second.IsInOrderList) {
+              for (unsigned i = EventWaitList.Length; i-- > 0;) {
+                // If the event is a multidevice event, then given driver in
+                // order lists, we cannot include this into the wait event list
+                // due to driver limitations.
+                if (EventWaitList.UrEventList[i]->IsMultiDevice) {
+                  EventWaitList.Length--;
+                  if (EventWaitList.Length != i) {
+                    std::swap(EventWaitList.UrEventList[i],
+                              EventWaitList.UrEventList[EventWaitList.Length]);
+                    std::swap(EventWaitList.ZeEventList[i],
+                              EventWaitList.ZeEventList[EventWaitList.Length]);
+                  }
+                }
               }
             }
+            ZE2UR_CALL(zeCommandListAppendWaitOnEvents,
+                       (CmdList->first, EventWaitList.Length,
+                        EventWaitList.ZeEventList));
           }
+          ZE2UR_CALL(zeCommandListAppendSignalEvent,
+                     (CmdList->first, Event->ZeEvent));
+        } else {
+          ZE2UR_CALL(zeCommandListAppendBarrier,
+                     (CmdList->first, Event->ZeEvent, EventWaitList.Length,
+                      EventWaitList.ZeEventList));
         }
-        ZE2UR_CALL(
-            zeCommandListAppendWaitOnEvents,
-            (CmdList->first, EventWaitList.Length, EventWaitList.ZeEventList));
-      }
-      ZE2UR_CALL(zeCommandListAppendSignalEvent,
-                 (CmdList->first, Event->ZeEvent));
-    } else {
-      ZE2UR_CALL(zeCommandListAppendBarrier,
-                 (CmdList->first, Event->ZeEvent, EventWaitList.Length,
-                  EventWaitList.ZeEventList));
-    }
 
-    return UR_RESULT_SUCCESS;
-  };
+        return UR_RESULT_SUCCESS;
+      };
 
   // If the queue is in-order then each command in it effectively acts as a
   // barrier, so we don't need to do anything except if we were requested
@@ -285,7 +285,7 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
 
     // Insert the barrier into the command-list and execute.
     UR_CALL(insertBarrierIntoCmdList(CmdList, TmpWaitList, ResultEvent,
-                                     IsInternal));
+                                     IsInternal, InterruptBasedEventsEnabled));
 
     UR_CALL(
         Queue->executeCommandList(CmdList, false /*IsBlocking*/, OkToBatch));
@@ -367,8 +367,9 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
     std::vector<ur_event_handle_t> EventWaitVector(CmdLists.size());
     for (size_t I = 0; I < CmdLists.size(); ++I) {
       _ur_ze_event_list_t waitlist;
-      UR_CALL(insertBarrierIntoCmdList(
-          CmdLists[I], waitlist, EventWaitVector[I], true /*IsInternal*/));
+      UR_CALL(insertBarrierIntoCmdList(CmdLists[I], waitlist,
+                                       EventWaitVector[I], true /*IsInternal*/,
+                                       InterruptBasedEventsEnabled));
     }
     // If there were multiple queues we need to create a "convergence" event to
     // be our active barrier. This convergence event is signalled by a barrier
@@ -388,14 +389,15 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
     // convergence command list. The resulting event signals the convergence of
     // all barriers.
     UR_CALL(insertBarrierIntoCmdList(ConvergenceCmdList, BaseWaitList,
-                                     ResultEvent, IsInternal));
+                                     ResultEvent, IsInternal,
+                                     InterruptBasedEventsEnabled));
   } else {
     // If there is only a single queue then insert a barrier and the single
     // result event can be used as our active barrier and used as the return
     // event. Take into account whether output event is discarded or not.
     _ur_ze_event_list_t waitlist;
     UR_CALL(insertBarrierIntoCmdList(CmdLists[0], waitlist, ResultEvent,
-                                     IsInternal));
+                                     IsInternal, InterruptBasedEventsEnabled));
   }
 
   // Execute each command list so the barriers can be encountered.
@@ -419,11 +421,30 @@ ur_result_t urEnqueueEventsWaitWithBarrier(
   return UR_RESULT_SUCCESS;
 }
 
+ur_result_t urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t Queue,      ///< [in] handle of the queue object
+    uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
+    const ur_event_handle_t
+        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
+                        ///< pointer to a list of events that must be complete
+                        ///< before this command can be executed. If nullptr,
+                        ///< the numEventsInWaitList must be 0, indicating that
+                        ///< all previously enqueued commands must be complete.
+    ur_event_handle_t
+        *OutEvent ///< [in,out][optional] return an event object that identifies
+                  ///< this particular command instance.
+) {
+  return static_cast<ur_result_t (*)(
+      ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
+      ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
+      Queue, NumEventsInWaitList, EventWaitList, OutEvent,
+      Queue->interruptBasedEventsEnabled());
+}
+
 ur_result_t urEnqueueEventsWaitWithBarrierExt(
     ur_queue_handle_t Queue, ///< [in] handle of the queue object
     const ur_exp_enqueue_ext_properties_t
         *EnqueueExtProp, ///< [in][optional] pointer to the extended enqueue
-                         ///< properties
     uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
     const ur_event_handle_t
         *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
@@ -438,297 +459,20 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
   bool InterruptBased =
       EnqueueExtProp &&
       (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS);
-  if (!InterruptBased) {
-    return ur::level_zero::urEnqueueEventsWaitWithBarrier(
-        Queue, NumEventsInWaitList, EventWaitList, OutEvent);
-  }
-  // Lock automatically releases when this goes out of scope.
-  std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
-
-  // Helper function for appending a barrier to a command list.
-  auto insertBarrierIntoCmdList = [&Queue](ur_command_list_ptr_t CmdList,
-                                           _ur_ze_event_list_t &EventWaitList,
-                                           ur_event_handle_t &Event,
-                                           bool IsInternal) {
-    UR_CALL(createEventAndAssociateQueue(
-        Queue, &Event, UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, CmdList, IsInternal,
-        false, std::nullopt, true));
-    Event->WaitList = EventWaitList;
-
-    // For in-order queue we don't need a real barrier, just wait for
-    // requested events in potentially different queues and add a "barrier"
-    // event signal because it is already guaranteed that previous commands
-    // in this queue are completed when the signal is started.
-    //
-    // Only consideration here is that when profiling is used, signalEvent
-    // cannot be used if EventWaitList.Length == 0. In those cases, we need
-    // to fallback directly to barrier to have correct timestamps. See here:
-    // https://spec.oneapi.io/level-zero/latest/core/api.html?highlight=appendsignalevent#_CPPv430zeCommandListAppendSignalEvent24ze_command_list_handle_t17ze_event_handle_t
-    //
-    // TODO: this and other special handling of in-order queues to be
-    // updated when/if Level Zero adds native support for in-order queues.
-    //
-    if (Queue->isInOrderQueue() && InOrderBarrierBySignal &&
-        !Queue->isProfilingEnabled()) {
-      if (EventWaitList.Length) {
-        if (CmdList->second.IsInOrderList) {
-          for (unsigned i = EventWaitList.Length; i-- > 0;) {
-            // If the event is a multidevice event, then given driver in order
-            // lists, we cannot include this into the wait event list due to
-            // driver limitations.
-            if (EventWaitList.UrEventList[i]->IsMultiDevice) {
-              EventWaitList.Length--;
-              if (EventWaitList.Length != i) {
-                std::swap(EventWaitList.UrEventList[i],
-                          EventWaitList.UrEventList[EventWaitList.Length]);
-                std::swap(EventWaitList.ZeEventList[i],
-                          EventWaitList.ZeEventList[EventWaitList.Length]);
-              }
-            }
-          }
-        }
-        ZE2UR_CALL(
-            zeCommandListAppendWaitOnEvents,
-            (CmdList->first, EventWaitList.Length, EventWaitList.ZeEventList));
-      }
-      ZE2UR_CALL(zeCommandListAppendSignalEvent,
-                 (CmdList->first, Event->ZeEvent));
-    } else {
-      ZE2UR_CALL(zeCommandListAppendBarrier,
-                 (CmdList->first, Event->ZeEvent, EventWaitList.Length,
-                  EventWaitList.ZeEventList));
-    }
-
-    return UR_RESULT_SUCCESS;
-  };
-
-  // If the queue is in-order then each command in it effectively acts as a
-  // barrier, so we don't need to do anything except if we were requested
-  // a "barrier" event to be created. Or if we need to wait for events in
-  // potentially different queues.
-  //
-  if (Queue->isInOrderQueue() && NumEventsInWaitList == 0 && !OutEvent) {
-    return UR_RESULT_SUCCESS;
-  }
-
-  ur_event_handle_t ResultEvent = nullptr;
-  bool IsInternal = OutEvent == nullptr;
-  // For in-order queue and wait-list which is empty or has events from
-  // the same queue just use the last command event as the barrier event.
-  // This optimization is disabled when profiling is enabled to ensure
-  // accurate profiling values & the overhead that profiling incurs.
-  if (Queue->isInOrderQueue() && !Queue->isProfilingEnabled() &&
-      WaitListEmptyOrAllEventsFromSameQueue(Queue, NumEventsInWaitList,
-                                            EventWaitList) &&
-      Queue->LastCommandEvent && !Queue->LastCommandEvent->IsDiscarded) {
-    UR_CALL(ur::level_zero::urEventRetain(Queue->LastCommandEvent));
-    ResultEvent = Queue->LastCommandEvent;
-    if (OutEvent) {
-      *OutEvent = ResultEvent;
-    }
-    return UR_RESULT_SUCCESS;
-  }
-
-  // Indicator for whether batching is allowed. This may be changed later in
-  // this function, but allow it by default.
-  bool OkToBatch = true;
-
-  // If we have a list of events to make the barrier from, then we can create a
-  // barrier on these and use the resulting event as our future barrier.
-  // We use the same approach if
-  // UR_L0_USE_MULTIPLE_COMMANDLIST_BARRIERS is not set to a
-  // positive value.
-  // We use the same approach if we have in-order queue because every command
-  // depends on previous one, so we don't need to insert barrier to multiple
-  // command lists.
-  if (NumEventsInWaitList || !UseMultipleCmdlistBarriers ||
-      Queue->isInOrderQueue()) {
-    // Retain the events as they will be owned by the result event.
-    _ur_ze_event_list_t TmpWaitList;
-    UR_CALL(TmpWaitList.createAndRetainUrZeEventList(
-        NumEventsInWaitList, EventWaitList, Queue, false /*UseCopyEngine=*/));
-
-    // Get an arbitrary command-list in the queue.
-    ur_command_list_ptr_t CmdList;
-    UR_CALL(Queue->Context->getAvailableCommandList(
-        Queue, CmdList, false /*UseCopyEngine=*/, NumEventsInWaitList,
-        EventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
-
-    // Insert the barrier into the command-list and execute.
-    UR_CALL(insertBarrierIntoCmdList(CmdList, TmpWaitList, ResultEvent,
-                                     IsInternal));
-
-    UR_CALL(
-        Queue->executeCommandList(CmdList, false /*IsBlocking*/, OkToBatch));
-
-    // Because of the dependency between commands in the in-order queue we don't
-    // need to keep track of any active barriers if we have in-order queue.
-    if (UseMultipleCmdlistBarriers && !Queue->isInOrderQueue()) {
-      auto UREvent = reinterpret_cast<ur_event_handle_t>(ResultEvent);
-      Queue->ActiveBarriers.add(UREvent);
-    }
-
-    if (OutEvent) {
-      *OutEvent = ResultEvent;
-    }
-    return UR_RESULT_SUCCESS;
-  }
-
-  // Since there are no events to explicitly create a barrier for, we are
-  // inserting a queue-wide barrier.
-
-  // Command list(s) for putting barriers.
-  std::vector<ur_command_list_ptr_t> CmdLists;
-
-  // There must be at least one L0 queue.
-  auto &ComputeGroup = Queue->ComputeQueueGroupsByTID.get();
-  auto &CopyGroup = Queue->CopyQueueGroupsByTID.get();
-  UR_ASSERT(!ComputeGroup.ZeQueues.empty() || !CopyGroup.ZeQueues.empty(),
-            UR_RESULT_ERROR_INVALID_QUEUE);
-
-  size_t NumQueues = 0;
-  for (auto &QueueMap :
-       {Queue->ComputeQueueGroupsByTID, Queue->CopyQueueGroupsByTID})
-    for (auto &QueueGroup : QueueMap)
-      NumQueues += QueueGroup.second.ZeQueues.size();
-
-  OkToBatch = true;
-  // Get an available command list tied to each command queue. We need
-  // these so a queue-wide barrier can be inserted into each command
-  // queue.
-  CmdLists.reserve(NumQueues);
-  for (auto &QueueMap :
-       {Queue->ComputeQueueGroupsByTID, Queue->CopyQueueGroupsByTID})
-    for (auto &QueueGroup : QueueMap) {
-      bool UseCopyEngine =
-          QueueGroup.second.Type != ur_queue_handle_t_::queue_type::Compute;
-      if (Queue->UsingImmCmdLists) {
-        // If immediate command lists are being used, each will act as their own
-        // queue, so we must insert a barrier into each.
-        for (auto &ImmCmdList : QueueGroup.second.ImmCmdLists)
-          if (ImmCmdList != Queue->CommandListMap.end())
-            CmdLists.push_back(ImmCmdList);
-      } else {
-        for (auto ZeQueue : QueueGroup.second.ZeQueues) {
-          if (ZeQueue) {
-            ur_command_list_ptr_t CmdList;
-            UR_CALL(Queue->Context->getAvailableCommandList(
-                Queue, CmdList, UseCopyEngine, NumEventsInWaitList,
-                EventWaitList, OkToBatch, &ZeQueue));
-            CmdLists.push_back(CmdList);
-          }
-        }
-      }
-    }
-
-  // If no activity has occurred on the queue then there will be no cmdlists.
-  // We need one for generating an Event, so create one.
-  if (CmdLists.size() == 0) {
-    // Get any available command list.
-    ur_command_list_ptr_t CmdList;
-    UR_CALL(Queue->Context->getAvailableCommandList(
-        Queue, CmdList, false /*UseCopyEngine=*/, NumEventsInWaitList,
-        EventWaitList, OkToBatch, nullptr /*ForcedCmdQueue*/));
-    CmdLists.push_back(CmdList);
-  }
-
-  if (CmdLists.size() > 1) {
-    // Insert a barrier into each unique command queue using the available
-    // command-lists.
-    std::vector<ur_event_handle_t> EventWaitVector(CmdLists.size());
-    for (size_t I = 0; I < CmdLists.size(); ++I) {
-      _ur_ze_event_list_t waitlist;
-      UR_CALL(insertBarrierIntoCmdList(
-          CmdLists[I], waitlist, EventWaitVector[I], true /*IsInternal*/));
-    }
-    // If there were multiple queues we need to create a "convergence" event to
-    // be our active barrier. This convergence event is signalled by a barrier
-    // on all the events from the barriers we have inserted into each queue.
-    // Use the first command list as our convergence command list.
-    ur_command_list_ptr_t &ConvergenceCmdList = CmdLists[0];
-
-    // Create an event list. It will take ownership over all relevant events so
-    // we relinquish ownership and let it keep all events it needs.
-    _ur_ze_event_list_t BaseWaitList;
-    UR_CALL(BaseWaitList.createAndRetainUrZeEventList(
-        EventWaitVector.size(),
-        reinterpret_cast<const ur_event_handle_t *>(EventWaitVector.data()),
-        Queue, ConvergenceCmdList->second.isCopy(Queue)));
-
-    // Insert a barrier with the events from each command-queue into the
-    // convergence command list. The resulting event signals the convergence of
-    // all barriers.
-    UR_CALL(insertBarrierIntoCmdList(ConvergenceCmdList, BaseWaitList,
-                                     ResultEvent, IsInternal));
+  if (InterruptBased) {
+    // Create the event with interrupt-based properties
+    return static_cast<ur_result_t (*)(
+        ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
+        ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
+        Queue, NumEventsInWaitList, EventWaitList, OutEvent, true);
   } else {
-    // If there is only a single queue then insert a barrier and the single
-    // result event can be used as our active barrier and used as the return
-    // event. Take into account whether output event is discarded or not.
-    _ur_ze_event_list_t waitlist;
-    UR_CALL(insertBarrierIntoCmdList(CmdLists[0], waitlist, ResultEvent,
-                                     IsInternal));
+    return static_cast<ur_result_t (*)(
+        ur_queue_handle_t, uint32_t, const ur_event_handle_t *,
+        ur_event_handle_t *, bool)>(EnqueueEventsWaitWithBarrier)(
+        Queue, NumEventsInWaitList, EventWaitList, OutEvent,
+        Queue->interruptBasedEventsEnabled());
   }
-
-  // Execute each command list so the barriers can be encountered.
-  for (ur_command_list_ptr_t &CmdList : CmdLists) {
-    bool IsCopy =
-        CmdList->second.isCopy(reinterpret_cast<ur_queue_handle_t>(Queue));
-    const auto &CommandBatch =
-        (IsCopy) ? Queue->CopyCommandBatch : Queue->ComputeCommandBatch;
-    // Only batch if the matching CmdList is already open.
-    OkToBatch = CommandBatch.OpenCommandList == CmdList;
-
-    UR_CALL(
-        Queue->executeCommandList(CmdList, false /*IsBlocking*/, OkToBatch));
-  }
-
-  UR_CALL(Queue->ActiveBarriers.clear());
-  Queue->ActiveBarriers.add(ResultEvent);
-  if (OutEvent) {
-    *OutEvent = ResultEvent;
-  }
-  return UR_RESULT_SUCCESS;
 }
-/*
-ur_result_t urEnqueueEventsWaitWithBarrierExt(
-    ur_queue_handle_t Queue, ///< [in] handle of the queue object
-    const ur_exp_enqueue_ext_properties_t
-        *EnqueueExtProp, ///< [in][optional] pointer to the extended enqueue
-properties uint32_t NumEventsInWaitList, ///< [in] size of the event wait list
-    const ur_event_handle_t
-        *EventWaitList, ///< [in][optional][range(0, numEventsInWaitList)]
-                        ///< pointer to a list of events that must be complete
-                        ///< before this command can be executed. If nullptr,
-                        ///< the numEventsInWaitList must be 0, indicating that
-                        ///< all previously enqueued commands must be complete.
-    ur_event_handle_t
-        *OutEvent ///< [in,out][optional] return an event object that identifies
-                  ///< this particular command instance.
-) {
-    bool InterruptBased = EnqueueExtProp && (EnqueueExtProp->flags &
-UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS); ur_event_handle_t ResultEvent =
-nullptr;
-
-    if (InterruptBased) {
-        // Create the event with interrupt-based properties
-        ur_command_list_ptr_t CmdList;
-        UR_CALL(Queue->Context->getAvailableCommandList(Queue, CmdList, false,
-NumEventsInWaitList, EventWaitList, true, nullptr));
-        UR_CALL(createEventAndAssociateQueue(Queue, &ResultEvent,
-UR_COMMAND_EVENTS_WAIT_WITH_BARRIER, CmdList, true, false, std::nullopt,
-InterruptBased));
-    }
-
-    ur_result_t result = ur::level_zero::urEnqueueEventsWaitWithBarrier(
-        Queue, NumEventsInWaitList, EventWaitList, OutEvent);
-
-    if (InterruptBased && OutEvent) {
-        *OutEvent = ResultEvent;
-    }
-    return result;
-}
-
-*/
 
 ur_result_t urEventGetInfo(
     ur_event_handle_t Event,  ///< [in] handle of the event object

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -189,10 +189,10 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
                   ///< this particular command instance.
 ) {
   bool InterruptBasedEventsEnabled =
-      EnqueueExtProp
-          ? (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS) ||
-                Queue->InterruptBasedEventsEnabled
-          : Queue->InterruptBasedEventsEnabled;
+      EnqueueExtProp ? (EnqueueExtProp->flags &
+                        UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS) ||
+                           Queue->InterruptBasedEventsEnabled
+                     : Queue->InterruptBasedEventsEnabled;
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex> lock(Queue->Mutex);
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -190,7 +190,7 @@ ur_result_t urEnqueueEventsWaitWithBarrierExt(
 ) {
   bool InterruptBasedEventsEnabled =
       EnqueueExtProp
-          ? (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS) |
+          ? (EnqueueExtProp->flags & UR_EXP_ENQUEUE_EXT_FLAG_LOW_POWER_EVENTS) ||
                 Queue->InterruptBasedEventsEnabled
           : Queue->InterruptBasedEventsEnabled;
   // Lock automatically releases when this goes out of scope.

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -279,6 +279,12 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle);
 ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
                                   bool SetEventCompleted);
 
+ur_result_t EnqueueEventsWaitWithBarrier(ur_queue_handle_t Queue,
+                                         uint32_t NumEventsInWaitList,
+                                         const ur_event_handle_t *EventList,
+                                         ur_event_handle_t *OutEvent,
+                                         bool InterruptBasedEventsEnabled);
+
 // Get value of device scope events env var setting or default setting
 static const EventsScope DeviceEventsSetting = [] {
   char *UrRet = std::getenv("UR_L0_DEVICE_SCOPE_EVENTS");

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -33,7 +33,8 @@ ur_result_t EventCreate(ur_context_handle_t Context, ur_queue_handle_t Queue,
                         bool IsMultiDevice, bool HostVisible,
                         ur_event_handle_t *RetEvent,
                         bool CounterBasedEventEnabled,
-                        bool ForceDisableProfiling);
+                        bool ForceDisableProfiling,
+                        bool InterruptBasedEventEnabled);
 } // extern "C"
 
 // This is an experimental option that allows to disable caching of events in
@@ -251,6 +252,8 @@ struct ur_event_handle_t_ : _ur_object {
   std::optional<ur_completion_batch_it> completionBatch;
   // Keeps track of whether we are using Counter-based Events.
   bool CounterBasedEventsEnabled = false;
+  // Keeps track of whether we are using Interrupt-based Events.
+  bool InterruptBasedEventsEnabled = false;
 };
 
 // Helper function to implement zeHostSynchronize.

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -279,12 +279,6 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle);
 ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
                                   bool SetEventCompleted);
 
-ur_result_t EnqueueEventsWaitWithBarrier(ur_queue_handle_t Queue,
-                                         uint32_t NumEventsInWaitList,
-                                         const ur_event_handle_t *EventList,
-                                         ur_event_handle_t *OutEvent,
-                                         bool InterruptBasedEventsEnabled);
-
 // Get value of device scope events env var setting or default setting
 static const EventsScope DeviceEventsSetting = [] {
   char *UrRet = std::getenv("UR_L0_DEVICE_SCOPE_EVENTS");

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1896,7 +1896,9 @@ ur_result_t createEventAndAssociateQueue(
     UR_CALL(EventCreate(
         Queue->Context, Queue, IsMultiDevice, HostVisible.value(), Event,
         Queue->CounterBasedEventsEnabled, false /*ForceDisableProfiling*/,
-        HostVisible.has_value() ? true : Queue->interruptBasedEventsEnabled()));
+        InterruptBasedEvents.has_value()
+            ? InterruptBasedEvents.value()
+            : Queue->interruptBasedEventsEnabled()));
 
   (*Event)->UrQueue = Queue;
   (*Event)->CommandType = CommandType;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -1192,20 +1192,12 @@ ur_queue_handle_t_::ur_queue_handle_t_(
     }
     return std::atoi(UrRet) != 0;
   }();
-  static const bool useInterruptBasedEvents = [] {
-    const char *UrRet = std::getenv("UR_L0_USE_INTERRUPT_BASED_EVENTS");
-    if (!UrRet) {
-      return true;
-    }
-    return std::atoi(UrRet) != 0;
-  }();
   this->CounterBasedEventsEnabled =
       UsingImmCmdLists && isInOrderQueue() && Device->useDriverInOrderLists() &&
       useDriverCounterBasedEvents &&
       Device->Platform->ZeDriverEventPoolCountingEventsExtensionFound;
-  this->InterruptBasedEventsEnabled = useInterruptBasedEvents &&
-                                      isLowPowerEvents() && isInOrderQueue() &&
-                                      Device->useDriverInOrderLists();
+  this->InterruptBasedEventsEnabled =
+      isLowPowerEvents() && isInOrderQueue() && Device->useDriverInOrderLists();
 }
 
 void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -533,6 +533,8 @@ struct ur_queue_handle_t_ : _ur_object {
   // queue.
   bool doReuseDiscardedEvents();
 
+  bool interruptBasedEventsEnabled();
+
   // Append command to provided command list to wait and reset the last event if
   // it is discarded and create new ur_event_handle_t wrapper using the same
   // native event and put it to the cache. We call this method after each
@@ -556,6 +558,9 @@ struct ur_queue_handle_t_ : _ur_object {
 
   // Returns true if the queue has discard events property.
   bool isDiscardEvents() const;
+
+  // Returns true if the queue has low power events property.
+  bool isLowPowerEvents() const;
 
   // Returns true if the queue has explicit priority set by user.
   bool isPriorityLow() const;
@@ -708,7 +713,7 @@ struct ur_queue_handle_t_ : _ur_object {
 ur_result_t createEventAndAssociateQueue(
     ur_queue_handle_t Queue, ur_event_handle_t *Event, ur_command_t CommandType,
     ur_command_list_ptr_t CommandList, bool IsInternal, bool IsMultiDevice,
-    std::optional<bool> HostVisible = std::nullopt);
+    std::optional<bool> HostVisible = std::nullopt, std::optional<bool> InterruptBasedEvents = std::nullopt);
 
 // This helper function checks to see if an event for a command can be included
 // at the end of a command list batch. This will only be true if the event does

--- a/source/adapters/level_zero/queue.hpp
+++ b/source/adapters/level_zero/queue.hpp
@@ -375,6 +375,8 @@ struct ur_queue_handle_t_ : _ur_object {
   // Keeps track of whether we are using Counter-based Events
   bool CounterBasedEventsEnabled = false;
 
+  bool InterruptBasedEventsEnabled = false;
+
   // Map of all command lists used in this queue.
   ur_command_list_map_t CommandListMap;
 
@@ -532,8 +534,6 @@ struct ur_queue_handle_t_ : _ur_object {
   // Helper method telling whether we need to reuse discarded event in this
   // queue.
   bool doReuseDiscardedEvents();
-
-  bool interruptBasedEventsEnabled();
 
   // Append command to provided command list to wait and reset the last event if
   // it is discarded and create new ur_event_handle_t wrapper using the same
@@ -713,7 +713,7 @@ struct ur_queue_handle_t_ : _ur_object {
 ur_result_t createEventAndAssociateQueue(
     ur_queue_handle_t Queue, ur_event_handle_t *Event, ur_command_t CommandType,
     ur_command_list_ptr_t CommandList, bool IsInternal, bool IsMultiDevice,
-    std::optional<bool> HostVisible = std::nullopt, std::optional<bool> InterruptBasedEvents = std::nullopt);
+    std::optional<bool> HostVisible = std::nullopt);
 
 // This helper function checks to see if an event for a command can be included
 // at the end of a command list batch. This will only be true if the event does


### PR DESCRIPTION
To expose this functionality in UR, we want two ways of enabling low-power events:

1. Queue-wide enabling so all events created on the queue are low-powered.
2. As a property passed to urEnqueueEventsWaitWithBarrier making the resulting event a low-power event. This will require the existing interface to be extended with properties, potentially through a new experimental function.

SYCL/LLVM: https://github.com/intel/llvm/pull/16252