### PR TITLE
[Benchmarks] fix running benchmarks when umf dir is not specified

### DIFF
--- a/scripts/benchmarks/benches/umf.py
+++ b/scripts/benchmarks/benches/umf.py
@@ -30,7 +30,7 @@ class UMFSuite(Suite):
 
     def benchmarks(self) -> list[Benchmark]:
         if not isUMFAvailable():
-            return
+            return []
         
         benches = [
             GBench(self),


### PR DESCRIPTION
benchmarks += s.benchmarks() was failing since benchmarks returned None