### PR TITLE
CUTensorMap is only in CUDA v12

### DIFF
--- a/source/adapters/cuda/tensor_map.cpp
+++ b/source/adapters/cuda/tensor_map.cpp
@@ -13,6 +13,24 @@
 
 #include "context.hpp"
 
+#if CUDA_VERSION < 12000
+UR_APIEXPORT ur_result_t UR_APICALL urTensorMapEncodeIm2ColExp(
+    ur_device_handle_t, ur_exp_tensor_map_data_type_flags_t, uint32_t, void *,
+    const uint64_t *, const uint64_t *, const int *, const int *, uint32_t,
+    uint32_t, const uint32_t *, ur_exp_tensor_map_interleave_flags_t,
+    ur_exp_tensor_map_swizzle_flags_t, ur_exp_tensor_map_l2_promotion_flags_t,
+    ur_exp_tensor_map_oob_fill_flags_t, ur_exp_tensor_map_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+UR_APIEXPORT ur_result_t UR_APICALL urTensorMapEncodeTiledExp(
+    ur_device_handle_t, ur_exp_tensor_map_data_type_flags_t, uint32_t, void *,
+    const uint64_t *, const uint64_t *, const uint32_t *, const uint32_t *,
+    ur_exp_tensor_map_interleave_flags_t, ur_exp_tensor_map_swizzle_flags_t,
+    ur_exp_tensor_map_l2_promotion_flags_t, ur_exp_tensor_map_oob_fill_flags_t,
+    ur_exp_tensor_map_handle_t *) {
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+#else
 struct ur_exp_tensor_map_handle_t_ {
   CUtensorMap Map;
 };
@@ -140,3 +158,4 @@ UR_APIEXPORT ur_result_t UR_APICALL urTensorMapEncodeTiledExp(
   }
   return UR_RESULT_SUCCESS;
 }
+#endif


### PR DESCRIPTION
The documentation at https://docs.nvidia.com/cuda/cutensor/latest/ say it's supported in 11.0, 11.8, and 12.x

Our local testing against 11.7 fails because none of the required types or functions are declared in the header.

It's safer to remain buildable with older versions but with this feature disabled than requiring a version bump that isn't otherwise warranted.