### PR TITLE
[L0] Remove zero size check from getImageRegionHelper

### DIFF
--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -578,8 +578,6 @@ ur_result_t getImageRegionHelper(ze_image_desc_t ZeImageDesc,
                 (ZeImageDesc.type == ZE_IMAGE_TYPE_3D),
             UR_RESULT_ERROR_INVALID_VALUE);
 
-  UR_ASSERT(Region->width && Region->height && Region->depth,
-            UR_RESULT_ERROR_INVALID_VALUE);
   UR_ASSERT(
       (ZeImageDesc.type == ZE_IMAGE_TYPE_1D && Region->height == 1 &&
        Region->depth == 1) ||


### PR DESCRIPTION
A SYCL bindless image test, that has ext_oneapi_copy call with copy region width = 0, fails in UR level-zero adapter due to the check.

On the other hand, the test can run successfully on cuda adapter. In order to make test behavior consistent across different adapters, this PR leaves the check to the level-zero backend and the backend is supposed to return success for this case.