### PR TITLE
Fix memory leak in loader urEventSetCallback

### DIFF
--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -65,15 +65,6 @@ namespace ur_loader
     %>${th.get_initial_null_set(obj)}
 
         [[maybe_unused]] auto context = getContext();
-        %if func_basename == "EventSetCallback":
-
-        // Replace the callback with a wrapper function that gives the callback the loader event rather than a
-        // backend-specific event
-        auto wrapper_data =
-            new event_callback_wrapper_data_t{pfnNotify, hEvent, pUserData};
-        pUserData = wrapper_data;
-        pfnNotify = event_callback_wrapper;
-        %endif
         %if func_basename == "AdapterGet":
         
         size_t adapterIndex = 0;
@@ -165,6 +156,16 @@ namespace ur_loader
         <%break%>
         %endif
         %endfor
+        %if func_basename == "EventSetCallback":
+
+        // Replace the callback with a wrapper function that gives the callback the loader event rather than a
+        // backend-specific event
+        auto *wrapper_data =
+            new event_callback_wrapper_data_t{pfnNotify, hEvent, pUserData};
+        pUserData = wrapper_data;
+        pfnNotify = event_callback_wrapper;
+
+        %endif
         %for i, item in enumerate(th.get_loader_prologue(n, tags, obj, meta)):
         %if 'range' in item:
         <%

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -4506,19 +4506,19 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
     [[maybe_unused]] auto context = getContext();
 
-    // Replace the callback with a wrapper function that gives the callback the loader event rather than a
-    // backend-specific event
-    auto wrapper_data =
-        new event_callback_wrapper_data_t{pfnNotify, hEvent, pUserData};
-    pUserData = wrapper_data;
-    pfnNotify = event_callback_wrapper;
-
     // extract platform's function pointer table
     auto dditable = reinterpret_cast<ur_event_object_t *>(hEvent)->dditable;
     auto pfnSetCallback = dditable->ur.Event.pfnSetCallback;
     if (nullptr == pfnSetCallback) {
         return UR_RESULT_ERROR_UNINITIALIZED;
     }
+
+    // Replace the callback with a wrapper function that gives the callback the loader event rather than a
+    // backend-specific event
+    auto *wrapper_data =
+        new event_callback_wrapper_data_t{pfnNotify, hEvent, pUserData};
+    pUserData = wrapper_data;
+    pfnNotify = event_callback_wrapper;
 
     // convert loader handle to platform handle
     hEvent = reinterpret_cast<ur_event_object_t *>(hEvent)->handle;


### PR DESCRIPTION
If the function pointer passed into the function was null, then the
wrapper is leaked. This change re-orders things so the wrapper is
created later.
