### PR TITLE
add a few missing Intel GPU device queries, fix device ID query

### DIFF
--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -377,18 +377,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_DEVICE_ID: {
     bool Supported = false;
     UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
-        cl_adapter::cast<cl_device_id>(hDevice), {"cl_intel_device_attribute_query"},
-        Supported));
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_device_attribute_query"}, Supported));
 
     if (!Supported) {
       return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     }
 
-    cl_uint DeviceId = {};
     CL_RETURN_ON_FAILURE(clGetDeviceInfo(
-        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_ID_INTEL,
-        sizeof(DeviceId), &DeviceId, nullptr));
-    return ReturnValue(DeviceId);
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_ID_INTEL, propSize,
+        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
   }
 
   case UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION: {
@@ -1019,9 +1019,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     constexpr size_t AddressBufferSize = 13;
     char AddressBuffer[AddressBufferSize];
     std::snprintf(AddressBuffer, AddressBufferSize, "%04x:%02x:%02x.%01x",
-                  PciInfo.pci_domain,
-                  PciInfo.pci_bus,
-                  PciInfo.pci_device,
+                  PciInfo.pci_domain, PciInfo.pci_bus, PciInfo.pci_device,
                   PciInfo.pci_function);
     return ReturnValue(AddressBuffer);
   }


### PR DESCRIPTION
Adds a few missing Intel GPU device queries, from the `cl_intel_device_attribute_query` extension:

https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_device_attribute_query.html

Also, adds the PCI address query, using `cl_khr_pci_bus_info`:

https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#cl_khr_pci_bus_info

Also, fixes the query for `UR_DEVICE_INFO_DEVICE_ID`.  This query should return the PCI device ID, not the PCI device number from the PCI bus info query.  For now, the query uses the device ID query from `cl_intel_device_attribute_query`, though this could be expanded to support similar queries from other vendors as well.