### PR TITLE
Added `DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS`

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2198,6 +2198,9 @@ typedef enum ur_device_info_t {
   /// to the `USMPool` entry points and usage of the `pool` parameter of the
   /// USM alloc entry points.
   UR_DEVICE_INFO_USM_POOL_SUPPORT = 119,
+  /// [::ur_bool_t] support the ::urProgramSetSpecializationConstants entry
+  /// point
+  UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS = 120,
   /// [::ur_bool_t] Returns true if the device supports the use of
   /// command-buffers.
   UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP = 0x1000,
@@ -5739,6 +5742,10 @@ typedef struct ur_specialization_constant_info_t {
 /// @brief Set an array of specialization constants on a Program.
 ///
 /// @details
+///     - This entry point is optional, the application should query for support
+///       with device query
+///       ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS passed to
+///       ::urDeviceGetInfo.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
@@ -5758,6 +5765,9 @@ typedef struct ur_specialization_constant_info_t {
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS query is
+///         false
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + A pSpecConstant entry contains a size that does not match that of
 ///         the specialization constant in the module.

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -2917,6 +2917,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_device_info_t value) {
   case UR_DEVICE_INFO_USM_POOL_SUPPORT:
     os << "UR_DEVICE_INFO_USM_POOL_SUPPORT";
     break;
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
+    os << "UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS";
+    break;
   case UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP:
     os << "UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP";
     break;
@@ -4536,6 +4539,19 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << ")";
   } break;
   case UR_DEVICE_INFO_USM_POOL_SUPPORT: {
+    const ur_bool_t *tptr = (const ur_bool_t *)ptr;
+    if (sizeof(ur_bool_t) > size) {
+      os << "invalid size (is: " << size
+         << ", expected: >=" << sizeof(ur_bool_t) << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
     const ur_bool_t *tptr = (const ur_bool_t *)ptr;
     if (sizeof(ur_bool_t) > size) {
       os << "invalid size (is: " << size

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -443,6 +443,8 @@ etors:
       desc: "[$x_bool_t] return true if the device supports the `EnqueueDeviceGlobalVariableWrite` and `EnqueueDeviceGlobalVariableRead` entry points."
     - name: USM_POOL_SUPPORT
       desc: "[$x_bool_t] return true if the device supports USM pooling. Pertains to the `USMPool` entry points and usage of the `pool` parameter of the USM alloc entry points."
+    - name: PROGRAM_SET_SPECIALIZATION_CONSTANTS
+      desc: "[$x_bool_t] support the $xProgramSetSpecializationConstants entry point"
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Retrieves various information about device"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -528,6 +528,7 @@ desc: "Set an array of specialization constants on a Program."
 class: $xProgram
 name: SetSpecializationConstants
 details:
+    - "This entry point is optional, the application should query for support with device query $X_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS passed to $xDeviceGetInfo."
     - "The application may call this function from simultaneous threads for the same device."
     - "The implementation of this function should be thread-safe."
     - "`hProgram` must have been created with the $xProgramCreateWithIL entry point."
@@ -546,6 +547,8 @@ params:
 returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "`count == 0`"
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
+        - "If $X_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS query is false"
     - $X_RESULT_ERROR_INVALID_VALUE:
         - "A pSpecConstant entry contains a size that does not match that of the specialization constant in the module."
         - "A pSpecConstant entry contains a nullptr pValue."

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -1065,6 +1065,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(AddressBuffer,
                        strnlen(AddressBuffer, AddressBufferSize - 1) + 1);
   }
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
   case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
     return ReturnValue(static_cast<ur_bool_t>(false));
     // TODO: Investigate if this information is available on CUDA.

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -789,6 +789,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(ur_bool_t{false});
   }
 
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
+    return ReturnValue(ur_bool_t{false});
+  }
+
   case UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
     ur_memory_order_capability_flags_t Capabilities =
         UR_MEMORY_ORDER_CAPABILITY_FLAG_RELAXED |

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1156,6 +1156,8 @@ ur_result_t urDeviceGetInfo(
     // L0 does not support sampling 1D USM sampled image data.
     return ReturnValue(false);
   }
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
+    return ReturnValue(true);
   case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
     return ReturnValue(false);
   case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -428,6 +428,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
     return ReturnValue(false);
+
+  case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
+    return ReturnValue(false);
+
   default:
     DIE_NO_IMPLEMENTATION;
   }

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -7,6 +7,7 @@
 //===-----------------------------------------------------------------===//
 
 #include "device.hpp"
+#include "adapter.hpp"
 #include "common.hpp"
 #include "platform.hpp"
 
@@ -1123,6 +1124,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
                         CL_DEVICE_UUID_KHR, UUID.size(), UUID.data(), nullptr));
     return ReturnValue(UUID);
+  }
+
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
+    return ReturnValue(
+        ur::cl::getAdapter()->clSetProgramSpecializationConstant != nullptr);
   }
 
   // We can't query to check if these are supported, they will need to be

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3543,6 +3543,10 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 /// @brief Set an array of specialization constants on a Program.
 ///
 /// @details
+///     - This entry point is optional, the application should query for support
+///       with device query
+///       ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS passed to
+///       ::urDeviceGetInfo.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
@@ -3562,6 +3566,9 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS query is
+///         false
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + A pSpecConstant entry contains a size that does not match that of
 ///         the specialization constant in the module.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3109,6 +3109,10 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 /// @brief Set an array of specialization constants on a Program.
 ///
 /// @details
+///     - This entry point is optional, the application should query for support
+///       with device query
+///       ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS passed to
+///       ::urDeviceGetInfo.
 ///     - The application may call this function from simultaneous threads for
 ///       the same device.
 ///     - The implementation of this function should be thread-safe.
@@ -3128,6 +3132,9 @@ ur_result_t UR_APICALL urProgramGetBuildInfo(
 ///         + `NULL == pSpecConstants`
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
 ///         + `count == 0`
+///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
+///         + If ::UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS query is
+///         false
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + A pSpecConstant entry contains a size that does not match that of
 ///         the specialization constant in the module.

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -110,6 +110,7 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_BFLOAT16, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, sizeof(uint32_t)},
     {UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
+    {UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_MEMORY_BUS_WIDTH, sizeof(uint32_t)},
     {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(size_t[3])},
     {UR_DEVICE_INFO_ASYNC_BARRIER, sizeof(ur_bool_t)},
@@ -251,7 +252,8 @@ UUR_DEVICE_TEST_SUITE_P(
         UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP,        //
         UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE,          //
         UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF,            //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT              //
+        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT,             //
+        UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS    //
         ),
     uur::deviceTestWithParamPrinter<ur_device_info_t>);
 

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -327,6 +327,9 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_USM_POOL_SUPPORT);
   std::cout << prefix;
+  printDeviceInfo<ur_bool_t>(
+      hDevice, UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS);
+  std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice,
                              UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP);
   std::cout << prefix;


### PR DESCRIPTION
THis is similar to the existing
`DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS` device info, only
it applies to programs rather than kernels. All of the adapters should
be updated to report it correctly, and tests have been added.
