### PR TITLE
Don't build level zero provider in non-l0 builds

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -7,6 +7,8 @@ if (UR_BUILD_ADAPTER_L0 OR UR_BUILD_ADAPTER_L0_V2)
     include(FetchLevelZero)
     set(UMF_BUILD_LEVEL_ZERO_PROVIDER ON CACHE INTERNAL "Build Level Zero Provider")
     set(UMF_LEVEL_ZERO_INCLUDE_DIR "${LEVEL_ZERO_INCLUDE_DIR}" CACHE INTERNAL "Level Zero headers")
+else()
+    set(UMF_BUILD_LEVEL_ZERO_PROVIDER OFF CACHE INTERNAL "Build Level Zero Provider")
 endif()
 
 add_ur_library(ur_common STATIC


### PR DESCRIPTION
We don't need it, and this saves a repo fetch and some compile time.
