### PR TITLE
[L0] Check that program is in exe state in urProgramGetGlobalVariablePointer

### DIFF
--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -618,6 +618,9 @@ ur_result_t urProgramGetGlobalVariablePointer(
                                     ///< variable if it is found in the program.
 ) {
   std::scoped_lock<ur_shared_mutex> lock(Program->Mutex);
+  if (Program->getState(Device->ZeDevice) != ur_program_handle_t_::Exe) {
+    return UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE;
+  }
 
   ze_module_handle_t ZeModuleEntry{};
   ZeModuleEntry = Program->getZeModuleHandle(Device->ZeDevice);

--- a/test/conformance/program/program_adapter_native_cpu.match
+++ b/test/conformance/program/program_adapter_native_cpu.match
@@ -41,6 +41,7 @@
 {{OPT}}urProgramGetGlobalVariablePointerTest.InvalidVariableName/*
 {{OPT}}urProgramGetGlobalVariablePointerTest.InvalidNullPointerVariableName/*
 {{OPT}}urProgramGetGlobalVariablePointerTest.InvalidNullPointerVariablePointer/*
+{{OPT}}urProgramGetGlobalVariablePointerTest.InvalidProgramExecutable/*
 {{OPT}}urProgramGetInfoTest.Success/*
 {{OPT}}urProgramGetInfoTest.InvalidNullHandleProgram/*
 {{OPT}}urProgramGetInfoTest.InvalidEnumeration/*

--- a/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
+++ b/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
@@ -59,3 +59,32 @@ TEST_P(urProgramGetGlobalVariablePointerTest,
                          &global_variable_size, nullptr),
                      UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
+
+TEST_P(urProgramGetGlobalVariablePointerTest, InvalidProgramExecutable) {
+    ur_platform_backend_t backend;
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
+                                     sizeof(ur_platform_backend_t), &backend,
+                                     nullptr));
+    if (backend != UR_PLATFORM_BACKEND_LEVEL_ZERO) {
+        GTEST_SKIP();
+    }
+    // Get IL from the compiled program.
+    size_t il_size = 0;
+    ASSERT_SUCCESS(
+        urProgramGetInfo(program, UR_PROGRAM_INFO_IL, 0, nullptr, &il_size));
+    ASSERT_GT(il_size, 0);
+    std::vector<char> il(il_size);
+    ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_IL, il_size,
+                                    il.data(), nullptr));
+    // Create program with IL.
+    ur_program_handle_t program_with_il;
+    ASSERT_SUCCESS(urProgramCreateWithIL(context, il.data(), il.size(), nullptr,
+                                         &program_with_il));
+    // Expect error when trying to get global variable pointer from a program which is not in exe state.
+    size_t global_variable_size = 0;
+    void *global_variable_pointer;
+    ASSERT_EQ_RESULT(urProgramGetGlobalVariablePointer(
+                         device, program_with_il, global_var.name.c_str(),
+                         &global_variable_size, &global_variable_pointer),
+                     UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE);
+}


### PR DESCRIPTION
I.e. make behavior similar to urProgramGetFunctionPointer. 

intel/llvm PR: https://github.com/intel/llvm/pull/16156