### PR TITLE
[DeivceASAN] Make ShadowMemory one instance per type

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -47,9 +47,9 @@ AsanInterceptor::~AsanInterceptor() {
   // detection depends on it.
   m_AllocationMap.clear();
 
-  for (auto &[_, ShadowManager] : m_ShadowMap) {
-    ShadowManager->Destory();
-    getContext()->urDdiTable.Context.pfnRelease(ShadowManager->Context);
+  for (auto &[_, ShadowMemory] : m_ShadowMap) {
+    ShadowMemory->Destory();
+    getContext()->urDdiTable.Context.pfnRelease(ShadowMemory->Context);
   }
 
   for (auto Adapter : m_Adapters) {

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -57,8 +57,6 @@ struct DeviceInfo {
   // Device handles are special and alive in the whole process lifetime,
   // so we needn't retain&release here.
   explicit DeviceInfo(ur_device_handle_t Device) : Handle(Device) {}
-
-  ur_result_t allocShadowMemory(ur_context_handle_t Context);
 };
 
 struct QueueInfo {
@@ -353,6 +351,9 @@ public:
 
   bool isNormalExit() { return m_NormalExit; }
 
+  std::shared_ptr<ShadowMemory>
+  getOrCreateShadowMemory(ur_device_handle_t Device, DeviceType Type);
+
 private:
   ur_result_t updateShadowMemory(std::shared_ptr<ContextInfo> &ContextInfo,
                                  std::shared_ptr<DeviceInfo> &DeviceInfo,
@@ -367,9 +368,6 @@ private:
                             std::shared_ptr<DeviceInfo> &DeviceInfo,
                             ur_queue_handle_t Queue, ur_kernel_handle_t Kernel,
                             LaunchInfo &LaunchInfo);
-
-  ur_result_t allocShadowMemory(ur_context_handle_t Context,
-                                std::shared_ptr<DeviceInfo> &DeviceInfo);
 
   ur_result_t registerDeviceGlobals(ur_program_handle_t Program);
   ur_result_t registerSpirKernels(ur_program_handle_t Program);
@@ -406,6 +404,9 @@ private:
   ur_shared_mutex m_AdaptersMutex;
 
   bool m_NormalExit = true;
+
+  std::unordered_map<DeviceType, std::shared_ptr<ShadowMemory>> m_ShadowMap;
+  ur_shared_mutex m_ShadowMapMutex;
 };
 
 } // namespace asan

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -156,7 +156,7 @@ DeviceType GetDeviceType(ur_context_handle_t Context,
     // by the value of device USM pointer (see "USM Allocation Range" in
     // asan_shadow.cpp)
     auto Type = DeviceType::UNKNOWN;
-    if (Ptr >> 48 == 0xff00U) {
+    if (((Ptr >> 48) & 0xff00U) == 0xff00U) {
       Type = DeviceType::GPU_PVC;
     } else {
       Type = DeviceType::GPU_DG2;

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -156,6 +156,10 @@ DeviceType GetDeviceType(ur_context_handle_t Context,
     // by the value of device USM pointer (see "USM Allocation Range" in
     // asan_shadow.cpp)
     auto Type = DeviceType::UNKNOWN;
+
+    // ((Ptr >> 48) & 0xff00U) is because I have seen a DeviceUSM of PVC having
+    // 0xff01xxxx addr. We need to confirm this with L0 team later about the
+    // address space mapping.
     if (((Ptr >> 48) & 0xff00U) == 0xff00U) {
       Type = DeviceType::GPU_PVC;
     } else {

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -157,10 +157,9 @@ DeviceType GetDeviceType(ur_context_handle_t Context,
     // asan_shadow.cpp)
     auto Type = DeviceType::UNKNOWN;
 
-    // ((Ptr >> 48) & 0xff00U) is because I have seen a DeviceUSM of PVC having
-    // 0xff01xxxx addr. We need to confirm this with L0 team later about the
-    // address space mapping.
-    if (((Ptr >> 48) & 0xff00U) == 0xff00U) {
+    // L0 changes their VA layout.
+    // TODO: update our shadow memory layout/algorithms to accordingly.
+    if (((Ptr >> 52) & 0xff0U) == 0xff0U) {
       Type = DeviceType::GPU_PVC;
     } else {
       Type = DeviceType::GPU_DG2;


### PR DESCRIPTION
Previously we had one `ShadowMemory` for every `DeviceInfo`. That is causing problem because it's release process is called too late. And only the first `ShadowMemory` would do the actual shadow memory bookkeeping.

This is a quick fix but also is heading in the direction we plan, which is one `ShadowMemory` for each device type. This relies on the fact that for the virtual memory with L0, it can access the address from different device and within different context with newer driver. And as for opencl CPU device, since it is host memory, it does not have to worry about this issue.

We will purpose PR later to do a better refactor, but for now we are trying to fix the issue with minimum changes to avoid any possible regression.

Intel/llvm PR: https://github.com/intel/llvm/pull/16687