### PR TITLE
[L0] Fix Event Memory Leak due to no destroy on delete

### DIFF
--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -422,6 +422,7 @@ ur_result_t ur_context_handle_t_::finalize() {
     for (auto &EventCache : EventCaches) {
       for (auto &Event : EventCache) {
         auto ZeResult = ZE_CALL_NOCHECK(zeEventDestroy, (Event->ZeEvent));
+        Event->ZeEvent = nullptr;
         // Gracefully handle the case that L0 was already unloaded.
         if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
           return ze2urResult(ZeResult);

--- a/source/adapters/level_zero/event.hpp
+++ b/source/adapters/level_zero/event.hpp
@@ -156,6 +156,8 @@ struct ur_event_handle_t_ : _ur_object {
                reinterpret_cast<ur_event_handle_t_ *>(HostVisibleEvent));
   }
 
+  ~ur_event_handle_t_();
+
   // Provide direct access to Context, instead of going via queue.
   // Not every PI event has a queue, and we need a handle to Context
   // to get to event pool related information.


### PR DESCRIPTION
- Given Internal Event that is not cached we must destroy the ze event
  at handle destroy. This can only occur if the associated queue does
not have discard events enabled.
- during context release and when event caching is disabled, the destroy
  sets the event handle to nullptr to avoid double cleanup.