### PR TITLE
[L0] For 3-Channel memory, disable Copy engine Usage

### DIFF
--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -265,7 +265,7 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
   return UR_RESULT_SUCCESS;
 }
 
-bool Is3ChannelOrder(ur_image_channel_order_t ChannelOrder) {
+static bool Is3ChannelOrder(ur_image_channel_order_t ChannelOrder) {
   switch (ChannelOrder) {
   case UR_IMAGE_CHANNEL_ORDER_RGB:
   case UR_IMAGE_CHANNEL_ORDER_RGX:

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -265,6 +265,16 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
   return UR_RESULT_SUCCESS;
 }
 
+bool Is3ChannelOrder(ur_image_channel_order_t ChannelOrder) {
+  switch (ChannelOrder) {
+  case UR_IMAGE_CHANNEL_ORDER_RGB:
+  case UR_IMAGE_CHANNEL_ORDER_RGX:
+    return true;
+  default:
+    return false;
+  }
+}
+
 /// Construct ZE image desc from UR image format and desc.
 ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
                            const ur_image_desc_t *ImageDesc,
@@ -843,6 +853,14 @@ ur_result_t urBindlessImagesImageCopyExp(
   UR_CALL(ur2zeImageDesc(pSrcImageFormat, pSrcImageDesc, ZeImageDesc));
 
   bool UseCopyEngine = hQueue->useCopyEngine(/*PreferCopyEngine*/ true);
+  // Due to the limitation of the copy engine, disable usage of Copy Engine
+  // Given 3 channel image
+  if (Is3ChannelOrder(
+          ur_cast<ur_image_channel_order_t>(pSrcImageFormat->channelOrder)) ||
+      Is3ChannelOrder(
+          ur_cast<ur_image_channel_order_t>(pDstImageFormat->channelOrder))) {
+    UseCopyEngine = false;
+  }
 
   _ur_ze_event_list_t TmpWaitList;
   UR_CALL(TmpWaitList.createAndRetainUrZeEventList(


### PR DESCRIPTION
- Due to limitations on certain systems, disable the usage of copy engines given 3-channel memory
- Currently only bindless requires this check due to 3-channel only being used in bindless and copy engine disabled by default in enqueueMemImageCommandHelper.