### PR TITLE
[L0 v2] introduce raii wrapper for UR handles

### DIFF
--- a/source/adapters/level_zero/v2/event.cpp
+++ b/source/adapters/level_zero/v2/event.cpp
@@ -154,6 +154,9 @@ ur_result_t ur_event_handle_t_::release() {
   if (isTimestamped() && !getEventEndTimestamp()) {
     // L0 will write end timestamp to this event some time in the future,
     // so we can't release it yet.
+
+    // If this code is being executed, queue has to be valid (queue cannot
+    // be released before all operations complete).
     assert(hQueue);
     hQueue->deferEventFree(this);
     return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/v2/event.hpp
+++ b/source/adapters/level_zero/v2/event.hpp
@@ -104,7 +104,7 @@ protected:
   const ze_event_handle_t hZeEvent;
 
   // queue and commandType that this event is associated with, set by enqueue
-  // commands
+  // commands.
   ur_queue_handle_t hQueue = nullptr;
   ur_command_t commandType = UR_COMMAND_FORCE_UINT32;
 
@@ -134,3 +134,27 @@ struct ur_native_event_t : ur_event_handle_t_ {
 private:
   v2::raii::ze_event_handle_t zeEvent;
 };
+
+namespace v2 {
+
+inline ur_result_t
+deferredEventRetain([[maybe_unused]] ur_event_handle_t hEvent) {
+  assert(hEvent);
+  assert(reinterpret_cast<_ur_object *>(hEvent)->RefCount.load() == 0);
+  return UR_RESULT_SUCCESS;
+}
+
+inline ur_result_t
+defferedEventRelease([[maybe_unused]] ur_event_handle_t hEvent) {
+  assert(hEvent);
+  assert(reinterpret_cast<_ur_object *>(hEvent)->RefCount.load() == 0);
+  return UR_RESULT_SUCCESS;
+}
+
+// deferredEvents have refCount equal to 0, the only operation that can be
+// called on them is releaseDeferred()
+using deferred_event_handle_t =
+    v2::raii::ref_counted<ur_event_handle_t, deferredEventRetain,
+                          defferedEventRelease>;
+
+} // namespace v2

--- a/source/adapters/level_zero/v2/event_pool.hpp
+++ b/source/adapters/level_zero/v2/event_pool.hpp
@@ -28,7 +28,6 @@ namespace v2 {
 
 class event_pool {
 public:
-  // store weak reference to the queue as event_pool is part of the queue
   event_pool(ur_context_handle_t hContext,
              std::unique_ptr<event_provider> Provider)
       : hContext(hContext), provider(std::move(Provider)),

--- a/source/adapters/level_zero/v2/event_pool_cache.cpp
+++ b/source/adapters/level_zero/v2/event_pool_cache.cpp
@@ -16,7 +16,7 @@ namespace v2 {
 event_pool_cache::event_pool_cache(ur_context_handle_t hContext,
                                    size_t max_devices,
                                    ProviderCreateFunc ProviderCreate)
-    : hContext(hContext), providerCreate(ProviderCreate) {
+    : hContext(std::move(hContext)), providerCreate(ProviderCreate) {
   pools.resize(max_devices * (1ULL << EVENT_FLAGS_USED_BITS));
 }
 

--- a/source/adapters/level_zero/v2/kernel.hpp
+++ b/source/adapters/level_zero/v2/kernel.hpp
@@ -18,7 +18,6 @@
 struct ur_single_device_kernel_t {
   ur_single_device_kernel_t(ur_device_handle_t hDevice,
                             ze_kernel_handle_t hKernel, bool ownZeHandle);
-  ur_result_t release();
 
   ur_device_handle_t hDevice;
   v2::raii::ze_kernel_handle_t hKernel;
@@ -74,7 +73,7 @@ public:
 
   std::vector<char> getSourceAttributes() const;
 
-  // Perform cleanup.
+  // Decrease the refcount and call destructor if new refcount == 0.
   ur_result_t release();
 
   // Add a pending memory allocation for which device is not yet known.
@@ -92,7 +91,7 @@ public:
 
 private:
   // Keep the program of the kernel.
-  const ur_program_handle_t hProgram;
+  const v2::raii::rc<ur_program_handle_t> hProgram;
 
   // Vector of ur_single_device_kernel_t indexed by deviceIndex().
   std::vector<std::optional<ur_single_device_kernel_t>> deviceKernels;

--- a/source/adapters/level_zero/v2/memory.hpp
+++ b/source/adapters/level_zero/v2/memory.hpp
@@ -48,7 +48,7 @@ struct ur_mem_handle_t_ : private _ur_object {
 
 protected:
   const device_access_mode_t accessMode;
-  const ur_context_handle_t hContext;
+  const v2::raii::rc<ur_context_handle_t> hContext;
   const size_t size;
 };
 
@@ -140,7 +140,6 @@ private:
   std::vector<usm_unique_ptr_t> deviceAllocations;
 
   // Specifies device on which the latest allocation resides.
-  // If null, there is no allocation.
   ur_device_handle_t activeAllocationDevice = nullptr;
 
   // If not null, copy the buffer content back to this memory on release.
@@ -157,7 +156,6 @@ private:
 struct ur_mem_sub_buffer_t : public ur_mem_handle_t_ {
   ur_mem_sub_buffer_t(ur_mem_handle_t hParent, size_t offset, size_t size,
                       device_access_mode_t accesMode);
-  ~ur_mem_sub_buffer_t();
 
   void *
   getDevicePtr(ur_device_handle_t, device_access_mode_t, size_t offset,
@@ -172,7 +170,7 @@ struct ur_mem_sub_buffer_t : public ur_mem_handle_t_ {
   ur_shared_mutex &getMutex() override;
 
 private:
-  ur_mem_handle_t hParent;
+  v2::raii::rc<ur_mem_handle_t> hParent;
   size_t offset;
   size_t size;
 };

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -36,7 +36,7 @@ struct ur_command_list_handler_t {
 
 struct ur_queue_immediate_in_order_t : _ur_object, public ur_queue_handle_t_ {
 private:
-  ur_context_handle_t hContext;
+  v2::raii::rc<ur_context_handle_t> hContext;
   ur_device_handle_t hDevice;
   ur_queue_flags_t flags;
 
@@ -46,8 +46,8 @@ private:
 
   std::vector<ze_event_handle_t> waitList;
 
-  std::vector<ur_event_handle_t> deferredEvents;
-  std::vector<ur_kernel_handle_t> submittedKernels;
+  std::vector<deferred_event_handle_t> deferredEvents;
+  std::vector<raii::rc<ur_kernel_handle_t>> submittedKernels;
 
   std::pair<ze_event_handle_t *, uint32_t>
   getWaitListView(const ur_event_handle_t *phWaitEvents,


### PR DESCRIPTION
Some entities (e.g. devices) do not need to be retained as they are owned by the platform. For such cases, only validate RefCount instead of acutally increasing/decreasing it.

It doesn't seem to be necessary to retain context whenever it's used to construct queue, etc. However, the spec is not very clear on this. I'm wondering if we should we update the spec or add retains on context?

Also, there are a few instances where I think calling retain() might be justified (we are not calling it right now) - e.g. when passing ur_mem_handle_t to urKernelSetArgMemObj / urKernelSetArgSampler.