### PR TITLE
Wrap urEventSetCallback when ran through loader

### DIFF
--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -13,6 +13,7 @@
 #include "ur_loader.hpp"
 
 namespace ur_loader {
+
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urAdapterGet
 __urdlllocal ur_result_t UR_APICALL urAdapterGet(
@@ -4476,6 +4477,22 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     return result;
 }
 
+namespace {
+struct event_callback_wrapper_data_t {
+    ur_event_callback_t fn;
+    ur_event_handle_t event;
+    void *userData;
+};
+
+void event_callback_wrapper([[maybe_unused]] ur_event_handle_t hEvent,
+                            ur_execution_info_t execStatus, void *pUserData) {
+    auto *wrapper =
+        reinterpret_cast<event_callback_wrapper_data_t *>(pUserData);
+    (wrapper->fn)(wrapper->event, execStatus, wrapper->userData);
+    delete wrapper;
+}
+} // namespace
+
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urEventSetCallback
 __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
@@ -4488,6 +4505,13 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     ur_result_t result = UR_RESULT_SUCCESS;
 
     [[maybe_unused]] auto context = getContext();
+
+    // Replace the callback with a wrapper function that gives the callback the loader event rather than a
+    // backend-specific event
+    auto wrapper_data =
+        new event_callback_wrapper_data_t{pfnNotify, hEvent, pUserData};
+    pUserData = wrapper_data;
+    pfnNotify = event_callback_wrapper;
 
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_event_object_t *>(hEvent)->dditable;

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -41,7 +41,7 @@ TEST_P(urEventSetCallbackTest, Success) {
  */
 TEST_P(urEventSetCallbackTest, ValidateParameters) {
     UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{}, uur::LevelZero{},
-                         uur::LevelZeroV2{}, uur::OpenCL{}, uur::NativeCPU{});
+                         uur::LevelZeroV2{}, uur::NativeCPU{});
 
     struct CallbackParameters {
         ur_event_handle_t event;


### PR DESCRIPTION
The events returned by the loader do not match the events returned by
openCL (or other backends), which causes issues when adding a callback
handler. This adds an intermediate wrapper to replace the event with the
loader event.
