### PR TITLE
Move urSamplerGetInfo success test from a switch to individual tests

### DIFF
--- a/test/conformance/sampler/sampler_adapter_level_zero.match
+++ b/test/conformance/sampler/sampler_adapter_level_zero.match
@@ -1,4 +1,8 @@
-{{OPT}}urSamplerGetInfoTestWithParam.Success/*
+{{OPT}}urSamplerGetInfoTest.SuccessReferenceCount/*
+{{OPT}}urSamplerGetInfoTest.SuccessContext/*
+{{OPT}}urSamplerGetInfoTest.SuccessNormalizedCoords/*
+{{OPT}}urSamplerGetInfoTest.SuccessAddressingMode/*
+{{OPT}}urSamplerGetInfoTest.SuccessFilterMode/*
 {{OPT}}urSamplerGetInfoTest.InvalidSizePropSizeSmall/*
 {{OPT}}urSamplerReleaseTest.Success/*
 {{OPT}}urSamplerRetainTest.Success/*

--- a/test/conformance/sampler/urSamplerGetInfo.cpp
+++ b/test/conformance/sampler/urSamplerGetInfo.cpp
@@ -5,60 +5,71 @@
 
 #include <uur/fixtures.h>
 
-using urSamplerGetInfoTestWithParam =
-    uur::urSamplerTestWithParam<ur_sampler_info_t>;
-UUR_TEST_SUITE_P(urSamplerGetInfoTestWithParam,
-                 ::testing::Values(UR_SAMPLER_INFO_REFERENCE_COUNT,
-                                   UR_SAMPLER_INFO_CONTEXT,
-                                   UR_SAMPLER_INFO_NORMALIZED_COORDS,
-                                   UR_SAMPLER_INFO_ADDRESSING_MODE,
-                                   UR_SAMPLER_INFO_FILTER_MODE),
-                 uur::deviceTestWithParamPrinter<ur_sampler_info_t>);
-
-TEST_P(urSamplerGetInfoTestWithParam, Success) {
-    size_t size = 0;
-    ur_sampler_info_t info = getParam();
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urSamplerGetInfo(sampler, info, 0, nullptr, &size), info);
-    ASSERT_NE(size, 0);
-    std::vector<uint8_t> infoData(size);
-    ASSERT_SUCCESS(
-        urSamplerGetInfo(sampler, info, size, infoData.data(), nullptr));
-
-    switch (info) {
-    case UR_SAMPLER_INFO_REFERENCE_COUNT: {
-        auto *value = reinterpret_cast<uint32_t *>(infoData.data());
-        ASSERT_TRUE(*value > 0);
-        break;
-    }
-    case UR_SAMPLER_INFO_CONTEXT: {
-        auto *value = reinterpret_cast<ur_context_handle_t *>(infoData.data());
-        ASSERT_EQ(*value, this->context);
-        break;
-    }
-    case UR_SAMPLER_INFO_NORMALIZED_COORDS: {
-        auto *value = reinterpret_cast<ur_bool_t *>(infoData.data());
-        ASSERT_EQ(*value, sampler_desc.normalizedCoords);
-        break;
-    }
-    case UR_SAMPLER_INFO_ADDRESSING_MODE: {
-        auto *value =
-            reinterpret_cast<ur_sampler_addressing_mode_t *>(infoData.data());
-        ASSERT_EQ(*value, sampler_desc.addressingMode);
-        break;
-    }
-    case UR_SAMPLER_INFO_FILTER_MODE: {
-        auto *value =
-            reinterpret_cast<ur_sampler_filter_mode_t *>(infoData.data());
-        ASSERT_EQ(*value, sampler_desc.filterMode);
-    }
-    default:
-        break;
-    }
-}
-
 using urSamplerGetInfoTest = uur::urSamplerTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetInfoTest);
+
+TEST_P(urSamplerGetInfoTest, SuccessReferenceCount) {
+    size_t size = 0;
+    auto infoType = UR_SAMPLER_INFO_REFERENCE_COUNT;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
+    ASSERT_EQ(sizeof(uint32_t), size);
+
+    uint32_t returned_reference_count = 0;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, size,
+                                    &returned_reference_count, nullptr));
+
+    ASSERT_GT(returned_reference_count, 0U);
+}
+
+TEST_P(urSamplerGetInfoTest, SuccessContext) {
+    size_t size = 0;
+    auto infoType = UR_SAMPLER_INFO_CONTEXT;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
+    ASSERT_EQ(sizeof(ur_context_handle_t), size);
+
+    ur_context_handle_t returned_context = nullptr;
+    ASSERT_SUCCESS(
+        urSamplerGetInfo(sampler, infoType, size, &returned_context, nullptr));
+
+    ASSERT_EQ(returned_context, context);
+}
+
+TEST_P(urSamplerGetInfoTest, SuccessNormalizedCoords) {
+    size_t size = 0;
+    auto infoType = UR_SAMPLER_INFO_NORMALIZED_COORDS;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
+    ASSERT_EQ(sizeof(ur_bool_t), size);
+}
+
+TEST_P(urSamplerGetInfoTest, SuccessAddressingMode) {
+    size_t size = 0;
+    auto infoType = UR_SAMPLER_INFO_ADDRESSING_MODE;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
+    ASSERT_EQ(sizeof(ur_sampler_addressing_mode_t), size);
+
+    ur_sampler_addressing_mode_t returned_mode =
+        UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32;
+    ASSERT_SUCCESS(
+        urSamplerGetInfo(sampler, infoType, size, &returned_mode, nullptr));
+
+    ASSERT_GE(returned_mode, UR_SAMPLER_ADDRESSING_MODE_NONE);
+    ASSERT_LT(returned_mode, UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32);
+}
+
+TEST_P(urSamplerGetInfoTest, SuccessFilterMode) {
+    size_t size = 0;
+    auto infoType = UR_SAMPLER_INFO_FILTER_MODE;
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
+    ASSERT_EQ(sizeof(ur_sampler_filter_mode_t), size);
+
+    ur_sampler_filter_mode_t returned_mode =
+        UR_SAMPLER_FILTER_MODE_FORCE_UINT32;
+    ASSERT_SUCCESS(
+        urSamplerGetInfo(sampler, infoType, size, &returned_mode, nullptr));
+
+    ASSERT_GE(returned_mode, UR_SAMPLER_FILTER_MODE_NEAREST);
+    ASSERT_LT(returned_mode, UR_SAMPLER_FILTER_MODE_FORCE_UINT32);
+}
 
 TEST_P(urSamplerGetInfoTest, InvalidNullHandleSampler) {
     uint32_t refcount = 0;
@@ -88,14 +99,14 @@ TEST_P(urSamplerGetInfoTest, InvalidNullPointerPropValue) {
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidSizePropSizeZero) {
-    ur_sampler_addressing_mode_t mode;
+    ur_sampler_addressing_mode_t mode = UR_SAMPLER_ADDRESSING_MODE_NONE;
     ASSERT_EQ_RESULT(urSamplerGetInfo(sampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
                                       0, &mode, nullptr),
                      UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidSizePropSizeSmall) {
-    ur_sampler_addressing_mode_t mode;
+    ur_sampler_addressing_mode_t mode = UR_SAMPLER_ADDRESSING_MODE_NONE;
     ASSERT_EQ_RESULT(urSamplerGetInfo(sampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
                                       sizeof(mode) - 1, &mode, nullptr),
                      UR_RESULT_ERROR_INVALID_SIZE);


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/2290