### PR TITLE
Improvements to align CTS and Spec for Device

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1441,20 +1441,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Supported platform info
 typedef enum ur_platform_info_t {
-  /// [char[]] The string denoting name of the platform. The size of the
-  /// info needs to be dynamically queried.
+  /// [char[]] The null-terminated string denoting name of the platform. The
+  /// size of the info needs to be dynamically queried.
   UR_PLATFORM_INFO_NAME = 1,
-  /// [char[]] The string denoting name of the vendor of the platform. The
-  /// size of the info needs to be dynamically queried.
+  /// [char[]] The null-terminated string denoting name of the vendor of the
+  /// platform. The size of the info needs to be dynamically queried.
   UR_PLATFORM_INFO_VENDOR_NAME = 2,
-  /// [char[]] The string denoting the version of the platform. The size of
-  /// the info needs to be dynamically queried.
+  /// [char[]] The null-terminated string denoting the version of the
+  /// platform. The size of the info needs to be dynamically queried.
   UR_PLATFORM_INFO_VERSION = 3,
-  /// [char[]] The string denoting extensions supported by the platform. The
-  /// size of the info needs to be dynamically queried.
+  /// [char[]] The null-terminated string denoting extensions supported by
+  /// the platform. The size of the info needs to be dynamically queried.
   UR_PLATFORM_INFO_EXTENSIONS = 4,
-  /// [char[]] The string denoting profile of the platform. The size of the
-  /// info needs to be dynamically queried.
+  /// [char[]] The null-terminated string denoting profile of the platform.
+  /// The size of the info needs to be dynamically queried.
   UR_PLATFORM_INFO_PROFILE = 5,
   /// [::ur_platform_backend_t] The backend of the platform. Identifies the
   /// native backend adapter implementing this platform.
@@ -2036,7 +2036,8 @@ typedef enum ur_device_info_t {
   UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES = 60,
   /// [::ur_queue_flags_t] host queue property bit-field
   UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES = 61,
-  /// [char[]] a semi-colon separated list of built-in kernels
+  /// [char[]] a null-terminated semi-colon separated list of built-in
+  /// kernels
   UR_DEVICE_INFO_BUILT_IN_KERNELS = 62,
   /// [::ur_platform_handle_t] the platform associated with the device
   UR_DEVICE_INFO_PLATFORM = 63,
@@ -2045,21 +2046,22 @@ typedef enum ur_device_info_t {
   /// It is unsuitable for general use in applications. This feature is
   /// provided for identifying memory leaks.
   UR_DEVICE_INFO_REFERENCE_COUNT = 64,
-  /// [char[]] IL version
+  /// [char[]] null-terminated IL version
   UR_DEVICE_INFO_IL_VERSION = 65,
-  /// [char[]] Device name
+  /// [char[]] null-terminated device name
   UR_DEVICE_INFO_NAME = 66,
-  /// [char[]] Device vendor
+  /// [char[]] null-terminated device vendor
   UR_DEVICE_INFO_VENDOR = 67,
-  /// [char[]] Driver version
+  /// [char[]] null-terminated driver version
   UR_DEVICE_INFO_DRIVER_VERSION = 68,
-  /// [char[]] Device profile
+  /// [char[]] null-terminated device profile
   UR_DEVICE_INFO_PROFILE = 69,
-  /// [char[]] Device version
+  /// [char[]] null-terminated device version
   UR_DEVICE_INFO_VERSION = 70,
-  /// [char[]] Version of backend runtime
+  /// [char[]] null-terminated version of backend runtime
   UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION = 71,
-  /// [char[]] Return a space separated list of extension names
+  /// [char[]] Return a null-terminated space separated list of extension
+  /// names
   UR_DEVICE_INFO_EXTENSIONS = 72,
   /// [size_t] Maximum size in bytes of internal printf buffer
   UR_DEVICE_INFO_PRINTF_BUFFER_SIZE = 73,
@@ -2079,9 +2081,8 @@ typedef enum ur_device_info_t {
   /// If the device does not support any affinity domains, then 0 will be
   /// returned.
   UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN = 78,
-  /// [::ur_device_partition_property_t[]] return an array of
-  /// ::ur_device_partition_property_t for properties specified in
-  /// ::urDevicePartition
+  /// [::ur_device_partition_property_t[]] returns an array of properties
+  /// specified in ::urDevicePartition
   UR_DEVICE_INFO_PARTITION_TYPE = 79,
   /// [uint32_t] max number of sub groups
   UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS = 80,
@@ -2106,7 +2107,7 @@ typedef enum ur_device_info_t {
   UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT = 87,
   /// [uint8_t[]][optional-query] return device UUID
   UR_DEVICE_INFO_UUID = 88,
-  /// [char[]][optional-query] return device PCI address
+  /// [char[]][optional-query] return null-terminated device PCI address
   UR_DEVICE_INFO_PCI_ADDRESS = 89,
   /// [uint32_t][optional-query] return Intel GPU EU count
   UR_DEVICE_INFO_GPU_EU_COUNT = 90,
@@ -2252,20 +2253,20 @@ typedef enum ur_device_info_t {
   /// [::ur_bool_t] returns true if the device supports sampling cubemapped
   /// images across face boundaries
   UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP = 0x2011,
-  /// [::ur_bool_t] returns true if the device is capable of fetching USM
-  /// backed 1D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports fetching USM backed
+  /// 1D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_EXP = 0x2012,
-  /// [::ur_bool_t] returns true if the device is capable of fetching
-  /// non-USM backed 1D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports fetching non-USM
+  /// backed 1D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_EXP = 0x2013,
-  /// [::ur_bool_t] returns true if the device is capable of fetching USM
-  /// backed 2D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports fetching USM backed
+  /// 2D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_USM_EXP = 0x2014,
-  /// [::ur_bool_t] returns true if the device is capable of fetching
-  /// non-USM backed 2D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports fetching non-USM
+  /// backed 2D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_EXP = 0x2015,
-  /// [::ur_bool_t] returns true if the device is capable of fetching
-  /// non-USM backed 3D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports fetching non-USM
+  /// backed 3D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_3D_EXP = 0x2017,
   /// [::ur_bool_t] returns true if the device supports timestamp recording
   UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP = 0x2018,
@@ -2275,11 +2276,11 @@ typedef enum ur_device_info_t {
   /// [::ur_bool_t] returns true if the device supports unique addressing
   /// per dimension.
   UR_DEVICE_INFO_BINDLESS_UNIQUE_ADDRESSING_PER_DIM_EXP = 0x201A,
-  /// [::ur_bool_t] returns true if the device is capable of sampling USM
-  /// backed 1D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports sampling USM backed
+  /// 1D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLE_1D_USM_EXP = 0x201B,
-  /// [::ur_bool_t] returns true if the device is capable of sampling USM
-  /// backed 2D sampled image data.
+  /// [::ur_bool_t] returns true if the device supports sampling USM backed
+  /// 2D sampled image data.
   UR_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_EXP = 0x201C,
   /// [::ur_bool_t] returns true if the device supports enqueueing of native
   /// work
@@ -5571,12 +5572,12 @@ typedef enum ur_program_info_t {
   UR_PROGRAM_INFO_DEVICES = 3,
   /// [char[]] Return program IL if the program was created with
   /// ::urProgramCreateWithIL, otherwise return size will be set to 0 and
-  /// nothing will be returned.
+  /// nothing will be returned. This is not null-terminated.
   UR_PROGRAM_INFO_IL = 4,
   /// [size_t[]] Return program binary sizes for each device.
   UR_PROGRAM_INFO_BINARY_SIZES = 5,
   /// [unsigned char[]] Return program binaries for all devices for this
-  /// Program.
+  /// Program. These are not null-terminated.
   UR_PROGRAM_INFO_BINARIES = 6,
   /// [size_t][optional-query] Number of kernels in Program, return type
   /// size_t.

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -320,7 +320,7 @@ etors:
     - name: QUEUE_ON_HOST_PROPERTIES
       desc: "[$x_queue_flags_t] host queue property bit-field"
     - name: BUILT_IN_KERNELS
-      desc: "[char[]] a semi-colon separated list of built-in kernels"
+      desc: "[char[]] a null-terminated semi-colon separated list of built-in kernels"
     - name: PLATFORM
       desc: "[$x_platform_handle_t] the platform associated with the device"
     - name: REFERENCE_COUNT
@@ -329,21 +329,21 @@ etors:
             The reference count returned should be considered immediately stale.
             It is unsuitable for general use in applications. This feature is provided for identifying memory leaks.
     - name: IL_VERSION
-      desc: "[char[]] IL version"
+      desc: "[char[]] null-terminated IL version"
     - name: NAME
-      desc: "[char[]] Device name"
+      desc: "[char[]] null-terminated device name"
     - name: VENDOR
-      desc: "[char[]] Device vendor"
+      desc: "[char[]] null-terminated device vendor"
     - name: DRIVER_VERSION
-      desc: "[char[]] Driver version"
+      desc: "[char[]] null-terminated driver version"
     - name: PROFILE
-      desc: "[char[]] Device profile"
+      desc: "[char[]] null-terminated device profile"
     - name: VERSION
-      desc: "[char[]] Device version"
+      desc: "[char[]] null-terminated device version"
     - name: BACKEND_RUNTIME_VERSION
-      desc: "[char[]] Version of backend runtime"
+      desc: "[char[]] null-terminated version of backend runtime"
     - name: EXTENSIONS
-      desc: "[char[]] Return a space separated list of extension names"
+      desc: "[char[]] Return a null-terminated space separated list of extension names"
     - name: PRINTF_BUFFER_SIZE
       desc: "[size_t] Maximum size in bytes of internal printf buffer"
     - name: PREFERRED_INTEROP_USER_SYNC
@@ -359,7 +359,7 @@ etors:
             [$x_device_affinity_domain_flags_t] Returns a bit-field of the supported affinity domains for partitioning.
             If the device does not support any affinity domains, then 0 will be returned.
     - name: PARTITION_TYPE
-      desc: "[$x_device_partition_property_t[]] return an array of $x_device_partition_property_t for properties specified in $xDevicePartition"
+      desc: "[$x_device_partition_property_t[]] returns an array of properties specified in $xDevicePartition"
     - name: MAX_NUM_SUB_GROUPS
       desc: "[uint32_t] max number of sub groups"
     - name: SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS
@@ -379,7 +379,7 @@ etors:
     - name: UUID
       desc: "[uint8_t[]][optional-query] return device UUID"
     - name: PCI_ADDRESS
-      desc: "[char[]][optional-query] return device PCI address"
+      desc: "[char[]][optional-query] return null-terminated device PCI address"
     - name: GPU_EU_COUNT
       desc: "[uint32_t][optional-query] return Intel GPU EU count"
     - name: GPU_EU_SIMD_WIDTH

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -88,19 +88,19 @@ etors:
       desc: "[$x_bool_t] returns true if the device supports sampling cubemapped images across face boundaries"
     - name: BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_EXP
       value: "0x2012"
-      desc: "[$x_bool_t] returns true if the device is capable of fetching USM backed 1D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports fetching USM backed 1D sampled image data."
     - name: BINDLESS_SAMPLED_IMAGE_FETCH_1D_EXP
       value: "0x2013"
-      desc: "[$x_bool_t] returns true if the device is capable of fetching non-USM backed 1D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports fetching non-USM backed 1D sampled image data."
     - name: BINDLESS_SAMPLED_IMAGE_FETCH_2D_USM_EXP
       value: "0x2014"
-      desc: "[$x_bool_t] returns true if the device is capable of fetching USM backed 2D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports fetching USM backed 2D sampled image data."
     - name: BINDLESS_SAMPLED_IMAGE_FETCH_2D_EXP
       value: "0x2015"
-      desc: "[$x_bool_t] returns true if the device is capable of fetching non-USM backed 2D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports fetching non-USM backed 2D sampled image data."
     - name: BINDLESS_SAMPLED_IMAGE_FETCH_3D_EXP
       value: "0x2017"
-      desc: "[$x_bool_t] returns true if the device is capable of fetching non-USM backed 3D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports fetching non-USM backed 3D sampled image data."
     - name: IMAGE_ARRAY_SUPPORT_EXP
       value: "0x2019"
       desc: "[$x_bool_t] returns true if the device supports allocating and accessing image array resources."
@@ -109,10 +109,10 @@ etors:
       desc: "[$x_bool_t] returns true if the device supports unique addressing per dimension."
     - name: BINDLESS_SAMPLE_1D_USM_EXP
       value: "0x201B"
-      desc: "[$x_bool_t] returns true if the device is capable of sampling USM backed 1D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports sampling USM backed 1D sampled image data."
     - name: BINDLESS_SAMPLE_2D_USM_EXP
       value: "0x201C"
-      desc: "[$x_bool_t] returns true if the device is capable of sampling USM backed 2D sampled image data."
+      desc: "[$x_bool_t] returns true if the device supports sampling USM backed 2D sampled image data."
 --- #--------------------------------------------------------------------------
 type: enum
 extend: true

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -59,20 +59,20 @@ typed_etors: True
 etors:
     - name: NAME
       value: "1"
-      desc: "[char[]] The string denoting name of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The null-terminated string denoting name of the platform. The size of the info needs to be dynamically queried."
     - name: VENDOR_NAME
       value: "2"
-      desc: "[char[]] The string denoting name of the vendor of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The null-terminated string denoting name of the vendor of the platform. The size of the info needs to be dynamically queried."
     - name: VERSION
       value: "3"
-      desc: "[char[]] The string denoting the version of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The null-terminated string denoting the version of the platform. The size of the info needs to be dynamically queried."
     - name: EXTENSIONS
       value: "4"
-      desc: "[char[]] The string denoting extensions supported by the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The null-terminated string denoting extensions supported by the platform. The size of the info needs to be dynamically queried."
       todo: "document extensions names and their meaning"
     - name: PROFILE
       value: "5"
-      desc: "[char[]] The string denoting profile of the platform. The size of the info needs to be dynamically queried."
+      desc: "[char[]] The null-terminated string denoting profile of the platform. The size of the info needs to be dynamically queried."
       todo: "currently always return FULL_PROFILE, deprecate?"
     - name: BACKEND
       value: "6"

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -381,11 +381,11 @@ etors:
           [$x_device_handle_t[]] Return list of devices associated with a program.
           This is either the list of devices associated with the context or a subset of those devices when the program is created using $xProgramCreateWithBinary.
     - name: IL
-      desc: "[char[]] Return program IL if the program was created with $xProgramCreateWithIL, otherwise return size will be set to 0 and nothing will be returned."
+      desc: "[char[]] Return program IL if the program was created with $xProgramCreateWithIL, otherwise return size will be set to 0 and nothing will be returned. This is not null-terminated."
     - name: BINARY_SIZES
       desc: "[size_t[]] Return program binary sizes for each device."
     - name: BINARIES
-      desc: "[unsigned char[]] Return program binaries for all devices for this Program."
+      desc: "[unsigned char[]] Return program binaries for all devices for this Program. These are not null-terminated."
     - name: NUM_KERNELS
       desc: "[size_t][optional-query] Number of kernels in Program, return type size_t."
     - name: KERNEL_NAMES

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -862,21 +862,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &tex_max_linear_width,
         CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH, hDevice->get()));
-    return ReturnValue(tex_max_linear_width);
+    return ReturnValue(static_cast<size_t>(tex_max_linear_width));
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP: {
     int32_t tex_max_linear_height = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &tex_max_linear_height,
         CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT, hDevice->get()));
-    return ReturnValue(tex_max_linear_height);
+    return ReturnValue(static_cast<size_t>(tex_max_linear_height));
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP: {
     int32_t tex_max_linear_pitch = 0;
     UR_CHECK_ERROR(cuDeviceGetAttribute(
         &tex_max_linear_pitch,
         CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH, hDevice->get()));
-    return ReturnValue(tex_max_linear_pitch);
+    return ReturnValue(static_cast<size_t>(tex_max_linear_pitch));
   }
   case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
     // CUDA supports mipmaps.

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -228,13 +228,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_IMAGE_SUPPORTED: {
     bool Enabled = false;
 
-    if (std::getenv("UR_HIP_ENABLE_IMAGE_SUPPORT") != nullptr) {
+    if (std::getenv("UR_HIP_ENABLE_IMAGE_SUPPORTED") != nullptr) {
       Enabled = true;
     } else {
       logger::always(
           "Images are not fully supported by the HIP BE, their support is "
           "disabled by default. Their partial support can be activated by "
-          "setting UR_HIP_ENABLE_IMAGE_SUPPORT environment variable at "
+          "setting UR_HIP_ENABLE_IMAGE_SUPPORTED environment variable at "
           "runtime.");
     }
 
@@ -823,17 +823,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP: {
     // Default values due to non-existent hipamd queries for linear sizes.
-    constexpr uint32_t MaxLinearWidth{1};
+    constexpr size_t MaxLinearWidth{1};
     return ReturnValue(MaxLinearWidth);
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP: {
     // Default values due to non-existent hipamd queries for linear sizes.
-    constexpr uint32_t MaxLinearHeight{1};
+    constexpr size_t MaxLinearHeight{1};
     return ReturnValue(MaxLinearHeight);
   }
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP: {
     // Default values due to non-existent hipamd queries for linear sizes.
-    constexpr uint32_t MaxLinearPitch{1};
+    constexpr size_t MaxLinearPitch{1};
     return ReturnValue(MaxLinearPitch);
   }
   case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
@@ -1070,6 +1070,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
   case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH:
   case UR_DEVICE_INFO_IP_VERSION:
+  case UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP:
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP:
     return ReturnValue(

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1105,7 +1105,7 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP:
     logger::error("Unsupported ParamName in urGetDeviceInfo");
     logger::error("ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
-    return UR_RESULT_ERROR_INVALID_VALUE;
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
     // L0 does not support mipmaps.
     return ReturnValue(false);
@@ -1117,7 +1117,7 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP:
     logger::error("Unsupported ParamName in urGetDeviceInfo");
     logger::error("ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
-    return UR_RESULT_ERROR_INVALID_VALUE;
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP: {
     // L0 does not support creation of images from individual mipmap levels.
     return ReturnValue(false);

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -434,6 +434,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS:
     return ReturnValue(false);
 
+  case UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT:
+    return ReturnValue(false);
+
   default:
     DIE_NO_IMPLEMENTATION;
   }

--- a/source/adapters/opencl/device.cpp
+++ b/source/adapters/opencl/device.cpp
@@ -151,203 +151,29 @@ mapCLDeviceFpConfigToUR(cl_device_fp_config CLValue) {
   return URValue;
 }
 
-static cl_int mapURDeviceInfoToCL(ur_device_info_t URPropName) {
-
-  switch (static_cast<uint32_t>(URPropName)) {
-  case UR_DEVICE_INFO_TYPE:
-    return CL_DEVICE_TYPE;
-  case UR_DEVICE_INFO_PARENT_DEVICE:
-    return CL_DEVICE_PARENT_DEVICE;
-  case UR_DEVICE_INFO_PLATFORM:
-    return CL_DEVICE_PLATFORM;
-  case UR_DEVICE_INFO_VENDOR_ID:
-    return CL_DEVICE_VENDOR_ID;
-  case UR_DEVICE_INFO_EXTENSIONS:
-    return CL_DEVICE_EXTENSIONS;
-  case UR_DEVICE_INFO_NAME:
-    return CL_DEVICE_NAME;
-  case UR_DEVICE_INFO_COMPILER_AVAILABLE:
-    return CL_DEVICE_COMPILER_AVAILABLE;
-  case UR_DEVICE_INFO_LINKER_AVAILABLE:
-    return CL_DEVICE_LINKER_AVAILABLE;
-  case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:
-    return CL_DEVICE_MAX_COMPUTE_UNITS;
-  case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
-    return CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS;
-  case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE:
-    return CL_DEVICE_MAX_WORK_GROUP_SIZE;
-  case UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES:
-    return CL_DEVICE_MAX_WORK_ITEM_SIZES;
-  case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY:
-    return CL_DEVICE_MAX_CLOCK_FREQUENCY;
-  case UR_DEVICE_INFO_ADDRESS_BITS:
-    return CL_DEVICE_ADDRESS_BITS;
-  case UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE:
-    return CL_DEVICE_MAX_MEM_ALLOC_SIZE;
-  case UR_DEVICE_INFO_GLOBAL_MEM_SIZE:
-    return CL_DEVICE_GLOBAL_MEM_SIZE;
-  case UR_DEVICE_INFO_LOCAL_MEM_SIZE:
-    return CL_DEVICE_LOCAL_MEM_SIZE;
-  case UR_DEVICE_INFO_IMAGE_SUPPORTED:
-    return CL_DEVICE_IMAGE_SUPPORT;
-  case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
-    return CL_DEVICE_HOST_UNIFIED_MEMORY;
-  case UR_DEVICE_INFO_AVAILABLE:
-    return CL_DEVICE_AVAILABLE;
-  case UR_DEVICE_INFO_VENDOR:
-    return CL_DEVICE_VENDOR;
-  case UR_DEVICE_INFO_DRIVER_VERSION:
-    return CL_DRIVER_VERSION;
-  case UR_DEVICE_INFO_VERSION:
-    return CL_DEVICE_VERSION;
-  case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
-    return CL_DEVICE_PARTITION_MAX_SUB_DEVICES;
-  case UR_DEVICE_INFO_REFERENCE_COUNT:
-    return CL_DEVICE_REFERENCE_COUNT;
-  case UR_DEVICE_INFO_SUPPORTED_PARTITIONS:
-    return CL_DEVICE_PARTITION_PROPERTIES;
-  case UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN:
-    return CL_DEVICE_PARTITION_AFFINITY_DOMAIN;
-  case UR_DEVICE_INFO_PARTITION_TYPE:
-    return CL_DEVICE_PARTITION_TYPE;
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
-    return CL_DEVICE_OPENCL_C_VERSION;
-  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC:
-    return CL_DEVICE_PREFERRED_INTEROP_USER_SYNC;
-  case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE:
-    return CL_DEVICE_PRINTF_BUFFER_SIZE;
-  case UR_DEVICE_INFO_PROFILE:
-    return CL_DEVICE_PROFILE;
-  case UR_DEVICE_INFO_BUILT_IN_KERNELS:
-    return CL_DEVICE_BUILT_IN_KERNELS;
-  case UR_DEVICE_INFO_QUEUE_PROPERTIES:
-    return CL_DEVICE_QUEUE_PROPERTIES;
-  case UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES:
-    return CL_DEVICE_QUEUE_ON_HOST_PROPERTIES;
-  case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES:
-    return CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES;
-  case UR_DEVICE_INFO_EXECUTION_CAPABILITIES:
-    return CL_DEVICE_EXECUTION_CAPABILITIES;
-  case UR_DEVICE_INFO_ENDIAN_LITTLE:
-    return CL_DEVICE_ENDIAN_LITTLE;
-  case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT:
-    return CL_DEVICE_ERROR_CORRECTION_SUPPORT;
-  case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION:
-    return CL_DEVICE_PROFILING_TIMER_RESOLUTION;
-  case UR_DEVICE_INFO_LOCAL_MEM_TYPE:
-    return CL_DEVICE_LOCAL_MEM_TYPE;
-  case UR_DEVICE_INFO_MAX_CONSTANT_ARGS:
-    return CL_DEVICE_MAX_CONSTANT_ARGS;
-  case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE:
-    return CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE;
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE:
-    return CL_DEVICE_GLOBAL_MEM_CACHE_TYPE;
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE:
-    return CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE;
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE:
-    return CL_DEVICE_GLOBAL_MEM_CACHE_SIZE;
-  case UR_DEVICE_INFO_MAX_PARAMETER_SIZE:
-    return CL_DEVICE_MAX_PARAMETER_SIZE;
-  case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN:
-    return CL_DEVICE_MEM_BASE_ADDR_ALIGN;
-  case UR_DEVICE_INFO_MAX_SAMPLERS:
-    return CL_DEVICE_MAX_SAMPLERS;
-  case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS:
-    return CL_DEVICE_MAX_READ_IMAGE_ARGS;
-  case UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS:
-    return CL_DEVICE_MAX_WRITE_IMAGE_ARGS;
-  case UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS:
-    return CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS;
-  case UR_DEVICE_INFO_SINGLE_FP_CONFIG:
-    return CL_DEVICE_SINGLE_FP_CONFIG;
-  case UR_DEVICE_INFO_HALF_FP_CONFIG:
-    return CL_DEVICE_HALF_FP_CONFIG;
-  case UR_DEVICE_INFO_DOUBLE_FP_CONFIG:
-    return CL_DEVICE_DOUBLE_FP_CONFIG;
-  case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH:
-    return CL_DEVICE_IMAGE2D_MAX_WIDTH;
-  case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT:
-    return CL_DEVICE_IMAGE2D_MAX_HEIGHT;
-  case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH:
-    return CL_DEVICE_IMAGE3D_MAX_WIDTH;
-  case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT:
-    return CL_DEVICE_IMAGE3D_MAX_HEIGHT;
-  case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH:
-    return CL_DEVICE_IMAGE3D_MAX_DEPTH;
-  case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE:
-    return CL_DEVICE_IMAGE_MAX_BUFFER_SIZE;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_INT;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE;
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF:
-    return CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF;
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF:
-    return CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF;
-  case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS:
-    return CL_DEVICE_MAX_NUM_SUB_GROUPS;
-  case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:
-    return CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS;
-  case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL:
-    return CL_DEVICE_SUB_GROUP_SIZES_INTEL;
-  case UR_DEVICE_INFO_IL_VERSION:
-    return CL_DEVICE_IL_VERSION;
-  case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE:
-    return CL_DEVICE_IMAGE_MAX_ARRAY_SIZE;
-  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
-    return CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL;
-  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
-    return CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL;
-  case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT:
-    return CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL;
-  case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT:
-    return CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL;
-  case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT:
-    return CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL;
-  case UR_DEVICE_INFO_GPU_EU_SLICES:
-    return CL_DEVICE_NUM_SLICES_INTEL;
-  case UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE:
-    return CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL;
-  case UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE:
-    return CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL;
-  case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
-    return CL_DEVICE_NUM_THREADS_PER_EU_INTEL;
-  case UR_DEVICE_INFO_IP_VERSION:
-    return CL_DEVICE_IP_VERSION_INTEL;
-  default:
-    return -1;
-  }
-}
-
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                                     ur_device_info_t propName,
                                                     size_t propSize,
                                                     void *pPropValue,
                                                     size_t *pPropSizeRet) {
+  /* We can convert between OpenCL and UR outputs because the sizes
+   * of OpenCL types are the same as UR.
+   * | CL                 | UR                     | Size |
+   * | char[]             | char[]                 | 8    |
+   * | cl_uint            | uint32_t               | 4    |
+   * | cl_ulong           | uint64_t               | 8    |
+   * | size_t             | size_t                 | 8    |
+   * | cl_platform_id     | ur_platform_handle_t   | 8    |
+   * | cl_device_id       | ur_device_handle_t     | 8    |
+   *
+   * These other types are equivalent:
+   * | cl_device_fp_config | ur_device_fp_capability_flags_t |
+   * | cl_bitfield / enum | ur_flags_t |
+   * | cl_bool | ur_bool_t |
+   * | cl_device_atomic_capabilities | ur_memory_order_capability_flags_t |
+   */
 
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
-
-  const cl_device_info CLPropName = mapURDeviceInfoToCL(propName);
 
   /* TODO UR: Casting to uint32_t to silence warnings due to some values not
    * being part of the enum. Can be removed once all UR_EXT enums are promoted
@@ -356,7 +182,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_TYPE: {
     cl_device_type CLType;
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_TYPE,
                         sizeof(cl_device_type), &CLType, nullptr));
 
     /* TODO UR: If the device is an Accelerator (FPGA, VPU, etc.), there is not
@@ -402,15 +228,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(Results.c_str(), Results.size() + 1);
   }
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS: {
+    const cl_device_info info_name = CL_DEVICE_PARTITION_PROPERTIES;
     size_t CLSize;
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName, 0,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name, 0,
                         nullptr, &CLSize));
     const size_t NProperties = CLSize / sizeof(cl_device_partition_property);
 
     std::vector<cl_device_partition_property> CLValue(NProperties);
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name,
                         CLSize, CLValue.data(), nullptr));
 
     /* The OpenCL implementation returns a value of 0 if no properties are
@@ -430,10 +257,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(URValue.data(), URValue.size());
   }
   case UR_DEVICE_INFO_PARTITION_TYPE: {
-
+    const cl_device_info info_name = CL_DEVICE_PARTITION_TYPE;
     size_t CLSize;
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName, 0,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name, 0,
                         nullptr, &CLSize));
     const size_t NProperties = CLSize / sizeof(cl_device_partition_property);
 
@@ -449,7 +276,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     auto CLValue =
         reinterpret_cast<cl_device_partition_property *>(alloca(CLSize));
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name,
                         CLSize, CLValue, nullptr));
 
     std::vector<ur_device_partition_property_t> URValue(NProperties - 1);
@@ -526,27 +353,37 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       return ReturnValue(1u);
     }
   }
-  case UR_DEVICE_INFO_SINGLE_FP_CONFIG:
-  case UR_DEVICE_INFO_HALF_FP_CONFIG:
-  case UR_DEVICE_INFO_DOUBLE_FP_CONFIG: {
-    /* CL type: cl_device_fp_config
-     * UR type: ur_device_fp_capability_flags_t */
-    if (propName == UR_DEVICE_INFO_HALF_FP_CONFIG) {
-      bool Supported;
-      UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
-          cl_adapter::cast<cl_device_id>(hDevice), {"cl_khr_fp16"}, Supported));
+  case UR_DEVICE_INFO_SINGLE_FP_CONFIG: {
+    cl_device_fp_config CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_SINGLE_FP_CONFIG,
+        sizeof(cl_device_fp_config), &CLValue, nullptr));
 
-      if (!Supported) {
-        // If we don't support the extension then our capabilities are 0.
-        ur_device_fp_capability_flags_t halfCapabilities = 0;
-        return ReturnValue(halfCapabilities);
-      }
+    return ReturnValue(mapCLDeviceFpConfigToUR(CLValue));
+  }
+  case UR_DEVICE_INFO_HALF_FP_CONFIG: {
+    bool Supported;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice), {"cl_khr_fp16"}, Supported));
+
+    if (!Supported) {
+      // If we don't support the extension then our capabilities are 0.
+      ur_device_fp_capability_flags_t halfCapabilities = 0;
+      return ReturnValue(halfCapabilities);
     }
 
     cl_device_fp_config CLValue;
-    CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                        sizeof(cl_device_fp_config), &CLValue, nullptr));
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_HALF_FP_CONFIG,
+        sizeof(cl_device_fp_config), &CLValue, nullptr));
+
+    return ReturnValue(mapCLDeviceFpConfigToUR(CLValue));
+  }
+  case UR_DEVICE_INFO_DOUBLE_FP_CONFIG: {
+    cl_device_fp_config CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_DOUBLE_FP_CONFIG,
+        sizeof(cl_device_fp_config), &CLValue, nullptr));
 
     return ReturnValue(mapCLDeviceFpConfigToUR(CLValue));
   }
@@ -597,8 +434,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                         UR_MEMORY_ORDER_CAPABILITY_FLAG_ACQ_REL |
                         UR_MEMORY_ORDER_CAPABILITY_FLAG_SEQ_CST;
     }
-    /* cl_device_atomic_capabilities is uint64_t and
-     * ur_memory_order_capability_flags_t is uint32_t */
     return ReturnValue(
         static_cast<ur_memory_order_capability_flags_t>(URCapabilities));
   }
@@ -653,8 +488,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       }
     }
 
-    /* cl_device_atomic_capabilities is uint64_t and
-     * ur_memory_scope_capability_flags_t is uint32_t */
     return ReturnValue(
         static_cast<ur_memory_scope_capability_flags_t>(URCapabilities));
   }
@@ -701,8 +534,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       }
     }
 
-    /* cl_device_atomic_capabilities is uint64_t and
-     * ur_memory_order_capability_flags_t is uint32_t */
     return ReturnValue(
         static_cast<ur_memory_order_capability_flags_t>(URCapabilities));
   }
@@ -772,8 +603,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       }
     }
 
-    /* cl_device_atomic_capabilities is uint64_t and
-     * ur_memory_scope_capability_flags_t is uint32_t */
     return ReturnValue(
         static_cast<ur_memory_scope_capability_flags_t>(URCapabilities));
   }
@@ -880,33 +709,68 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         {"cl_intel_global_variable_access"}, Supported));
     return ReturnValue(Supported);
   }
-  case UR_DEVICE_INFO_QUEUE_PROPERTIES:
-  case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES:
-  case UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES:
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE:
-  case UR_DEVICE_INFO_LOCAL_MEM_TYPE:
-  case UR_DEVICE_INFO_EXECUTION_CAPABILITIES:
-  case UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN: {
-    /* CL type: cl_bitfield / enum
-     * UR type: ur_flags_t (uint32_t) */
-
+  case UR_DEVICE_INFO_QUEUE_PROPERTIES: {
     cl_bitfield CLValue = 0;
-    CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                        sizeof(cl_bitfield), &CLValue, nullptr));
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_QUEUE_PROPERTIES,
+        sizeof(cl_bitfield), &CLValue, nullptr));
 
-    /* We can just static_cast the output because OpenCL and UR bitfields
-     * map 1 to 1 for these properties. cl_bitfield is uint64_t and ur_flags_t
-     * types are uint32_t */
     return ReturnValue(static_cast<uint32_t>(CLValue));
   }
-  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
-  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
-  case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT:
-  case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT:
-  case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT: {
-    /* CL type: cl_bitfield / enum
-     * UR type: ur_flags_t (uint32_t) */
+  case UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES,
+                        sizeof(cl_bitfield), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_QUEUE_ON_HOST_PROPERTIES, sizeof(cl_bitfield),
+                        &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_GLOBAL_MEM_CACHE_TYPE, sizeof(cl_bitfield),
+                        &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_LOCAL_MEM_TYPE: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_LOCAL_MEM_TYPE,
+        sizeof(cl_bitfield), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_EXECUTION_CAPABILITIES: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_EXECUTION_CAPABILITIES, sizeof(cl_bitfield),
+                        &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN: {
+    cl_bitfield CLValue = 0;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PARTITION_AFFINITY_DOMAIN,
+                        sizeof(cl_bitfield), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<uint32_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_USM_HOST_SUPPORT: {
     bool Supported = false;
     UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
         cl_adapter::cast<cl_device_id>(hDevice),
@@ -914,36 +778,145 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     if (Supported) {
       cl_bitfield CLValue = 0;
       CL_RETURN_ON_FAILURE(
-          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL,
                           sizeof(cl_bitfield), &CLValue, nullptr));
       return ReturnValue(static_cast<uint32_t>(CLValue));
     } else {
       return ReturnValue(0);
     }
   }
-  case UR_DEVICE_INFO_IMAGE_SUPPORTED:
-  case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT:
-  case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
-  case UR_DEVICE_INFO_ENDIAN_LITTLE:
-  case UR_DEVICE_INFO_AVAILABLE:
-  case UR_DEVICE_INFO_COMPILER_AVAILABLE:
-  case UR_DEVICE_INFO_LINKER_AVAILABLE:
-  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
-    /* CL type: cl_bool
-     * UR type: ur_bool_t */
+  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT: {
+    bool Supported = false;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_unified_shared_memory"}, Supported));
+    if (Supported) {
+      cl_bitfield CLValue = 0;
+      CL_RETURN_ON_FAILURE(
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL,
+                          sizeof(cl_bitfield), &CLValue, nullptr));
+      return ReturnValue(static_cast<uint32_t>(CLValue));
+    } else {
+      return ReturnValue(0);
+    }
+  }
+  case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT: {
+    bool Supported = false;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_unified_shared_memory"}, Supported));
+    if (Supported) {
+      cl_bitfield CLValue = 0;
+      CL_RETURN_ON_FAILURE(
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+                          sizeof(cl_bitfield), &CLValue, nullptr));
+      return ReturnValue(static_cast<uint32_t>(CLValue));
+    } else {
+      return ReturnValue(0);
+    }
+  }
+  case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT: {
+    bool Supported = false;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_unified_shared_memory"}, Supported));
+    if (Supported) {
+      cl_bitfield CLValue = 0;
+      CL_RETURN_ON_FAILURE(
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL,
+                          sizeof(cl_bitfield), &CLValue, nullptr));
+      return ReturnValue(static_cast<uint32_t>(CLValue));
+    } else {
+      return ReturnValue(0);
+    }
+  }
+  case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT: {
+    bool Supported = false;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_unified_shared_memory"}, Supported));
+    if (Supported) {
+      cl_bitfield CLValue = 0;
+      CL_RETURN_ON_FAILURE(
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL,
+                          sizeof(cl_bitfield), &CLValue, nullptr));
+      return ReturnValue(static_cast<uint32_t>(CLValue));
+    } else {
+      return ReturnValue(0);
+    }
+  }
+  case UR_DEVICE_INFO_IMAGE_SUPPORTED: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE_SUPPORT,
+        sizeof(cl_bool), &CLValue, nullptr));
 
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     cl_bool CLValue;
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                        sizeof(cl_bool), &CLValue, nullptr));
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_ERROR_CORRECTION_SUPPORT, sizeof(cl_bool),
+                        &CLValue, nullptr));
 
-    /* cl_bool is uint32_t and ur_bool_t is bool */
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_HOST_UNIFIED_MEMORY,
+        sizeof(cl_bool), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_ENDIAN_LITTLE: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_ENDIAN_LITTLE,
+        sizeof(cl_bool), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_AVAILABLE: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_AVAILABLE,
+        sizeof(cl_bool), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_COMPILER_AVAILABLE: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_COMPILER_AVAILABLE,
+        sizeof(cl_bool), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_LINKER_AVAILABLE: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_LINKER_AVAILABLE,
+        sizeof(cl_bool), &CLValue, nullptr));
+
+    return ReturnValue(static_cast<ur_bool_t>(CLValue));
+  }
+  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC: {
+    cl_bool CLValue;
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_INTEROP_USER_SYNC, sizeof(cl_bool),
+                        &CLValue, nullptr));
+
     return ReturnValue(static_cast<ur_bool_t>(CLValue));
   }
   case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {
-    /* CL type: cl_bool
-     * UR type: ur_bool_t */
-
     oclv::OpenCLVersion DevVer;
     CL_RETURN_ON_FAILURE(cl_adapter::getDeviceVersion(
         cl_adapter::cast<cl_device_id>(hDevice), DevVer));
@@ -952,84 +925,418 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     if (DevVer >= oclv::V2_1) {
       cl_bool CLValue;
       CL_RETURN_ON_FAILURE(
-          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+          clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                          CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
                           sizeof(cl_bool), &CLValue, nullptr));
 
-      /* cl_bool is uint32_t and ur_bool_t is bool */
       return ReturnValue(static_cast<ur_bool_t>(CLValue));
     } else {
       return ReturnValue(false);
     }
   }
-  case UR_DEVICE_INFO_VENDOR_ID:
-  case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:
-  case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE:
-  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE:
-  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF:
-  case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY:
-  case UR_DEVICE_INFO_ADDRESS_BITS:
-  case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS:
-  case UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS:
-  case UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS:
-  case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN:
-  case UR_DEVICE_INFO_MAX_SAMPLERS:
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE:
-  case UR_DEVICE_INFO_MAX_CONSTANT_ARGS:
-  case UR_DEVICE_INFO_REFERENCE_COUNT:
-  case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
-  case UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE:
-  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE:
-  case UR_DEVICE_INFO_GLOBAL_MEM_SIZE:
-  case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE:
-  case UR_DEVICE_INFO_LOCAL_MEM_SIZE:
-  case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE:
-  case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH:
-  case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT:
-  case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH:
-  case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT:
-  case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH:
-  case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE:
-  case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE:
-  case UR_DEVICE_INFO_MAX_PARAMETER_SIZE:
-  case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION:
-  case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE:
-  case UR_DEVICE_INFO_PLATFORM:
-  case UR_DEVICE_INFO_PARENT_DEVICE:
-  case UR_DEVICE_INFO_IL_VERSION:
-  case UR_DEVICE_INFO_NAME:
-  case UR_DEVICE_INFO_VENDOR:
-  case UR_DEVICE_INFO_DRIVER_VERSION:
-  case UR_DEVICE_INFO_PROFILE:
-  case UR_DEVICE_INFO_VERSION:
-  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
-  case UR_DEVICE_INFO_BUILT_IN_KERNELS:
-  case UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES: {
-    /* We can just use the OpenCL outputs because the sizes of OpenCL types
-     * are the same as UR.
-     * | CL                 | UR                     | Size |
-     * | char[]             | char[]                 | 8    |
-     * | cl_uint            | uint32_t               | 4    |
-     * | cl_ulong           | uint64_t               | 8    |
-     * | size_t             | size_t                 | 8    |
-     * | cl_platform_id     | ur_platform_handle_t   | 8    |
-     * | ur_device_handle_t | cl_device_id           | 8    |
-     */
+  case UR_DEVICE_INFO_VENDOR_ID: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_VENDOR_ID, propSize,
+        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_COMPUTE_UNITS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_INT, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_LONG, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_FLOAT, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_SHORT, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        CL_DEVICE_NATIVE_VECTOR_WIDTH_INT, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_LONG, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_FLOAT, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_DOUBLE, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NATIVE_VECTOR_WIDTH_HALF, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_CLOCK_FREQUENCY,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_ADDRESS_BITS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_ADDRESS_BITS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_READ_IMAGE_ARGS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS: {
 
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MEM_BASE_ADDR_ALIGN,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_SAMPLERS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_SAMPLERS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_CONSTANT_ARGS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_CONSTANT_ARGS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_REFERENCE_COUNT: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_REFERENCE_COUNT,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PARTITION_MAX_SUB_DEVICES, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_MEM_ALLOC_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_GLOBAL_MEM_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_LOCAL_MEM_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_LOCAL_MEM_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_WORK_GROUP_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE2D_MAX_WIDTH,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE2D_MAX_HEIGHT,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE3D_MAX_WIDTH,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE3D_MAX_HEIGHT,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE3D_MAX_DEPTH,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        CL_DEVICE_IMAGE_MAX_BUFFER_SIZE, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IMAGE_MAX_ARRAY_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_PARAMETER_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_PARAMETER_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PROFILING_TIMER_RESOLUTION, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_PRINTF_BUFFER_SIZE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PLATFORM: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_PLATFORM, propSize,
+        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PARENT_DEVICE: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_PARENT_DEVICE,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IL_VERSION: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IL_VERSION, propSize,
+        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_NAME: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_NAME,
                         propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_VENDOR: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_VENDOR, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_DRIVER_VERSION: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DRIVER_VERSION, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_PROFILE: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_PROFILE, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_VERSION: {
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_VERSION, propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_OPENCL_C_VERSION,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_BUILT_IN_KERNELS: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_BUILT_IN_KERNELS,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES: {
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_MAX_WORK_ITEM_SIZES,
+        propSize, pPropValue, pPropSizeRet));
 
     return UR_RESULT_SUCCESS;
   }
@@ -1081,11 +1388,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
 
     return UR_RESULT_SUCCESS;
   }
-  case UR_DEVICE_INFO_GPU_EU_SLICES:
-  case UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE:
-  case UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE:
-  case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
-  case UR_DEVICE_INFO_IP_VERSION: {
+  case UR_DEVICE_INFO_GPU_EU_SLICES: {
+    bool Supported;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_device_attribute_query"}, Supported));
+    if (!Supported) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_NUM_SLICES_INTEL,
+        propSize, pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE: {
     bool Supported;
     UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
         cl_adapter::cast<cl_device_id>(hDevice),
@@ -1094,13 +1411,59 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
       return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     }
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
-                        propSize, pPropValue, pPropSizeRet));
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NUM_EUS_PER_SUB_SLICE_INTEL, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE: {
+    bool Supported;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_device_attribute_query"}, Supported));
+    if (!Supported) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NUM_SUB_SLICES_PER_SLICE_INTEL, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU: {
+    bool Supported;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_device_attribute_query"}, Supported));
+    if (!Supported) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+    CL_RETURN_ON_FAILURE(
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice),
+                        CL_DEVICE_NUM_THREADS_PER_EU_INTEL, propSize,
+                        pPropValue, pPropSizeRet));
+
+    return UR_RESULT_SUCCESS;
+  }
+  case UR_DEVICE_INFO_IP_VERSION: {
+    bool Supported;
+    UR_RETURN_ON_FAILURE(cl_adapter::checkDeviceExtensions(
+        cl_adapter::cast<cl_device_id>(hDevice),
+        {"cl_intel_device_attribute_query"}, Supported));
+    if (!Supported) {
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+    }
+    CL_RETURN_ON_FAILURE(clGetDeviceInfo(
+        cl_adapter::cast<cl_device_id>(hDevice), CL_DEVICE_IP_VERSION_INTEL,
+        propSize, pPropValue, pPropSizeRet));
 
     return UR_RESULT_SUCCESS;
   }
 
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
+    const cl_device_info info_name = CL_DEVICE_SUB_GROUP_SIZES_INTEL;
     bool isExtensionSupported;
     if (cl_adapter::checkDeviceExtensions(
             cl_adapter::cast<cl_device_id>(hDevice),
@@ -1115,11 +1478,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // Have to convert size_t to uint32_t
     size_t SubGroupSizesSize = 0;
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName, 0,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name, 0,
                         nullptr, &SubGroupSizesSize));
     std::vector<size_t> SubGroupSizes(SubGroupSizesSize / sizeof(size_t));
     CL_RETURN_ON_FAILURE(
-        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), CLPropName,
+        clGetDeviceInfo(cl_adapter::cast<cl_device_id>(hDevice), info_name,
                         SubGroupSizesSize, SubGroupSizes.data(), nullptr));
     return ReturnValue.template operator()<uint32_t>(SubGroupSizes.data(),
                                                      SubGroupSizes.size());
@@ -1157,38 +1520,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                         CL_DEVICE_UUID_KHR, UUID.size(), UUID.data(), nullptr));
     return ReturnValue(UUID);
   }
-
-  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
-    return ReturnValue(
-        ur::cl::getAdapter()->clSetProgramSpecializationConstant != nullptr);
-  }
-
-  // We can't query to check if these are supported, they will need to be
-  // manually updated if support is ever implemented.
-  case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
-  case UR_DEVICE_INFO_BFLOAT16:
-  case UR_DEVICE_INFO_ASYNC_BARRIER: {
-    return ReturnValue(false);
-  }
-
-  case UR_DEVICE_INFO_USM_POOL_SUPPORT: {
-    return ReturnValue(false);
-  }
-
-  /* TODO: Check regularly to see if support is enabled in OpenCL. Intel GPU
-   * EU device-specific information extensions. Some of the queries are
-   * enabled by cl_intel_device_attribute_query extension, but it's not yet in
-   * the Registry. */
-  case UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH:
-  case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH:
-  /* This enums have no equivalent in OpenCL */
-  case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP:
-  case UR_DEVICE_INFO_GLOBAL_MEM_FREE:
-  case UR_DEVICE_INFO_MEMORY_CLOCK_RATE:
-  case UR_DEVICE_INFO_MEMORY_BUS_WIDTH:
-  case UR_DEVICE_INFO_COMPONENT_DEVICES:
-  case UR_DEVICE_INFO_COMPOSITE_DEVICE:
-    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   case UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP: {
     bool Is2DBlockIOSupported = false;
     if (cl_adapter::checkDeviceExtensions(
@@ -1223,10 +1554,59 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         getDeviceCommandBufferUpdateCapabilities(Dev, UpdateCapabilities));
     return ReturnValue(UpdateCapabilities);
   }
+  case UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS: {
+    return ReturnValue(
+        ur::cl::getAdapter()->clSetProgramSpecializationConstant != nullptr);
+  }
+  // TODO: We can't query to check if these are supported, they will need to be
+  // manually updated if support is ever implemented.
+  case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
+  case UR_DEVICE_INFO_BFLOAT16:
+  case UR_DEVICE_INFO_ASYNC_BARRIER:
+  case UR_DEVICE_INFO_USM_POOL_SUPPORT: // end of TODO
   case UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP:
-    return ReturnValue(false);
   case UR_DEVICE_INFO_LOW_POWER_EVENTS_EXP:
+  case UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP:
+  case UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP:
+  case UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP:
+  case UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP:
+  case UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP:
+  case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP:
+  case UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP:
+  case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP:
+  case UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP:
+  case UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP:
+  case UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP:
+  case UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_USM_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_3D_EXP:
+  case UR_DEVICE_INFO_IMAGE_ARRAY_SUPPORT_EXP:
+  case UR_DEVICE_INFO_BINDLESS_UNIQUE_ADDRESSING_PER_DIM_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLE_1D_USM_EXP:
+  case UR_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_EXP:
     return ReturnValue(false);
+  case UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP:
+  case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP:
+  case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP:
+  case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP:
+  case UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP:
+  /* TODO: Check regularly to see if support is enabled in OpenCL. Intel GPU
+   * EU device-specific information extensions. Some of the queries are
+   * enabled by cl_intel_device_attribute_query extension, but it's not yet in
+   * the Registry. */
+  case UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH:
+  case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH:
+  /* These enums have no equivalent in OpenCL */
+  case UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP:
+  case UR_DEVICE_INFO_GLOBAL_MEM_FREE:
+  case UR_DEVICE_INFO_MEMORY_CLOCK_RATE:
+  case UR_DEVICE_INFO_MEMORY_BUS_WIDTH:
+  case UR_DEVICE_INFO_COMPONENT_DEVICES:
+  case UR_DEVICE_INFO_COMPOSITE_DEVICE:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default: {
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -10,335 +10,2558 @@
 #include <uur/fixtures.h>
 #include <uur/known_failure.h>
 
-static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
-    {UR_DEVICE_INFO_TYPE, sizeof(ur_device_type_t)},
-    {UR_DEVICE_INFO_VENDOR_ID, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_DEVICE_ID, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_COMPUTE_UNITS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_SINGLE_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
-    {UR_DEVICE_INFO_HALF_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
-    {UR_DEVICE_INFO_DOUBLE_FP_CONFIG, sizeof(ur_device_fp_capability_flags_t)},
-    {UR_DEVICE_INFO_QUEUE_PROPERTIES, sizeof(ur_queue_flags_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MEMORY_CLOCK_RATE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_ADDRESS_BITS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_IMAGE_SUPPORTED, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_MAX_SAMPLERS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_PARAMETER_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE, sizeof(ur_device_mem_cache_type_t)},
-    {UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_GLOBAL_MEM_SIZE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_GLOBAL_MEM_FREE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_MAX_CONSTANT_ARGS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_LOCAL_MEM_TYPE, sizeof(ur_device_local_mem_type_t)},
-    {UR_DEVICE_INFO_LOCAL_MEM_SIZE, sizeof(uint64_t)},
-    {UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_HOST_UNIFIED_MEMORY, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION, sizeof(size_t)},
-    {UR_DEVICE_INFO_ENDIAN_LITTLE, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_AVAILABLE, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_COMPILER_AVAILABLE, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_LINKER_AVAILABLE, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_EXECUTION_CAPABILITIES,
-     sizeof(ur_device_exec_capability_flags_t)},
-    {UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES, sizeof(ur_queue_flags_t)},
-    {UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES, sizeof(ur_queue_flags_t)},
-    {UR_DEVICE_INFO_PLATFORM, sizeof(ur_platform_handle_t)},
-    {UR_DEVICE_INFO_REFERENCE_COUNT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PRINTF_BUFFER_SIZE, sizeof(size_t)},
-    {UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_PARENT_DEVICE, sizeof(ur_device_handle_t)},
-    {UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,
-     sizeof(ur_device_affinity_domain_flags_t)},
-    {UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_USM_HOST_SUPPORT,
-     sizeof(ur_device_usm_access_capability_flags_t)},
-    {UR_DEVICE_INFO_USM_DEVICE_SUPPORT,
-     sizeof(ur_device_usm_access_capability_flags_t)},
-    {UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,
-     sizeof(ur_device_usm_access_capability_flags_t)},
-    {UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,
-     sizeof(ur_device_usm_access_capability_flags_t)},
-    {UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,
-     sizeof(ur_device_usm_access_capability_flags_t)},
-    {UR_DEVICE_INFO_GPU_EU_COUNT, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GPU_EU_SLICES, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_IMAGE_SRGB, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_BUILD_ON_SUBDEVICE, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_ATOMIC_64, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,
-     sizeof(ur_memory_order_capability_flags_t)},
-    {UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES,
-     sizeof(ur_memory_scope_capability_flags_t)},
-    {UR_DEVICE_INFO_BFLOAT16, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MEMORY_BUS_WIDTH, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_WORK_GROUPS_3D, sizeof(size_t[3])},
-    {UR_DEVICE_INFO_ASYNC_BARRIER, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_COMPONENT_DEVICES, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_COMPOSITE_DEVICE, sizeof(ur_device_handle_t)},
-    {UR_DEVICE_INFO_USM_POOL_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP,
-     sizeof(ur_exp_device_2d_block_array_capability_flags_t)},
-    {UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES,
-     sizeof(ur_memory_order_capability_flags_t)},
-    {UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES,
-     sizeof(ur_memory_scope_capability_flags_t)},
-    {UR_DEVICE_INFO_ESIMD_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_IP_VERSION, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT, sizeof(ur_bool_t)},
-    {UR_DEVICE_INFO_NUM_COMPUTE_UNITS, sizeof(uint32_t)}};
+using urDeviceGetInfoTest = uur::urDeviceTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetInfoTest);
 
-using urDeviceGetInfoTest = uur::urDeviceTestWithParam<ur_device_info_t>;
+TEST_P(urDeviceGetInfoTest, SuccessDeviceType) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_TYPE;
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
-    urDeviceGetInfoTest,
-    ::testing::Values(
-
-        UR_DEVICE_INFO_TYPE,
-        UR_DEVICE_INFO_VENDOR_ID,                              //
-        UR_DEVICE_INFO_DEVICE_ID,                              //
-        UR_DEVICE_INFO_MAX_COMPUTE_UNITS,                      //
-        UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,               //
-        UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,                    //
-        UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,                    //
-        UR_DEVICE_INFO_SINGLE_FP_CONFIG,                       //
-        UR_DEVICE_INFO_HALF_FP_CONFIG,                         //
-        UR_DEVICE_INFO_DOUBLE_FP_CONFIG,                       //
-        UR_DEVICE_INFO_QUEUE_PROPERTIES,                       //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR,            //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT,           //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG,            //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT,           //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR,               //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT,              //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT,                //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG,               //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT,              //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE,             //
-        UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF,               //
-        UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY,                    //
-        UR_DEVICE_INFO_MEMORY_CLOCK_RATE,                      //
-        UR_DEVICE_INFO_ADDRESS_BITS,                           //
-        UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,                     //
-        UR_DEVICE_INFO_IMAGE_SUPPORTED,                        //
-        UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS,                    //
-        UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS,                   //
-        UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,              //
-        UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH,                      //
-        UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT,                     //
-        UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH,                      //
-        UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT,                     //
-        UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH,                      //
-        UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE,                  //
-        UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE,                   //
-        UR_DEVICE_INFO_MAX_SAMPLERS,                           //
-        UR_DEVICE_INFO_MAX_PARAMETER_SIZE,                     //
-        UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN,                    //
-        UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE,                  //
-        UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE,              //
-        UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE,                  //
-        UR_DEVICE_INFO_GLOBAL_MEM_SIZE,                        //
-        UR_DEVICE_INFO_GLOBAL_MEM_FREE,                        //
-        UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE,               //
-        UR_DEVICE_INFO_MAX_CONSTANT_ARGS,                      //
-        UR_DEVICE_INFO_LOCAL_MEM_TYPE,                         //
-        UR_DEVICE_INFO_LOCAL_MEM_SIZE,                         //
-        UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT,               //
-        UR_DEVICE_INFO_HOST_UNIFIED_MEMORY,                    //
-        UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION,             //
-        UR_DEVICE_INFO_ENDIAN_LITTLE,                          //
-        UR_DEVICE_INFO_AVAILABLE,                              //
-        UR_DEVICE_INFO_COMPILER_AVAILABLE,                     //
-        UR_DEVICE_INFO_LINKER_AVAILABLE,                       //
-        UR_DEVICE_INFO_EXECUTION_CAPABILITIES,                 //
-        UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,             //
-        UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,               //
-        UR_DEVICE_INFO_BUILT_IN_KERNELS,                       //
-        UR_DEVICE_INFO_PLATFORM,                               //
-        UR_DEVICE_INFO_REFERENCE_COUNT,                        //
-        UR_DEVICE_INFO_IL_VERSION,                             //
-        UR_DEVICE_INFO_NAME,                                   //
-        UR_DEVICE_INFO_VENDOR,                                 //
-        UR_DEVICE_INFO_DRIVER_VERSION,                         //
-        UR_DEVICE_INFO_PROFILE,                                //
-        UR_DEVICE_INFO_VERSION,                                //
-        UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION,                //
-        UR_DEVICE_INFO_EXTENSIONS,                             //
-        UR_DEVICE_INFO_PRINTF_BUFFER_SIZE,                     //
-        UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC,            //
-        UR_DEVICE_INFO_PARENT_DEVICE,                          //
-        UR_DEVICE_INFO_SUPPORTED_PARTITIONS,                   //
-        UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES,              //
-        UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN,              //
-        UR_DEVICE_INFO_PARTITION_TYPE,                         //
-        UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS,                     //
-        UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, //
-        UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL,                  //
-        UR_DEVICE_INFO_USM_HOST_SUPPORT,                       //
-        UR_DEVICE_INFO_USM_DEVICE_SUPPORT,                     //
-        UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT,              //
-        UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT,               //
-        UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT,              //
-        UR_DEVICE_INFO_UUID,                                   //
-        UR_DEVICE_INFO_PCI_ADDRESS,                            //
-        UR_DEVICE_INFO_GPU_EU_COUNT,                           //
-        UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,                      //
-        UR_DEVICE_INFO_GPU_EU_SLICES,                          //
-        UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE,              //
-        UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,                //
-        UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU,                  //
-        UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,                   //
-        UR_DEVICE_INFO_IMAGE_SRGB,                             //
-        UR_DEVICE_INFO_BUILD_ON_SUBDEVICE,                     //
-        UR_DEVICE_INFO_ATOMIC_64,                              //
-        UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES,       //
-        UR_DEVICE_INFO_BFLOAT16,                               //
-        UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES,              //
-        UR_DEVICE_INFO_MEMORY_BUS_WIDTH,                       //
-        UR_DEVICE_INFO_MAX_WORK_GROUPS_3D,                     //
-        UR_DEVICE_INFO_ASYNC_BARRIER,                          //
-        UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT,                    //
-        UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED,         //
-        UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP,           //
-        UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT,                 //
-        UR_DEVICE_INFO_USM_POOL_SUPPORT,                       //
-        UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES,        //
-        UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES,        //
-        UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES,       //
-        UR_DEVICE_INFO_IP_VERSION,                             //
-        UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS,    //
-        UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP,        //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE,          //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF,            //
-        UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT,             //
-        UR_DEVICE_INFO_NUM_COMPUTE_UNITS,                      //
-        UR_DEVICE_INFO_PROGRAM_SET_SPECIALIZATION_CONSTANTS    //
-        ),
-    uur::deviceTestWithParamPrinter<ur_device_info_t>);
-
-using urDeviceGetInfoSingleTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetInfoSingleTest);
-
-bool doesReturnArray(ur_device_info_t info_type) {
-  if (info_type == UR_DEVICE_INFO_SUPPORTED_PARTITIONS ||
-      info_type == UR_DEVICE_INFO_PARTITION_TYPE) {
-    return true;
-  }
-  return false;
-}
-
-const std::set<ur_device_info_t> nativeCPUFails = {
-    UR_DEVICE_INFO_DEVICE_ID,
-    UR_DEVICE_INFO_MEMORY_CLOCK_RATE,
-    UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS,
-    UR_DEVICE_INFO_GLOBAL_MEM_FREE,
-    UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES,
-    UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES,
-    UR_DEVICE_INFO_IL_VERSION,
-    UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS,
-    UR_DEVICE_INFO_UUID,
-    UR_DEVICE_INFO_PCI_ADDRESS,
-    UR_DEVICE_INFO_GPU_EU_COUNT,
-    UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH,
-    UR_DEVICE_INFO_GPU_EU_SLICES,
-    UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE,
-    UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,
-    UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU,
-    UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH,
-    UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES,
-    UR_DEVICE_INFO_MEMORY_BUS_WIDTH,
-    UR_DEVICE_INFO_MAX_WORK_GROUPS_3D,
-    UR_DEVICE_INFO_ASYNC_BARRIER,
-    UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED,
-    UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP,
-    UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS,
-    UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES,
-    UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES};
-
-TEST_P(urDeviceGetInfoTest, Success) {
-  ur_device_info_t info_type = getParam();
-
-  if (info_type == UR_DEVICE_INFO_GLOBAL_MEM_FREE) {
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-  }
-
-  if (info_type == UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS) {
-    UUR_KNOWN_FAILURE_ON(uur::CUDA{});
-  }
-
-  if (nativeCPUFails.count(info_type)) {
-    UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
-  }
-
-  size_t size = 0;
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-      urDeviceGetInfo(device, info_type, 0, nullptr, &size), info_type);
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_type_t));
 
-  if (doesReturnArray(info_type) && size == 0) {
-    return;
-  }
-  ASSERT_NE(size, 0);
+  ur_device_type_t property_value = UR_DEVICE_TYPE_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
 
-  if (const auto expected_size = device_info_size_map.find(info_type);
-      expected_size != device_info_size_map.end()) {
-    ASSERT_EQ(expected_size->second, size);
-  }
+  ASSERT_GE(property_value, UR_DEVICE_TYPE_DEFAULT);
+  ASSERT_LT(property_value, UR_DEVICE_TYPE_FORCE_UINT32);
+}
 
-  std::vector<char> info_data(size);
+TEST_P(urDeviceGetInfoTest, SuccessVendorId) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_VENDOR_ID;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessDeviceId) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_DEVICE_ID;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxComputeUnits) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_COMPUTE_UNITS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxWorkItemDimensions) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxWorkItemSizes) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES;
+
   ASSERT_SUCCESS(
-      urDeviceGetInfo(device, info_type, size, info_data.data(), nullptr));
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_GT(property_size, 0);
 
-  if (info_type == UR_DEVICE_INFO_PLATFORM) {
-    auto returned_platform =
-        reinterpret_cast<ur_platform_handle_t *>(info_data.data());
-    ASSERT_EQ(*returned_platform, platform);
+  size_t dimension_property_size = 0;
+  ASSERT_SUCCESS(urDeviceGetInfo(device,
+                                 UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS, 0,
+                                 nullptr, &dimension_property_size));
+  ASSERT_EQ(dimension_property_size, sizeof(uint32_t));
+
+  size_t max_dimensions = 0;
+  ASSERT_SUCCESS(
+      urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS,
+                      dimension_property_size, &max_dimensions, nullptr));
+  ASSERT_GT(max_dimensions, 0);
+
+  std::vector<size_t> max_work_item_sizes(max_dimensions);
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name,
+                                 max_dimensions * sizeof(size_t),
+                                 max_work_item_sizes.data(), nullptr));
+
+  EXPECT_EQ(property_size, max_dimensions * sizeof(size_t));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxWorkGroupSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessSingleFPConfig) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_SINGLE_FP_CONFIG;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_fp_capability_flags_t));
+
+  ur_device_fp_capability_flags_t property_value =
+      UR_DEVICE_FP_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_FP_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessHalfFPConfig) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_HALF_FP_CONFIG;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_fp_capability_flags_t));
+
+  ur_device_fp_capability_flags_t property_value =
+      UR_DEVICE_FP_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_FP_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessDoubleFPConfig) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_DOUBLE_FP_CONFIG;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_fp_capability_flags_t));
+
+  ur_device_fp_capability_flags_t property_value =
+      UR_DEVICE_FP_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_FP_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessQueueProperties) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_QUEUE_PROPERTIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_queue_flags_t));
+
+  ur_queue_flags_t property_value = UR_QUEUE_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_QUEUE_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthChar) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthShort) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthInt) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthLong) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthFloat) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthDouble) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredVectorWidthHalf) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthChar) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthShort) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthInt) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthLong) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthFloat) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthDouble) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessNativeVectorWidthHalf) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxClockFrequency) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMemoryClockRate) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MEMORY_CLOCK_RATE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAddressBits) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_ADDRESS_BITS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxMemAllocSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImageSupported) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_SUPPORTED;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxReadImageArgs) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxWriteImageArgs) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxReadWriteImageArgs) {
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_READ_WRITE_IMAGE_ARGS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImage2DMaxWidth) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImage2DMaxHeight) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImage3DMaxWidth) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImage3DMaxHeight) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImage3DMaxDepth) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImageMaxBufferSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_MAX_BUFFER_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImageMaxArraySize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxSamplers) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_SAMPLERS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxParameterSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_PARAMETER_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMemoryBaseAddressAlignment) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalMemoryCacheType) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_mem_cache_type_t));
+
+  ur_device_mem_cache_type_t property_value =
+      UR_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_GE(property_value, UR_DEVICE_MEM_CACHE_TYPE_NONE);
+  ASSERT_LT(property_value, UR_DEVICE_MEM_CACHE_TYPE_FORCE_UINT32);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalMemoryCacheLineSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalMemoryCacheSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalMemorySize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GLOBAL_MEM_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalMemoryFreeSize) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{}, uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GLOBAL_MEM_FREE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxConstantBufferSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxConstantArgs) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_CONSTANT_ARGS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessLocalMemoryType) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_LOCAL_MEM_TYPE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_local_mem_type_t));
+
+  ur_device_local_mem_type_t property_value =
+      UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_GE(property_value, UR_DEVICE_LOCAL_MEM_TYPE_NONE);
+  ASSERT_LT(property_value, UR_DEVICE_LOCAL_MEM_TYPE_FORCE_UINT32);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessLocalMemorySize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_LOCAL_MEM_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessErrorCorrectionSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessHostUnifiedMemory) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_HOST_UNIFIED_MEMORY;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessProfilingTimerResolution) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessEndianLittle) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_ENDIAN_LITTLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAvailable) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_AVAILABLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCompilerAvailable) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_COMPILER_AVAILABLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessLinkerAvailable) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_LINKER_AVAILABLE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessExecutionCapabilities) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_EXECUTION_CAPABILITIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_exec_capability_flags_t));
+
+  ur_device_exec_capability_flags_t property_value =
+      UR_DEVICE_EXEC_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_EXEC_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessQueueOnDeviceProperties) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_QUEUE_ON_DEVICE_PROPERTIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_queue_flags_t));
+
+  ur_queue_flags_t property_value = UR_QUEUE_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_QUEUE_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessQueueOnHostProperties) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_QUEUE_ON_HOST_PROPERTIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_queue_flags_t));
+
+  ur_queue_flags_t property_value = UR_QUEUE_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_QUEUE_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBuiltInKernels) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_BUILT_IN_KERNELS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPlatform) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PLATFORM;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_platform_handle_t));
+
+  ur_platform_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value, platform);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessReferenceCount) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_REFERENCE_COUNT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessILVersion) {
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IL_VERSION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessName) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_NAME;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessVendor) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_VENDOR;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessDriverVersion) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_DRIVER_VERSION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessProfile) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PROFILE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessVersion) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_VERSION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBackendRuntimeVersion) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_BACKEND_RUNTIME_VERSION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessExtensions) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_EXTENSIONS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPrintfBufferSize) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PRINTF_BUFFER_SIZE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPreferredInteropUserSync) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessParentDevice) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PARENT_DEVICE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_handle_t));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessSupportedPartitions) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_SUPPORTED_PARTITIONS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  if (property_size > 0) {
+    size_t num_partitions = property_size / sizeof(ur_device_partition_t);
+    std::vector<ur_device_partition_t> partitions(num_partitions);
+    ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                   partitions.data(), nullptr));
+
+    for (const auto &partition : partitions) {
+      EXPECT_GE(partition, UR_DEVICE_PARTITION_EQUALLY);
+      EXPECT_LT(partition, UR_DEVICE_PARTITION_FORCE_UINT32);
+    }
+  } else {
+    ASSERT_EQ(property_size, 0);
   }
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidNullHandleDevice) {
+TEST_P(urDeviceGetInfoTest, SuccessPartitionMaxSubDevices) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPartitionAffinityDomain) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_affinity_domain_flags_t));
+
+  ur_device_affinity_domain_flags_t property_value =
+      UR_DEVICE_AFFINITY_DOMAIN_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_AFFINITY_DOMAIN_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPartitionType) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PARTITION_TYPE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  if (property_size > 0) {
+    size_t num_properties =
+        property_size / sizeof(ur_device_partition_property_t);
+    std::vector<ur_device_partition_property_t> properties(num_properties);
+
+    ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                   properties.data(), nullptr));
+
+    for (const auto prop : properties) {
+      ASSERT_GE(prop.type, UR_DEVICE_PARTITION_EQUALLY);
+      ASSERT_LE(prop.type, UR_DEVICE_PARTITION_FORCE_UINT32);
+    }
+  } else {
+    ASSERT_EQ(property_size, 0);
+  }
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxSubGroups) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessSubGroupIndependentForwardProgress) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessSubGroupSizesIntel) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL;
+
+  ASSERT_SUCCESS(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+
+  ASSERT_EQ(property_size % sizeof(uint32_t), 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMHostSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_USM_HOST_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_usm_access_capability_flags_t));
+
+  ur_device_usm_access_capability_flags_t property_value =
+      UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMDeviceSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_USM_DEVICE_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_usm_access_capability_flags_t));
+
+  ur_device_usm_access_capability_flags_t property_value =
+      UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMSingleSharedSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_usm_access_capability_flags_t));
+
+  ur_device_usm_access_capability_flags_t property_value =
+      UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMCrossSharedSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_usm_access_capability_flags_t));
+
+  ur_device_usm_access_capability_flags_t property_value =
+      UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMSystemSharedSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_device_usm_access_capability_flags_t));
+
+  ur_device_usm_access_capability_flags_t property_value =
+      UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_DEVICE_USM_ACCESS_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUUID) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_UUID;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<uint8_t> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  EXPECT_NE(property_value[0], '\0');
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessPCIAddress) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_PCI_ADDRESS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_GT(property_size, 0);
+
+  std::vector<char> property_value(property_size, '\0');
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 property_value.data(), nullptr));
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUEUCount) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GPU_EU_COUNT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUEUSIMDWidth) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUEUSlices) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GPU_EU_SLICES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUEUCountPerSlice) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUSubslicesPerSplice) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelGPUHWThreadsPerEU) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIntelMaxMemoryBandwidth) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImageSRGB) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_SRGB;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAtomic64) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_ATOMIC_64;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
+  size_t property_size = 0;
+  ur_device_info_t property_name =
+      UR_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
+
+  ur_memory_order_capability_flags_t property_value =
+      UR_MEMORY_ORDER_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+  size_t property_size = 0;
+  ur_device_info_t property_name =
+      UR_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
+
+  ur_memory_scope_capability_flags_t property_value =
+      UR_MEMORY_SCOPE_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
+
+  ur_memory_order_capability_flags_t property_value =
+      UR_MEMORY_ORDER_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
+
+  ur_memory_scope_capability_flags_t property_value =
+      UR_MEMORY_SCOPE_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBFloat64) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_BFLOAT16;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxComputeQueueIndices) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessKernelSetSpecializationConstants) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMemoryBusWidth) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MEMORY_BUS_WIDTH;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxWorkGroups3D) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MAX_WORK_GROUPS_3D;
+
+  ASSERT_SUCCESS(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(size_t) * 3);
+
+  std::array<size_t, 3> max_work_group_sizes = {};
+  ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_WORK_GROUPS_3D,
+                                 sizeof(max_work_group_sizes),
+                                 max_work_group_sizes.data(), nullptr));
+  for (size_t i = 0; i < 3; i++) {
+    ASSERT_NE(max_work_group_sizes[i], 0);
+  }
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessAsyncBarrier) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_ASYNC_BARRIER;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMemoryChannelSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessHostPipeReadWriteSupport) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxRegistersPerWorkGroup) {
+  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_REGISTERS_PER_WORK_GROUP;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessIPVersion) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IP_VERSION;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessVirtualMemorySupported) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessESIMDSupported) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_ESIMD_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCompositeDevice) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_COMPOSITE_DEVICE;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      UR_DEVICE_INFO_COMPOSITE_DEVICE);
+
+  ASSERT_EQ(property_size, sizeof(ur_device_handle_t));
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessGlobalVariableSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_GLOBAL_VARIABLE_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessUSMPoolSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_USM_POOL_SUPPORT;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCommandBufferSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_COMMAND_BUFFER_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCommandBufferUpdateCapabilities) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_COMMAND_BUFFER_UPDATE_CAPABILITIES_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size,
+            sizeof(ur_device_command_buffer_update_capability_flags_t));
+
+  ur_device_command_buffer_update_capability_flags_t property_value =
+      UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value &
+                UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAGS_MASK,
+            0);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCommandBufferEventSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_COMMAND_BUFFER_EVENT_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessClusterLaunch) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_CLUSTER_LAUNCH_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessImagesSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_IMAGES_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessImagesSharedUSMSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_IMAGES_SHARED_USM_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessImagesShared1DUSMSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_IMAGES_1D_USM_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessImagesShared2DUSMSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_IMAGES_2D_USM_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImagePitchAlign) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_PITCH_ALIGN_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxImageLinearWidth) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxImageLinearHeight) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMaxImageLinearPitch) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(size_t));
+
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMipMapSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMipMapAnisotropySupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MIPMAP_ANISOTROPY_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMipMapMaxAnisotropy) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urDeviceGetInfo(device, property_name,
+                                             property_size, &property_value,
+                                             nullptr),
+                             property_value);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessMipMapLevelReferenceSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessExternalMemoryImportSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_EXTERNAL_MEMORY_IMPORT_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessExternalSemaphoreImportSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_EXTERNAL_SEMAPHORE_IMPORT_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCubemapSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_CUBEMAP_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessCubemapSeamlessFilteringSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_CUBEMAP_SEAMLESS_FILTERING_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSampledImageFetch1DUSM) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_USM_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSampledImageFetch1D) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_1D_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSampledImageFetch2DUSM) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_USM_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSampledImageFetch2D) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_2D_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSampledImageFetch3D) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLED_IMAGE_FETCH_3D_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessTimestampRecordingSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_TIMESTAMP_RECORDING_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessImageArraySupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name = UR_DEVICE_INFO_IMAGE_ARRAY_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessUniqueAddressingPerDim) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_UNIQUE_ADDRESSING_PER_DIM_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSample1DUSM) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLE_1D_USM_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessBindlessSample2DUSM) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_BINDLESS_SAMPLE_2D_USM_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, SuccessEnqueueNativeCommandSupport) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_ENQUEUE_NATIVE_COMMAND_SUPPORT_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size, sizeof(ur_bool_t));
+
+  ur_bool_t property_value = false;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  bool casted_value = static_cast<bool>(property_value);
+  ASSERT_TRUE(casted_value == false || casted_value == true);
+}
+
+TEST_P(urDeviceGetInfoTest, Success2DBlockArrayCapabilities) {
+  size_t property_size = 0;
+  const ur_device_info_t property_name =
+      UR_DEVICE_INFO_2D_BLOCK_ARRAY_CAPABILITIES_EXP;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urDeviceGetInfo(device, property_name, 0, nullptr, &property_size));
+  ASSERT_EQ(property_size,
+            sizeof(ur_exp_device_2d_block_array_capability_flags_t));
+
+  ur_exp_device_2d_block_array_capability_flags_t property_value =
+      UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAG_FORCE_UINT32;
+  ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                 &property_value, nullptr));
+
+  ASSERT_EQ(property_value &
+                UR_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAGS_MASK,
+            0);
+}
+
+TEST_P(urDeviceGetInfoTest, InvalidNullHandleDevice) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urDeviceGetInfo(nullptr, UR_DEVICE_INFO_TYPE,
@@ -346,7 +2569,7 @@ TEST_P(urDeviceGetInfoSingleTest, InvalidNullHandleDevice) {
                                    nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidEnumerationInfoType) {
+TEST_P(urDeviceGetInfoTest, InvalidEnumerationInfoType) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urDeviceGetInfo(device, UR_DEVICE_INFO_FORCE_UINT32,
@@ -354,14 +2577,14 @@ TEST_P(urDeviceGetInfoSingleTest, InvalidEnumerationInfoType) {
                                    nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidSizePropSize) {
+TEST_P(urDeviceGetInfoTest, InvalidSizePropSize) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_SIZE,
       urDeviceGetInfo(device, UR_DEVICE_INFO_TYPE, 0, &device_type, nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidSizePropSizeSmall) {
+TEST_P(urDeviceGetInfoTest, InvalidSizePropSizeSmall) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                    urDeviceGetInfo(device, UR_DEVICE_INFO_TYPE,
@@ -369,33 +2592,66 @@ TEST_P(urDeviceGetInfoSingleTest, InvalidSizePropSizeSmall) {
                                    nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidNullPointerPropValue) {
+TEST_P(urDeviceGetInfoTest, InvalidNullPointerPropValue) {
   ur_device_type_t device_type;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
                    urDeviceGetInfo(device, UR_DEVICE_INFO_TYPE,
                                    sizeof(device_type), nullptr, nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, InvalidNullPointerPropSizeRet) {
+TEST_P(urDeviceGetInfoTest, InvalidNullPointerPropSizeRet) {
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_NULL_POINTER,
       urDeviceGetInfo(device, UR_DEVICE_INFO_TYPE, 0, nullptr, nullptr));
 }
 
-TEST_P(urDeviceGetInfoSingleTest, MaxWorkGroupSizeIsNonzero) {
-  UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
+using urDeviceGetInfoComponentDevicesTest = uur::urAllDevicesTest;
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urDeviceGetInfoComponentDevicesTest);
 
-  size_t max_global_size;
+TEST_P(urDeviceGetInfoComponentDevicesTest, SuccessComponentDevices) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
-  ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-                                 sizeof(size_t), &max_global_size, nullptr));
-  ASSERT_NE(max_global_size, 0);
+  const ur_device_info_t property_name = UR_DEVICE_INFO_COMPONENT_DEVICES;
 
-  std::array<size_t, 3> max_work_group_sizes;
-  ASSERT_SUCCESS(urDeviceGetInfo(device, UR_DEVICE_INFO_MAX_WORK_GROUPS_3D,
-                                 sizeof(max_work_group_sizes),
-                                 max_work_group_sizes.data(), nullptr));
-  for (size_t i = 0; i < 3; i++) {
-    ASSERT_NE(max_work_group_sizes[i], 0);
+  for (const ur_device_handle_t device : devices) {
+    ASSERT_NE(device, nullptr);
+
+    ur_bool_t isComposite = false;
+    ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+        urDeviceGetInfo(device, UR_DEVICE_INFO_COMPOSITE_DEVICE,
+                        sizeof(ur_device_handle_t), &isComposite, nullptr),
+        UR_DEVICE_INFO_COMPOSITE_DEVICE);
+
+    if (isComposite) {
+      size_t size = 0;
+      ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+          urDeviceGetInfo(device, property_name, 0, nullptr, &size),
+          property_name);
+
+      size_t numComponents = size / sizeof(ur_device_handle_t);
+      ASSERT_EQ(size % sizeof(ur_device_handle_t), 0);
+      ASSERT_GT(numComponents, 0);
+
+      std::vector<ur_device_handle_t> componentDevices(numComponents);
+      ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, size,
+                                     componentDevices.data(), nullptr));
+
+      for (const ur_device_handle_t componentDevice : componentDevices) {
+        ASSERT_NE(componentDevice, nullptr);
+      }
+    } else {
+      size_t property_size = 999;
+
+      ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+          urDeviceGetInfo(device, property_name, 0, nullptr, &property_size),
+          property_name);
+      ASSERT_EQ(property_size, 0);
+
+      std::vector<ur_device_handle_t> componentDevices(property_size);
+      ASSERT_SUCCESS(urDeviceGetInfo(device, property_name, property_size,
+                                     componentDevices.data(), nullptr));
+
+      ASSERT_TRUE(componentDevices.empty());
+    }
   }
 }

--- a/test/conformance/testing/include/uur/checks.h
+++ b/test/conformance/testing/include/uur/checks.h
@@ -30,6 +30,24 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
   return out;
 }
 
+#define UUR_RETURN_ON_FATAL_FAILURE(...)                                       \
+  __VA_ARGS__;                                                                 \
+  if (this->HasFatalFailure() || this->IsSkipped()) {                          \
+    return;                                                                    \
+  }                                                                            \
+  (void)0
+
+#define UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(ret)                                 \
+  do {                                                                         \
+    auto status = ret;                                                         \
+    if (status == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||                       \
+        status == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {                   \
+      GTEST_SKIP();                                                            \
+    } else {                                                                   \
+      ASSERT_EQ(status, UR_RESULT_SUCCESS);                                    \
+    }                                                                          \
+  } while (0)
+
 inline bool stringPropertyIsValid(const char *property,
                                   const size_t property_size) {
   if (!property) {

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -16,24 +16,6 @@
 
 #include <random>
 
-#define UUR_RETURN_ON_FATAL_FAILURE(...)                                       \
-  __VA_ARGS__;                                                                 \
-  if (this->HasFatalFailure() || this->IsSkipped()) {                          \
-    return;                                                                    \
-  }                                                                            \
-  (void)0
-
-#define UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(ret)                                 \
-  do {                                                                         \
-    auto status = ret;                                                         \
-    if (status == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||                       \
-        status == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {                   \
-      GTEST_SKIP();                                                            \
-    } else {                                                                   \
-      ASSERT_EQ(status, UR_RESULT_SUCCESS);                                    \
-    }                                                                          \
-  } while (0)
-
 namespace uur {
 
 struct urAdapterTest : ::testing::Test,

--- a/test/conformance/testing/include/uur/utils.h
+++ b/test/conformance/testing/include/uur/utils.h
@@ -269,7 +269,7 @@ ur_result_t GetDeviceAddressBits(ur_device_handle_t device,
 ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device,
                                      uint64_t &alloc_size);
 ur_result_t GetDeviceImageSupport(ur_device_handle_t device,
-                                  bool &image_support);
+                                  bool &image_supported);
 ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device,
                                       uint32_t &read_arg);
 ur_result_t GetDeviceMaxWriteImageArgs(ur_device_handle_t device,

--- a/test/conformance/testing/source/utils.cpp
+++ b/test/conformance/testing/source/utils.cpp
@@ -213,9 +213,9 @@ ur_result_t GetDeviceMaxMemAllocSize(ur_device_handle_t device,
 }
 
 ur_result_t GetDeviceImageSupport(ur_device_handle_t device,
-                                  bool &image_support) {
+                                  bool &image_supported) {
   return GetDeviceInfo<bool>(device, UR_DEVICE_INFO_IMAGE_SUPPORTED,
-                             image_support);
+                             image_supported);
 }
 
 ur_result_t GetDeviceMaxReadImageArgs(ur_device_handle_t device,


### PR DESCRIPTION
- Rework urDeviceGetInfoTest to move all enums to their own tests instead of a switch case - https://github.com/oneapi-src/unified-runtime/issues/2290
- Remove the UR/OpenCL Device enum map function - no point maintaining both a switch case and a separate mapping function
- Update some spec wording for consistency
- Add missing Device info enums to OpenCL adapater
- Add new urDevicePartition test for checking UR_DEVICE_INFO_PARENT_DEVICE
- Move UUR_RETURN_ON_FATAL_FAILURE and UUR_ASSERT_SUCCESS_OR_UNSUPPORTED to join similar macros in checks.h
- Update spec to say info queries that return char[] are null-terminated
- Add missing unsupported device enums to HIP adapter
- Reverted bindless image types back to size_t
- Moved ComponentDevices test to a separate PlatformTest derived fixture
- Added new ASSERT_QUERY_RETURNS_VALUE macro as a helper to validate simple numerical GetInfo queries
- Added new stringPropertyIsValid helper function to validate string queries
- Add missing unsupported device enums to HIP adapter

https://github.com/intel/llvm/pull/16746