### PR TITLE
[L0] fix use-after-free in urProgramLinkExp

### DIFF
--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -452,9 +452,11 @@ ur_result_t urProgramLinkExp(
       // Build flags may be different for different devices, so handle them
       // here. Clear values of the previous device first.
       BuildFlagPtrs.clear();
+      std::vector<std::string> TemporaryOptionsStrings;
       for (uint32_t I = 0; I < count; I++) {
-        BuildFlagPtrs.push_back(
-            phPrograms[I]->getBuildOptions(ZeDevice).c_str());
+        TemporaryOptionsStrings.push_back(
+            phPrograms[I]->getBuildOptions(ZeDevice));
+        BuildFlagPtrs.push_back(TemporaryOptionsStrings.back().c_str());
       }
       ZeExtModuleDesc.pBuildFlags = BuildFlagPtrs.data();
       if (count == 1)


### PR DESCRIPTION
Found by memcheck. The BuildFlagPtr vector was being populated by the backing data of temporarily created std::string.