### PR TITLE
[L0] Disabling Driver In Order Lists by default

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -598,16 +598,15 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
  */
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
-  std::ignore = Context;
-  std::ignore = CommandBufferDesc;
+  const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
   // In-order command-lists are not available in old driver version.
-  // bool CompatibleDriver =
-  // Context->getPlatform()->isDriverVersionNewerOrSimilar(
-  //     1, 3, L0_DRIVER_INORDER_MIN_VERSION);
-  // return CompatibleDriver
-  //            ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
-  //            : false;
-  return false;
+  bool DriverInOrderRequested = UrRet ? std::atoi(UrRet) != 0 : false;
+  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
+      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+  bool CanUseDriverInOrderLists = CompatibleDriver && DriverInOrderRequested;
+  return CanUseDriverInOrderLists
+             ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
+             : false;
 }
 
 /**

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -598,12 +598,16 @@ ur_result_t createMainCommandList(ur_context_handle_t Context,
  */
 bool canBeInOrder(ur_context_handle_t Context,
                   const ur_exp_command_buffer_desc_t *CommandBufferDesc) {
+  std::ignore = Context;
+  std::ignore = CommandBufferDesc;
   // In-order command-lists are not available in old driver version.
-  bool CompatibleDriver = Context->getPlatform()->isDriverVersionNewerOrSimilar(
-      1, 3, L0_DRIVER_INORDER_MIN_VERSION);
-  return CompatibleDriver
-             ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
-             : false;
+  // bool CompatibleDriver =
+  // Context->getPlatform()->isDriverVersionNewerOrSimilar(
+  //     1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+  // return CompatibleDriver
+  //            ? (CommandBufferDesc ? CommandBufferDesc->isInOrder : false)
+  //            : false;
+  return false;
 }
 
 /**

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1518,10 +1518,10 @@ bool ur_device_handle_t_::useDriverInOrderLists() {
 
   static const bool UseDriverInOrderLists = [&] {
     const char *UrRet = std::getenv("UR_L0_USE_DRIVER_INORDER_LISTS");
-    bool CompatibleDriver = this->Platform->isDriverVersionNewerOrSimilar(
-        1, 3, L0_DRIVER_INORDER_MIN_VERSION);
+    // bool CompatibleDriver = this->Platform->isDriverVersionNewerOrSimilar(
+    //     1, 3, L0_DRIVER_INORDER_MIN_VERSION);
     if (!UrRet)
-      return CompatibleDriver;
+      return false;
     return std::atoi(UrRet) != 0;
   }();
 


### PR DESCRIPTION
- Due to L0 Driver issues related to performance using driver in order lists, the feature is being disabled for the time being.
- Once issues with the L0 Drivers implementing this feature are resolved, then this feature will be re-enabled.