### PR TITLE
Update usage of zeCommandListImmediateAppendCommandListsExp to use dlsym

### DIFF
--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -224,6 +224,7 @@ ur_result_t ur_platform_handle_t_::initialize() {
 
   bool MutableCommandListSpecExtensionSupported = false;
   bool ZeIntelExternalSemaphoreExtensionSupported = false;
+  bool ZeImmediateCommandListAppendExtensionFound = false;
   for (auto &extension : ZeExtensions) {
     // Check if global offset extension is available
     if (strncmp(extension.name, ZE_GLOBAL_OFFSET_EXP_NAME,
@@ -246,6 +247,14 @@ ur_result_t ur_platform_handle_t_::initialize() {
       if (extension.version ==
           ZE_EVENT_POOL_COUNTER_BASED_EXP_VERSION_CURRENT) {
         ZeDriverEventPoolCountingEventsExtensionFound = true;
+      }
+    }
+    // Check if the ImmediateAppendCommandLists extension is available.
+    if (strncmp(extension.name, ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME,
+                strlen(ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_NAME) + 1) == 0) {
+      if (extension.version ==
+          ZE_IMMEDIATE_COMMAND_LIST_APPEND_EXP_VERSION_CURRENT) {
+        ZeImmediateCommandListAppendExtensionFound = true;
       }
     }
     // Check if extension is available for Mutable Command List v1.1.
@@ -427,6 +436,21 @@ ur_result_t ur_platform_handle_t_::initialize() {
                   &ZeMutableCmdListExt
                        .zexCommandListGetNextCommandIdWithKernelsExp))) == 0);
   }
+
+  // Check if ImmediateAppendCommandList is supported and initialize the
+  // function pointer.
+  if (ZeImmediateCommandListAppendExtensionFound) {
+    ZeCommandListImmediateAppendExt
+        .zeCommandListImmediateAppendCommandListsExp =
+        (ze_pfnCommandListImmediateAppendCommandListsExp_t)
+            ur_loader::LibLoader::getFunctionPtr(
+                GlobalAdapter->processHandle,
+                "zeCommandListImmediateAppendCommandListsExp");
+    ZeCommandListImmediateAppendExt.Supported =
+        ZeCommandListImmediateAppendExt
+            .zeCommandListImmediateAppendCommandListsExp != nullptr;
+  }
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/level_zero/platform.hpp
+++ b/source/adapters/level_zero/platform.hpp
@@ -134,4 +134,11 @@ struct ur_platform_handle_t_ : public _ur_platform {
     ze_result_t (*zexDeviceReleaseExternalSemaphoreExp)(
         ze_intel_external_semaphore_exp_handle_t);
   } ZeExternalSemaphoreExt;
+
+  struct ZeCommandListImmediateAppendExtension {
+    bool Supported = false;
+    ze_result_t (*zeCommandListImmediateAppendCommandListsExp)(
+        ze_command_list_handle_t, uint32_t, ze_command_list_handle_t *,
+        ze_event_handle_t, uint32_t, ze_event_handle_t *);
+  } ZeCommandListImmediateAppendExt;
 };


### PR DESCRIPTION
The implementation was using zeCommandListImmediateAppendCommandListsExp directly with the loader. This creates an issue with old loaders that don't support this entrypoint. Instead, this change uses dlsym to load the function if available.

intel/llvm PR: https://github.com/intel/llvm/pull/16458