### PR TITLE
Assert unsupported result for urKernelGetInfo and urUSMGetMemAllocInfo 

### DIFF
--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -668,6 +668,8 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   case UR_USM_ALLOC_INFO_DEVICE:
     PropNameCL = CL_MEM_ALLOC_DEVICE_INTEL;
     break;
+  case UR_USM_ALLOC_INFO_POOL:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     return UR_RESULT_ERROR_INVALID_VALUE;
   }

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1098,6 +1098,12 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
             GTEST_SKIP() << "Device USM in not supported";
         }
         if (use_pool) {
+            ur_bool_t poolSupport = false;
+            ASSERT_SUCCESS(
+                uur::GetDeviceUSMPoolSupport(this->device, poolSupport));
+            if (!poolSupport) {
+                GTEST_SKIP() << "USM pools are not supported.";
+            }
             ur_usm_pool_desc_t pool_desc = {};
             ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
         }


### PR DESCRIPTION
Temporary change to urKernelGetInfo and urUSMGetMemAllocInfo to assert unsupported - this will be further modified in currently ongoing PRs:

- https://github.com/oneapi-src/unified-runtime/pull/1332/
- https://github.com/oneapi-src/unified-runtime/pull/2444