### PR TITLE
Fix Unsupported feature returns

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5369,15 +5369,12 @@ urKernelSetSpecializationConstants(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel,        ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel,        ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 );
 
@@ -5415,7 +5412,6 @@ typedef struct ur_kernel_native_properties_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 UR_APIEXPORT ur_result_t UR_APICALL
 urKernelCreateWithNativeHandle(
     ur_native_handle_t hNativeKernel,                 ///< [in][nocheck] the native handle of the kernel.

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -495,14 +495,13 @@ params:
     - type: "$x_kernel_handle_t"
       name: hKernel
       desc: |
-            [in] handle of the kernel.
+            [in][nocheck] handle of the kernel.
     - type: $x_native_handle_t*
       name: phNativeKernel
       desc: |
             [out] a pointer to the native handle of the kernel.
 returns:
-    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "If the adapter has no underlying equivalent handle."
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Properties for for $xKernelCreateWithNativeHandle."
@@ -547,8 +546,7 @@ params:
       desc: |
             [out] pointer to the handle of the kernel object created.
 returns:
-    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
-        - "If the adapter has no underlying equivalent handle."
+    - $X_RESULT_ERROR_UNSUPPORTED_FEATURE
     - $X_RESULT_ERROR_INVALID_NULL_HANDLE:
         - "If `hProgram == NULL` and the implementation requires a valid program."
 --- #--------------------------------------------------------------------------

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -4507,7 +4507,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
     ) try {

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -3812,7 +3812,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3898,7 +3898,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
@@ -3910,10 +3910,6 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
     }
 
     if (getContext()->enableParameterValidation) {
-        if (NULL == hKernel) {
-            return UR_RESULT_ERROR_INVALID_NULL_HANDLE;
-        }
-
         if (NULL == phNativeKernel) {
             return UR_RESULT_ERROR_INVALID_NULL_POINTER;
         }

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -3744,7 +3744,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Intercept function for urKernelGetNativeHandle
 __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -4187,14 +4187,11 @@ ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
     ) try {
@@ -4231,7 +4228,6 @@ ur_result_t UR_APICALL urKernelGetNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3564,14 +3564,11 @@ ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 ///     - ::UR_RESULT_ERROR_UNINITIALIZED
 ///     - ::UR_RESULT_ERROR_DEVICE_LOST
 ///     - ::UR_RESULT_ERROR_ADAPTER_SPECIFIC
-///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
-///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phNativeKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 ur_result_t UR_APICALL urKernelGetNativeHandle(
-    ur_kernel_handle_t hKernel, ///< [in] handle of the kernel.
+    ur_kernel_handle_t hKernel, ///< [in][nocheck] handle of the kernel.
     ur_native_handle_t
         *phNativeKernel ///< [out] a pointer to the native handle of the kernel.
 ) {
@@ -3601,7 +3598,6 @@ ur_result_t UR_APICALL urKernelGetNativeHandle(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phKernel`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE
-///         + If the adapter has no underlying equivalent handle.
 ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_native_handle_t
         hNativeKernel, ///< [in][nocheck] the native handle of the kernel.


### PR DESCRIPTION
* urKernelCreateWithNativeHandle handle param is [nocheck]. Remove invalid handle as reason to return unsupported feature.
* Mark urKernelGetNativeHandle handle param as [nocheck]. Remove invalid handle as reason to return unsupported feature.