### PR TITLE
[common] Bump UMF to early 0.11 version, from main

### DIFF
--- a/source/common/CMakeLists.txt
+++ b/source/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2022-2023 Intel Corporation
+# Copyright (C) 2022-2025 Intel Corporation
 # Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM Exceptions.
 # See LICENSE.TXT
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -32,10 +32,11 @@ if (NOT DEFINED UMF_REPO)
 endif()
 
 if (NOT DEFINED UMF_TAG)
-    # Tagger: Łukasz Stolarczuk <lukasz.stolarczuk@intel.com>
-    # Date:   Fri Jan 10 13:30:49 2025 +0100
-    # 0.10.1 release
-    set(UMF_TAG v0.10.1)
+    # commit 6709535de92933d6bfc1e1d19a324f17afec3877
+    # Author: Rafał Rudnicki <rafal.rudnicki@intel.com>
+    # Date:   Mon Jan 27 10:57:57 2025 +0100
+    # Merge pull request #1056 from lukaszstolarczuk/hwloc-revert-examples-win
+    set(UMF_TAG 6709535de92933d6bfc1e1d19a324f17afec3877)
 endif()
 
 message(STATUS "Will fetch Unified Memory Framework from ${UMF_REPO}")

--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (C) 2023-2024 Intel Corporation
+ * Copyright (C) 2023-2025 Intel Corporation
  *
  * Part of the Unified-Runtime Project, under the Apache License v2.0 with LLVM
  * Exceptions. See LICENSE.TXT
@@ -168,7 +168,7 @@ auto memoryProviderMakeUnique(Args &&...args) {
   UMF_ASSIGN_OP(ops, T, get_recommended_page_size, UMF_RESULT_ERROR_UNKNOWN);
   UMF_ASSIGN_OP(ops, T, get_min_page_size, UMF_RESULT_ERROR_UNKNOWN);
   UMF_ASSIGN_OP(ops, T, get_name, "");
-  UMF_ASSIGN_OP(ops.ext, T, free, UMF_RESULT_ERROR_UNKNOWN);
+  UMF_ASSIGN_OP(ops, T, free, UMF_RESULT_ERROR_UNKNOWN);
   UMF_ASSIGN_OP(ops.ext, T, purge_lazy, UMF_RESULT_ERROR_UNKNOWN);
   UMF_ASSIGN_OP(ops.ext, T, purge_force, UMF_RESULT_ERROR_UNKNOWN);
   UMF_ASSIGN_OP(ops.ext, T, allocation_merge, UMF_RESULT_ERROR_UNKNOWN);


### PR DESCRIPTION
intel/llvm testing: https://github.com/intel/llvm/pull/16749