### PR TITLE
[CTS] adjust timestamp test

### DIFF
--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -168,5 +168,5 @@ TEST_P(urEventGetProfilingInfoForWaitWithBarrier, Success) {
     auto end_timing = reinterpret_cast<size_t *>(complete_data.data());
     ASSERT_NE(*end_timing, 0);
 
-    ASSERT_GT(*end_timing, *start_timing);
+    ASSERT_GE(*end_timing, *start_timing);
 }


### PR DESCRIPTION
End and start timing can be the same if the operation that is being measure is fast enough.