### PR TITLE
ShadowMemory should increment/decrement device handle

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_shadow.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_shadow.hpp
@@ -22,9 +22,11 @@ namespace asan {
 
 struct ShadowMemory {
     ShadowMemory(ur_context_handle_t Context, ur_device_handle_t Device)
-        : Context(Context), Device(Device) {}
+        : Context(Context), Device(Device) {
+        urDeviceRetain(Device);
+    }
 
-    virtual ~ShadowMemory() {}
+    virtual ~ShadowMemory() { urDeviceRelease(Device); }
 
     virtual ur_result_t Setup() = 0;
 


### PR DESCRIPTION
ShadowMemory holds a reference to the appropriate device, but did not
retain/release it properly, resulting in use-after-frees in the asan
testing.
