### PR TITLE
fix UR build, re-generate print API

### DIFF
--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -15107,16 +15107,20 @@ inline std::ostream &operator<<(std::ostream &os, [[maybe_unused]] const struct 
     os << *(params->pnumEventsInWaitList);
 
     os << ", ";
-    os << ".phEventWaitList = {";
-    for (size_t i = 0; *(params->pphEventWaitList) != NULL && i < *params->pnumEventsInWaitList; ++i) {
-        if (i != 0) {
-            os << ", ";
-        }
+    os << ".phEventWaitList = ";
+    ur::details::printPtr(os, reinterpret_cast<const void *>(*(params->pphEventWaitList)));
+    if (*(params->pphEventWaitList) != NULL) {
+        os << " {";
+        for (size_t i = 0; i < *params->pnumEventsInWaitList; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
 
-        ur::details::printPtr(os,
-                              (*(params->pphEventWaitList))[i]);
+            ur::details::printPtr(os,
+                                  (*(params->pphEventWaitList))[i]);
+        }
+        os << "}";
     }
-    os << "}";
 
     os << ", ";
     os << ".phEvent = ";


### PR DESCRIPTION
Recent API change required a regeneration that https://github.com/oneapi-src/unified-runtime/pull/2240 didn't include (but wasn't conflicting).
This patch just runs the generate target.