### PR TITLE
[benchmarks] add support for stddev

### DIFF
--- a/scripts/benchmarks/benches/compute.py
+++ b/scripts/benchmarks/benches/compute.py
@@ -118,9 +118,9 @@ class ComputeBenchmark(Benchmark):
         result = self.run_bench(command, env_vars)
         parsed_results = self.parse_output(result)
         ret = []
-        for label, mean, unit in parsed_results:
+        for label, median, stddev, unit in parsed_results:
             extra_label = " CPU count" if parse_unit_type(unit) == "instr" else ""
-            ret.append(Result(label=self.name() + extra_label, value=mean, command=command, env=env_vars, stdout=result, unit=parse_unit_type(unit)))
+            ret.append(Result(label=self.name() + extra_label, value=median, stddev=stddev, command=command, env=env_vars, stdout=result, unit=parse_unit_type(unit)))
         return ret
 
     def parse_output(self, output):
@@ -135,8 +135,11 @@ class ComputeBenchmark(Benchmark):
             try:
                 label = data_row[0]
                 mean = float(data_row[1])
+                median = float(data_row[2])
+                # compute benchmarks report stddev as %
+                stddev = mean * (float(data_row[3].strip('%')) / 100.0)
                 unit = data_row[7]
-                results.append((label, mean, unit))
+                results.append((label, median, stddev, unit))
             except (ValueError, IndexError) as e:
                 raise ValueError(f"Error parsing output: {e}")
         if len(results) == 0:

--- a/scripts/benchmarks/benches/result.py
+++ b/scripts/benchmarks/benches/result.py
@@ -18,12 +18,14 @@ class Result:
     stdout: str
     passed: bool = True
     unit: str = ""
-    # values should not be set by the benchmark
+    # stddev can be optionally set by the benchmark,
+    # if not set, it will be calculated automatically.
+    stddev: float = 0.0
+    # values below should not be set by the benchmark
     name: str = ""
     lower_is_better: bool = True
     git_hash: str = ''
     date: Optional[datetime] = None
-    stddev: float = 0.0
 
 @dataclass_json
 @dataclass

--- a/scripts/benchmarks/main.py
+++ b/scripts/benchmarks/main.py
@@ -103,7 +103,10 @@ def process_results(results: dict[str, list[Result]]) -> tuple[bool, list[Result
         rlist.sort(key=lambda res: res.value)
         median_index = len(rlist) // 2
         median_result = rlist[median_index]
-        median_result.stddev = stddev
+
+        # only override the stddev if not already set
+        if median_result.stddev == 0.0:
+            median_result.stddev = stddev
 
         processed.append(median_result)
 
@@ -160,7 +163,6 @@ def main(directory, additional_env_vars, save_name, compare_names, filter):
                 if valid:
                     break
             results += processed
-
         except Exception as e:
             if options.exit_on_failure:
                 raise e


### PR DESCRIPTION
This makes use of the recently added stddev calculations to display errorbars on the html output timeline chart.

![image](https://github.com/user-attachments/assets/8f873610-9d88-4426-946b-2eb102cdabbd)
