### PR TITLE
Mark urKernelGetGroupInfoMaxWorkGroupSize as failing on 12th gen

### DIFF
--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -23,8 +23,9 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoFixedWorkGroupSizeTest);
 
 struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
     void SetUp() override {
-        UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{},
-                             uur::OpenCL{"13th Gen", "Intel(R) Xeon"});
+        UUR_KNOWN_FAILURE_ON(
+            uur::CUDA{}, uur::HIP{},
+            uur::OpenCL{"12th Gen", "13th Gen", "Intel(R) Xeon"});
         program_name = "max_wg_size";
         UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
     }


### PR DESCRIPTION
I have a 12th gen CPU, and this is reporting an error to stdout saying
it is unsupported.
