### PR TITLE
[L0] Fix issue with test include path

### DIFF
--- a/test/adapters/level_zero/ze_tracer_common.hpp
+++ b/test/adapters/level_zero/ze_tracer_common.hpp
@@ -5,7 +5,7 @@
 
 #include "uur/fixtures.h"
 
-#include <level_zero/layers/zel_tracing_api.h>
+#include <layers/zel_tracing_api.h>
 #include <loader/ze_loader.h>
 
 #include <memory>


### PR DESCRIPTION
- Fix include path for the L0 tracing layer header which prevents it from being picked up from the deps downloaded by UR.

The previous path I believe is expected for L0 loader/headers installed on the system level but breaks if this is not present, as the headers downloaded and included by UR itself do not have `level_zero` folder containing the individual include folders (layer, loader etc.).