### PR TITLE
[benchmarks] pin benchmarks to specific cores

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -179,8 +179,18 @@ jobs:
     - name: Run benchmarks
       working-directory: ${{ github.workspace }}/ur-repo/
       id: benchmarks
-      run: >
-        numactl -N 0 ${{ github.workspace }}/ur-repo/scripts/benchmarks/main.py
+      run: |
+        # Compute the core range for the first NUMA node, skipping the first 4 cores.
+        # This is to avoid the first cores that the kernel is likely to schedule more work on.
+        CORES=$(lscpu | awk '
+          /NUMA node0 CPU|On-line CPU/ {line=$0}
+          END {
+            split(line, a, " ")
+            split(a[4], b, ",")
+            sub(/^0/, "4", b[1])
+            print b[1]
+          }')
+        taskset -c $CORES ${{ github.workspace }}/ur-repo/scripts/benchmarks/main.py
         ~/bench_workdir
         --sycl ${{ github.workspace }}/sycl_build
         --ur ${{ github.workspace }}/ur_install

--- a/scripts/benchmarks/benches/umf.py
+++ b/scripts/benchmarks/benches/umf.py
@@ -43,6 +43,8 @@ class UMFSuite(Suite):
 
 class ComputeUMFBenchmark(Benchmark):
     def __init__(self, bench, name):
+        super().__init__(bench.directory, bench)
+
         self.bench = bench
         self.bench_name = name
         self.oneapi = get_oneapi()
@@ -54,8 +56,6 @@ class ComputeUMFBenchmark(Benchmark):
         self.col_time_unit = None
 
         self.col_statistics_time = None
-
-        super().__init__(bench.directory)
 
     def bin_args(self) -> list[str]:
         return []


### PR DESCRIPTION
Currently we use numactl to pin the benchmark scripts to
an entire numa node. However, after some testing, this
proved to be insufficient to make all the benchmarks stable.

This patch will change the workflow to now use taskset
to pin the benchmark script to physical cores of the
first numa node, with the exception for the first four,
which are more likely to be used by the kernel for
bookkeeping work or e.g., handling interrupts.