### PR TITLE
[NFC] Add a 2 minute per-test timeout in e2e tests

### DIFF
--- a/.github/workflows/e2e_core.yml
+++ b/.github/workflows/e2e_core.yml
@@ -115,6 +115,9 @@ jobs:
         ref: refs/heads/sycl
         path: sycl-repo
 
+    - name: Install psutil for test timeout
+      run: pip3 install psutil
+
     - name: Set CUDA env vars
       if: matrix.adapter.name == 'CUDA'
       run: |

--- a/.github/workflows/e2e_cuda.yml
+++ b/.github/workflows/e2e_cuda.yml
@@ -20,5 +20,5 @@ jobs:
       prefix: "ext_oneapi_"
       config: "--cuda"
       unit: "gpu"
-      extra_lit_flags: "-sv --max-time=3600"
+      extra_lit_flags: "-sv --max-time=3600 --timeout=120"
       xfail: "Regression/device_num.cpp"

--- a/.github/workflows/e2e_level_zero.yml
+++ b/.github/workflows/e2e_level_zero.yml
@@ -28,4 +28,4 @@ jobs:
       filter_out: "Basic/accessor/accessor.cpp|DeviceArchitecture/device_architecture_comparison_on_device_aot.cpp|Graph/Explicit/interop-level-zero-launch-kernel.cpp|Graph/RecordReplay/interop-level-zero-launch-kernel.cpp|syclcompat/launch/launch_policy_lmem.cpp"
       # These runners by default spawn upwards of 260 workers.
       # We also add a time out just in case some test hangs
-      extra_lit_flags: "--param gpu-intel-pvc=True --param gpu-intel-pvc-1T=True -sv -j 100 --max-time=3600"
+      extra_lit_flags: "--param gpu-intel-pvc=True --param gpu-intel-pvc-1T=True -sv -j 100 --max-time=3600 --timeout=120"

--- a/.github/workflows/e2e_opencl.yml
+++ b/.github/workflows/e2e_opencl.yml
@@ -21,4 +21,4 @@ jobs:
       config: ""
       unit: "cpu"
       xfail: "AOT/double.cpp;AOT/half.cpp;AOT/reqd-sg-size.cpp;Basic/built-ins/marray_geometric.cpp;KernelCompiler/kernel_compiler_spirv.cpp;KernelCompiler/opencl_queries.cpp;NonUniformGroups/ballot_group.cpp;NonUniformGroups/ballot_group_algorithms.cpp;NonUniformGroups/fixed_size_group_algorithms.cpp;NonUniformGroups/opportunistic_group.cpp;NonUniformGroups/opportunistic_group_algorithms.cpp;NonUniformGroups/tangle_group.cpp;NonUniformGroups/tangle_group_algorithms.cpp"
-      extra_lit_flags: "-sv --max-time=3600"
+      extra_lit_flags: "-sv --max-time=3600 --timeout=120"


### PR DESCRIPTION
Some tests hang, this ensures that the e2e run ends in a timely amount
of time.
