### PR TITLE
Add rocm path to find_package

### DIFF
--- a/cmake/FindRocmAgentEnumerator.cmake
+++ b/cmake/FindRocmAgentEnumerator.cmake
@@ -9,7 +9,7 @@
 #                                  rocm_agent_enumerator is found.
 #
 
-find_program(ROCM_AGENT_ENUMERATOR NAMES rocm_agent_enumerator)
+find_program(ROCM_AGENT_ENUMERATOR NAMES rocm_agent_enumerator PATHS /opt/rocm/bin)
 
 if(ROCM_AGENT_ENUMERATOR)
     set(ROCM_AGENT_ENUMERATOR_FOUND TRUE)


### PR DESCRIPTION
When installed via deb, rocm is installed into `/opt/rocm` and wasn't
included in $PATH. Include this directory as a possible location to
find `ROCM_AGENT_ENUMERATOR`.
