### PR TITLE
[L0] Fix use after free with Module build strings

### DIFF
--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -452,11 +452,9 @@ ur_result_t urProgramLinkExp(
       // Build flags may be different for different devices, so handle them
       // here. Clear values of the previous device first.
       BuildFlagPtrs.clear();
-      std::vector<std::string> TemporaryOptionsStrings;
       for (uint32_t I = 0; I < count; I++) {
-        TemporaryOptionsStrings.push_back(
-            phPrograms[I]->getBuildOptions(ZeDevice));
-        BuildFlagPtrs.push_back(TemporaryOptionsStrings.back().c_str());
+        BuildFlagPtrs.push_back(
+            phPrograms[I]->getBuildOptions(ZeDevice).c_str());
       }
       ZeExtModuleDesc.pBuildFlags = BuildFlagPtrs.data();
       if (count == 1)

--- a/source/adapters/level_zero/program.hpp
+++ b/source/adapters/level_zero/program.hpp
@@ -169,7 +169,7 @@ struct ur_program_handle_t_ : _ur_object {
     DeviceDataMap[ZeDevice].BuildFlags += Options;
   }
 
-  std::string getBuildOptions(ze_device_handle_t ZeDevice) {
+  std::string &getBuildOptions(ze_device_handle_t ZeDevice) {
     return DeviceDataMap[ZeDevice].BuildFlags;
   }
 


### PR DESCRIPTION
- Address Sanitizer HASAN fails with temporary strings even after last use after free patch. This change resolves all use after free of these strings satifsying the address sanitzer checks with HASAN.