### PR TITLE
Assert unsupported result for urKernelGetInfo and urUSMGetMemAllocInfo

### DIFF
--- a/source/adapters/opencl/usm.cpp
+++ b/source/adapters/opencl/usm.cpp
@@ -668,6 +668,8 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
   case UR_USM_ALLOC_INFO_DEVICE:
     PropNameCL = CL_MEM_ALLOC_DEVICE_INTEL;
     break;
+  case UR_USM_ALLOC_INFO_POOL:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     return UR_RESULT_ERROR_INVALID_VALUE;
   }

--- a/test/conformance/kernel/kernel_adapter_opencl.match
+++ b/test/conformance/kernel/kernel_adapter_opencl.match
@@ -1,1 +1,0 @@
-urKernelGetInfoTest.Success/*_UR_KERNEL_INFO_NUM_REGS

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -1098,6 +1098,12 @@ struct urUSMDeviceAllocTestWithParam : urQueueTestWithParam<T> {
             GTEST_SKIP() << "Device USM in not supported";
         }
         if (use_pool) {
+            ur_bool_t poolSupport = false;
+            ASSERT_SUCCESS(
+                uur::GetDeviceUSMPoolSupport(this->device, poolSupport));
+            if (!poolSupport) {
+                GTEST_SKIP() << "USM pools are not supported.";
+            }
             ur_usm_pool_desc_t pool_desc = {};
             ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
         }

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -33,49 +33,55 @@ static std::unordered_map<ur_usm_alloc_info_t, size_t> usm_info_size_map = {
 TEST_P(urUSMGetMemAllocInfoTest, Success) {
     size_t size = 0;
     auto alloc_info = getParam();
-    ASSERT_SUCCESS(
-        urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
+    ur_result_t result =
+        urUSMGetMemAllocInfo(context, ptr, alloc_info, 0, nullptr, &size);
 
-    if (const auto expected_size = usm_info_size_map.find(alloc_info);
-        expected_size != usm_info_size_map.end()) {
-        ASSERT_EQ(expected_size->second, size);
-    }
+    if (result == UR_RESULT_SUCCESS) {
 
-    std::vector<uint8_t> info_data(size);
-    ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size,
-                                        info_data.data(), nullptr));
-    switch (alloc_info) {
-    case UR_USM_ALLOC_INFO_DEVICE: {
-        auto returned_device =
-            reinterpret_cast<ur_device_handle_t *>(info_data.data());
-        ASSERT_EQ(*returned_device, device);
-        break;
-    }
-    case UR_USM_ALLOC_INFO_SIZE: {
-        auto returned_size = reinterpret_cast<size_t *>(info_data.data());
-        ASSERT_GE(*returned_size, allocation_size);
-        break;
-    }
-    case UR_USM_ALLOC_INFO_BASE_PTR: {
-        auto returned_ptr = reinterpret_cast<void **>(info_data.data());
-        ASSERT_EQ(*returned_ptr, ptr);
-        break;
-    }
-    case UR_USM_ALLOC_INFO_POOL: {
-        auto returned_pool =
-            reinterpret_cast<ur_usm_pool_handle_t *>(info_data.data());
-        ASSERT_EQ(*returned_pool, pool);
-        break;
-    }
-    case UR_USM_ALLOC_INFO_TYPE: {
-        auto returned_type =
-            reinterpret_cast<ur_usm_type_t *>(info_data.data());
-        ASSERT_EQ(*returned_type, UR_USM_TYPE_DEVICE);
-        break;
-    }
-    default:
-        break;
+        ASSERT_NE(size, 0);
+
+        if (const auto expected_size = usm_info_size_map.find(alloc_info);
+            expected_size != usm_info_size_map.end()) {
+            ASSERT_EQ(expected_size->second, size);
+        }
+
+        std::vector<uint8_t> info_data(size);
+        ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, alloc_info, size,
+                                            info_data.data(), nullptr));
+        switch (alloc_info) {
+        case UR_USM_ALLOC_INFO_DEVICE: {
+            auto returned_device =
+                reinterpret_cast<ur_device_handle_t *>(info_data.data());
+            ASSERT_EQ(*returned_device, device);
+            break;
+        }
+        case UR_USM_ALLOC_INFO_SIZE: {
+            auto returned_size = reinterpret_cast<size_t *>(info_data.data());
+            ASSERT_GE(*returned_size, allocation_size);
+            break;
+        }
+        case UR_USM_ALLOC_INFO_BASE_PTR: {
+            auto returned_ptr = reinterpret_cast<void **>(info_data.data());
+            ASSERT_EQ(*returned_ptr, ptr);
+            break;
+        }
+        case UR_USM_ALLOC_INFO_POOL: {
+            auto returned_pool =
+                reinterpret_cast<ur_usm_pool_handle_t *>(info_data.data());
+            ASSERT_EQ(*returned_pool, pool);
+            break;
+        }
+        case UR_USM_ALLOC_INFO_TYPE: {
+            auto returned_type =
+                reinterpret_cast<ur_usm_type_t *>(info_data.data());
+            ASSERT_EQ(*returned_type, UR_USM_TYPE_DEVICE);
+            break;
+        }
+        default:
+            break;
+        }
+    } else {
+        UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(result);
     }
 }
 

--- a/test/conformance/usm/usm_adapter_opencl.match
+++ b/test/conformance/usm/usm_adapter_opencl.match
@@ -1,1 +1,0 @@
-urUSMGetMemAllocInfoTest.Success/*__UR_USM_ALLOC_INFO_POOL


### PR DESCRIPTION
Temporary change to urKernelGetInfo and urUSMGetMemAllocInfo to assert unsupported - this will be further modified in currently ongoing PRs:

- https://github.com/oneapi-src/unified-runtime/pull/1332
- https://github.com/oneapi-src/unified-runtime/pull/2444