### PR TITLE
[L0] Add support for the MCL 1.1 apis thru the spec extensions

### DIFF
--- a/source/adapters/level_zero/adapter.hpp
+++ b/source/adapters/level_zero/adapter.hpp
@@ -45,6 +45,7 @@ struct ur_adapter_handle_t_ {
   std::optional<ze_result_t> ZesResult;
   ZeCache<Result<PlatformVec>> PlatformCache;
   logger::Logger &logger;
+  HMODULE processHandle = nullptr;
 };
 
 extern ur_adapter_handle_t_ *GlobalAdapter;

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -12,6 +12,7 @@
 #include "common.hpp"
 #include "ur_api.h"
 #include "ze_api.h"
+#include "ze_ddi.h"
 #include "zes_api.h"
 
 struct ur_device_handle_t_;


### PR DESCRIPTION
- Use the MCL 1.1 spec extensions instead of the driver experimental extensions when available.