### PR TITLE
Fix potential deadlock in the WaitEvent path of CmdBuffers

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -1683,10 +1683,15 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
         (ZeCopyCommandQueue, 1, &CommandBuffer->ZeCopyCommandList, nullptr));
   }
 
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (SignalCommandList->first, nullptr, 1,
+              &(CommandBuffer->ExecutionFinishedEvent->ZeEvent)));
+
   // Reset the wait-event for the UR command-buffer that is signaled when its
   // submission dependencies have been satisfied.
   ZE2UR_CALL(zeCommandListAppendEventReset,
              (SignalCommandList->first, CommandBuffer->WaitEvent->ZeEvent));
+
   // Reset the all-reset-event for the UR command-buffer that is signaled when
   // all events of the main command-list have been reset.
   ZE2UR_CALL(zeCommandListAppendEventReset,
@@ -1694,13 +1699,11 @@ ur_result_t enqueueWaitEventPath(ur_exp_command_buffer_handle_t CommandBuffer,
 
   if (DoProfiling) {
     UR_CALL(appendProfilingQueries(CommandBuffer, SignalCommandList->first,
-                                   *Event,
-                                   CommandBuffer->ExecutionFinishedEvent));
-  } else {
-    ZE2UR_CALL(zeCommandListAppendBarrier,
-               (SignalCommandList->first, (*Event)->ZeEvent, 1,
-                &(CommandBuffer->ExecutionFinishedEvent->ZeEvent)));
+                                   nullptr, nullptr));
   }
+
+  ZE2UR_CALL(zeCommandListAppendBarrier,
+             (SignalCommandList->first, (*Event)->ZeEvent, 0, nullptr));
 
   UR_CALL(Queue->executeCommandList(SignalCommandList, false /*IsBlocking*/,
                                     false /*OKToBatchCommand*/));


### PR DESCRIPTION
Add barriers to the SignalCommandList that guarantee that resetting the WaitEvent is done at the right time.

This fixes a potential race condition where, if the SignalCommandList executes before the ComputeCommandList, the WaitEvent could be reset before the ComputeCommandList can wait on it and, consequently, create a deadlock.