### PR TITLE
Fix the CL_CORE_FUNCTION macro on windows.

### DIFF
--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -24,7 +24,7 @@ ur_adapter_handle_t_::ur_adapter_handle_t_() {
   auto handle = LoadLibraryA("OpenCL.dll");
 
 #define CL_CORE_FUNCTION(FUNC)                                                 \
-  FUNC = reinterpret_cast<decltype(::FUNC) *>(GetProcAddress(handle, "FUNC"));
+  FUNC = reinterpret_cast<decltype(::FUNC) *>(GetProcAddress(handle, #FUNC));
 #include "core_functions.def"
 #undef CL_CORE_FUNCTION
 


### PR DESCRIPTION
It should have been using the stringizing operator like the linux path.