### PR TITLE
[DeviceASAN] Register globals for the program

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -112,6 +112,7 @@ struct ProgramInfo {
     std::atomic<int32_t> RefCount = 1;
 
     // Program is built only once, so we don't need to lock it
+    std::unordered_set<std::shared_ptr<AllocInfo>> AllocInfoForGlobals;
     std::unordered_set<std::string> InstrumentedKernels;
 
     explicit ProgramInfo(ur_program_handle_t Program) : Handle(Program) {


### PR DESCRIPTION
OpenMP program would pass the global variables' address as kernel arguments. Therefore we would need to register those globals in order not to report them as invalid arguments.

This patch is targeted for v0.11, please help tag it.

Intel/llvm PR: https://github.com/intel/llvm/pull/16358