### PR TITLE
Fix error returns of urUSMHostAlloc

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -3554,10 +3554,10 @@ typedef struct ur_usm_pool_limits_desc_t {
 ///         + If ::UR_DEVICE_INFO_USM_HOST_SUPPORT is false.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
-///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///         + If `align` is greater that the size of the largest data type supported by any device in `hContext`.
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///         + `size == 0`
-///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE for any device in `hContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -257,10 +257,10 @@ returns:
       - "If $X_DEVICE_INFO_USM_HOST_SUPPORT is false."
     - $X_RESULT_ERROR_INVALID_VALUE:
       - "`pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`" # alignment must be power of two
-      - "If `align` is greater that the size of the largest data type supported by `hDevice`."
+      - "If `align` is greater that the size of the largest data type supported by any device in `hContext`."
     - $X_RESULT_ERROR_INVALID_USM_SIZE:
       - "`size == 0`"
-      - "`size` is greater than $X_DEVICE_INFO_MAX_MEM_ALLOC_SIZE."
+      - "`size` is greater than $X_DEVICE_INFO_MAX_MEM_ALLOC_SIZE for any device in `hContext`"
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -1130,7 +1130,7 @@ def make_param_checks(namespace, tags, obj, cpp=False, meta=None):
         for key, values in item.items():
             key = subt(namespace, tags, key, False, cpp)
             for val in values:
-                code = re.match(r"^\`(.*)\`$", val)
+                code = re.match(r"^\`([^`]*)\`$", val)
                 if code:
                     if key not in checks:
                         checks[key] = []

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -2252,10 +2252,10 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///         + If ::UR_DEVICE_INFO_USM_HOST_SUPPORT is false.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
-///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///         + If `align` is greater that the size of the largest data type supported by any device in `hContext`.
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///         + `size == 0`
-///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE for any device in `hContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -1946,10 +1946,10 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 ///         + If ::UR_DEVICE_INFO_USM_HOST_SUPPORT is false.
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
 ///         + `pUSMDesc && pUSMDesc->align != 0 && ((pUSMDesc->align & (pUSMDesc->align-1)) != 0)`
-///         + If `align` is greater that the size of the largest data type supported by `hDevice`.
+///         + If `align` is greater that the size of the largest data type supported by any device in `hContext`.
 ///     - ::UR_RESULT_ERROR_INVALID_USM_SIZE
 ///         + `size == 0`
-///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE.
+///         + `size` is greater than ::UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE for any device in `hContext`
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_FEATURE


### PR DESCRIPTION
This previously referenced a nonexistent `hDevice` parameter. It has
been updated to match the OpenCL function.

Also, the validation layer generator logic has been updated to handle
conditions that contain "`", which was an edge case that wasn't handled
before.
