### PR TITLE
Disable CUDA sycl e2e tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -221,13 +221,14 @@ jobs:
     needs: [ubuntu-build, opencl]
     uses: ./.github/workflows/e2e_opencl.yml
 
-  e2e-cuda:
-    name: E2E CUDA
-    permissions:
-      contents: read
-      pull-requests: write
-    needs: [ubuntu-build, cuda]
-    uses: ./.github/workflows/e2e_cuda.yml
+  # Causes hangs: https://github.com/oneapi-src/unified-runtime/issues/2398
+  #e2e-cuda:
+  #  name: E2E CUDA
+  #  permissions:
+  #    contents: read
+  #    pull-requests: write
+  #  needs: [ubuntu-build, cuda]
+  #  uses: ./.github/workflows/e2e_cuda.yml
 
   windows-build:
     name: Build - Windows


### PR DESCRIPTION
They seem to cause hangs in our CI.

Relates to: #2398
