### PR TITLE
[OpenCL] Fix macro to string conversion when getting function ptr

### DIFF
--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -24,7 +24,7 @@ ur_adapter_handle_t_::ur_adapter_handle_t_() {
   auto handle = LoadLibraryA("OpenCL.dll");
 
 #define CL_CORE_FUNCTION(FUNC)                                                 \
-  FUNC = reinterpret_cast<decltype(::FUNC) *>(GetProcAddress(handle, "FUNC"));
+  FUNC = reinterpret_cast<decltype(::FUNC) *>(GetProcAddress(handle, #FUNC));
 #include "core_functions.def"
 #undef CL_CORE_FUNCTION
 


### PR DESCRIPTION
This fixes SpecConstants test regression in #2219.

intel/llvm PR: https://github.com/intel/llvm/pull/16114