### PR TITLE
Redo various urXGetInfo query tests so the first call uses the ASSERT_SUCCESS_OR_OPTIONAL_QUERY macro

### DIFF
--- a/test/conformance/adapter/urAdapterGetInfo.cpp
+++ b/test/conformance/adapter/urAdapterGetInfo.cpp
@@ -12,55 +12,65 @@ using urAdapterGetInfoTest = uur::urAdapterTest;
 UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(urAdapterGetInfoTest);
 
 TEST_P(urAdapterGetInfoTest, SuccessBackend) {
-    auto info_type = UR_ADAPTER_INFO_BACKEND;
-    size_t size = 0;
-    ASSERT_SUCCESS(urAdapterGetInfo(adapter, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_adapter_backend_t));
+    ur_adapter_info_t property_name = UR_ADAPTER_INFO_BACKEND;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urAdapterGetInfo(adapter, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_adapter_backend_t));
 
     ur_adapter_backend_t backend = UR_ADAPTER_BACKEND_UNKNOWN;
-    ASSERT_SUCCESS(
-        urAdapterGetInfo(adapter, info_type, size, &backend, nullptr));
+    ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
+                                    &backend, nullptr));
 
     ASSERT_TRUE(backend >= UR_ADAPTER_BACKEND_LEVEL_ZERO &&
                 backend <= UR_ADAPTER_BACKEND_NATIVE_CPU);
 }
 
 TEST_P(urAdapterGetInfoTest, SuccessReferenceCount) {
-    auto info_type = UR_ADAPTER_INFO_REFERENCE_COUNT;
-    size_t size = 0;
-    ASSERT_SUCCESS(urAdapterGetInfo(adapter, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ur_adapter_info_t property_name = UR_ADAPTER_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urAdapterGetInfo(adapter, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t reference_count = 0;
-    ASSERT_SUCCESS(
-        urAdapterGetInfo(adapter, info_type, size, &reference_count, nullptr));
+    ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
+                                    &reference_count, nullptr));
     ASSERT_GE(reference_count, 0);
 }
 
 TEST_P(urAdapterGetInfoTest, SuccessVersion) {
-    auto info_type = UR_ADAPTER_INFO_VERSION;
-    size_t size = 0;
-    ASSERT_SUCCESS(urAdapterGetInfo(adapter, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ur_adapter_info_t property_name = UR_ADAPTER_INFO_VERSION;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urAdapterGetInfo(adapter, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t returned_version = 46;
-    ASSERT_SUCCESS(
-        urAdapterGetInfo(adapter, info_type, size, &returned_version, nullptr));
+    ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
+                                    &returned_version, nullptr));
     ASSERT_NE(42, returned_version);
 }
 
 TEST_P(urAdapterGetInfoTest, InvalidNullHandleAdapter) {
-    size_t size = 0;
-    ASSERT_EQ_RESULT(
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-        urAdapterGetInfo(nullptr, UR_ADAPTER_INFO_BACKEND, 0, nullptr, &size));
+    size_t property_size = 0;
+    ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                     urAdapterGetInfo(nullptr, UR_ADAPTER_INFO_BACKEND, 0,
+                                      nullptr, &property_size));
 }
 
 TEST_P(urAdapterGetInfoTest, InvalidEnumerationAdapterInfoType) {
-    size_t size = 0;
+    size_t property_size = 0;
+
     ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                      urAdapterGetInfo(adapter, UR_ADAPTER_INFO_FORCE_UINT32, 0,
-                                      nullptr, &size));
+                                      nullptr, &property_size));
 }
 
 TEST_P(urAdapterGetInfoTest, InvalidSizeZero) {

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -8,120 +8,138 @@ using urContextGetInfoTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetInfoTest);
 
 TEST_P(urContextGetInfoTest, SuccessNumDevices) {
-    ur_context_info_t info_type = UR_CONTEXT_INFO_NUM_DEVICES;
-    size_t size = 0;
+    ur_context_info_t property_name = UR_CONTEXT_INFO_NUM_DEVICES;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t nDevices = 0;
-    ASSERT_SUCCESS(
-        urContextGetInfo(context, info_type, size, &nDevices, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &nDevices, nullptr));
 
     ASSERT_EQ(nDevices, 1);
 }
 
 TEST_P(urContextGetInfoTest, SuccessDevices) {
-    ur_context_info_t info_type = UR_CONTEXT_INFO_DEVICES;
-    size_t size = 0;
+    ur_context_info_t property_name = UR_CONTEXT_INFO_DEVICES;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     ur_device_handle_t queried_device = nullptr;
-    ASSERT_SUCCESS(
-        urContextGetInfo(context, info_type, size, &queried_device, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &queried_device, nullptr));
 
-    size_t devices_count = size / sizeof(ur_device_handle_t);
+    size_t devices_count = property_size / sizeof(ur_device_handle_t);
     ASSERT_EQ(devices_count, 1);
     ASSERT_EQ(queried_device, device);
 }
 
 TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
-    ur_context_info_t info_type = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
-    size_t size = 0;
+    ur_context_info_t property_name = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_bool_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_bool_t));
 }
 
 TEST_P(urContextGetInfoTest, SuccessUSMFill2DSupport) {
-    ur_context_info_t info_type = UR_CONTEXT_INFO_USM_FILL2D_SUPPORT;
-    size_t size = 0;
+    ur_context_info_t property_name = UR_CONTEXT_INFO_USM_FILL2D_SUPPORT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_bool_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_bool_t));
 }
 
 TEST_P(urContextGetInfoTest, SuccessReferenceCount) {
-    ur_context_info_t info_type = UR_CONTEXT_INFO_REFERENCE_COUNT;
-    size_t size = 0;
+    ur_context_info_t property_name = UR_CONTEXT_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t reference_count = 0;
-    ASSERT_SUCCESS(
-        urContextGetInfo(context, info_type, size, &reference_count, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &reference_count, nullptr));
     ASSERT_GT(reference_count, 0U);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
-    ur_context_info_t info_type =
+    ur_context_info_t property_name =
         UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES;
-    size_t size = 0;
+    size_t property_size = 0;
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
 
     ur_memory_order_capability_flags_t flags = 0;
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &flags, nullptr));
 
     ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
-    ur_context_info_t info_type =
+    ur_context_info_t property_name =
         UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES;
-    size_t size = 0;
+    size_t property_size = 0;
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
 
     ur_memory_scope_capability_flags_t flags = 0;
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &flags, nullptr));
 
     ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
-    ur_context_info_t info_type =
+    ur_context_info_t property_name =
         UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES;
-    size_t size = 0;
+    size_t property_size = 0;
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_EQ(size, sizeof(ur_memory_order_capability_flags_t));
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
 
     ur_memory_order_capability_flags_t flags = 0;
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &flags, nullptr));
 
     ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
-    ur_context_info_t info_type =
+    ur_context_info_t property_name =
         UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES;
-    size_t size = 0;
+    size_t property_size = 0;
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urContextGetInfo(context, info_type, 0, nullptr, &size), info_type);
-    ASSERT_EQ(size, sizeof(ur_memory_scope_capability_flags_t));
+        urContextGetInfo(context, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
 
     ur_memory_scope_capability_flags_t flags = 0;
-    ASSERT_SUCCESS(urContextGetInfo(context, info_type, size, &flags, nullptr));
+    ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                    &flags, nullptr));
 
     ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
 }

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -9,29 +9,33 @@
 using urEventGetInfoTest = uur::event::urEventTest;
 
 TEST_P(urEventGetInfoTest, SuccessCommandQueue) {
-    ur_event_info_t info_type = UR_EVENT_INFO_COMMAND_QUEUE;
-    size_t size = 0;
+    ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_queue_handle_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_queue_handle_t));
 
     ur_queue_handle_t returned_queue = nullptr;
-    ASSERT_SUCCESS(
-        urEventGetInfo(event, info_type, size, &returned_queue, nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
+                                  &returned_queue, nullptr));
 
     ASSERT_EQ(queue, returned_queue);
 }
 
 TEST_P(urEventGetInfoTest, SuccessContext) {
-    ur_event_info_t info_type = UR_EVENT_INFO_CONTEXT;
-    size_t size = 0;
+    ur_event_info_t property_name = UR_EVENT_INFO_CONTEXT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_context_handle_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(
-        urEventGetInfo(event, info_type, size, &returned_context, nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
+                                  &returned_context, nullptr));
 
     ASSERT_EQ(context, returned_context);
 }
@@ -39,73 +43,84 @@ TEST_P(urEventGetInfoTest, SuccessContext) {
 TEST_P(urEventGetInfoTest, SuccessCommandType) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-    ur_event_info_t info_type = UR_EVENT_INFO_COMMAND_TYPE;
-    size_t size = 0;
+    ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_TYPE;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_command_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_command_t));
 
     ur_command_t returned_command_type = UR_COMMAND_FORCE_UINT32;
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, size,
+    ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
                                   &returned_command_type, nullptr));
 
     ASSERT_EQ(UR_COMMAND_MEM_BUFFER_WRITE, returned_command_type);
 }
 
 TEST_P(urEventGetInfoTest, SuccessCommandExecutionStatus) {
-    ur_event_info_t info_type = UR_EVENT_INFO_COMMAND_EXECUTION_STATUS;
-    size_t size = 0;
+    ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_EXECUTION_STATUS;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_event_status_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_event_status_t));
 
     ur_event_status_t returned_status = UR_EVENT_STATUS_FORCE_UINT32;
-    ASSERT_SUCCESS(
-        urEventGetInfo(event, info_type, size, &returned_status, nullptr));
+    ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
+                                  &returned_status, nullptr));
 
     ASSERT_EQ(UR_EVENT_STATUS_COMPLETE, returned_status);
 }
 
 TEST_P(urEventGetInfoTest, SuccessReferenceCount) {
-    ur_event_info_t info_type = UR_EVENT_INFO_REFERENCE_COUNT;
-    size_t size = 0;
+    ur_event_info_t property_name = UR_EVENT_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, size,
+    ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
                                   &returned_reference_count, nullptr));
 
     ASSERT_GT(returned_reference_count, 0U);
 }
 
 TEST_P(urEventGetInfoTest, InvalidNullHandle) {
-    ur_event_info_t info_type = UR_EVENT_INFO_COMMAND_QUEUE;
-    size_t size;
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
-    std::vector<uint8_t> data(size);
+    ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+    size_t property_size;
+
+    ASSERT_SUCCESS(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size));
+    ASSERT_NE(property_size, 0);
+    std::vector<uint8_t> data(property_size);
 
     /* Invalid hEvent */
-    ASSERT_EQ_RESULT(
-        urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0, nullptr, &size),
-        UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+    ASSERT_EQ_RESULT(urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0,
+                                    nullptr, &property_size),
+                     UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urEventGetInfoTest, InvalidEnumeration) {
-    size_t size = 0;
-    ASSERT_EQ_RESULT(
-        urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0, nullptr, &size),
-        UR_RESULT_ERROR_INVALID_ENUMERATION);
+    size_t property_size = 0;
+
+    ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_FORCE_UINT32, 0,
+                                    nullptr, &property_size),
+                     UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
 TEST_P(urEventGetInfoTest, InvalidSizePropSize) {
-    ur_event_info_t info_type = UR_EVENT_INFO_COMMAND_QUEUE;
-    size_t size = 0;
-    ASSERT_SUCCESS(urEventGetInfo(event, info_type, 0, nullptr, &size));
-    ASSERT_NE(size, 0);
-    std::vector<uint8_t> data(size);
+    ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS(
+        urEventGetInfo(event, property_name, 0, nullptr, &property_size));
+    ASSERT_NE(property_size, 0);
+    std::vector<uint8_t> data(property_size);
 
     /* Invalid propSize */
     ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0,
@@ -115,6 +130,7 @@ TEST_P(urEventGetInfoTest, InvalidSizePropSize) {
 
 TEST_P(urEventGetInfoTest, InvalidSizePropSizeSmall) {
     ur_queue_handle_t queue = nullptr;
+
     ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE,
                                     sizeof(queue) - 1, &queue, nullptr),
                      UR_RESULT_ERROR_INVALID_SIZE);

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -21,6 +21,28 @@ struct urKernelGetGroupInfoFixedWorkGroupSizeTest : uur::urKernelTest {
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoFixedWorkGroupSizeTest);
 
+TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest,
+       SuccessCompileWorkGroupSize) {
+    UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
+
+    ur_kernel_group_info_t property_name =
+        UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, 3 * sizeof(size_t));
+
+    std::array<size_t, 3> property_value;
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+
+    ASSERT_EQ(property_value, work_group_size);
+}
+
 struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
     void SetUp() override {
         UUR_KNOWN_FAILURE_ON(
@@ -39,107 +61,12 @@ struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
 };
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoMaxWorkGroupSizeTest);
 
-using urKernelGetGroupInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoTest);
-
-TEST_P(urKernelGetGroupInfoTest, GlobalWorkSize) {
-    auto property_name = UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE;
+TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
+       SuccessCompileMaxWorkGroupSize) {
+    ur_kernel_group_info_t property_name =
+        UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE;
     size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, 3 * sizeof(size_t));
 
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-}
-
-TEST_P(urKernelGetGroupInfoTest, WorkGroupSize) {
-    auto property_name = UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(size_t));
-
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-}
-
-TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest, CompileWorkGroupSize) {
-    UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
-
-    auto property_name = UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, 3 * sizeof(size_t));
-
-    std::array<size_t, 3> property_value;
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-
-    ASSERT_EQ(property_value, work_group_size);
-}
-
-TEST_P(urKernelGetGroupInfoTest, LocalMemSize) {
-    auto property_name = UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(size_t));
-
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-}
-
-TEST_P(urKernelGetGroupInfoTest, PreferredWorkGroupSizeMultiple) {
-    auto property_name =
-        UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(size_t));
-
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-}
-
-TEST_P(urKernelGetGroupInfoTest, PrivateMemSize) {
-    auto property_name = UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
-                             &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(size_t));
-
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                        property_size, property_value.data(),
-                                        nullptr));
-}
-
-TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest, CompileMaxWorkGroupSize) {
-    auto property_name = UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE;
-    size_t property_size = 0;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
                              &property_size),
@@ -155,10 +82,11 @@ TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest, CompileMaxWorkGroupSize) {
 }
 
 TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
-       CompileMaxLinearWorkGroupSize) {
-    auto property_name =
+       SuccessCompileMaxLinearWorkGroupSize) {
+    ur_kernel_group_info_t property_name =
         UR_KERNEL_GROUP_INFO_COMPILE_MAX_LINEAR_WORK_GROUP_SIZE;
     size_t property_size = 0;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
                              &property_size),
@@ -171,6 +99,120 @@ TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
                                         nullptr));
 
     ASSERT_EQ(property_value, max_linear_work_group_size);
+}
+
+using urKernelGetGroupInfoTest = uur::urKernelTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoTest);
+
+TEST_P(urKernelGetGroupInfoTest, SuccessGlobalWorkSize) {
+    ur_kernel_group_info_t property_name =
+        UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, 3 * sizeof(size_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessWorkGroupSize) {
+    ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessLocalMemSize) {
+    ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessPreferredWorkGroupSizeMultiple) {
+    ur_kernel_group_info_t property_name =
+        UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessPrivateMemSize) {
+    ur_kernel_group_info_t property_name =
+        UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetGroupInfo(kernel, device, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
+                                        property_size, property_value.data(),
+                                        nullptr));
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessCompileWorkGroupSizeEmpty) {
+    // Returns 0 by default when there is no specific information
+    std::array<size_t, 3> read_dims{1, 1, 1};
+    std::array<size_t, 3> zero{0, 0, 0};
+
+    ASSERT_SUCCESS(urKernelGetGroupInfo(
+        kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
+        sizeof(read_dims), read_dims.data(), nullptr));
+
+    ASSERT_EQ(read_dims, zero);
+}
+
+TEST_P(urKernelGetGroupInfoTest, SuccessCompileMaxWorkGroupSizeEmpty) {
+    // Returns 0 by default when there is no specific information
+    std::array<size_t, 3> read_dims{1, 1, 1};
+    std::array<size_t, 3> zero{0, 0, 0};
+
+    auto result = urKernelGetGroupInfo(
+        kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE,
+        sizeof(read_dims), read_dims.data(), nullptr);
+
+    if (result == UR_RESULT_SUCCESS) {
+        ASSERT_EQ(read_dims, zero);
+    } else {
+        ASSERT_EQ(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
+    }
 }
 
 TEST_P(urKernelGetGroupInfoTest, InvalidNullHandleKernel) {
@@ -195,28 +237,4 @@ TEST_P(urKernelGetGroupInfoTest, InvalidEnumeration) {
                      urKernelGetGroupInfo(kernel, device,
                                           UR_KERNEL_GROUP_INFO_FORCE_UINT32, 0,
                                           nullptr, &bad_enum_length));
-}
-
-TEST_P(urKernelGetGroupInfoTest, CompileWorkGroupSizeEmpty) {
-    // Returns 0 by default when there is no specific information
-    std::array<size_t, 3> read_dims{1, 1, 1};
-    std::array<size_t, 3> zero{0, 0, 0};
-    ASSERT_SUCCESS(urKernelGetGroupInfo(
-        kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
-        sizeof(read_dims), read_dims.data(), nullptr));
-    ASSERT_EQ(read_dims, zero);
-}
-
-TEST_P(urKernelGetGroupInfoTest, CompileMaxWorkGroupSizeEmpty) {
-    // Returns 0 by default when there is no specific information
-    std::array<size_t, 3> read_dims{1, 1, 1};
-    std::array<size_t, 3> zero{0, 0, 0};
-    auto result = urKernelGetGroupInfo(
-        kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE,
-        sizeof(read_dims), read_dims.data(), nullptr);
-    if (result == UR_RESULT_SUCCESS) {
-        ASSERT_EQ(read_dims, zero);
-    } else {
-        ASSERT_EQ(result, UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
-    }
 }

--- a/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/test/conformance/kernel/urKernelGetInfo.cpp
@@ -10,8 +10,8 @@
 using urKernelGetInfoTest = uur::urKernelTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetInfoTest);
 
-TEST_P(urKernelGetInfoTest, FunctionName) {
-    auto property_name = UR_KERNEL_INFO_FUNCTION_NAME;
+TEST_P(urKernelGetInfoTest, SuccessFunctionName) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_FUNCTION_NAME;
     size_t property_size = 0;
 
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -23,12 +23,13 @@ TEST_P(urKernelGetInfoTest, FunctionName) {
                                    property_value.data(), nullptr));
 }
 
-TEST_P(urKernelGetInfoTest, NumArgs) {
-    auto property_name = UR_KERNEL_INFO_NUM_ARGS;
+TEST_P(urKernelGetInfoTest, SuccessNumArgs) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_NUM_ARGS;
     size_t property_size = 0;
 
-    ASSERT_SUCCESS(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
     ASSERT_EQ(property_size, sizeof(uint32_t));
 
     std::vector<char> property_value(property_size);
@@ -36,12 +37,13 @@ TEST_P(urKernelGetInfoTest, NumArgs) {
                                    property_value.data(), nullptr));
 }
 
-TEST_P(urKernelGetInfoTest, ReferenceCount) {
-    auto property_name = UR_KERNEL_INFO_REFERENCE_COUNT;
+TEST_P(urKernelGetInfoTest, SuccessReferenceCount) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_REFERENCE_COUNT;
     size_t property_size = 0;
 
-    ASSERT_SUCCESS(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
     ASSERT_EQ(property_size, sizeof(uint32_t));
 
     std::vector<char> property_value(property_size);
@@ -53,12 +55,13 @@ TEST_P(urKernelGetInfoTest, ReferenceCount) {
     ASSERT_GT(*returned_reference_count, 0U);
 }
 
-TEST_P(urKernelGetInfoTest, Context) {
-    auto property_name = UR_KERNEL_INFO_CONTEXT;
+TEST_P(urKernelGetInfoTest, SuccessContext) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_CONTEXT;
     size_t property_size = 0;
 
-    ASSERT_SUCCESS(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
     ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
     std::vector<char> property_value(property_size);
@@ -70,12 +73,13 @@ TEST_P(urKernelGetInfoTest, Context) {
     ASSERT_EQ(context, *returned_context);
 }
 
-TEST_P(urKernelGetInfoTest, Program) {
-    auto property_name = UR_KERNEL_INFO_PROGRAM;
+TEST_P(urKernelGetInfoTest, SuccessProgram) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_PROGRAM;
     size_t property_size = 0;
 
-    ASSERT_SUCCESS(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
     ASSERT_EQ(property_size, sizeof(ur_program_handle_t));
 
     std::vector<char> property_value(property_size);
@@ -87,12 +91,13 @@ TEST_P(urKernelGetInfoTest, Program) {
     ASSERT_EQ(program, *returned_program);
 }
 
-TEST_P(urKernelGetInfoTest, Attributes) {
-    auto property_name = UR_KERNEL_INFO_ATTRIBUTES;
+TEST_P(urKernelGetInfoTest, SuccessAttributes) {
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_ATTRIBUTES;
     size_t property_size = 0;
 
-    ASSERT_SUCCESS(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
 
     std::vector<char> property_value(property_size);
     ASSERT_SUCCESS(urKernelGetInfo(kernel, property_name, property_size,
@@ -114,13 +119,15 @@ TEST_P(urKernelGetInfoTest, Attributes) {
     }
 }
 
-TEST_P(urKernelGetInfoTest, NumRegs) {
+TEST_P(urKernelGetInfoTest, SuccessNumRegs) {
     UUR_KNOWN_FAILURE_ON(uur::HIP{}, uur::OpenCL{});
-    auto property_name = UR_KERNEL_INFO_NUM_REGS;
+
+    ur_kernel_info_t property_name = UR_KERNEL_INFO_NUM_REGS;
     size_t property_size = 0;
 
-    UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
-        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+        property_name);
     ASSERT_EQ(property_size, sizeof(uint32_t));
 
     std::vector<char> property_value(property_size);

--- a/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
@@ -21,46 +21,12 @@ struct urKernelGetSubGroupInfoFixedSubGroupSizeTest : uur::urKernelTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
     urKernelGetSubGroupInfoFixedSubGroupSizeTest);
 
-struct urKernelGetSubGroupInfoTest : uur::urKernelTest {
-    void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
-    }
-};
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetSubGroupInfoTest);
-
-TEST_P(urKernelGetSubGroupInfoTest, MaxSubGroupSize) {
-    auto property_name = UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE;
+TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
+       SuccessCompileNumSubGroups) {
+    ur_kernel_sub_group_info_t property_name =
+        UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS;
     size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
-                                &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(uint32_t));
 
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
-                                           property_size, property_value.data(),
-                                           nullptr));
-}
-
-TEST_P(urKernelGetSubGroupInfoTest, MaxNumSubGroups) {
-    auto property_name = UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS;
-    size_t property_size = 0;
-    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
-                                &property_size),
-        property_name);
-    ASSERT_EQ(property_size, sizeof(uint32_t));
-
-    std::vector<char> property_value(property_size);
-    ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
-                                           property_size, property_value.data(),
-                                           nullptr));
-}
-
-TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest, CompileNumSubGroups) {
-    auto property_name = UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS;
-    size_t property_size = 0;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
                                 &property_size),
@@ -74,9 +40,18 @@ TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest, CompileNumSubGroups) {
     ASSERT_EQ(property_value, num_sub_groups);
 }
 
-TEST_P(urKernelGetSubGroupInfoTest, SubGroupSizeIntel) {
-    auto property_name = UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL;
+struct urKernelGetSubGroupInfoTest : uur::urKernelTest {
+    void SetUp() override {
+        UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
+    }
+};
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetSubGroupInfoTest);
+
+TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxSubGroupSize) {
+    ur_kernel_sub_group_info_t property_name =
+        UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE;
     size_t property_size = 0;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
         urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
                                 &property_size),
@@ -87,6 +62,49 @@ TEST_P(urKernelGetSubGroupInfoTest, SubGroupSizeIntel) {
     ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
                                            property_size, property_value.data(),
                                            nullptr));
+}
+
+TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxNumSubGroups) {
+    ur_kernel_sub_group_info_t property_name =
+        UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
+                                &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
+                                           property_size, property_value.data(),
+                                           nullptr));
+}
+
+TEST_P(urKernelGetSubGroupInfoTest, SuccessSubGroupSizeIntel) {
+    ur_kernel_sub_group_info_t property_name =
+        UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
+                                &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
+
+    std::vector<char> property_value(property_size);
+    ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
+                                           property_size, property_value.data(),
+                                           nullptr));
+}
+
+TEST_P(urKernelGetSubGroupInfoTest, SuccessCompileNumSubgroupsIsZero) {
+    // Returns 0 by default when there is no specific information
+    size_t subgroups = 1;
+    ASSERT_SUCCESS(urKernelGetSubGroupInfo(
+        kernel, device, UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS,
+        sizeof(subgroups), &subgroups, nullptr));
+    ASSERT_EQ(subgroups, 0);
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, InvalidNullHandleKernel) {
@@ -113,13 +131,4 @@ TEST_P(urKernelGetSubGroupInfoTest, InvalidEnumeration) {
                      urKernelGetSubGroupInfo(
                          kernel, device, UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32,
                          0, nullptr, &bad_enum_length));
-}
-
-TEST_P(urKernelGetSubGroupInfoTest, CompileNumSubgroupsIsZero) {
-    // Returns 0 by default when there is no specific information
-    size_t subgroups = 1;
-    ASSERT_SUCCESS(urKernelGetSubGroupInfo(
-        kernel, device, UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS,
-        sizeof(subgroups), &subgroups, nullptr));
-    ASSERT_EQ(subgroups, 0);
 }

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -12,44 +12,53 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetInfoTest);
 
 TEST_P(urMemGetInfoTest, SuccessSize) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    ur_mem_info_t info_type = UR_MEM_INFO_SIZE;
-    size_t size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(buffer, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(size_t));
+    ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(buffer, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
 
     size_t returned_size = 0;
-    ASSERT_SUCCESS(
-        urMemGetInfo(buffer, info_type, size, &returned_size, nullptr));
+    ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
+                                &returned_size, nullptr));
 
     ASSERT_GE(returned_size, allocation_size);
 }
 
 TEST_P(urMemGetInfoTest, SuccessContext) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    ur_mem_info_t info_type = UR_MEM_INFO_CONTEXT;
-    size_t size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(buffer, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_context_handle_t));
+    ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(buffer, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(
-        urMemGetInfo(buffer, info_type, size, &returned_context, nullptr));
+    ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
+                                &returned_context, nullptr));
 
     ASSERT_EQ(context, returned_context);
 }
 
 TEST_P(urMemGetInfoTest, SuccessReferenceCount) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-    ur_mem_info_t info_type = UR_MEM_INFO_REFERENCE_COUNT;
-    size_t size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(buffer, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(buffer, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(urMemGetInfo(buffer, info_type, size,
+    ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
                                 &returned_reference_count, nullptr));
 
     ASSERT_GT(returned_reference_count, 0);
@@ -108,15 +117,18 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetInfoImageTest);
 
 TEST_P(urMemGetInfoImageTest, SuccessSize) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::OpenCL{"UHD Graphics"});
-    ur_mem_info_t info_type = UR_MEM_INFO_SIZE;
-    size_t size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(image, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(size_t));
+    ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(image, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(size_t));
 
     size_t image_size_bytes = 0;
-    ASSERT_SUCCESS(
-        urMemGetInfo(image, info_type, size, &image_size_bytes, nullptr));
+    ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
+                                &image_size_bytes, nullptr));
 
     const size_t expected_pixel_size = sizeof(uint8_t) * 4;
     const size_t expected_image_size = expected_pixel_size *
@@ -127,28 +139,32 @@ TEST_P(urMemGetInfoImageTest, SuccessSize) {
 }
 
 TEST_P(urMemGetInfoImageTest, SuccessContext) {
-    ur_mem_info_t info_type = UR_MEM_INFO_CONTEXT;
-    size_t size = 0;
+    ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(image, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_context_handle_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(image, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(
-        urMemGetInfo(image, info_type, size, &returned_context, nullptr));
+    ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
+                                &returned_context, nullptr));
 
     ASSERT_EQ(context, returned_context);
 }
 
 TEST_P(urMemGetInfoImageTest, SuccessReferenceCount) {
-    ur_mem_info_t info_type = UR_MEM_INFO_REFERENCE_COUNT;
-    size_t size = 0;
+    ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urMemGetInfo(image, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(uint32_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urMemGetInfo(image, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(uint32_t));
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(urMemGetInfo(image, info_type, size,
+    ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
                                 &returned_reference_count, nullptr));
 
     ASSERT_GT(returned_reference_count, 0);

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -12,84 +12,96 @@ using urPlatformGetInfoTest = uur::urPlatformTest;
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformGetInfoTest);
 
 TEST_P(urPlatformGetInfoTest, SuccessName) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_NAME;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_NAME;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    std::vector<char> returned_name(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    std::vector<char> returned_name(property_size);
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      returned_name.data(), nullptr));
 
-    ASSERT_EQ(size, returned_name.size());
+    ASSERT_EQ(property_size, returned_name.size());
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessVendorName) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_VENDOR_NAME;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_VENDOR_NAME;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    std::vector<char> returned_vendor_name(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    std::vector<char> returned_vendor_name(property_size);
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      returned_vendor_name.data(), nullptr));
 
-    ASSERT_EQ(size, returned_vendor_name.size());
+    ASSERT_EQ(property_size, returned_vendor_name.size());
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessVersion) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_VERSION;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_VERSION;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    std::vector<char> returned_version(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    std::vector<char> returned_version(property_size);
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      returned_version.data(), nullptr));
 
-    ASSERT_EQ(size, returned_version.size());
+    ASSERT_EQ(property_size, returned_version.size());
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessExtensions) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_EXTENSIONS;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_EXTENSIONS;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    std::vector<char> returned_extensions(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    std::vector<char> returned_extensions(property_size);
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      returned_extensions.data(), nullptr));
 
-    ASSERT_EQ(size, returned_extensions.size());
+    ASSERT_EQ(property_size, returned_extensions.size());
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessProfile) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_PROFILE;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_PROFILE;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    std::vector<char> returned_profile(size);
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    std::vector<char> returned_profile(property_size);
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      returned_profile.data(), nullptr));
 
-    ASSERT_EQ(size, returned_profile.size());
+    ASSERT_EQ(property_size, returned_profile.size());
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessBackend) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_BACKEND;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_BACKEND;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_platform_backend_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_platform_backend_t));
 
     ur_platform_backend_t returned_backend = UR_PLATFORM_BACKEND_UNKNOWN;
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      &returned_backend, nullptr));
 
     ASSERT_TRUE(returned_backend >= UR_PLATFORM_BACKEND_LEVEL_ZERO &&
@@ -97,14 +109,16 @@ TEST_P(urPlatformGetInfoTest, SuccessBackend) {
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessAdapter) {
-    ur_platform_info_t info_type = UR_PLATFORM_INFO_ADAPTER;
-    size_t size = 0;
+    ur_platform_info_t property_name = UR_PLATFORM_INFO_ADAPTER;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, 0, nullptr, &size));
-    ASSERT_EQ(size, sizeof(ur_adapter_handle_t));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPlatformGetInfo(platform, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(property_size, sizeof(ur_adapter_handle_t));
 
     ur_adapter_handle_t returned_adapter = nullptr;
-    ASSERT_SUCCESS(urPlatformGetInfo(platform, info_type, size,
+    ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
                                      &returned_adapter, nullptr));
 
     auto adapter_found = std::find(

--- a/test/conformance/program/urProgramGetBuildInfo.cpp
+++ b/test/conformance/program/urProgramGetBuildInfo.cpp
@@ -17,66 +17,82 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetBuildInfoTest);
 TEST_P(urProgramGetBuildInfoTest, SuccessStatus) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
-    size_t size = 0;
-    auto info_type = UR_PROGRAM_BUILD_INFO_STATUS;
-    ASSERT_SUCCESS(
-        urProgramGetBuildInfo(program, device, info_type, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_program_build_status_t), size);
+    size_t property_size = 0;
+    ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_STATUS;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
+                              &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_program_build_status_t), property_size);
 
     ur_program_build_status_t returned_status =
         UR_PROGRAM_BUILD_STATUS_FORCE_UINT32;
-    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, info_type, size,
-                                         &returned_status, nullptr));
+    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
+                                         property_size, &returned_status,
+                                         nullptr));
 
     ASSERT_GE(returned_status, UR_PROGRAM_BUILD_STATUS_NONE);
     ASSERT_LE(returned_status, UR_PROGRAM_BUILD_STATUS_IN_PROGRESS);
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessOptions) {
-    size_t size = 0;
-    auto info_type = UR_PROGRAM_BUILD_INFO_OPTIONS;
-    ASSERT_SUCCESS(
-        urProgramGetBuildInfo(program, device, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    size_t property_size = 0;
+    ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_OPTIONS;
 
-    std::vector<char> returned_options(size);
-    returned_options[size - 1] = 'x';
-    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, info_type, size,
-                                         returned_options.data(), nullptr));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
+                              &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    ASSERT_EQ(size, returned_options.size());
-    ASSERT_EQ(returned_options[size - 1], '\0');
+    std::vector<char> returned_options(property_size);
+    returned_options[property_size - 1] = 'x';
+    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
+                                         property_size, returned_options.data(),
+                                         nullptr));
+
+    ASSERT_EQ(property_size, returned_options.size());
+    ASSERT_EQ(returned_options[property_size - 1], '\0');
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessLog) {
     UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
-    size_t size = 0;
-    auto info_type = UR_PROGRAM_BUILD_INFO_LOG;
-    ASSERT_SUCCESS(
-        urProgramGetBuildInfo(program, device, info_type, 0, nullptr, &size));
-    ASSERT_GT(size, 0);
+    size_t property_size = 0;
+    ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_LOG;
 
-    std::vector<char> returned_log(size);
-    returned_log[size - 1] = 'x';
-    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, info_type, size,
-                                         returned_log.data(), nullptr));
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
+                              &property_size),
+        property_name);
+    ASSERT_GT(property_size, 0);
 
-    ASSERT_EQ(size, returned_log.size());
-    ASSERT_EQ(returned_log[size - 1], '\0');
+    std::vector<char> returned_log(property_size);
+    returned_log[property_size - 1] = 'x';
+    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
+                                         property_size, returned_log.data(),
+                                         nullptr));
+
+    ASSERT_EQ(property_size, returned_log.size());
+    ASSERT_EQ(returned_log[property_size - 1], '\0');
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessBinaryType) {
-    size_t size = 0;
-    auto info_type = UR_PROGRAM_BUILD_INFO_BINARY_TYPE;
-    ASSERT_SUCCESS(
-        urProgramGetBuildInfo(program, device, info_type, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_program_binary_type_t), size);
+    size_t property_size = 0;
+    ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_BINARY_TYPE;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
+                              &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_program_binary_type_t), property_size);
 
     ur_program_binary_type_t returned_binary_type =
         UR_PROGRAM_BINARY_TYPE_FORCE_UINT32;
-    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, info_type, size,
-                                         &returned_binary_type, nullptr));
+    ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
+                                         property_size, &returned_binary_type,
+                                         nullptr));
 
     ASSERT_GE(returned_binary_type, UR_PROGRAM_BINARY_TYPE_NONE);
     ASSERT_LE(returned_binary_type, UR_PROGRAM_BINARY_TYPE_EXECUTABLE);

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -8,78 +8,89 @@
 using urQueueGetInfoTest = uur::urQueueTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetInfoTest);
 
-TEST_P(urQueueGetInfoTest, Context) {
+TEST_P(urQueueGetInfoTest, SuccessContext) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-    size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_CONTEXT;
+    size_t property_size = 0;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_CONTEXT;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_EQ(sizeof(ur_context_handle_t), size);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_context_handle_t), property_size);
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(
-        urQueueGetInfo(queue, infoType, size, &returned_context, nullptr));
+    ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
+                                  &returned_context, nullptr));
 
     ASSERT_EQ(context, returned_context);
 }
 
-TEST_P(urQueueGetInfoTest, Device) {
+TEST_P(urQueueGetInfoTest, SuccessDevice) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-    size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_DEVICE;
+    size_t property_size = 0;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_DEVICE;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_EQ(sizeof(ur_device_handle_t), size);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_device_handle_t), property_size);
 
     ur_device_handle_t returned_device = nullptr;
-    ASSERT_SUCCESS(
-        urQueueGetInfo(queue, infoType, size, &returned_device, nullptr));
+    ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
+                                  &returned_device, nullptr));
 
     ASSERT_EQ(device, returned_device);
 }
 
-TEST_P(urQueueGetInfoTest, Flags) {
+TEST_P(urQueueGetInfoTest, SuccessFlags) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-    size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_FLAGS;
+    size_t property_size = 0;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_FLAGS;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_EQ(sizeof(ur_queue_flags_t), size);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_queue_flags_t), property_size);
 
     ur_queue_flags_t returned_flags = 0;
-    ASSERT_SUCCESS(
-        urQueueGetInfo(queue, infoType, size, &returned_flags, nullptr));
+    ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
+                                  &returned_flags, nullptr));
 
     EXPECT_EQ(returned_flags, queue_properties.flags);
 }
 
-TEST_P(urQueueGetInfoTest, ReferenceCount) {
+TEST_P(urQueueGetInfoTest, SuccessReferenceCount) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-    size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_REFERENCE_COUNT;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_EQ(sizeof(uint32_t), size);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(uint32_t), property_size);
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(urQueueGetInfo(queue, infoType, size,
+    ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
                                   &returned_reference_count, nullptr));
 
     ASSERT_GT(returned_reference_count, 0U);
 }
 
-TEST_P(urQueueGetInfoTest, EmptyQueue) {
+TEST_P(urQueueGetInfoTest, SuccessEmptyQueue) {
     UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-    size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_EMPTY;
+    size_t property_size = 0;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_EMPTY;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
-    ASSERT_EQ(sizeof(ur_bool_t), size);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
+        property_name);
+
+    ASSERT_EQ(sizeof(ur_bool_t), property_size);
 }
 
 TEST_P(urQueueGetInfoTest, InvalidNullHandleQueue) {
@@ -162,28 +173,28 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetInfoDeviceQueueTestWithInfoParam);
 
 TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, DeviceDefault) {
     size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_DEVICE_DEFAULT;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_DEVICE_DEFAULT;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &size), property_name);
     ASSERT_EQ(sizeof(ur_queue_handle_t), size);
 
     ur_queue_handle_t returned_queue = nullptr;
     ASSERT_SUCCESS(
-        urQueueGetInfo(queue, infoType, size, &returned_queue, nullptr));
+        urQueueGetInfo(queue, property_name, size, &returned_queue, nullptr));
 
     ASSERT_EQ(queue, returned_queue);
 }
 
 TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, Size) {
     size_t size = 0;
-    auto infoType = UR_QUEUE_INFO_SIZE;
+    ur_queue_info_t property_name = UR_QUEUE_INFO_SIZE;
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urQueueGetInfo(queue, infoType, 0, nullptr, &size), infoType);
+        urQueueGetInfo(queue, property_name, 0, nullptr, &size), property_name);
     ASSERT_EQ(sizeof(uint32_t), size);
 
     uint32_t returned_size = 0;
     ASSERT_SUCCESS(
-        urQueueGetInfo(queue, infoType, size, &returned_size, nullptr));
+        urQueueGetInfo(queue, property_name, size, &returned_size, nullptr));
 
     ASSERT_GT(returned_size, 0);
 }

--- a/test/conformance/sampler/urSamplerGetInfo.cpp
+++ b/test/conformance/sampler/urSamplerGetInfo.cpp
@@ -11,13 +11,17 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetInfoTest);
 
 TEST_P(urSamplerGetInfoTest, SuccessReferenceCount) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-    size_t size = 0;
-    auto infoType = UR_SAMPLER_INFO_REFERENCE_COUNT;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(uint32_t), size);
+
+    size_t property_size = 0;
+    ur_sampler_info_t property_name = UR_SAMPLER_INFO_REFERENCE_COUNT;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(uint32_t), property_size);
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, size,
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
                                     &returned_reference_count, nullptr));
 
     ASSERT_GT(returned_reference_count, 0U);
@@ -25,37 +29,49 @@ TEST_P(urSamplerGetInfoTest, SuccessReferenceCount) {
 
 TEST_P(urSamplerGetInfoTest, SuccessContext) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-    size_t size = 0;
-    auto infoType = UR_SAMPLER_INFO_CONTEXT;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_context_handle_t), size);
+
+    size_t property_size = 0;
+    ur_sampler_info_t property_name = UR_SAMPLER_INFO_CONTEXT;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_context_handle_t), property_size);
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(
-        urSamplerGetInfo(sampler, infoType, size, &returned_context, nullptr));
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
+                                    &returned_context, nullptr));
 
     ASSERT_EQ(returned_context, context);
 }
 
 TEST_P(urSamplerGetInfoTest, SuccessNormalizedCoords) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-    size_t size = 0;
-    auto infoType = UR_SAMPLER_INFO_NORMALIZED_COORDS;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_bool_t), size);
+
+    size_t property_size = 0;
+    ur_sampler_info_t property_name = UR_SAMPLER_INFO_NORMALIZED_COORDS;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_bool_t), property_size);
 }
 
 TEST_P(urSamplerGetInfoTest, SuccessAddressingMode) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-    size_t size = 0;
-    auto infoType = UR_SAMPLER_INFO_ADDRESSING_MODE;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_sampler_addressing_mode_t), size);
+
+    size_t property_size = 0;
+    ur_sampler_info_t property_name = UR_SAMPLER_INFO_ADDRESSING_MODE;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_sampler_addressing_mode_t), property_size);
 
     ur_sampler_addressing_mode_t returned_mode =
         UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32;
-    ASSERT_SUCCESS(
-        urSamplerGetInfo(sampler, infoType, size, &returned_mode, nullptr));
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
+                                    &returned_mode, nullptr));
 
     ASSERT_GE(returned_mode, UR_SAMPLER_ADDRESSING_MODE_NONE);
     ASSERT_LT(returned_mode, UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32);
@@ -63,15 +79,19 @@ TEST_P(urSamplerGetInfoTest, SuccessAddressingMode) {
 
 TEST_P(urSamplerGetInfoTest, SuccessFilterMode) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-    size_t size = 0;
-    auto infoType = UR_SAMPLER_INFO_FILTER_MODE;
-    ASSERT_SUCCESS(urSamplerGetInfo(sampler, infoType, 0, nullptr, &size));
-    ASSERT_EQ(sizeof(ur_sampler_filter_mode_t), size);
+
+    size_t property_size = 0;
+    ur_sampler_info_t property_name = UR_SAMPLER_INFO_FILTER_MODE;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(ur_sampler_filter_mode_t), property_size);
 
     ur_sampler_filter_mode_t returned_mode =
         UR_SAMPLER_FILTER_MODE_FORCE_UINT32;
-    ASSERT_SUCCESS(
-        urSamplerGetInfo(sampler, infoType, size, &returned_mode, nullptr));
+    ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
+                                    &returned_mode, nullptr));
 
     ASSERT_GE(returned_mode, UR_SAMPLER_FILTER_MODE_NEAREST);
     ASSERT_LT(returned_mode, UR_SAMPLER_FILTER_MODE_FORCE_UINT32);

--- a/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
@@ -8,86 +8,100 @@
 using urPhysicalMemGetInfoTest = uur::urPhysicalMemTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urPhysicalMemGetInfoTest);
 
-TEST_P(urPhysicalMemGetInfoTest, Context) {
+TEST_P(urPhysicalMemGetInfoTest, SuccessContext) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-    size_t info_size = 0;
+    ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_CONTEXT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(
-        physical_mem, UR_PHYSICAL_MEM_INFO_CONTEXT, 0, nullptr, &info_size));
-    ASSERT_NE(info_size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPhysicalMemGetInfo(physical_mem, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     ur_context_handle_t returned_context = nullptr;
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_CONTEXT, info_size,
-                                        &returned_context, nullptr));
+    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
+                                        property_size, &returned_context,
+                                        nullptr));
 
     ASSERT_EQ(context, returned_context);
 }
 
-TEST_P(urPhysicalMemGetInfoTest, Device) {
+TEST_P(urPhysicalMemGetInfoTest, SuccessDevice) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-    size_t info_size = 0;
+    ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_DEVICE;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(
-        physical_mem, UR_PHYSICAL_MEM_INFO_DEVICE, 0, nullptr, &info_size));
-    ASSERT_NE(info_size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPhysicalMemGetInfo(physical_mem, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     ur_device_handle_t returned_device = nullptr;
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_DEVICE, info_size,
-                                        &returned_device, nullptr));
+    ASSERT_SUCCESS(urPhysicalMemGetInfo(
+        physical_mem, property_name, property_size, &returned_device, nullptr));
 
     ASSERT_EQ(device, returned_device);
 }
 
-TEST_P(urPhysicalMemGetInfoTest, Size) {
+TEST_P(urPhysicalMemGetInfoTest, SuccessSize) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-    size_t info_size = 0;
+    ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_SIZE;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_SIZE,
-                                        0, nullptr, &info_size));
-    ASSERT_NE(info_size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPhysicalMemGetInfo(physical_mem, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     size_t returned_size = 0;
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_SIZE,
-                                        info_size, &returned_size, nullptr));
+    ASSERT_SUCCESS(urPhysicalMemGetInfo(
+        physical_mem, property_name, property_size, &returned_size, nullptr));
 
     ASSERT_EQ(size, returned_size);
 }
 
-TEST_P(urPhysicalMemGetInfoTest, Properties) {
+TEST_P(urPhysicalMemGetInfoTest, SuccessProperties) {
     UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
-    size_t info_size = 0;
 
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(
-        physical_mem, UR_PHYSICAL_MEM_INFO_PROPERTIES, 0, nullptr, &info_size));
-    ASSERT_NE(info_size, 0);
+    ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_PROPERTIES;
+    size_t property_size = 0;
+
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPhysicalMemGetInfo(physical_mem, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     ur_physical_mem_properties_t returned_properties = {};
-    ASSERT_SUCCESS(
-        urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_PROPERTIES,
-                             info_size, &returned_properties, nullptr));
+    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
+                                        property_size, &returned_properties,
+                                        nullptr));
 
     ASSERT_EQ(properties.stype, returned_properties.stype);
     ASSERT_EQ(properties.pNext, returned_properties.pNext);
     ASSERT_EQ(properties.flags, returned_properties.flags);
 }
 
-TEST_P(urPhysicalMemGetInfoTest, ReferenceCount) {
-    size_t info_size = 0;
+TEST_P(urPhysicalMemGetInfoTest, SuccessReferenceCount) {
+    ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT;
+    size_t property_size = 0;
 
-    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem,
-                                        UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT, 0,
-                                        nullptr, &info_size));
-    ASSERT_NE(info_size, 0);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urPhysicalMemGetInfo(physical_mem, property_name, 0, nullptr,
+                             &property_size),
+        property_name);
+    ASSERT_NE(property_size, 0);
 
     uint32_t returned_reference_count = 0;
-    ASSERT_SUCCESS(
-        urPhysicalMemGetInfo(physical_mem, UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT,
-                             info_size, &returned_reference_count, nullptr));
+    ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
+                                        property_size,
+                                        &returned_reference_count, nullptr));
 
     ASSERT_EQ(returned_reference_count, 1);
 }

--- a/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
@@ -4,13 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #include <uur/fixtures.h>
 
-struct urVirtualMemGranularityGetInfoTest
-    : uur::urContextTestWithParam<ur_virtual_mem_granularity_info_t> {
+struct urVirtualMemGranularityGetInfoTest : uur::urContextTest {
     void SetUp() override {
         UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
-        UUR_RETURN_ON_FATAL_FAILURE(
-            urContextTestWithParam<ur_virtual_mem_granularity_info_t>::SetUp());
+        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
         ur_bool_t virtual_memory_support = false;
         ASSERT_SUCCESS(urDeviceGetInfo(
             this->device, UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT,
@@ -21,78 +19,65 @@ struct urVirtualMemGranularityGetInfoTest
     }
 };
 
-UUR_DEVICE_TEST_SUITE_P(
-    urVirtualMemGranularityGetInfoTest,
-    ::testing::Values(UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM,
-                      UR_VIRTUAL_MEM_GRANULARITY_INFO_RECOMMENDED),
-    uur::deviceTestWithParamPrinter<ur_virtual_mem_granularity_info_t>);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemGranularityGetInfoTest);
 
-TEST_P(urVirtualMemGranularityGetInfoTest, Success) {
-    size_t size = 0;
-    ur_virtual_mem_granularity_info_t info = getParam();
+TEST_P(urVirtualMemGranularityGetInfoTest, SuccessMinimum) {
+    size_t property_size = 0;
+    ur_virtual_mem_granularity_info_t property_name =
+        UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM;
+
     ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-        urVirtualMemGranularityGetInfo(context, device, info, 0, nullptr,
-                                       &size),
-        info);
-    ASSERT_NE(size, 0);
+        urVirtualMemGranularityGetInfo(context, device, property_name, 0,
+                                       nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(size_t), property_size);
 
-    std::vector<uint8_t> infoData(size);
-    ASSERT_SUCCESS(urVirtualMemGranularityGetInfo(
-        context, device, info, infoData.size(), infoData.data(), nullptr));
+    uint32_t returned_minimum = 0;
+    ASSERT_SUCCESS(urVirtualMemGranularityGetInfo(context, device,
+                                                  property_name, property_size,
+                                                  &returned_minimum, nullptr));
 
-    switch (info) {
-    case UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM: {
-        ASSERT_EQ(size, sizeof(size_t));
-        size_t minimum = *reinterpret_cast<size_t *>(infoData.data());
-        ASSERT_GT(minimum, 0);
-    } break;
-    case UR_VIRTUAL_MEM_GRANULARITY_INFO_RECOMMENDED: {
-        ASSERT_EQ(size, sizeof(size_t));
-        size_t recommended = *reinterpret_cast<size_t *>(infoData.data());
-        ASSERT_GT(recommended, 0);
-    } break;
-    default:
-        FAIL() << "Unhandled ur_virtual_mem_granularity_info_t enumeration: "
-               << info;
-        break;
-    }
+    ASSERT_GT(returned_minimum, 0);
 }
 
-struct urVirtualMemGranularityGetInfoNegativeTest : uur::urContextTest {
-    void SetUp() override {
-        UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
+TEST_P(urVirtualMemGranularityGetInfoTest, SuccessRecommended) {
+    size_t property_size = 0;
+    ur_virtual_mem_granularity_info_t property_name =
+        UR_VIRTUAL_MEM_GRANULARITY_INFO_RECOMMENDED;
 
-        ur_bool_t virtual_memory_support = false;
-        ASSERT_SUCCESS(urDeviceGetInfo(
-            device, UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT, sizeof(ur_bool_t),
-            &virtual_memory_support, nullptr));
-        if (!virtual_memory_support) {
-            GTEST_SKIP() << "Virtual memory is not supported.";
-        }
-    }
-};
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemGranularityGetInfoNegativeTest);
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urVirtualMemGranularityGetInfo(context, device, property_name, 0,
+                                       nullptr, &property_size),
+        property_name);
+    ASSERT_EQ(sizeof(size_t), property_size);
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest, InvalidNullHandleContext) {
-    size_t size = 0;
+    uint32_t returned_recommended = 0;
+    ASSERT_SUCCESS(urVirtualMemGranularityGetInfo(
+        context, device, property_name, property_size, &returned_recommended,
+        nullptr));
+
+    ASSERT_GT(returned_recommended, 0);
+}
+
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidNullHandleContext) {
+    size_t property_size = 0;
     ASSERT_EQ_RESULT(
         urVirtualMemGranularityGetInfo(nullptr, device,
                                        UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM,
-                                       0, nullptr, &size),
+                                       0, nullptr, &property_size),
         UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest, InvalidEnumeration) {
-    size_t size = 0;
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidEnumeration) {
+    size_t property_size = 0;
     ASSERT_EQ_RESULT(urVirtualMemGranularityGetInfo(
                          context, device,
                          UR_VIRTUAL_MEM_GRANULARITY_INFO_FORCE_UINT32, 0,
-                         nullptr, &size),
+                         nullptr, &property_size),
                      UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest,
-       InvalidNullPointerPropSizeRet) {
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidNullPointerPropSizeRet) {
     ASSERT_EQ_RESULT(
         urVirtualMemGranularityGetInfo(context, device,
                                        UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM,
@@ -100,8 +85,7 @@ TEST_P(urVirtualMemGranularityGetInfoNegativeTest,
         UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest,
-       InvalidNullPointerPropValue) {
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidNullPointerPropValue) {
     ASSERT_EQ_RESULT(
         urVirtualMemGranularityGetInfo(context, device,
                                        UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM,
@@ -109,7 +93,7 @@ TEST_P(urVirtualMemGranularityGetInfoNegativeTest,
         UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest, InvalidPropSizeZero) {
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidPropSizeZero) {
     size_t minimum = 0;
     ASSERT_EQ_RESULT(
         urVirtualMemGranularityGetInfo(context, device,
@@ -118,7 +102,7 @@ TEST_P(urVirtualMemGranularityGetInfoNegativeTest, InvalidPropSizeZero) {
         UR_RESULT_ERROR_INVALID_SIZE);
 }
 
-TEST_P(urVirtualMemGranularityGetInfoNegativeTest, InvalidSizePropSizeSmall) {
+TEST_P(urVirtualMemGranularityGetInfoTest, InvalidSizePropSizeSmall) {
     size_t minimum = 0;
     ASSERT_EQ_RESULT(
         urVirtualMemGranularityGetInfo(context, device,


### PR DESCRIPTION
Redo various urXGetInfo query tests so the first call uses the ASSERT_SUCCESS_OR_OPTIONAL_QUERY macro.
Rework urVirtualMemGranularityGetInfoTest into separate tests.
Various tidying up of the urXGetInfo tests for better consistency.

For https://github.com/oneapi-src/unified-runtime/issues/2290