### PR TITLE
Enable the registry of level_zero_v2

### DIFF
--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -121,8 +121,9 @@ private:
   // to load the adapter.
   std::vector<std::vector<fs::path>> adaptersLoadPaths;
 
-  static constexpr std::array<const char *, 5> knownAdapterNames{
+  static constexpr std::array<const char *, 6> knownAdapterNames{
       MAKE_LIBRARY_NAME("ur_adapter_level_zero", "0"),
+      MAKE_LIBRARY_NAME("ur_adapter_level_zero_v2", "0"),
       MAKE_LIBRARY_NAME("ur_adapter_opencl", "0"),
       MAKE_LIBRARY_NAME("ur_adapter_cuda", "0"),
       MAKE_LIBRARY_NAME("ur_adapter_hip", "0"),


### PR DESCRIPTION
This PR enable us to register level_zero_v2 in the list of UR adapters, so it could be used with dpc++.