### PR TITLE
Enable creation of bindless images backed by host USM

### DIFF
--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -533,8 +533,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
         image_res_desc.resType = CU_RESOURCE_TYPE_MIPMAPPED_ARRAY;
         image_res_desc.res.mipmap.hMipmappedArray = (CUmipmappedArray)hImageMem;
       }
-    } else if (mem_type == CU_MEMORYTYPE_DEVICE) {
-      // We have a USM pointer
+    } else if (mem_type == CU_MEMORYTYPE_DEVICE ||
+               mem_type == CU_MEMORYTYPE_HOST) {
+      // We have a USM pointer.
+      // Images may be created from device or host USM.
       if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
         image_res_desc.resType = CU_RESOURCE_TYPE_LINEAR;
         image_res_desc.res.linear.devPtr = (CUdeviceptr)hImageMem;


### PR DESCRIPTION
Small patch to enable bindless images backed by host USM in the CUDA adapter.

Host and Device USM pointers are usable across the host and device for all versions of CUDA that we support. There is no need to provide the `CU_MEMHOSTALLOC_DEVICEMAP` flag during allocation, or calling `cuMemHostGetDevicePointer` to retrieve a device usable address.

Passing a `CU_MEMHOSTALLOC_WRITECOMBINED` flag to the host USM allocation will enhance performance in certain scenarios, however, an extension allowing this is not yet available.

Related DPC++ PR: https://github.com/intel/llvm/pull/16607