### PR TITLE
[DeviceASAN] Fix urKernelCreateWithNativeHandle segfault

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -648,8 +648,8 @@ KernelInfo &AsanInterceptor::getOrCreateKernelInfo(ur_kernel_handle_t Kernel) {
     }
 
     // Create new KernelInfo
-    auto hProgram = GetProgram(Kernel);
-    auto PI = getAsanInterceptor()->getProgramInfo(hProgram);
+    auto Program = GetProgram(Kernel);
+    auto PI = getProgramInfo(Program);
     bool IsInstrumented = PI->isKernelInstrumented(Kernel);
 
     std::scoped_lock<ur_shared_mutex> Guard(m_KernelMapMutex);

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -696,6 +696,7 @@ ur_result_t AsanInterceptor::prepareLaunch(
     std::shared_ptr<DeviceInfo> &DeviceInfo, ur_queue_handle_t Queue,
     ur_kernel_handle_t Kernel, LaunchInfo &LaunchInfo) {
     auto &KernelInfo = getOrCreateKernelInfo(Kernel);
+    std::shared_lock<ur_shared_mutex> Guard(KernelInfo.Mutex);
 
     auto ArgNums = GetKernelNumArgs(Kernel);
     auto LocalMemoryUsage =

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -308,9 +308,6 @@ class AsanInterceptor {
     ur_result_t insertProgram(ur_program_handle_t Program);
     ur_result_t eraseProgram(ur_program_handle_t Program);
 
-    ur_result_t insertKernel(ur_kernel_handle_t Kernel);
-    ur_result_t eraseKernel(ur_kernel_handle_t Kernel);
-
     ur_result_t insertMemBuffer(std::shared_ptr<MemBuffer> MemBuffer);
     ur_result_t eraseMemBuffer(ur_mem_handle_t MemHandle);
     std::shared_ptr<MemBuffer> getMemBuffer(ur_mem_handle_t MemHandle);
@@ -350,11 +347,8 @@ class AsanInterceptor {
         return nullptr;
     }
 
-    std::shared_ptr<KernelInfo> getKernelInfo(ur_kernel_handle_t Kernel) {
-        std::shared_lock<ur_shared_mutex> Guard(m_KernelMapMutex);
-        assert(m_KernelMap.find(Kernel) != m_KernelMap.end());
-        return m_KernelMap[Kernel];
-    }
+    KernelInfo &getOrCreateKernelInfo(ur_kernel_handle_t Kernel);
+    ur_result_t eraseKernelInfo(ur_kernel_handle_t Kernel);
 
     const AsanOptions &getOptions() { return m_Options; }
 
@@ -401,7 +395,7 @@ class AsanInterceptor {
         m_ProgramMap;
     ur_shared_mutex m_ProgramMapMutex;
 
-    std::unordered_map<ur_kernel_handle_t, std::shared_ptr<KernelInfo>>
+    std::unordered_map<ur_kernel_handle_t, std::unique_ptr<KernelInfo>>
         m_KernelMap;
     ur_shared_mutex m_KernelMapMutex;
 

--- a/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -298,16 +298,26 @@ ur_result_t MsanInterceptor::eraseProgram(ur_program_handle_t Program) {
     return UR_RESULT_SUCCESS;
 }
 
-ur_result_t MsanInterceptor::insertKernel(ur_kernel_handle_t Kernel) {
-    std::scoped_lock<ur_shared_mutex> Guard(m_KernelMapMutex);
-    if (m_KernelMap.find(Kernel) != m_KernelMap.end()) {
-        return UR_RESULT_SUCCESS;
+KernelInfo &MsanInterceptor::getOrCreateKernelInfo(ur_kernel_handle_t Kernel) {
+    {
+        std::shared_lock<ur_shared_mutex> Guard(m_KernelMapMutex);
+        if (m_KernelMap.find(Kernel) != m_KernelMap.end()) {
+            return *m_KernelMap[Kernel].get();
+        }
     }
-    m_KernelMap.emplace(Kernel, std::make_shared<KernelInfo>(Kernel));
-    return UR_RESULT_SUCCESS;
+
+    // Create new KernelInfo
+    auto Program = GetProgram(Kernel);
+    auto PI = getProgramInfo(Program);
+    bool IsInstrumented = PI->isKernelInstrumented(Kernel);
+
+    std::scoped_lock<ur_shared_mutex> Guard(m_KernelMapMutex);
+    m_KernelMap.emplace(Kernel,
+                        std::make_unique<KernelInfo>(Kernel, IsInstrumented));
+    return *m_KernelMap[Kernel].get();
 }
 
-ur_result_t MsanInterceptor::eraseKernel(ur_kernel_handle_t Kernel) {
+ur_result_t MsanInterceptor::eraseKernelInfo(ur_kernel_handle_t Kernel) {
     std::scoped_lock<ur_shared_mutex> Guard(m_KernelMapMutex);
     assert(m_KernelMap.find(Kernel) != m_KernelMap.end());
     m_KernelMap.erase(Kernel);
@@ -360,10 +370,9 @@ ur_result_t MsanInterceptor::prepareLaunch(
         };
 
     // Set membuffer arguments
-    auto KernelInfo = getKernelInfo(Kernel);
-    assert(KernelInfo && "Kernel must be instrumented");
+    auto &KernelInfo = getOrCreateKernelInfo(Kernel);
 
-    for (const auto &[ArgIndex, MemBuffer] : KernelInfo->BufferArgs) {
+    for (const auto &[ArgIndex, MemBuffer] : KernelInfo.BufferArgs) {
         char *ArgPointer = nullptr;
         UR_CALL(MemBuffer->getHandle(DeviceInfo->Handle, ArgPointer));
         ur_result_t URes = getContext()->urDdiTable.Kernel.pfnSetArgPointer(
@@ -374,6 +383,10 @@ ur_result_t MsanInterceptor::prepareLaunch(
                 ur_cast<ur_mem_handle_t>(MemBuffer.get()), ArgIndex, Kernel,
                 URes);
         }
+    }
+
+    if (!KernelInfo.IsInstrumented) {
+        return UR_RESULT_SUCCESS;
     }
 
     // Set LaunchInfo

--- a/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -371,6 +371,7 @@ ur_result_t MsanInterceptor::prepareLaunch(
 
     // Set membuffer arguments
     auto &KernelInfo = getOrCreateKernelInfo(Kernel);
+    std::shared_lock<ur_shared_mutex> Guard(KernelInfo.Mutex);
 
     for (const auto &[ArgIndex, MemBuffer] : KernelInfo.BufferArgs) {
         char *ArgPointer = nullptr;


### PR DESCRIPTION
LLVM: https://github.com/intel/llvm/pull/16473

Since we can't get nullptr when calling `getKernelInfo`, I changed the return type of this function to reference.

To make it support "urKernelCreateXXX" APIs automatically, I changed `getKernelInfo` to `getOrCreateKernelInfo`, so that we needn't intercept "urKernelCreateXXX" anymore.

Sync those changes to msan.