### PR TITLE
Set cmake options before including helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,19 +16,6 @@ include(CheckCXXSourceCompiles)
 include(CMakePackageConfigHelpers)
 include(CTest)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-include(helpers)
-
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(Python3_FIND_FRAMEWORK NEVER)
-    set(Python3_FIND_STRATEGY LOCATION)
-endif()
-
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
 # Build Options
 option(UR_BUILD_EXAMPLES "Build example applications." ON)
 option(UR_BUILD_TESTS "Build unit tests." ON)
@@ -80,6 +67,19 @@ set(UR_ADAPTER_HIP_SOURCE_DIR "" CACHE PATH
     "Path to external 'hip' adapter source dir")
 set(UR_ADAPTER_NATIVE_CPU_SOURCE_DIR "" CACHE PATH
     "Path to external 'native_cpu' adapter source dir")
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(helpers)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(Python3_FIND_FRAMEWORK NEVER)
+    set(Python3_FIND_STRATEGY LOCATION)
+endif()
+
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # There's little reason not to generate the compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
Previously we defined options after including `helpers.cmake`. However,
on the first cmake invocation, this means that it doesn't have
visibility of the default values.

This defines the options before the import, so they are visible to
`helpers.cmake`.
