### PR TITLE
[HIP] Implement num regs kernel query

### DIFF
--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -225,6 +225,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
     return ReturnValue(hKernel->getProgram());
   case UR_KERNEL_INFO_ATTRIBUTES:
     return ReturnValue("");
+  case UR_KERNEL_INFO_NUM_REGS: {
+    int NumRegs = 0;
+    UR_CHECK_ERROR(hipFuncGetAttribute(&NumRegs, HIP_FUNC_ATTRIBUTE_NUM_REGS,
+                                       hKernel->get()));
+    return ReturnValue(static_cast<uint32_t>(NumRegs));
+  }
   default:
     break;
   }

--- a/test/conformance/kernel/kernel_adapter_hip.match
+++ b/test/conformance/kernel/kernel_adapter_hip.match
@@ -1,5 +1,4 @@
 urKernelGetGroupInfoWgSizeTest.CompileWorkGroupSize/*
-urKernelGetInfoTest.Success/*__UR_KERNEL_INFO_NUM_REGS
 urKernelSetArgLocalTest.InvalidKernelArgumentIndex/*
 urKernelSetArgMemObjTest.InvalidKernelArgumentIndex/*
 urKernelSetArgPointerNegativeTest.InvalidKernelArgumentIndex/*


### PR DESCRIPTION
This patch adds the num regs query implementation for the HIP adapter.