### PR TITLE
update GitHub Cache action to 4.2.0

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -232,7 +232,7 @@ jobs:
 
     - name: Upload HTML report
       if: ${{ always() && inputs.upload_report }}
-      uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: ur-repo/benchmark_results.html
         key: benchmark-results-${{ matrix.adapter.str_name }}-${{ github.run_id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Download benchmark HTML
         id: download-bench-html
-        uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ur-repo/benchmark_results.html
           key: benchmark-results-


### PR DESCRIPTION
The cache action is stopping support for anything but the very latest version. We need to update to 4.2.0 for the cache to continue functioning.

https://github.com/actions/cache/discussions/1510