### PR TITLE
Move urMemImageGetInfo success test from a switch to individual test

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3324,6 +3324,12 @@ typedef enum ur_image_info_t {
   UR_IMAGE_INFO_HEIGHT = 5,
   /// [size_t] image depth
   UR_IMAGE_INFO_DEPTH = 6,
+  /// [size_t] array size
+  UR_IMAGE_INFO_ARRAY_SIZE = 7,
+  /// [uint32_t] number of MIP levels
+  UR_IMAGE_INFO_NUM_MIP_LEVELS = 8,
+  /// [uint32_t] number of samples
+  UR_IMAGE_INFO_NUM_SAMPLES = 9,
   /// @cond
   UR_IMAGE_INFO_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -3837,7 +3843,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -9499,7 +9505,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -6466,6 +6466,15 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_image_info_t value) {
   case UR_IMAGE_INFO_DEPTH:
     os << "UR_IMAGE_INFO_DEPTH";
     break;
+  case UR_IMAGE_INFO_ARRAY_SIZE:
+    os << "UR_IMAGE_INFO_ARRAY_SIZE";
+    break;
+  case UR_IMAGE_INFO_NUM_MIP_LEVELS:
+    os << "UR_IMAGE_INFO_NUM_MIP_LEVELS";
+    break;
+  case UR_IMAGE_INFO_NUM_SAMPLES:
+    os << "UR_IMAGE_INFO_NUM_SAMPLES";
+    break;
   default:
     os << "unknown enumerator";
     break;
@@ -6565,6 +6574,45 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     const size_t *tptr = (const size_t *)ptr;
     if (sizeof(size_t) > size) {
       os << "invalid size (is: " << size << ", expected: >=" << sizeof(size_t)
+         << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_IMAGE_INFO_ARRAY_SIZE: {
+    const size_t *tptr = (const size_t *)ptr;
+    if (sizeof(size_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(size_t)
+         << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_IMAGE_INFO_NUM_MIP_LEVELS: {
+    const uint32_t *tptr = (const uint32_t *)ptr;
+    if (sizeof(uint32_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)
+         << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_IMAGE_INFO_NUM_SAMPLES: {
+    const uint32_t *tptr = (const uint32_t *)ptr;
+    if (sizeof(uint32_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)
          << ")";
       return UR_RESULT_ERROR_INVALID_SIZE;
     }

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -160,6 +160,12 @@ etors:
     desc: "[size_t] image height"
   - name: DEPTH
     desc: "[size_t] image depth"
+  - name: ARRAY_SIZE
+    desc: "[size_t] array size"
+  - name: NUM_MIP_LEVELS
+    desc: "[uint32_t] number of MIP levels"
+  - name: NUM_SAMPLES
+    desc: "[uint32_t] number of samples"
 --- #--------------------------------------------------------------------------
 type: struct
 desc: "Image format including channel layout and data type"

--- a/source/adapters/opencl/memory.cpp
+++ b/source/adapters/opencl/memory.cpp
@@ -10,6 +10,92 @@
 
 #include "common.hpp"
 
+#include <unordered_map>
+
+const std::unordered_map<ur_image_channel_order_t, cl_channel_order>
+    ChannelOrderMap = {
+        {UR_IMAGE_CHANNEL_ORDER_A, CL_A},
+        {UR_IMAGE_CHANNEL_ORDER_R, CL_R},
+        {UR_IMAGE_CHANNEL_ORDER_RG, CL_RG},
+        {UR_IMAGE_CHANNEL_ORDER_RA, CL_RA},
+        {UR_IMAGE_CHANNEL_ORDER_RGB, CL_RGB},
+        {UR_IMAGE_CHANNEL_ORDER_RGBA, CL_RGBA},
+        {UR_IMAGE_CHANNEL_ORDER_BGRA, CL_BGRA},
+        {UR_IMAGE_CHANNEL_ORDER_ARGB, CL_ARGB},
+        {UR_IMAGE_CHANNEL_ORDER_ABGR, CL_ABGR},
+        {UR_IMAGE_CHANNEL_ORDER_INTENSITY, CL_INTENSITY},
+        {UR_IMAGE_CHANNEL_ORDER_LUMINANCE, CL_LUMINANCE},
+        {UR_IMAGE_CHANNEL_ORDER_RX, CL_Rx},
+        {UR_IMAGE_CHANNEL_ORDER_RGX, CL_RGx},
+        {UR_IMAGE_CHANNEL_ORDER_RGBX, CL_RGBx},
+        {UR_IMAGE_CHANNEL_ORDER_SRGBA, CL_sRGBA},
+};
+
+const std::unordered_map<ur_image_channel_type_t, cl_channel_type>
+    ChannelTypeMap = {
+        {UR_IMAGE_CHANNEL_TYPE_SNORM_INT8, CL_SNORM_INT8},
+        {UR_IMAGE_CHANNEL_TYPE_SNORM_INT16, CL_SNORM_INT16},
+        {UR_IMAGE_CHANNEL_TYPE_UNORM_INT8, CL_UNORM_INT8},
+        {UR_IMAGE_CHANNEL_TYPE_UNORM_INT16, CL_UNORM_INT16},
+        {UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_565, CL_UNORM_SHORT_565},
+        {UR_IMAGE_CHANNEL_TYPE_UNORM_SHORT_555, CL_UNORM_SHORT_555},
+        {UR_IMAGE_CHANNEL_TYPE_INT_101010, CL_UNORM_INT_101010},
+        {UR_IMAGE_CHANNEL_TYPE_SIGNED_INT8, CL_SIGNED_INT8},
+        {UR_IMAGE_CHANNEL_TYPE_SIGNED_INT16, CL_SIGNED_INT16},
+        {UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32, CL_SIGNED_INT32},
+        {UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8, CL_UNSIGNED_INT8},
+        {UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT16, CL_UNSIGNED_INT16},
+        {UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32, CL_UNSIGNED_INT32},
+        {UR_IMAGE_CHANNEL_TYPE_HALF_FLOAT, CL_HALF_FLOAT},
+        {UR_IMAGE_CHANNEL_TYPE_FLOAT, CL_FLOAT},
+};
+
+cl_image_format mapURImageFormatToCL(const ur_image_format_t &PImageFormat) {
+  cl_image_format CLImageFormat = {UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32,
+                                   UR_IMAGE_CHANNEL_TYPE_FORCE_UINT32};
+
+  auto channelOrderIt = ChannelOrderMap.find(PImageFormat.channelOrder);
+  if (channelOrderIt != ChannelOrderMap.end()) {
+    CLImageFormat.image_channel_order = channelOrderIt->second;
+  }
+
+  auto channelTypeIt = ChannelTypeMap.find(PImageFormat.channelType);
+  if (channelTypeIt != ChannelTypeMap.end()) {
+    CLImageFormat.image_channel_data_type = channelTypeIt->second;
+  }
+
+  return CLImageFormat;
+}
+
+ur_image_format_t mapCLImageFormatToUR(const cl_image_format *PImageFormat) {
+  ur_image_format_t URImageFormat = {UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32,
+                                     UR_IMAGE_CHANNEL_TYPE_FORCE_UINT32};
+
+  auto reverseChannelOrderIt =
+      std::find_if(ChannelOrderMap.begin(), ChannelOrderMap.end(),
+                   [PImageFormat](const auto &pair) {
+                     return pair.second == PImageFormat->image_channel_order;
+                   });
+  if (reverseChannelOrderIt != ChannelOrderMap.end()) {
+    URImageFormat.channelOrder = reverseChannelOrderIt->first;
+  }
+
+  URImageFormat.channelOrder = (reverseChannelOrderIt != ChannelOrderMap.end())
+                                   ? reverseChannelOrderIt->first
+                                   : UR_IMAGE_CHANNEL_ORDER_FORCE_UINT32;
+
+  auto reverseChannelTypeIt = std::find_if(
+      ChannelTypeMap.begin(), ChannelTypeMap.end(),
+      [PImageFormat](const auto &pair) {
+        return pair.second == PImageFormat->image_channel_data_type;
+      });
+  if (reverseChannelTypeIt != ChannelTypeMap.end()) {
+    URImageFormat.channelType = reverseChannelTypeIt->first;
+  }
+
+  return URImageFormat;
+}
+
 cl_image_format mapURImageFormatToCL(const ur_image_format_t *PImageFormat) {
   cl_image_format CLImageFormat;
   switch (PImageFormat->channelOrder) {
@@ -174,6 +260,12 @@ cl_int mapURMemImageInfoToCL(ur_image_info_t URPropName) {
     return CL_IMAGE_HEIGHT;
   case UR_IMAGE_INFO_DEPTH:
     return CL_IMAGE_DEPTH;
+  case UR_IMAGE_INFO_ARRAY_SIZE:
+    return CL_IMAGE_ARRAY_SIZE;
+  case UR_IMAGE_INFO_NUM_MIP_LEVELS:
+    return CL_IMAGE_NUM_MIP_LEVELS;
+  case UR_IMAGE_INFO_NUM_SAMPLES:
+    return CL_IMAGE_NUM_SAMPLES;
   default:
     return -1;
   }
@@ -397,7 +489,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
   CL_RETURN_ON_FAILURE(ClResult);
   if (pPropSizeRet) {
     *pPropSizeRet = CheckPropSize;
+  } else {
+    if (propName == UR_IMAGE_INFO_FORMAT) {
+      ur_image_format_t format = mapCLImageFormatToUR(
+          reinterpret_cast<const cl_image_format *>(pPropValue));
+      return ReturnValue(format);
+    }
   }
+
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -1470,7 +1470,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     if (pPropValue == NULL && pPropSizeRet == NULL)
       return UR_RESULT_ERROR_INVALID_NULL_POINTER;
 
-    if (UR_IMAGE_INFO_DEPTH < propName)
+    if (UR_IMAGE_INFO_NUM_SAMPLES < propName)
       return UR_RESULT_ERROR_INVALID_ENUMERATION;
 
     if (propSize == 0 && pPropValue != NULL)
@@ -7069,7 +7069,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     if (pPropValue == NULL && pPropSizeRet == NULL)
       return UR_RESULT_ERROR_INVALID_NULL_POINTER;
 
-    if (UR_IMAGE_INFO_DEPTH < propName)
+    if (UR_IMAGE_INFO_NUM_SAMPLES < propName)
       return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
 

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -1943,7 +1943,7 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -7120,7 +7120,7 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1720,7 +1720,7 @@ ur_result_t UR_APICALL urMemGetInfo(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hMemory`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE
@@ -6249,7 +6249,7 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hContext`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_IMAGE_INFO_DEPTH < propName`
+///         + `::UR_IMAGE_INFO_NUM_SAMPLES < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -170,30 +170,34 @@ struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
 
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetInfoDeviceQueueTestWithInfoParam);
 
-TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, DeviceDefault) {
-  size_t size = 0;
+TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, SuccessDeviceDefault) {
+  size_t property_size = 0;
   ur_queue_info_t property_name = UR_QUEUE_INFO_DEVICE_DEFAULT;
+
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-      urQueueGetInfo(queue, property_name, 0, nullptr, &size), property_name);
-  ASSERT_EQ(sizeof(ur_queue_handle_t), size);
+      urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(sizeof(ur_queue_handle_t), property_size);
 
   ur_queue_handle_t returned_queue = nullptr;
-  ASSERT_SUCCESS(
-      urQueueGetInfo(queue, property_name, size, &returned_queue, nullptr));
+  ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
+                                &returned_queue, nullptr));
 
   ASSERT_EQ(queue, returned_queue);
 }
 
-TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, Size) {
-  size_t size = 0;
+TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, SuccessSize) {
+  size_t property_size = 0;
   ur_queue_info_t property_name = UR_QUEUE_INFO_SIZE;
+
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-      urQueueGetInfo(queue, property_name, 0, nullptr, &size), property_name);
-  ASSERT_EQ(sizeof(uint32_t), size);
+      urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(sizeof(uint32_t), property_size);
 
   uint32_t returned_size = 0;
-  ASSERT_SUCCESS(
-      urQueueGetInfo(queue, property_name, size, &returned_size, nullptr));
+  ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
+                                &returned_size, nullptr));
 
   ASSERT_GT(returned_size, 0);
 }

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -358,44 +358,6 @@ template <class T> struct urSamplerTestWithParam : urContextTestWithParam<T> {
   ur_sampler_desc_t sampler_desc;
 };
 
-template <class T> struct urMemImageTestWithParam : urContextTestWithParam<T> {
-  void SetUp() override {
-    UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
-    ur_bool_t imageSupported = false;
-    ASSERT_SUCCESS(urDeviceGetInfo(this->device, UR_DEVICE_INFO_IMAGE_SUPPORTED,
-                                   sizeof(ur_bool_t), &imageSupported,
-                                   nullptr));
-    if (!imageSupported) {
-      GTEST_SKIP();
-    }
-    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-        urMemImageCreate(this->context, UR_MEM_FLAG_READ_WRITE, &format, &desc,
-                         nullptr, &image));
-    ASSERT_NE(nullptr, image);
-  }
-
-  void TearDown() override {
-    if (image) {
-      EXPECT_SUCCESS(urMemRelease(image));
-    }
-    UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
-  }
-  ur_mem_handle_t image = nullptr;
-  ur_image_format_t format = {UR_IMAGE_CHANNEL_ORDER_RGBA,
-                              UR_IMAGE_CHANNEL_TYPE_FLOAT};
-  ur_image_desc_t desc = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                          nullptr,                      // pNext
-                          UR_MEM_TYPE_IMAGE1D,          // mem object type
-                          1024,                         // image width
-                          1,                            // image height
-                          1,                            // image depth
-                          1,                            // array size
-                          0,                            // row pitch
-                          0,                            // slice pitch
-                          0,                            // mip levels
-                          0};                           // num samples
-};
-
 struct urQueueTest : urContextTest {
   void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/2290

Also adds a few missing enums to the `ur_image_info_t` struct

https://github.com/intel/llvm/pull/16655