### PR TITLE
Fix calls to ze destructors in level-zero adapter v2

### DIFF
--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -340,6 +340,9 @@ bool setEnvVar(const char *name, const char *value);
 // Map Level Zero runtime error code to UR error code.
 ur_result_t ze2urResult(ze_result_t ZeResult);
 
+// Parse Level Zero error code and return the error string.
+void zeParseError(ze_result_t ZeError, const char *&ErrorString);
+
 // Trace a call to Level-Zero RT
 #define ZE2UR_CALL(ZeName, ZeArgs)                                             \
   {                                                                            \
@@ -359,6 +362,9 @@ ur_result_t ze2urResult(ze_result_t ZeResult);
 // Perform traced call to L0 without checking for errors
 #define ZE_CALL_NOCHECK(ZeName, ZeArgs)                                        \
   ZeCall().doCall(ZeName ZeArgs, #ZeName, #ZeArgs, false)
+  
+#define ZE_CALL_NOCHECK_NAME(ZeName, ZeArgs, callName)                                        \
+  ZeCall().doCall(ZeName ZeArgs, callName, #ZeArgs, false)
 
 // This wrapper around std::atomic is created to limit operations with reference
 // counter and to make allowed operations more transparent in terms of

--- a/source/adapters/level_zero/v2/common.hpp
+++ b/source/adapters/level_zero/v2/common.hpp
@@ -15,12 +15,21 @@
 
 #include "../common.hpp"
 #include "logger/ur_logger.hpp"
+namespace {
+  const char* desturctorNames[] = {
+  "zeKernelDestroy",
+  "zeEventDestroy",
+  "zeEventPoolDestroy",
+  "zeContextDestroy",
+  "zeCommandListDestroy"
+  };
+}
 
 namespace v2 {
 
 namespace raii {
 
-template <typename ZeHandleT, ze_result_t (*destroy)(ZeHandleT)>
+template <typename ZeHandleT, ze_result_t (*destroy)(ZeHandleT), size_t nameId>
 struct ze_handle_wrapper {
   ze_handle_wrapper(bool ownZeHandle = true)
       : handle(nullptr), ownZeHandle(ownZeHandle) {}
@@ -65,7 +74,7 @@ struct ze_handle_wrapper {
     }
 
     if (ownZeHandle) {
-      auto zeResult = ZE_CALL_NOCHECK(destroy, (handle));
+      auto zeResult = ZE_CALL_NOCHECK_NAME(destroy, (handle), desturctorNames[nameId]);
       // Gracefully handle the case that L0 was already unloaded.
       if (zeResult && zeResult != ZE_RESULT_ERROR_UNINITIALIZED)
         throw ze2urResult(zeResult);
@@ -90,19 +99,19 @@ private:
 };
 
 using ze_kernel_handle_t =
-    ze_handle_wrapper<::ze_kernel_handle_t, zeKernelDestroy>;
+    ze_handle_wrapper<::ze_kernel_handle_t, zeKernelDestroy, 0>;
 
 using ze_event_handle_t =
-    ze_handle_wrapper<::ze_event_handle_t, zeEventDestroy>;
+    ze_handle_wrapper<::ze_event_handle_t, zeEventDestroy, 1>;
 
 using ze_event_pool_handle_t =
-    ze_handle_wrapper<::ze_event_pool_handle_t, zeEventPoolDestroy>;
+    ze_handle_wrapper<::ze_event_pool_handle_t, zeEventPoolDestroy, 2>;
 
 using ze_context_handle_t =
-    ze_handle_wrapper<::ze_context_handle_t, zeContextDestroy>;
+    ze_handle_wrapper<::ze_context_handle_t, zeContextDestroy, 3>;
 
 using ze_command_list_handle_t =
-    ze_handle_wrapper<::ze_command_list_handle_t, zeCommandListDestroy>;
+    ze_handle_wrapper<::ze_command_list_handle_t, zeCommandListDestroy, 4>;
 
 } // namespace raii
 } // namespace v2

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -73,7 +73,7 @@ ur_command_list_handler_t::ur_command_list_handler_t(
     : commandList(hZeCommandList,
                   [ownZeHandle](ze_command_list_handle_t hZeCommandList) {
                     if (ownZeHandle) {
-                      zeCommandListDestroy(hZeCommandList);
+                      ZE_CALL_NOCHECK(zeCommandListDestroy, (hZeCommandList));
                     }
                   }) {}
 


### PR DESCRIPTION
Currently, when using level zero v2 adapter, all destructions reported with use of UR_L0_DEBUG flag are labeled as "destroy(handle)". It provides no information on which objects are destroyed and which level zero functions are called. It also breaks leak detection using UR_L0_LEAKS_DEBUG flag - it does not report any objects freed this way.

This is a bit crude workaround, however I wasn't able to come up with any cleaner solution.