### PR TITLE
Move urMemoryGetInfo success test from a switch to individual tests

### DIFF
--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -14,7 +14,7 @@ TEST_P(urEventGetInfoTest, SuccessCommandQueue) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, sizeof(ur_queue_handle_t));
 
-    ur_queue_handle_t returned_queue;
+    ur_queue_handle_t returned_queue = nullptr;
     ASSERT_SUCCESS(
         urEventGetInfo(event, info_type, size, &returned_queue, nullptr));
 
@@ -28,7 +28,7 @@ TEST_P(urEventGetInfoTest, SuccessContext) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, sizeof(ur_context_handle_t));
 
-    ur_context_handle_t returned_context;
+    ur_context_handle_t returned_context = nullptr;
     ASSERT_SUCCESS(
         urEventGetInfo(event, info_type, size, &returned_context, nullptr));
 
@@ -42,7 +42,7 @@ TEST_P(urEventGetInfoTest, SuccessCommandType) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, sizeof(ur_command_t));
 
-    ur_command_t returned_command_type;
+    ur_command_t returned_command_type = UR_COMMAND_FORCE_UINT32;
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, size,
                                   &returned_command_type, nullptr));
 
@@ -56,7 +56,7 @@ TEST_P(urEventGetInfoTest, SuccessCommandExecutionStatus) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, sizeof(ur_event_status_t));
 
-    ur_event_status_t returned_status;
+    ur_event_status_t returned_status = UR_EVENT_STATUS_FORCE_UINT32;
     ASSERT_SUCCESS(
         urEventGetInfo(event, info_type, size, &returned_status, nullptr));
 
@@ -70,7 +70,7 @@ TEST_P(urEventGetInfoTest, SuccessReferenceCount) {
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
     ASSERT_EQ(size, sizeof(uint32_t));
 
-    uint32_t returned_reference_count;
+    uint32_t returned_reference_count = 0;
     ASSERT_SUCCESS(urEventGetInfo(event, info_type, size,
                                   &returned_reference_count, nullptr));
 
@@ -91,7 +91,7 @@ TEST_P(urEventGetInfoTest, InvalidNullHandle) {
 }
 
 TEST_P(urEventGetInfoTest, InvalidEnumeration) {
-    size_t size;
+    size_t size = 0;
     ASSERT_EQ_RESULT(
         urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size),
         UR_RESULT_ERROR_INVALID_ENUMERATION);
@@ -111,9 +111,9 @@ TEST_P(urEventGetInfoTest, InvalidSizePropSize) {
 }
 
 TEST_P(urEventGetInfoTest, InvalidSizePropSizeSmall) {
-    ur_queue_handle_t q;
+    ur_queue_handle_t queue = nullptr;
     ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE,
-                                    sizeof(q) - 1, &q, nullptr),
+                                    sizeof(queue) - 1, &queue, nullptr),
                      UR_RESULT_ERROR_INVALID_SIZE);
 }
 

--- a/test/conformance/memory/memory_adapter_level_zero.match
+++ b/test/conformance/memory/memory_adapter_level_zero.match
@@ -4,7 +4,7 @@ urMemBufferPartitionWithFlagsTest.Success/*__UR_MEM_FLAG_READ_ONLY
 urMemBufferPartitionTest.InvalidValueCreateType/*
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/*
 {{OPT}}urMemImageCreateWithNativeHandleTest.Success/*
-{{OPT}}urMemGetInfoImageTest.Success/*__UR_MEM_INFO_SIZE
+{{OPT}}urMemGetInfoImageTest.SuccessSize/*
 {{OPT}}urMemImageCreateTestWithImageFormatParam.Success/*__UR_IMAGE_CHANNEL_ORDER_RGBA__*
 
 # These tests fail in the "Multi device testing" job, but pass in the hardware specific test

--- a/test/conformance/memory/memory_adapter_native_cpu.match
+++ b/test/conformance/memory/memory_adapter_native_cpu.match
@@ -2,7 +2,9 @@ urMemBufferPartitionWithFlagsTest.Success/*__UR_MEM_FLAG_WRITE_ONLY
 urMemBufferPartitionWithFlagsTest.Success/*__UR_MEM_FLAG_READ_ONLY
 urMemBufferPartitionTest.InvalidValueCreateType/*
 urMemBufferPartitionTest.InvalidValueBufferCreateInfoOutOfBounds/*
-urMemGetInfoTestWithParam.Success/*
+urMemGetInfoTest.SuccessSize/*
+urMemGetInfoTest.SuccessContext/*
+urMemGetInfoTest.SuccessReferenceCount/*
 urMemGetInfoTest.InvalidSizeSmall/*
 urMemReleaseTest.Success/*
 urMemReleaseTest.CheckReferenceCount/*

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -14,12 +14,11 @@ TEST_P(urQueueGetInfoTest, Context) {
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
     ASSERT_EQ(sizeof(ur_context_handle_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    ur_context_handle_t returned_context = nullptr;
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, infoType, size, &returned_context, nullptr));
 
-    auto returned_context =
-        reinterpret_cast<ur_context_handle_t *>(data.data());
-    ASSERT_EQ(context, *returned_context);
+    ASSERT_EQ(context, returned_context);
 }
 
 TEST_P(urQueueGetInfoTest, Device) {
@@ -29,11 +28,11 @@ TEST_P(urQueueGetInfoTest, Device) {
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
     ASSERT_EQ(sizeof(ur_device_handle_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    ur_device_handle_t returned_device = nullptr;
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, infoType, size, &returned_device, nullptr));
 
-    auto returned_device = reinterpret_cast<ur_device_handle_t *>(data.data());
-    ASSERT_EQ(device, *returned_device);
+    ASSERT_EQ(device, returned_device);
 }
 
 TEST_P(urQueueGetInfoTest, Flags) {
@@ -43,11 +42,11 @@ TEST_P(urQueueGetInfoTest, Flags) {
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
     ASSERT_EQ(sizeof(ur_queue_flags_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    ur_queue_flags_t returned_flags = 0;
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, infoType, size, &returned_flags, nullptr));
 
-    auto returned_flags = reinterpret_cast<ur_queue_flags_t *>(data.data());
-    EXPECT_EQ(*returned_flags, queue_properties.flags);
+    EXPECT_EQ(returned_flags, queue_properties.flags);
 }
 
 TEST_P(urQueueGetInfoTest, ReferenceCount) {
@@ -57,11 +56,11 @@ TEST_P(urQueueGetInfoTest, ReferenceCount) {
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
     ASSERT_EQ(sizeof(uint32_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    uint32_t returned_reference_count = 0;
+    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size,
+                                  &returned_reference_count, nullptr));
 
-    auto returned_reference_count = reinterpret_cast<uint32_t *>(data.data());
-    ASSERT_GT(*returned_reference_count, 0U);
+    ASSERT_GT(returned_reference_count, 0U);
 }
 
 TEST_P(urQueueGetInfoTest, EmptyQueue) {
@@ -70,12 +69,6 @@ TEST_P(urQueueGetInfoTest, EmptyQueue) {
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
     ASSERT_EQ(sizeof(ur_bool_t), size);
-
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
-
-    auto returned_empty_queue = reinterpret_cast<ur_bool_t *>(data.data());
-    ASSERT_TRUE(returned_empty_queue);
 }
 
 TEST_P(urQueueGetInfoTest, InvalidNullHandleQueue) {
@@ -125,7 +118,7 @@ TEST_P(urQueueGetInfoTest, InvalidNullPointerPropSizeRet) {
 struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
     void SetUp() {
         urQueueGetInfoTest::SetUp();
-        ur_queue_flags_t deviceQueueCapabilities;
+        ur_queue_flags_t deviceQueueCapabilities = 0;
         ASSERT_SUCCESS(
             urDeviceGetInfo(device, UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,
                             sizeof(deviceQueueCapabilities),
@@ -159,14 +152,13 @@ TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, DeviceDefault) {
     auto infoType = UR_QUEUE_INFO_DEVICE_DEFAULT;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(ur_queue_handle_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    ur_queue_handle_t returned_queue = nullptr;
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, infoType, size, &returned_queue, nullptr));
 
-    auto returned_queue = reinterpret_cast<ur_queue_handle_t *>(data.data());
-    ASSERT_EQ(queue, *returned_queue);
+    ASSERT_EQ(queue, returned_queue);
 }
 
 TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, Size) {
@@ -175,12 +167,11 @@ TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, Size) {
     auto infoType = UR_QUEUE_INFO_SIZE;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_NE(size, 0);
     ASSERT_EQ(sizeof(uint32_t), size);
 
-    std::vector<uint8_t> data(size);
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size, data.data(), nullptr));
+    uint32_t returned_size = 0;
+    ASSERT_SUCCESS(
+        urQueueGetInfo(queue, infoType, size, &returned_size, nullptr));
 
-    auto returned_size = reinterpret_cast<uint32_t *>(data.data());
-    ASSERT_GT(*returned_size, 0);
+    ASSERT_GT(returned_size, 0);
 }

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -222,8 +222,8 @@ struct urSamplerTest : urContextTest {
 struct urMemBufferTest : urContextTest {
     void SetUp() override {
         UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE, 4096,
-                                         nullptr, &buffer));
+        ASSERT_SUCCESS(urMemBufferCreate(context, UR_MEM_FLAG_READ_WRITE,
+                                         allocation_size, nullptr, &buffer));
         ASSERT_NE(nullptr, buffer);
     }
 
@@ -235,6 +235,7 @@ struct urMemBufferTest : urContextTest {
     }
 
     ur_mem_handle_t buffer = nullptr;
+    size_t allocation_size = 4096;
 };
 
 struct urMemImageTest : urContextTest {
@@ -331,24 +332,6 @@ template <class T> struct urSamplerTestWithParam : urContextTestWithParam<T> {
 
     ur_sampler_handle_t sampler = nullptr;
     ur_sampler_desc_t sampler_desc;
-};
-
-template <class T> struct urMemBufferTestWithParam : urContextTestWithParam<T> {
-    void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
-        ASSERT_SUCCESS(urMemBufferCreate(this->context, UR_MEM_FLAG_READ_WRITE,
-                                         allocation_size, nullptr, &buffer));
-        ASSERT_NE(nullptr, buffer);
-    }
-
-    void TearDown() override {
-        if (buffer) {
-            EXPECT_SUCCESS(urMemRelease(buffer));
-        }
-        UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
-    }
-    ur_mem_handle_t buffer = nullptr;
-    size_t allocation_size = 4096;
 };
 
 template <class T> struct urMemImageTestWithParam : urContextTestWithParam<T> {

--- a/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
@@ -14,14 +14,12 @@ TEST_P(urPhysicalMemGetInfoTest, Context) {
         physical_mem, UR_PHYSICAL_MEM_INFO_CONTEXT, 0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
 
-    std::vector<uint8_t> data(info_size);
+    ur_context_handle_t returned_context = nullptr;
     ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_CONTEXT,
-                                        data.size(), data.data(), nullptr));
+                                        UR_PHYSICAL_MEM_INFO_CONTEXT, info_size,
+                                        &returned_context, nullptr));
 
-    auto returned_context =
-        reinterpret_cast<ur_context_handle_t *>(data.data());
-    ASSERT_EQ(context, *returned_context);
+    ASSERT_EQ(context, returned_context);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, Device) {
@@ -31,13 +29,12 @@ TEST_P(urPhysicalMemGetInfoTest, Device) {
         physical_mem, UR_PHYSICAL_MEM_INFO_DEVICE, 0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
 
-    std::vector<uint8_t> data(info_size);
+    ur_device_handle_t returned_device = nullptr;
     ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_DEVICE,
-                                        data.size(), data.data(), nullptr));
+                                        UR_PHYSICAL_MEM_INFO_DEVICE, info_size,
+                                        &returned_device, nullptr));
 
-    auto returned_device = reinterpret_cast<ur_device_handle_t *>(data.data());
-    ASSERT_EQ(device, *returned_device);
+    ASSERT_EQ(device, returned_device);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, Size) {
@@ -47,12 +44,11 @@ TEST_P(urPhysicalMemGetInfoTest, Size) {
                                         0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
 
-    std::vector<uint8_t> data(info_size);
+    size_t returned_size = 0;
     ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_SIZE,
-                                        data.size(), data.data(), nullptr));
+                                        info_size, &returned_size, nullptr));
 
-    auto returned_size = reinterpret_cast<size_t *>(data.data());
-    ASSERT_EQ(size, *returned_size);
+    ASSERT_EQ(size, returned_size);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, Properties) {
@@ -62,16 +58,14 @@ TEST_P(urPhysicalMemGetInfoTest, Properties) {
         physical_mem, UR_PHYSICAL_MEM_INFO_PROPERTIES, 0, nullptr, &info_size));
     ASSERT_NE(info_size, 0);
 
-    std::vector<uint8_t> data(info_size);
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_PROPERTIES,
-                                        data.size(), data.data(), nullptr));
+    ur_physical_mem_properties_t returned_properties = {};
+    ASSERT_SUCCESS(
+        urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_PROPERTIES,
+                             info_size, &returned_properties, nullptr));
 
-    auto returned_properties =
-        reinterpret_cast<ur_physical_mem_properties_t *>(data.data());
-    ASSERT_EQ(properties.stype, returned_properties->stype);
-    ASSERT_EQ(properties.pNext, returned_properties->pNext);
-    ASSERT_EQ(properties.flags, returned_properties->flags);
+    ASSERT_EQ(properties.stype, returned_properties.stype);
+    ASSERT_EQ(properties.pNext, returned_properties.pNext);
+    ASSERT_EQ(properties.flags, returned_properties.flags);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, ReferenceCount) {
@@ -82,12 +76,10 @@ TEST_P(urPhysicalMemGetInfoTest, ReferenceCount) {
                                         nullptr, &info_size));
     ASSERT_NE(info_size, 0);
 
-    std::vector<uint8_t> data(info_size);
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT,
-                                        data.size(), data.data(), nullptr));
+    uint32_t returned_reference_count = 0;
+    ASSERT_SUCCESS(
+        urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT,
+                             info_size, &returned_reference_count, nullptr));
 
-    const size_t ReferenceCount =
-        *reinterpret_cast<const uint32_t *>(data.data());
-    ASSERT_EQ(ReferenceCount, 1);
+    ASSERT_EQ(returned_reference_count, 1);
 }


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/2290

Also reworked urAdapterGetInfo - ValidAdapterBackend test was redundant. 
Also tidy up some other urXGetInfo tests with default values and removing unneccessary casts.