### PR TITLE
Temporarily disable clang-cl builds on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -256,10 +256,12 @@ jobs:
            compiler: {c: clang-cl, cxx: clang-cl}
 
         build_type: [Debug, Release]
-        compiler: [{c: cl, cxx: cl}, {c: clang-cl, cxx: clang-cl}]
+        # TODO: clang-cl seems to be fully broken (https://github.com/oneapi-src/unified-runtime/issues/2348)
+        #compiler: [{c: cl, cxx: cl}, {c: clang-cl, cxx: clang-cl}]
+        compiler: [{c: cl, cxx: cl}]
         include:
-          - compiler: {c: clang-cl, cxx: clang-cl}
-            toolset: "-T ClangCL"
+          #- compiler: {c: clang-cl, cxx: clang-cl}
+          #  toolset: "-T ClangCL"
           - os: 'windows-2022'
             adapter: {name: L0, var: '-DUR_BUILD_ADAPTER_L0=ON -DUR_STATIC_ADAPTER_L0=ON'}
             build_type: 'Release'


### PR DESCRIPTION
They currently break in our CI (#2348).
