### PR TITLE
[L0] Fixed getImmCmdList returning cmdlist with wrong properties

### DIFF
--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -2398,7 +2398,11 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
   uint32_t QueueIndex, QueueOrdinal;
   auto Index = getQueueIndex(&QueueOrdinal, &QueueIndex);
 
-  if (ImmCmdLists[Index] != Queue->CommandListMap.end())
+  if ((ImmCmdLists[Index] != Queue->CommandListMap.end()) &&
+      (!Queue->CounterBasedEventsEnabled ||
+       (Queue->CounterBasedEventsEnabled &&
+        (ImmCmdLists[Index]->second.ZeQueueDesc.flags &
+         ZE_COMMAND_QUEUE_FLAG_IN_ORDER))))
     return ImmCmdLists[Index];
 
   ZeStruct<ze_command_queue_desc_t> ZeCommandQueueDesc;


### PR DESCRIPTION
When using counterbased events, sometimes when retrieving immediate commandlist, we would return a commandlist that is does not have the ZE_COMMAND_QUEUE_FLAG_IN_ORDER flag set which causes an invalid argument when trying to use that commandlist later. 
SYCL/LLVM: https://github.com/intel/llvm/pull/16291