### PR TITLE
Update urProgramGetFunctionPointer test

### DIFF
--- a/test/conformance/program/urProgramGetFunctionPointer.cpp
+++ b/test/conformance/program/urProgramGetFunctionPointer.cpp
@@ -21,10 +21,13 @@ struct urProgramGetFunctionPointerTest : uur::urProgramTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetFunctionPointerTest);
 
 TEST_P(urProgramGetFunctionPointerTest, Success) {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) UHD Graphics 770"});
     void *function_pointer = nullptr;
-    ASSERT_SUCCESS(urProgramGetFunctionPointer(
-        device, program, function_name.data(), &function_pointer));
+    ur_result_t res = urProgramGetFunctionPointer(
+        device, program, function_name.data(), &function_pointer);
+    if (res == UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE) {
+        return;
+    }
+    ASSERT_SUCCESS(res);
     ASSERT_NE(function_pointer, nullptr);
 }
 


### PR DESCRIPTION
The spec says that implementations may return
`UR_RESULT_ERROR_FUNCTION_ADDRESS_NOT_AVAILABLE` for this function, but
that wasn't handled by this test.
