### PR TITLE
Addition of num_compute_units query for device info

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1719,6 +1719,7 @@ typedef enum ur_device_info_t {
     UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP = 0x2021,                    ///< [::ur_bool_t] returns true if the device supports low-power events.
     UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP = 0x2022,         ///< [::ur_exp_device_2d_block_array_capability_flags_t] return a bit-field
                                                                      ///< of Intel GPU 2D block array capabilities
+    UR_DEVICE_INFO_NUM_COMPUTE_UNITS = 0x2023,                       ///< [uint32_t] the number of compute units for specific backend
     /// @cond
     UR_DEVICE_INFO_FORCE_UINT32 = 0x7fffffff
     /// @endcond

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2291,6 +2291,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
     case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:
         os << "UR_DEVICE_INFO_MAX_COMPUTE_UNITS";
         break;
+    case UR_DEVICE_INFO_NUM_COMPUTE_UNITS:
+        os << "UR_DEVICE_INFO_NUM_COMPUTE_UNITS";
+        break;
     case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
         os << "UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS";
         break;
@@ -2791,6 +2794,18 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr, ur_device_info
         os << ")";
     } break;
     case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
+        const uint32_t *tptr = (const uint32_t *)ptr;
+        if (sizeof(uint32_t) > size) {
+            os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t) << ")";
+            return UR_RESULT_ERROR_INVALID_SIZE;
+        }
+        os << (const void *)(tptr) << " (";
+
+        os << *tptr;
+
+        os << ")";
+    } break;
+        case UR_DEVICE_INFO_NUM_COMPUTE_UNITS: {
         const uint32_t *tptr = (const uint32_t *)ptr;
         if (sizeof(uint32_t) > size) {
             os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t) << ")";

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -56,6 +56,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_VENDOR_ID: {
     return ReturnValue(4318u);
   }
+  case UR_DEVICE_INFO_NUM_COMPUTE_UNITS:
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
     return ReturnValue(hDevice->getNumComputeUnits());
   }

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -57,6 +57,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 #endif
     return ReturnValue(VendorId);
   }
+  case UR_DEVICE_INFO_NUM_COMPUTE_UNITS:
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
     int ComputeUnits = 0;
     UR_CHECK_ERROR(hipDeviceGetAttribute(

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -322,6 +322,12 @@ ur_result_t urDeviceGetInfo(
 
     return ReturnValue(uint32_t{MaxComputeUnits});
   }
+  case UR_DEVICE_INFO_NUM_COMPUTE_UNITS:{
+    uint32_t NumComputeUnits =  
+        Device->ZeDeviceProperties->numSubslicesPerSlice *
+        Device->ZeDeviceProperties->numSlices;
+    return ReturnValue(uint32_t{NumComputeUnits});
+  }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
     // Level Zero spec defines only three dimensions
     return ReturnValue(uint32_t{3});

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -164,6 +164,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(bool{true});
   case UR_DEVICE_INFO_LINKER_AVAILABLE:
     return ReturnValue(bool{true});
+  case UR_DEVICE_INFO_NUM_COMPUTE_UNITS:
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:
     return ReturnValue(static_cast<uint32_t>(hDevice->tp.num_threads()));
   case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:


### PR DESCRIPTION
This change introduces new enumerator for `enum ur_device_info_t` with name `UR_DEVICE_INFO_NUM_COMPUTE_UNITS` to get number of compute units for different combinations of device and backend.
It's needed for extension `sycl_ext_oneapi_num_compute_units` https://github.com/Pennycook/llvm/blob/100b35b47bc6e35f3cf0bcc3c185df854d4da9c9/sycl/doc/extensions/proposed/sycl_ext_oneapi_num_compute_units.asciidoc 