### PR TITLE
[HIP] Disable SYCL images by default

### DIFF
--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -292,7 +292,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       logger::always(
           "Images are not fully supported by the CUDA BE, their support is "
           "disabled by default. Their partial support can be activated by "
-          "setting SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
+          "setting UR_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
           "runtime.");
     }
 

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -12,6 +12,7 @@
 #include "adapter.hpp"
 #include "context.hpp"
 #include "event.hpp"
+#include "logger/ur_logger.hpp"
 
 #include <sstream>
 
@@ -223,7 +224,19 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint64_t{MaxAlloc});
   }
   case UR_DEVICE_INFO_IMAGE_SUPPORTED: {
-    return ReturnValue(ur_bool_t{true});
+    bool Enabled = false;
+
+    if (std::getenv("UR_HIP_ENABLE_IMAGE_SUPPORT") != nullptr) {
+      Enabled = true;
+    } else {
+      logger::always(
+          "Images are not fully supported by the HIP BE, their support is "
+          "disabled by default. Their partial support can be activated by "
+          "setting UR_HIP_ENABLE_IMAGE_SUPPORT environment variable at "
+          "runtime.");
+    }
+
+    return ReturnValue(Enabled);
   }
   case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS: {
     // This call doesn't match to HIP as it doesn't have images, but instead


### PR DESCRIPTION
Align the HIP adapter with the CUDA adapter and report SYCL images disabled by default, they're implemented at about the same level as the ones in CUDA, so there's no reason to treat them differently on HIP.

Also any future work to improve the HIP image support should focus on bindless images rather than this SYCL image support, so it makes sense to consider this essentially "deprecated".