### PR TITLE
Get rid of extra-confounding test helper code

### DIFF
--- a/test/adapters/cuda/fixtures.h
+++ b/test/adapters/cuda/fixtures.h
@@ -8,36 +8,12 @@
 #include <cuda.h>
 #include <uur/fixtures.h>
 
-namespace uur {
-struct ResultCuda {
-
-    constexpr ResultCuda(CUresult result) noexcept : value(result) {}
-
-    inline bool operator==(const ResultCuda &rhs) const noexcept {
-        return rhs.value == value;
-    }
-
-    CUresult value;
-};
-
-} // namespace uur
-
-#ifndef ASSERT_EQ_RESULT_CUDA
-#define ASSERT_EQ_RESULT_CUDA(EXPECTED, ACTUAL)                                \
-    ASSERT_EQ(uur::ResultCuda(EXPECTED), uur::ResultCuda(ACTUAL))
-#endif // ASSERT_EQ_RESULT_CUDA
-
 #ifndef ASSERT_SUCCESS_CUDA
-#define ASSERT_SUCCESS_CUDA(ACTUAL) ASSERT_EQ_RESULT_CUDA(CUDA_SUCCESS, ACTUAL)
+#define ASSERT_SUCCESS_CUDA(ACTUAL) ASSERT_EQ(CUDA_SUCCESS, (ACTUAL))
 #endif // ASSERT_SUCCESS_CUDA
 
-#ifndef EXPECT_EQ_RESULT_CUDA
-#define EXPECT_EQ_RESULT_CUDA(EXPECTED, ACTUAL)                                \
-    EXPECT_EQ(uur::ResultCuda(EXPECTED), uur::ResultCuda(ACTUAL))
-#endif // EXPECT_EQ_RESULT_CUDA
-
 #ifndef EXPECT_SUCCESS_CUDA
-#define EXPECT_SUCCESS_CUDA(ACTUAL) EXPECT_EQ_RESULT_CUDA(CUDA_SUCCESS, ACTUAL)
+#define EXPECT_SUCCESS_CUDA(ACTUAL) EXPECT_EQ(CUDA_SUCCESS, (ACTUAL))
 #endif // EXPECT_EQ_RESULT_CUDA
 
 #endif // UR_TEST_CONFORMANCE_ADAPTERS_CUDA_FIXTURES_H_INCLUDED

--- a/test/adapters/hip/fixtures.h
+++ b/test/adapters/hip/fixtures.h
@@ -8,36 +8,12 @@
 #include <hip/hip_runtime.h>
 #include <uur/fixtures.h>
 
-namespace uur {
-
-struct ResultHip {
-    constexpr ResultHip(hipError_t result) noexcept : value(result) {}
-
-    inline bool operator==(const ResultHip &rhs) const noexcept {
-        return rhs.value == value;
-    }
-
-    hipError_t value;
-};
-
-} // namespace uur
-
-#ifndef ASSERT_EQ_RESULT_HIP
-#define ASSERT_EQ_RESULT_HIP(EXPECTED, ACTUAL)                                 \
-    ASSERT_EQ(uur::ResultHip(EXPECTED), uur::ResultHip(ACTUAL))
-#endif // ASSERT_EQ_RESULT_HIP
-
 #ifndef ASSERT_SUCCESS_HIP
-#define ASSERT_SUCCESS_HIP(ACTUAL) ASSERT_EQ_RESULT_HIP(hipSuccess, ACTUAL)
+#define ASSERT_SUCCESS_HIP(ACTUAL) ASSERT_EQ(hipSuccess, (ACTUAL))
 #endif // ASSERT_SUCCESS_HIP
 
-#ifndef EXPECT_EQ_RESULT_HIP
-#define EXPECT_EQ_RESULT_HIP(EXPECTED, ACTUAL)                                 \
-    EXPECT_EQ_RESULT_HIP(uur::ResultHip(EXPECTED), uur::ResultHip(ACTUAL))
-#endif // EXPECT_EQ_RESULT_HIP
-
 #ifndef EXPECT_SUCCESS_HIP
-#define EXPECT_SUCCESS_HIP(ACTUAL) EXPECT_EQ_RESULT_HIP(hipSuccess, ACTUAL)
+#define EXPECT_SUCCESS_HIP(ACTUAL) EXPECT_EQ(hipSuccess, (ACTUAL))
 #endif // EXPECT_EQ_RESULT_HIP
 
 #endif // UR_TEST_CONFORMANCE_ADAPTERS_HIP_FIXTURES_H_INCLUDED


### PR DESCRIPTION
I can't work out why all this complexity could be needed. My guess is there was a plan to mould this further into something useful, but we're not using it and it's fairly confusing to boot. DELETE.