### PR TITLE
Update spec to make kernel validation optional

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -7429,6 +7429,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters may perform validation on the number of arguments set to the
+///       kernel, but are not required to do so and may return
+///       `::UR_RESULT_SUCCESS` even for invalid invocations.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -7456,8 +7461,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values have not been specified and the adapter
+///         is able to detect this.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -16,6 +16,9 @@ type: function
 desc: "Enqueue a command to execute a kernel"
 class: $xEnqueue
 name: KernelLaunch
+details:
+  - "Adapters may perform validation on the number of arguments set to the kernel, but are not required to do so and may
+    return `$X_RESULT_SUCCESS` even for invalid invocations."
 ordinal: "0"
 analogue:
     - "**clEnqueueNDRangeKernel**"
@@ -65,8 +68,8 @@ returns:
     - $X_RESULT_ERROR_INVALID_WORK_DIMENSION
     - $X_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
     - $X_RESULT_ERROR_INVALID_VALUE
-    - $X_RESULT_ERROR_INVALID_KERNEL_ARGS
-        - "The kernel argument values have not been specified."
+    - $X_RESULT_ERROR_INVALID_KERNEL_ARGS:
+        - "The kernel argument values have not been specified and the adapter is able to detect this."
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_RESOURCES
 --- #--------------------------------------------------------------------------

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -4980,6 +4980,11 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters may perform validation on the number of arguments set to the
+///       kernel, but are not required to do so and may return
+///       `::UR_RESULT_SUCCESS` even for invalid invocations.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -5007,8 +5012,9 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values have not been specified and the adapter
+///         is able to detect this.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -4345,6 +4345,11 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Enqueue a command to execute a kernel
 ///
+/// @details
+///     - Adapters may perform validation on the number of arguments set to the
+///       kernel, but are not required to do so and may return
+///       `::UR_RESULT_SUCCESS` even for invalid invocations.
+///
 /// @remarks
 ///   _Analogues_
 ///     - **clEnqueueNDRangeKernel**
@@ -4372,8 +4377,9 @@ ur_result_t UR_APICALL urEventSetCallback(
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_DIMENSION
 ///     - ::UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE
 ///     - ::UR_RESULT_ERROR_INVALID_VALUE
-///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS - "The kernel argument values
-///     have not been specified."
+///     - ::UR_RESULT_ERROR_INVALID_KERNEL_ARGS
+///         + The kernel argument values have not been specified and the adapter
+///         is able to detect this.
 ///     - ::UR_RESULT_ERROR_OUT_OF_HOST_MEMORY
 ///     - ::UR_RESULT_ERROR_OUT_OF_RESOURCES
 ur_result_t UR_APICALL urEnqueueKernelLaunch(

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -154,26 +154,18 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidWorkGroupSize) {
 }
 
 TEST_P(urEnqueueKernelLaunchTest, InvalidKernelArgs) {
-  // Cuda and hip both lack any way to validate kernel args
-  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
-  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-
-  ur_platform_backend_t backend;
-  ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                   sizeof(ur_platform_backend_t), &backend,
-                                   nullptr));
-
-  if (backend == UR_PLATFORM_BACKEND_CUDA ||
-      backend == UR_PLATFORM_BACKEND_HIP ||
-      backend == UR_PLATFORM_BACKEND_LEVEL_ZERO) {
-    GTEST_FAIL() << "AMD, L0 and Nvidia can't check kernel arguments.";
-  }
+  // Seems to segfault
+  UUR_KNOWN_FAILURE_ON(uur::HIP{});
+  // cuLaunchKernel seems to be returning CUDA_ERROR_INVALID_VALUE which is
+  // converted to UR_RESULT_ERROR_INVALID_VALUE
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
   // Enqueue kernel without setting any args
-  ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
-                                         &global_offset, &global_size, nullptr,
-                                         0, nullptr, nullptr),
-                   UR_RESULT_ERROR_INVALID_KERNEL_ARGS);
+  auto error =
+      urEnqueueKernelLaunch(queue, kernel, n_dimensions, &global_offset,
+                            &global_size, nullptr, 0, nullptr, nullptr);
+  ASSERT_TRUE(error == UR_RESULT_ERROR_INVALID_KERNEL_ARGS ||
+              error == UR_RESULT_SUCCESS);
 }
 
 TEST_P(urEnqueueKernelLaunchKernelWgSizeTest, Success) {


### PR DESCRIPTION
Several adapters don't support validating kernel signatures when
enqueued. To handle this, we now allow urEnqueueKernelLaunch to return
`SUCCESS` even when parameters are invalid.
