### PR TITLE
Fix L0 match entry for urEnqueueEventsWaitMultiDeviceMTTest

### DIFF
--- a/test/conformance/enqueue/enqueue_adapter_level_zero.match
+++ b/test/conformance/enqueue/enqueue_adapter_level_zero.match
@@ -20,7 +20,7 @@
 {{OPT}}urEnqueueMemImageReadTest.InvalidOrigin1D/*
 {{OPT}}urEnqueueMemImageReadTest.InvalidOrigin2D/*
 {{OPT}}urEnqueueMemImageReadTest.InvalidOrigin3D/*
-{{OPT}}urEnqueueEventsWaitMultiDeviceMTTest/*
+{{OPT}}urEnqueueEventsWaitMultiDeviceMTTest*
 {{OPT}}urEnqueueEventsWaitWithBarrierOrderingTest.SuccessEventDependencies/*
 {{OPT}}urEnqueueEventsWaitWithBarrierOrderingTest.SuccessEventDependenciesBarrierOnly/*
 {{OPT}}urEnqueueEventsWaitWithBarrierOrderingTest.SuccessEventDependenciesLaunchOnly/*


### PR DESCRIPTION
The match entry for `urEnqueueEventsWaitMultiDeviceMTTest` previously matches `urEnqueueEventsWaitMultiDeviceMTTest/*` but this doesn't actually match the test names which are of the form `urEnqueueEventsWaitMultiDeviceMTTest.<TestName>/...`. This patch removes the `/` in order to match all tests using this fixture name.

Failures like the following have been occurring in unrelated PR's today:

```
[ RUN      ] urEnqueueEventsWaitMultiDeviceMTTest.EnqueueWaitSingleQueueMultiOps/MultiThread
/home/test-user/actions-runner/_work/unified-runtime/unified-runtime/test/conformance/enqueue/urEnqueueEventsWaitMultiDevice.cpp:54: Failure
Expected equality of these values:
  reinterpret_cast<uint32_t *>(ptr)[i]
    Which is: 0
  pattern
    Which is: 42
[  FAILED  ] urEnqueueEventsWaitMultiDeviceMTTest.EnqueueWaitSingleQueueMultiOps/MultiThread, where GetParam() = 40-byte object
```
