### PR TITLE
[CUDA] Fix potential issue with command buffer fills on CUDA

### DIFF
--- a/source/adapters/cuda/command_buffer.hpp
+++ b/source/adapters/cuda/command_buffer.hpp
@@ -172,12 +172,19 @@ struct usm_memcpy_command_handle : ur_exp_command_buffer_command_handle_t_ {
 struct usm_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
   usm_fill_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
                           CUgraphNode Node, CUgraphNode SignalNode,
-                          const std::vector<CUgraphNode> &WaitNodes)
+                          const std::vector<CUgraphNode> &WaitNodes,
+                          const std::vector<CUgraphNode> &DecomposedNodes = {})
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
-                                                WaitNodes) {}
+                                                WaitNodes),
+        DecomposedNodes(std::move(DecomposedNodes)) {}
   CommandType getCommandType() const noexcept override {
     return CommandType::USMFill;
   }
+
+  // If this fill command was decomposed into multiple nodes, this vector
+  // contains all of those nodes in the order they were added to the graph.
+  // Currently unused but will be required for updating in future.
+  std::vector<CUgraphNode> DecomposedNodes;
 };
 
 struct buffer_copy_command_handle : ur_exp_command_buffer_command_handle_t_ {
@@ -250,14 +257,21 @@ struct buffer_write_rect_command_handle
 };
 
 struct buffer_fill_command_handle : ur_exp_command_buffer_command_handle_t_ {
-  buffer_fill_command_handle(ur_exp_command_buffer_handle_t CommandBuffer,
-                             CUgraphNode Node, CUgraphNode SignalNode,
-                             const std::vector<CUgraphNode> &WaitNodes)
+  buffer_fill_command_handle(
+      ur_exp_command_buffer_handle_t CommandBuffer, CUgraphNode Node,
+      CUgraphNode SignalNode, const std::vector<CUgraphNode> &WaitNodes,
+      const std::vector<CUgraphNode> &DecomposedNodes = {})
       : ur_exp_command_buffer_command_handle_t_(CommandBuffer, Node, SignalNode,
-                                                WaitNodes) {}
+                                                WaitNodes),
+        DecomposedNodes(std::move(DecomposedNodes)) {}
   CommandType getCommandType() const noexcept override {
     return CommandType::MemBufferFill;
   }
+
+  // If this fill command was decomposed into multiple nodes, this vector
+  // contains all of those nodes in the order they were added to the graph.
+  // Currently unused but will be required for updating in future.
+  std::vector<CUgraphNode> DecomposedNodes;
 };
 
 struct usm_prefetch_command_handle : ur_exp_command_buffer_command_handle_t_ {

--- a/test/conformance/exp_command_buffer/exp_command_buffer_adapter_level_zero_v2.match
+++ b/test/conformance/exp_command_buffer/exp_command_buffer_adapter_level_zero_v2.match
@@ -33,6 +33,8 @@ CommandEventSyncTest.USMPrefetchExp/*
 CommandEventSyncTest.USMAdviseExp/*
 CommandEventSyncTest.MultipleEventCommands/*
 CommandEventSyncTest.MultipleEventCommandsBetweenCommandBuffers/*
+CommandEventSyncTest.USMFillLargePatternExp/*
+CommandEventSyncTest.MemBufferFillLargePatternExp/*
 CommandEventSyncUpdateTest.USMMemcpyExp/*
 CommandEventSyncUpdateTest.USMFillExp/*
 CommandEventSyncUpdateTest.MemBufferCopyExp/*
@@ -45,3 +47,5 @@ CommandEventSyncUpdateTest.MemBufferFillExp/*
 CommandEventSyncUpdateTest.USMPrefetchExp/*
 CommandEventSyncUpdateTest.USMAdviseExp/*
 CommandEventSyncUpdateTest.MultipleEventCommands/*
+CommandEventSyncUpdateTest.USMFillLargePatternExp/*
+CommandEventSyncUpdateTest.MemBufferFillLargePatternExp/*


### PR DESCRIPTION
- Fix a potential issue where decomposed fill nodes for large patterns would overwrite external event dependencies provided by the user when stored in a command handle, this could lead to an error when events were updatd.
- Also store decomposed nodes in fill command handles for future use when updating.
- Add missing event_sync tests with and without event update for large pattern fills (> 4 bytes)