### PR TITLE
Fix command_buffer coverity issues

### DIFF
--- a/source/adapters/cuda/command_buffer.cpp
+++ b/source/adapters/cuda/command_buffer.cpp
@@ -105,7 +105,7 @@ ur_result_t ur_exp_command_buffer_handle_t_::addWaitNodes(
   }
   // Set DepsLists as an output parameter for communicating the list of wait
   // nodes created.
-  DepsList = WaitNodes;
+  DepsList = std::move(WaitNodes);
   return UR_RESULT_SUCCESS;
 }
 
@@ -115,7 +115,7 @@ kernel_command_handle::kernel_command_handle(
     const size_t *GlobalWorkOffsetPtr, const size_t *GlobalWorkSizePtr,
     const size_t *LocalWorkSizePtr, uint32_t NumKernelAlternatives,
     ur_kernel_handle_t *KernelAlternatives, CUgraphNode SignalNode,
-    std::vector<CUgraphNode> WaitNodes)
+    const std::vector<CUgraphNode> &WaitNodes)
     : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                               WaitNodes),
       Kernel(Kernel), Params(Params), WorkDim(WorkDim) {
@@ -146,7 +146,7 @@ kernel_command_handle::kernel_command_handle(
 ur_exp_command_buffer_command_handle_t_::
     ur_exp_command_buffer_command_handle_t_(
         ur_exp_command_buffer_handle_t CommandBuffer, CUgraphNode Node,
-        CUgraphNode SignalNode, std::vector<CUgraphNode> WaitNodes)
+        CUgraphNode SignalNode, const std::vector<CUgraphNode> &WaitNodes)
     : CommandBuffer(CommandBuffer), Node(Node), SignalNode(SignalNode),
       WaitNodes(WaitNodes), RefCountInternal(1), RefCountExternal(1) {
   CommandBuffer->incrementInternalReferenceCount();
@@ -339,7 +339,7 @@ static ur_result_t enqueueCommandBufferFillHelper(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        NumEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        NumEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new T(CommandBuffer, GraphNode, SignalNode, WaitNodes);
     CommandBuffer->CommandHandles.push_back(NewCommand);
 
@@ -537,7 +537,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new kernel_command_handle(
         hCommandBuffer, hKernel, GraphNode, NodeParams, workDim,
         pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize,
@@ -595,7 +595,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new usm_memcpy_command_handle(hCommandBuffer, GraphNode,
                                                     SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -663,9 +663,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_copy_command_handle(hCommandBuffer, GraphNode,
                                                      SignalNode, WaitNodes);
+    hCommandBuffer->CommandHandles.push_back(NewCommand);
 
     if (phCommand) {
       NewCommand->incrementInternalReferenceCount();
@@ -727,7 +728,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_copy_rect_command_handle(
         hCommandBuffer, GraphNode, SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -788,7 +789,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_write_command_handle(hCommandBuffer, GraphNode,
                                                       SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -848,7 +849,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_read_command_handle(hCommandBuffer, GraphNode,
                                                      SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -913,7 +914,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_write_rect_command_handle(
         hCommandBuffer, GraphNode, SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -978,7 +979,7 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new buffer_read_rect_command_handle(
         hCommandBuffer, GraphNode, SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -1034,7 +1035,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new usm_prefetch_command_handle(hCommandBuffer, GraphNode,
                                                       SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);
@@ -1090,7 +1091,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     }
 
     std::vector<CUgraphNode> WaitNodes =
-        numEventsInWaitList ? DepsList : std::vector<CUgraphNode>();
+        numEventsInWaitList ? std::move(DepsList) : std::vector<CUgraphNode>();
     auto NewCommand = new usm_advise_command_handle(hCommandBuffer, GraphNode,
                                                     SignalNode, WaitNodes);
     hCommandBuffer->CommandHandles.push_back(NewCommand);

--- a/source/adapters/cuda/command_buffer.hpp
+++ b/source/adapters/cuda/command_buffer.hpp
@@ -56,7 +56,7 @@ enum class CommandType {
 struct ur_exp_command_buffer_command_handle_t_ {
   ur_exp_command_buffer_command_handle_t_(
       ur_exp_command_buffer_handle_t CommandBuffer, CUgraphNode Node,
-      CUgraphNode SignalNode, std::vector<CUgraphNode> WaitNodes);
+      CUgraphNode SignalNode, const std::vector<CUgraphNode> &WaitNodes);
 
   virtual ~ur_exp_command_buffer_command_handle_t_() {}
 
@@ -102,7 +102,7 @@ struct kernel_command_handle : ur_exp_command_buffer_command_handle_t_ {
       const size_t *GlobalWorkOffsetPtr, const size_t *GlobalWorkSizePtr,
       const size_t *LocalWorkSizePtr, uint32_t NumKernelAlternatives,
       ur_kernel_handle_t *KernelAlternatives, CUgraphNode SignalNode,
-      std::vector<CUgraphNode> WaitNodes);
+      const std::vector<CUgraphNode> &WaitNodes);
 
   CommandType getCommandType() const noexcept override {
     return CommandType::Kernel;
@@ -161,7 +161,7 @@ struct kernel_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct usm_memcpy_command_handle : ur_exp_command_buffer_command_handle_t_ {
   usm_memcpy_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                             CUgraphNode Node, CUgraphNode SignalNode,
-                            std::vector<CUgraphNode> WaitNodes)
+                            const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -172,7 +172,7 @@ struct usm_memcpy_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct usm_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
   usm_fill_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                           CUgraphNode Node, CUgraphNode SignalNode,
-                          std::vector<CUgraphNode> WaitNodes)
+                          const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -183,7 +183,7 @@ struct usm_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct buffer_copy_command_handle : ur_exp_command_buffer_command_handle_t_ {
   buffer_copy_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                              CUgraphNode Node, CUgraphNode SignalNode,
-                             std::vector<CUgraphNode> WaitNodes)
+                             const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -195,7 +195,7 @@ struct buffer_copy_rect_command_handle
     : ur_exp_command_buffer_command_handle_t_ {
   buffer_copy_rect_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                                   CUgraphNode Node, CUgraphNode SignalNode,
-                                  std::vector<CUgraphNode> WaitNodes)
+                                  const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -206,7 +206,7 @@ struct buffer_copy_rect_command_handle
 struct buffer_read_command_handle : ur_exp_command_buffer_command_handle_t_ {
   buffer_read_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                              CUgraphNode Node, CUgraphNode SignalNode,
-                             std::vector<CUgraphNode> WaitNodes)
+                             const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -218,7 +218,7 @@ struct buffer_read_rect_command_handle
     : ur_exp_command_buffer_command_handle_t_ {
   buffer_read_rect_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                                   CUgraphNode Node, CUgraphNode SignalNode,
-                                  std::vector<CUgraphNode> WaitNodes)
+                                  const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -229,7 +229,7 @@ struct buffer_read_rect_command_handle
 struct buffer_write_command_handle : ur_exp_command_buffer_command_handle_t_ {
   buffer_write_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                               CUgraphNode Node, CUgraphNode SignalNode,
-                              std::vector<CUgraphNode> WaitNodes)
+                              const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -241,7 +241,7 @@ struct buffer_write_rect_command_handle
     : ur_exp_command_buffer_command_handle_t_ {
   buffer_write_rect_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                                    CUgraphNode Node, CUgraphNode SignalNode,
-                                   std::vector<CUgraphNode> WaitNodes)
+                                   const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -252,7 +252,7 @@ struct buffer_write_rect_command_handle
 struct buffer_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
   buffer_fill_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                              CUgraphNode Node, CUgraphNode SignalNode,
-                             std::vector<CUgraphNode> WaitNodes)
+                             const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -263,7 +263,7 @@ struct buffer_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct usm_prefetch_command_handle : ur_exp_command_buffer_command_handle_t_ {
   usm_prefetch_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                               CUgraphNode Node, CUgraphNode SignalNode,
-                              std::vector<CUgraphNode> WaitNodes)
+                              const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {
@@ -274,7 +274,7 @@ struct usm_prefetch_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct usm_advise_command_handle : ur_exp_command_buffer_command_handle_t_ {
   usm_advise_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                             CUgraphNode Node, CUgraphNode SignalNode,
-                            std::vector<CUgraphNode> WaitNodes)
+                            const std::vector<CUgraphNode> &WaitNodes)
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
                                                 WaitNodes) {}
   CommandType getCommandType() const noexcept override {


### PR DESCRIPTION
- Change command handle constructors to accept const ref for vector types
- Add std::move to certain vector assignments
- Add missing call to store command handle in command buffer in urCommandBufferAppendMemBufferCopyExp

DPC++ PR https://github.com/intel/llvm/pull/16215