### PR TITLE
Move urContextGetInfo success test from a switch to individual tests

### DIFF
--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -12,7 +12,6 @@ TEST_P(urContextGetInfoTest, SuccessNumDevices) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(uint32_t));
 
     uint32_t nDevices = 0;
@@ -29,23 +28,19 @@ TEST_P(urContextGetInfoTest, SuccessDevices) {
     ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
     ASSERT_NE(size, 0);
 
-    if (size > 0) {
-        ur_device_handle_t devices = 0;
-        ASSERT_SUCCESS(
-            urContextGetInfo(context, info_type, size, &devices, nullptr));
+    ur_device_handle_t devices = 0;
+    ASSERT_SUCCESS(
+        urContextGetInfo(context, info_type, size, &devices, nullptr));
 
-        size_t devices_count = size / sizeof(ur_device_handle_t);
-        ASSERT_GT(devices_count, 0);
+    size_t devices_count = size / sizeof(ur_device_handle_t);
+    ASSERT_GT(devices_count, 0);
 
-        for (uint32_t i = 0; i < devices_count; i++) {
-            auto &devices = uur::DevicesEnvironment::instance->devices;
-            auto queried_device =
-                std::find(devices.begin(), devices.end(), devices[i]);
-            EXPECT_TRUE(queried_device != devices.end())
-                << "device associated with the context is not valid";
-        }
-    } else {
-        ASSERT_EQ(size, 0);
+    for (uint32_t i = 0; i < devices_count; i++) {
+        auto &devices = uur::DevicesEnvironment::instance->devices;
+        auto queried_device =
+            std::find(devices.begin(), devices.end(), devices[i]);
+        EXPECT_TRUE(queried_device != devices.end())
+            << "device associated with the context is not valid";
     }
 }
 
@@ -54,7 +49,6 @@ TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_bool_t));
 }
 
@@ -63,7 +57,6 @@ TEST_P(urContextGetInfoTest, SuccessUSMFill2DSupport) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_bool_t));
 }
 
@@ -72,7 +65,6 @@ TEST_P(urContextGetInfoTest, SuccessReferenceCount) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(uint32_t));
 
     uint32_t reference_count = 0;
@@ -88,7 +80,6 @@ TEST_P(urContextGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
 
     ur_memory_order_capability_flags_t flags = 0;
@@ -104,7 +95,6 @@ TEST_P(urContextGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
 
     ur_memory_scope_capability_flags_t flags = 0;
@@ -120,7 +110,6 @@ TEST_P(urContextGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
 
     ur_memory_order_capability_flags_t flags = 0;
@@ -136,7 +125,6 @@ TEST_P(urContextGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
 
     ur_memory_scope_capability_flags_t flags = 0;

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -4,116 +4,147 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-struct urContextGetInfoTestWithInfoParam
-    : uur::urContextTestWithParam<ur_context_info_t> {
+using urContextGetInfoTest = uur::urContextTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetInfoTest);
 
-    void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(
-            uur::urContextTestWithParam<ur_context_info_t>::SetUp());
+TEST_P(urContextGetInfoTest, SuccessNumDevices) {
+    ur_context_info_t info_type = UR_CONTEXT_INFO_NUM_DEVICES;
+    size_t size = 0;
 
-        ctx_info_size_map = {
-            {UR_CONTEXT_INFO_NUM_DEVICES, sizeof(uint32_t)},
-            {UR_CONTEXT_INFO_DEVICES, sizeof(ur_device_handle_t)},
-            {UR_CONTEXT_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
-            {UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT, sizeof(bool)},
-            {UR_CONTEXT_INFO_USM_FILL2D_SUPPORT, sizeof(bool)},
-            {UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
-             sizeof(ur_memory_order_capability_flags_t)},
-            {UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES,
-             sizeof(ur_memory_order_capability_flags_t)},
-            {UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES,
-             sizeof(ur_memory_order_capability_flags_t)},
-            {UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES,
-             sizeof(ur_memory_order_capability_flags_t)}};
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(uint32_t));
 
-        ctx_info_mem_flags_map = {
-            {UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
-             UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK},
-            {UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES,
-             UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK},
-            {UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES,
-             UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK},
-            {UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES,
-             UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK},
-        };
-    }
-
-    void TearDown() override {
-        UUR_RETURN_ON_FATAL_FAILURE(
-            uur::urContextTestWithParam<ur_context_info_t>::TearDown());
-    }
-
-    std::unordered_map<ur_context_info_t, size_t> ctx_info_size_map;
-    std::unordered_map<ur_context_info_t, ur_memory_order_capability_flags_t>
-        ctx_info_mem_flags_map;
-};
-
-UUR_TEST_SUITE_P(urContextGetInfoTestWithInfoParam,
-                 ::testing::Values(
-
-                     UR_CONTEXT_INFO_NUM_DEVICES,                      //
-                     UR_CONTEXT_INFO_DEVICES,                          //
-                     UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT,             //
-                     UR_CONTEXT_INFO_USM_FILL2D_SUPPORT,               //
-                     UR_CONTEXT_INFO_REFERENCE_COUNT,                  //
-                     UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES, //
-                     UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES, //
-                     UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES,  //
-                     UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES   //
-                     ),
-                 uur::deviceTestWithParamPrinter<ur_context_info_t>);
-
-TEST_P(urContextGetInfoTestWithInfoParam, Success) {
-    ur_context_info_t info = getParam();
-    size_t info_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urContextGetInfo(context, info, 0, nullptr, &info_size), info);
-    ASSERT_NE(info_size, 0);
-
-    if (const auto expected_size = ctx_info_size_map.find(info);
-        expected_size != ctx_info_size_map.end()) {
-        ASSERT_EQ(expected_size->second, info_size);
-    }
-
-    std::vector<uint8_t> info_data(info_size);
+    uint32_t nDevices = 0;
     ASSERT_SUCCESS(
-        urContextGetInfo(context, info, info_size, info_data.data(), nullptr));
+        urContextGetInfo(context, info_type, size, &nDevices, nullptr));
 
-    switch (info) {
-    case UR_CONTEXT_INFO_NUM_DEVICES: {
-        auto returned_num_of_devices =
-            reinterpret_cast<uint32_t *>(info_data.data());
-        ASSERT_GE(uur::DevicesEnvironment::instance->devices.size(),
-                  *returned_num_of_devices);
-        break;
-    }
-    case UR_CONTEXT_INFO_DEVICES: {
-        auto returned_devices =
-            reinterpret_cast<ur_device_handle_t *>(info_data.data());
-        size_t devices_count = info_size / sizeof(ur_device_handle_t);
+    ASSERT_GE(uur::DevicesEnvironment::instance->devices.size(), nDevices);
+}
+
+TEST_P(urContextGetInfoTest, SuccessDevices) {
+    ur_context_info_t info_type = UR_CONTEXT_INFO_DEVICES;
+    size_t size = 0;
+
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+
+    if (size > 0) {
+        ur_device_handle_t devices = 0;
+        ASSERT_SUCCESS(
+            urContextGetInfo(context, info_type, size, &devices, nullptr));
+
+        size_t devices_count = size / sizeof(ur_device_handle_t);
         ASSERT_GT(devices_count, 0);
+
         for (uint32_t i = 0; i < devices_count; i++) {
             auto &devices = uur::DevicesEnvironment::instance->devices;
             auto queried_device =
-                std::find(devices.begin(), devices.end(), returned_devices[i]);
+                std::find(devices.begin(), devices.end(), devices[i]);
             EXPECT_TRUE(queried_device != devices.end())
                 << "device associated with the context is not valid";
         }
-        break;
-    }
-    case UR_CONTEXT_INFO_REFERENCE_COUNT: {
-        auto returned_reference_count =
-            reinterpret_cast<uint32_t *>(info_data.data());
-        ASSERT_GT(*returned_reference_count, 0U);
-        break;
-    }
-    default:
-        break;
+    } else {
+        ASSERT_EQ(size, 0);
     }
 }
 
-using urContextGetInfoTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetInfoTest);
+TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
+    ur_context_info_t info_type = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
+    size_t size = 0;
+
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_bool_t));
+}
+
+TEST_P(urContextGetInfoTest, SuccessUSMFill2DSupport) {
+    ur_context_info_t info_type = UR_CONTEXT_INFO_USM_FILL2D_SUPPORT;
+    size_t size = 0;
+
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_bool_t));
+}
+
+TEST_P(urContextGetInfoTest, SuccessReferenceCount) {
+    ur_context_info_t info_type = UR_CONTEXT_INFO_REFERENCE_COUNT;
+    size_t size = 0;
+
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(uint32_t));
+
+    uint32_t reference_count = 0;
+    ASSERT_SUCCESS(
+        urContextGetInfo(context, info_type, size, &reference_count, nullptr));
+    ASSERT_GT(reference_count, 0U);
+}
+
+TEST_P(urContextGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
+    ur_context_info_t info_type =
+        UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES;
+    size_t size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
+
+    ur_memory_order_capability_flags_t flags = 0;
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+
+    ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urContextGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
+    ur_context_info_t info_type =
+        UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES;
+    size_t size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
+
+    ur_memory_scope_capability_flags_t flags = 0;
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+
+    ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urContextGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
+    ur_context_info_t info_type =
+        UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES;
+    size_t size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
+
+    ur_memory_order_capability_flags_t flags = 0;
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+
+    ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urContextGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
+    ur_context_info_t info_type =
+        UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES;
+    size_t size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
+    ASSERT_NE(size, 0);
+    ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
+
+    ur_memory_scope_capability_flags_t flags = 0;
+    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+
+    ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+}
+
 TEST_P(urContextGetInfoTest, InvalidNullHandleContext) {
     uint32_t nDevices = 0;
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -12,7 +12,6 @@ TEST_P(urEventGetInfoTest, SuccessCommandQueue) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_queue_handle_t));
 
     ur_queue_handle_t returned_queue;
@@ -27,7 +26,6 @@ TEST_P(urEventGetInfoTest, SuccessContext) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_context_handle_t));
 
     ur_context_handle_t returned_context;
@@ -42,7 +40,6 @@ TEST_P(urEventGetInfoTest, SuccessCommandType) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_command_t));
 
     ur_command_t returned_command_type;
@@ -57,7 +54,6 @@ TEST_P(urEventGetInfoTest, SuccessCommandExecutionStatus) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(ur_event_status_t));
 
     ur_event_status_t returned_status;
@@ -72,7 +68,6 @@ TEST_P(urEventGetInfoTest, SuccessReferenceCount) {
     size_t size = 0;
 
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
     ASSERT_EQ(size, sizeof(uint32_t));
 
     uint32_t returned_reference_count;

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -12,7 +12,6 @@ TEST_P(urQueueGetInfoTest, Context) {
     auto infoType = UR_QUEUE_INFO_CONTEXT;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(ur_context_handle_t), size);
 
     std::vector<uint8_t> data(size);
@@ -28,7 +27,6 @@ TEST_P(urQueueGetInfoTest, Device) {
     auto infoType = UR_QUEUE_INFO_DEVICE;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(ur_device_handle_t), size);
 
     std::vector<uint8_t> data(size);
@@ -43,7 +41,6 @@ TEST_P(urQueueGetInfoTest, Flags) {
     auto infoType = UR_QUEUE_INFO_FLAGS;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(ur_queue_flags_t), size);
 
     std::vector<uint8_t> data(size);
@@ -58,7 +55,6 @@ TEST_P(urQueueGetInfoTest, ReferenceCount) {
     auto infoType = UR_QUEUE_INFO_REFERENCE_COUNT;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(uint32_t), size);
 
     std::vector<uint8_t> data(size);
@@ -73,7 +69,6 @@ TEST_P(urQueueGetInfoTest, EmptyQueue) {
     auto infoType = UR_QUEUE_INFO_EMPTY;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(ur_bool_t), size);
 
     std::vector<uint8_t> data(size);


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/2290