### PR TITLE
[benchmarks] use template for html output and set unknown suite

### DIFF
--- a/scripts/benchmarks/benches/result.py
+++ b/scripts/benchmarks/benches/result.py
@@ -27,7 +27,7 @@ class Result:
     lower_is_better: bool = True
     git_hash: str = ""
     date: Optional[datetime] = None
-    suite: str = ""
+    suite: str = "Unknown"
 
 @dataclass_json
 @dataclass

--- a/scripts/benchmarks/benchmark_results.html.template
+++ b/scripts/benchmarks/benchmark_results.html.template
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Benchmark Results</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            margin: 0;
+            padding: 16px;
+            background: #f8f9fa;
+        }
+        .container {
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+        h1, h2 {
+            color: #212529;
+            text-align: center;
+            margin-bottom: 24px;
+            font-weight: 500;
+        }
+        .chart {
+            background: white;
+            border-radius: 8px;
+            padding: 24px;
+            margin-bottom: 24px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            overflow-x: auto;
+        }
+        .chart > div {
+            min-width: 600px;
+            margin: 0 auto;
+        }
+        @media (max-width: 768px) {
+            body {
+                padding: 12px;
+            }
+            .chart {
+                padding: 16px;
+                border-radius: 6px;
+            }
+            h1 {
+                font-size: 24px;
+                margin-bottom: 16px;
+            }
+        }
+        .filter-container {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+        .filter-container input {
+            padding: 8px;
+            font-size: 16px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            width: 400px;
+            max-width: 100%;
+        }
+        .suite-filter-container {
+            text-align: center;
+            margin-bottom: 24px;
+            padding: 16px;
+            background: #e9ecef;
+            border-radius: 8px;
+        }
+        .suite-checkbox {
+            margin: 0 8px;
+        }
+        details {
+            margin-bottom: 24px;
+        }
+        summary {
+            font-size: 18px;
+            font-weight: 500;
+            cursor: pointer;
+            padding: 12px;
+            background: #e9ecef;
+            border-radius: 8px;
+            user-select: none;
+        }
+        summary:hover {
+            background: #dee2e6;
+        }
+    </style>
+    <script>
+        function getQueryParam(param) {
+            const urlParams = new URLSearchParams(window.location.search);
+            return urlParams.get(param);
+        }
+
+        function filterCharts() {
+            const regexInput = document.getElementById('bench-filter').value;
+            const regex = new RegExp(regexInput, 'i');
+            const activeSuites = Array.from(document.querySelectorAll('.suite-checkbox:checked')).map(checkbox => checkbox.getAttribute('data-suite'));
+            const charts = document.querySelectorAll('.chart');
+
+            charts.forEach(chart => {
+                const label = chart.getAttribute('data-label');
+                const suite = chart.getAttribute('data-suite');
+                if (regex.test(label) && activeSuites.includes(suite)) {
+                    chart.style.display = '';
+                } else {
+                    chart.style.display = 'none';
+                }
+            });
+
+            updateURL();
+        }
+
+        function updateURL() {
+            const url = new URL(window.location);
+            const regex = document.getElementById('bench-filter').value;
+            const activeSuites = Array.from(document.querySelectorAll('.suite-checkbox:checked')).map(checkbox => checkbox.getAttribute('data-suite'));
+
+            if (regex) {
+                url.searchParams.set('regex', regex);
+            } else {
+                url.searchParams.delete('regex');
+            }
+
+            if (activeSuites.length > 0) {
+                url.searchParams.set('suites', activeSuites.join(','));
+            } else {
+                url.searchParams.delete('suites');
+            }
+
+            history.replaceState(null, '', url);
+        }
+
+        document.addEventListener('DOMContentLoaded', (event) => {
+            const regexParam = getQueryParam('regex');
+            const suitesParam = getQueryParam('suites');
+
+            if (regexParam) {
+                document.getElementById('bench-filter').value = regexParam;
+            }
+
+            const suiteCheckboxes = document.querySelectorAll('.suite-checkbox');
+            if (suitesParam) {
+                const suites = suitesParam.split(',');
+                suiteCheckboxes.forEach(checkbox => {
+                    if (suites.includes(checkbox.getAttribute('data-suite'))) {
+                        checkbox.checked = true;
+                    } else {
+                        checkbox.checked = false;
+                    }
+                });
+            } else {
+                suiteCheckboxes.forEach(checkbox => {
+                    checkbox.checked = true;
+                });
+            }
+            filterCharts();
+
+            suiteCheckboxes.forEach(checkbox => {
+                checkbox.addEventListener('change', () => {
+                    filterCharts();
+                });
+            });
+
+            document.getElementById('bench-filter').addEventListener('input', () => {
+                filterCharts();
+            });
+        });
+    </script>
+</head>
+<body>
+    <div class="container">
+        <h1>Benchmark Results</h1>
+        <div class="filter-container">
+            <input type="text" id="bench-filter" placeholder="Regex...">
+        </div>
+        <div class="suite-filter-container">
+            ${suite_checkboxes_html}
+        </div>
+        <details class="timeseries">
+            <summary>Historical Results</summary>
+            <div class="charts">
+                ${timeseries_charts_html}
+            </div>
+        </details>
+        <details class="bar-charts">
+            <summary>Comparisons</summary>
+            <div class="charts">
+                ${bar_charts_html}
+            </div>
+        </details>
+    </div>
+</body>
+</html>

--- a/scripts/benchmarks/output_html.py
+++ b/scripts/benchmarks/output_html.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import matplotlib.dates as mdates
 from benches.result import BenchmarkRun, Result
 import numpy as np
+from string import Template
 
 @dataclass
 class BenchmarkMetadata:
@@ -255,198 +256,14 @@ def generate_html(benchmark_runs: list[BenchmarkRun], github_repo: str, compare_
     suite_names = {t.suite for t in timeseries}
     suite_checkboxes_html = ' '.join(f'<label><input type="checkbox" class="suite-checkbox" data-suite="{suite}" checked> {suite}</label>' for suite in suite_names)
 
-    html_template = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Benchmark Results</title>
-        <style>
-            body {{
-                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-                margin: 0;
-                padding: 16px;
-                background: #f8f9fa;
-            }}
-            .container {{
-                max-width: 1100px;
-                margin: 0 auto;
-            }}
-            h1, h2 {{
-                color: #212529;
-                text-align: center;
-                margin-bottom: 24px;
-                font-weight: 500;
-            }}
-            .chart {{
-                background: white;
-                border-radius: 8px;
-                padding: 24px;
-                margin-bottom: 24px;
-                box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-                overflow-x: auto;
-            }}
-            .chart > div {{
-                min-width: 600px;
-                margin: 0 auto;
-            }}
-            @media (max-width: 768px) {{
-                body {{
-                    padding: 12px;
-                }}
-                .chart {{
-                    padding: 16px;
-                    border-radius: 6px;
-                }}
-                h1 {{
-                    font-size: 24px;
-                    margin-bottom: 16px;
-                }}
-            }}
-            .filter-container {{
-                text-align: center;
-                margin-bottom: 24px;
-            }}
-            .filter-container input {{
-                padding: 8px;
-                font-size: 16px;
-                border: 1px solid #ccc;
-                border-radius: 4px;
-                width: 400px;
-                max-width: 100%;
-            }}
-            .suite-filter-container {{
-                text-align: center;
-                margin-bottom: 24px;
-                padding: 16px;
-                background: #e9ecef;
-                border-radius: 8px;
-            }}
-            .suite-checkbox {{
-                margin: 0 8px;
-            }}
-            details {{
-                margin-bottom: 24px;
-            }}
-            summary {{
-                font-size: 18px;
-                font-weight: 500;
-                cursor: pointer;
-                padding: 12px;
-                background: #e9ecef;
-                border-radius: 8px;
-                user-select: none;
-            }}
-            summary:hover {{
-                background: #dee2e6;
-            }}
-        </style>
-        <script>
-            function getQueryParam(param) {{
-                const urlParams = new URLSearchParams(window.location.search);
-                return urlParams.get(param);
-            }}
+    with open('benchmark_results.html.template', 'r') as file:
+        html_template = file.read()
 
-            function filterCharts() {{
-                const regexInput = document.getElementById('bench-filter').value;
-                const regex = new RegExp(regexInput, 'i');
-                const activeSuites = Array.from(document.querySelectorAll('.suite-checkbox:checked')).map(checkbox => checkbox.getAttribute('data-suite'));
-                const charts = document.querySelectorAll('.chart');
+    template = Template(html_template)
+    data = {
+        'suite_checkboxes_html': suite_checkboxes_html,
+        'timeseries_charts_html': timeseries_charts_html,
+        'bar_charts_html': bar_charts_html,
+    }
 
-                charts.forEach(chart => {{
-                    const label = chart.getAttribute('data-label');
-                    const suite = chart.getAttribute('data-suite');
-                    if (regex.test(label) && activeSuites.includes(suite)) {{
-                        chart.style.display = '';
-                    }} else {{
-                        chart.style.display = 'none';
-                    }}
-                }});
-
-                updateURL();
-            }}
-
-            function updateURL() {{
-                const url = new URL(window.location);
-                const regex = document.getElementById('bench-filter').value;
-                const activeSuites = Array.from(document.querySelectorAll('.suite-checkbox:checked')).map(checkbox => checkbox.getAttribute('data-suite'));
-
-                if (regex) {{
-                    url.searchParams.set('regex', regex);
-                }} else {{
-                    url.searchParams.delete('regex');
-                }}
-
-                if (activeSuites.length > 0) {{
-                    url.searchParams.set('suites', activeSuites.join(','));
-                }} else {{
-                    url.searchParams.delete('suites');
-                }}
-
-                history.replaceState(null, '', url);
-            }}
-
-            document.addEventListener('DOMContentLoaded', (event) => {{
-                const regexParam = getQueryParam('regex');
-                const suitesParam = getQueryParam('suites');
-
-                if (regexParam) {{
-                    document.getElementById('bench-filter').value = regexParam;
-                }}
-
-                const suiteCheckboxes = document.querySelectorAll('.suite-checkbox');
-                if (suitesParam) {{
-                    const suites = suitesParam.split(',');
-                    suiteCheckboxes.forEach(checkbox => {{
-                        if (suites.includes(checkbox.getAttribute('data-suite'))) {{
-                            checkbox.checked = true;
-                        }} else {{
-                            checkbox.checked = false;
-                        }}
-                    }});
-                }} else {{
-                    suiteCheckboxes.forEach(checkbox => {{
-                        checkbox.checked = true;
-                    }});
-                }}
-                filterCharts();
-
-                suiteCheckboxes.forEach(checkbox => {{
-                    checkbox.addEventListener('change', () => {{
-                        filterCharts();
-                    }});
-                }});
-
-                document.getElementById('bench-filter').addEventListener('input', () => {{
-                    filterCharts();
-                }});
-            }});
-        </script>
-    </head>
-    <body>
-        <div class="container">
-            <h1>Benchmark Results</h1>
-            <div class="filter-container">
-                <input type="text" id="bench-filter" placeholder="Regex...">
-            </div>
-            <div class="suite-filter-container">
-                {suite_checkboxes_html}
-            </div>
-            <details class="timeseries">
-                <summary>Historical Results</summary>
-                <div class="charts">
-                    {timeseries_charts_html}
-                </div>
-            </details>
-            <details class="bar-charts">
-                <summary>Comparisons</summary>
-                <div class="charts">
-                    {bar_charts_html}
-                </div>
-            </details>
-        </div>
-    </body>
-    </html>
-    """
-    return html_template
+    return template.substitute(data)


### PR DESCRIPTION
[benchmarks] use "unknown" suite for old results

Using a simple f-string was starting to get annoying
with the increased use of javascript.



[benchmarks] use "unknown" suite for old results

This fixes the empty "" checkbox on the results html.