### PR TITLE
[common] Bump UMF version

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -32,8 +32,11 @@ if (NOT DEFINED UMF_REPO)
 endif()
 
 if (NOT DEFINED UMF_TAG)
-    # main 28.10.2024: Merge pull request #832 ...
-    set(UMF_TAG 43e9af0f50b70ccb989f786243881035dd829203)
+    # special branch with cherry-picks for incoming pulldown
+    # contains UMF PRs: #866, #924, and #930
+    # branch was based on commit: 3bae087c9a8c0cbed5bde40f0d5a2
+    # umf-fixes-nov-pulldown: 25.11.2024: Disable libudev in hwloc builds
+    set(UMF_TAG a7b6152b7b095c88ddf34bc7d442eb4c2b3f74d6)
 endif()
 
 message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")


### PR DESCRIPTION
In comparison to the previous version it contains only a few extra UMF PRs. This version is not taken from UMF's main branch, but rather from special '[umf-fixes-nov-pulldown](https://github.com/oneapi-src/unified-memory-framework/tree/umf-fixes-nov-pulldown)'.

// Testing in sycl repo: https://github.com/intel/llvm/pull/16170