### PR TITLE
DO NOT MERGE: Improved lifetime handling and docs of loader

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -944,7 +944,7 @@ typedef enum ur_device_init_flag_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 UR_APIEXPORT ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1217,8 +1217,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -1649,7 +1650,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1859,7 +1860,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -2733,7 +2734,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2901,7 +2902,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4645,7 +4646,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5245,7 +5246,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5304,7 +5305,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5419,7 +5420,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5810,7 +5811,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5855,7 +5856,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram);
 
 #if !defined(__GNUC__)
@@ -6530,7 +6531,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6770,7 +6771,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6921,7 +6922,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7345,7 +7346,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7481,9 +7482,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7528,9 +7530,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7577,9 +7579,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7636,9 +7638,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7695,9 +7697,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7781,9 +7783,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7868,9 +7870,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7923,9 +7925,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8000,9 +8002,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8061,9 +8063,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8126,9 +8128,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8191,9 +8193,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8248,9 +8250,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8345,9 +8347,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -8396,9 +8398,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8449,9 +8451,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8499,9 +8501,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8553,9 +8555,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8594,8 +8596,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8655,9 +8657,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8718,9 +8721,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8766,9 +8770,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8814,9 +8819,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8862,10 +8868,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8912,10 +8919,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)
@@ -9483,9 +9491,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9811,9 +9819,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9854,9 +9862,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -34,7 +34,7 @@ params:
     - type: "$x_adapter_handle_t*"
       name: phAdapters
       desc: |
-            [out][optional][range(0, NumEntries)] array of handle of adapters.
+            [out][optional][range(0, NumEntries)][alloc] array of handle of adapters.
             If NumEntries is less than the number of adapters available, then $xAdapterGet shall only retrieve that number of adapters.
     - type: "uint32_t*"
       name: "pNumAdapters"

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -59,7 +59,7 @@ params:
             [in][optional] pointer to context creation properties.
     - type: $x_context_handle_t*
       name: phContext
-      desc: "[out] pointer to handle of context object created"
+      desc: "[out][alloc] pointer to handle of context object created"
 returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_DEVICE_MEMORY

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -136,7 +136,7 @@ params:
     - type: "$x_device_handle_t*"
       name: phDevices
       desc: |
-            [out][optional][range(0, NumEntries)] array of handle of devices.
+            [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
             If NumEntries is less than the number of devices available, then platform shall only retrieve that number of devices.
     - type: "uint32_t*"
       name: pNumDevices
@@ -832,7 +832,7 @@ params:
       desc: "[in][optional] pointer to native device properties struct."
     - type: "$x_device_handle_t*"
       name: phDevice
-      desc: "[out] pointer to the handle of the device object created."
+      desc: "[out][alloc] pointer to the handle of the device object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -51,7 +51,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -96,7 +96,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -137,7 +137,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -190,7 +190,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -245,7 +245,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -316,7 +316,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -394,7 +394,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -454,7 +454,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -520,7 +520,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -581,7 +581,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -647,7 +647,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -708,7 +708,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -761,7 +761,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -819,7 +819,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -898,7 +898,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
     - type: void**
       name: ppRetMap
       desc: "[out] return mapped pointer.  TODO: move it before numEventsInWaitList?"
@@ -970,7 +970,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1012,7 +1012,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1058,7 +1058,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1109,7 +1109,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1157,7 +1157,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1197,7 +1197,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance.
+            [out][optional][alloc] return an event object that identifies this particular command instance.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1246,7 +1246,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`pitch == 0`"
@@ -1310,7 +1310,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`srcPitch == 0`"
@@ -1369,7 +1369,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
@@ -1416,7 +1416,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
@@ -1463,7 +1463,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] returns an event object that identifies this read command
+            [out][optional][alloc] returns an event object that identifies this read command
             and can be used to query or queue a wait for this command to complete. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
@@ -1511,7 +1511,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] returns an event object that identifies this write command
+            [out][optional][alloc] returns an event object that identifies this write command
             and can be used to query or queue a wait for this command to complete. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -317,7 +317,7 @@ params:
     - type: "$x_event_handle_t*"
       name: phEvent
       desc: |
-            [out] pointer to the handle of the event object created.
+            [out][alloc] pointer to the handle of the event object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -581,7 +581,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -870,7 +870,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -909,7 +909,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -545,7 +545,7 @@ params:
     - type: "$x_kernel_handle_t*"
       name: phKernel
       desc: |
-            [out] pointer to the handle of the kernel object created.
+            [out][alloc] pointer to the handle of the kernel object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/loader.yml
+++ b/scripts/core/loader.yml
@@ -37,7 +37,7 @@ decl: static
 params:
     - type: $x_loader_config_handle_t*
       name: phLoaderConfig
-      desc: "[out] Pointer to handle of loader config object created."
+      desc: "[out][alloc] Pointer to handle of loader config object created."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get a reference to the loader config object."

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -229,7 +229,7 @@ params:
       desc: "[in][optional] pointer to native platform properties struct."
     - type: "$x_platform_handle_t*"
       name: phPlatform
-      desc: "[out] pointer to the handle of the platform object created."
+      desc: "[out][alloc] pointer to the handle of the platform object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -105,7 +105,7 @@ params:
       desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of program object created."
+      desc: "[out][alloc] pointer to handle of program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_POINTER:
         - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
@@ -152,7 +152,7 @@ params:
       desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of Program object created."
+      desc: "[out][alloc] pointer to handle of Program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_POINTER:
         - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
@@ -243,7 +243,7 @@ params:
       desc: "[in][optional] pointer to linker options null-terminated string."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of program object created."
+      desc: "[out][alloc] pointer to handle of program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_PROGRAM:
       - "If one of the programs in `phPrograms` isn't a valid program object."
@@ -574,7 +574,7 @@ params:
     - type: $x_native_handle_t*
       name: phNativeProgram
       desc: |
-            [out] a pointer to the native handle of the program.
+            [out][alloc] a pointer to the native handle of the program.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."
@@ -614,7 +614,7 @@ params:
       desc: "[in][optional] pointer to native program properties struct."
     - type: "$x_program_handle_t*"
       name: phProgram
-      desc: "[out] pointer to the handle of the program object created."
+      desc: "[out][alloc] pointer to the handle of the program object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -161,7 +161,7 @@ params:
       desc: "[in][optional] pointer to queue creation properties."
     - type: $x_queue_handle_t*
       name: phQueue
-      desc: "[out] pointer to handle of queue object created"
+      desc: "[out][alloc] pointer to handle of queue object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_DEVICE
@@ -293,7 +293,7 @@ params:
     - type: "$x_queue_handle_t*"
       name: phQueue
       desc: |
-            [out] pointer to the handle of the queue object created.
+            [out][alloc] pointer to the handle of the queue object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -424,7 +424,7 @@ params:
       desc: "[in] pointer to USM pool descriptor. Can be chained with $x_usm_pool_limits_desc_t"
     - type: $x_usm_pool_handle_t*
       name: ppPool
-      desc: "[out] pointer to USM memory pool"
+      desc: "[out][alloc] pointer to USM memory pool"
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_HANDLE
     - $X_RESULT_ERROR_INVALID_VALUE

--- a/scripts/templates/helper.py
+++ b/scripts/templates/helper.py
@@ -384,6 +384,7 @@ class param_traits:
     RE_TYPENAME = r".*\[typename\((.+),\s(.+)\)\].*"
     RE_TAGGED   = r".*\[tagged_by\((.+)\)].*"
     RE_BOUNDS   = r".*\[bounds\((.+),\s*(.+)\)].*"
+    RE_ALLOC = r".*\[alloc\].*"
 
     @classmethod
     def is_mbz(cls, item):
@@ -480,6 +481,13 @@ class param_traits:
     def is_release(cls, item):
         try:
             return True if re.match(cls.RE_RELEASE, item['desc']) else False
+        except:
+            return False
+
+    @classmethod
+    def is_alloc(cls, item):
+        try:
+            return True if re.match(cls.RE_ALLOC, item['desc']) else False
         except:
             return False
 
@@ -1542,6 +1550,7 @@ def get_loader_epilogue(specs, namespace, tags, obj, meta):
                         'factory': fty_name,
                         'retain': param_traits.is_retain(item),
                         'release': param_traits.is_release(item),
+                        'alloc': param_traits.is_alloc(item),
                         'range': (range_start, range_end)
                     })
                 else:
@@ -1552,6 +1561,7 @@ def get_loader_epilogue(specs, namespace, tags, obj, meta):
                         'factory': fty_name,
                         'retain': param_traits.is_retain(item),
                         'release': param_traits.is_release(item),
+                        'alloc': param_traits.is_alloc(item),
                         'optional': param_traits.is_optional(item)
                     })
             elif param_traits.is_typename(item):
@@ -1590,6 +1600,7 @@ def get_loader_epilogue(specs, namespace, tags, obj, meta):
                                      'obj': obj_name,
                                      'retain': False,
                                      'release': False,
+                                     'alloc': False,
                                      'typename': typename,
                                      'size': prop_size,
                                      'etors': handle_etors})

--- a/scripts/templates/ldrddi.cpp.mako
+++ b/scripts/templates/ldrddi.cpp.mako
@@ -322,7 +322,12 @@ namespace ur_loader
         %endif
         %if not item['release'] and not item['retain'] and not '_native_object_' in item['obj'] or th.make_func_name(n, tags, obj) == 'urPlatformCreateWithNativeHandle':
         try
-        {
+        {<%
+                def getInstanceCall(handle):
+                    if item['alloc']:
+                        return "getInstance( {}, dditable )".format(handle)
+                    return "getInstanceNonOwning( {} )".format(handle)
+            %>
             %if 'typename' in item:
             if (${item['name']} != nullptr) {
                 switch (${item['typename']}) {
@@ -333,7 +338,7 @@ namespace ur_loader
                             for (size_t i = 0; i < nelements; ++i) {
                                 if (handles[i] != nullptr) {
                                     handles[i] = reinterpret_cast<${etor['type']}>(
-                                        context->factories.${etor['factory']}.getInstance( handles[i], dditable ) );
+                                        context->factories.${etor['factory']}.${getInstanceCall("handles[i]")} );
                                 }
                             }
                         } break;
@@ -345,16 +350,16 @@ namespace ur_loader
             // convert platform handles to loader handles
             for( size_t i = ${item['range'][0]}; ( nullptr != ${item['name']} ) && ( i < ${item['range'][1]} ); ++i )
                 ${item['name']}[ i ] = reinterpret_cast<${item['type']}>(
-                    context->factories.${item['factory']}.getInstance( ${item['name']}[ i ], dditable ) );
+                    context->factories.${item['factory']}.${getInstanceCall(item['name'] + "[ i ]")} );
             %else:
             // convert platform handle to loader handle
             %if item['optional'] or th.always_wrap_outputs(obj):
             if( nullptr != ${item['name']} )
                 *${item['name']} = reinterpret_cast<${item['type']}>(
-                    context->factories.${item['factory']}.getInstance( *${item['name']}, dditable ) );
+                    context->factories.${item['factory']}.${getInstanceCall("*" + item['name'])} );
             %else:
             *${item['name']} = reinterpret_cast<${item['type']}>(
-                context->factories.${item['factory']}.getInstance( *${item['name']}, dditable ) );
+                context->factories.${item['factory']}.${getInstanceCall("*" + item['name'])} );
             %endif
             %endif
         }

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -23,8 +23,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -477,7 +478,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -582,7 +583,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -935,7 +936,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1038,7 +1039,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2447,7 +2448,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3198,7 +3199,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3257,7 +3258,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3402,7 +3403,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -3811,7 +3812,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3860,7 +3861,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4613,7 +4614,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4781,7 +4782,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4967,7 +4968,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5385,7 +5386,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5507,9 +5508,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5573,9 +5575,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5632,9 +5634,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5703,9 +5705,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5773,9 +5775,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5855,9 +5857,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5939,9 +5941,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6010,9 +6012,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6087,9 +6089,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6158,9 +6160,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6238,9 +6240,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6314,9 +6316,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6388,9 +6390,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6457,9 +6459,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -6526,9 +6528,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6594,9 +6596,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6662,9 +6664,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6727,9 +6729,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6785,8 +6787,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6856,9 +6858,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6931,9 +6934,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7004,9 +7008,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7079,9 +7084,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7155,10 +7161,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7230,10 +7237,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7695,9 +7703,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8264,9 +8272,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8337,9 +8345,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -25,8 +25,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -389,7 +390,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -479,7 +480,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -762,7 +763,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -850,7 +851,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   auto pfnCreate = getContext()->urDdiTable.Context.pfnCreate;
 
@@ -1985,7 +1986,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   auto pfnPoolCreate = getContext()->urDdiTable.USM.pfnPoolCreate;
 
@@ -2598,7 +2599,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithIL = getContext()->urDdiTable.Program.pfnCreateWithIL;
 
@@ -2648,7 +2649,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithBinary =
       getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -2769,7 +2770,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3111,7 +3112,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) {
   auto pfnGetNativeHandle = getContext()->urDdiTable.Program.pfnGetNativeHandle;
 
@@ -3152,7 +3153,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3773,7 +3774,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -3915,7 +3916,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   auto pfnCreate = getContext()->urDdiTable.Queue.pfnCreate;
 
@@ -4059,7 +4060,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4389,7 +4390,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -4493,9 +4494,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -4548,9 +4550,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWait = getContext()->urDdiTable.Enqueue.pfnEventsWait;
 
@@ -4595,9 +4597,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrier =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -4654,9 +4656,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferRead = getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -4714,9 +4716,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWrite = getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -4786,9 +4788,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferReadRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -4863,9 +4865,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWriteRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -4927,9 +4929,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopy = getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -4994,9 +4996,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopyRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5058,9 +5060,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferFill = getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -5128,9 +5130,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageRead = getContext()->urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -5193,9 +5195,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageWrite = getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -5257,9 +5259,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageCopy = getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -5315,9 +5317,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5371,9 +5373,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemUnmap = getContext()->urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -5427,9 +5429,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill = getContext()->urDdiTable.Enqueue.pfnUSMFill;
 
@@ -5484,9 +5486,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -5538,9 +5540,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMPrefetch = getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -5584,8 +5586,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   auto pfnUSMAdvise = getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
 
@@ -5642,9 +5644,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill2D = getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -5706,9 +5709,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy2D = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -5768,9 +5772,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableWrite =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -5832,9 +5837,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableRead =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -5897,10 +5903,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnReadHostPipe = getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
 
@@ -5961,10 +5968,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWriteHostPipe = getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
 
@@ -6367,9 +6375,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnImageCopyExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -6858,9 +6866,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWaitExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
@@ -6921,9 +6929,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnSignalExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -24,8 +24,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -345,7 +346,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -419,7 +420,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -693,7 +694,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -768,7 +769,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   auto pfnCreate = getContext()->urDdiTable.Context.pfnCreate;
 
@@ -1965,7 +1966,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   auto pfnPoolCreate = getContext()->urDdiTable.USM.pfnPoolCreate;
 
@@ -2559,7 +2560,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithIL = getContext()->urDdiTable.Program.pfnCreateWithIL;
 
@@ -2622,7 +2623,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithBinary =
       getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -2762,7 +2763,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3101,7 +3102,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) {
   auto pfnGetNativeHandle = getContext()->urDdiTable.Program.pfnGetNativeHandle;
 
@@ -3136,7 +3137,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3721,7 +3722,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -3876,7 +3877,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   auto pfnCreate = getContext()->urDdiTable.Queue.pfnCreate;
 
@@ -4021,7 +4022,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4318,7 +4319,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -4420,9 +4421,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -4488,9 +4490,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWait = getContext()->urDdiTable.Enqueue.pfnEventsWait;
 
@@ -4541,9 +4543,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrier =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -4604,9 +4606,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferRead = getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -4685,9 +4687,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWrite = getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -4778,9 +4780,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferReadRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -4903,9 +4905,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWriteRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -5015,9 +5017,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopy = getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -5116,9 +5118,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopyRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5238,9 +5240,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferFill = getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -5339,9 +5341,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageRead = getContext()->urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -5428,9 +5430,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageWrite = getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -5515,9 +5517,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageCopy = getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -5611,9 +5613,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5692,9 +5694,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemUnmap = getContext()->urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -5764,9 +5766,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill = getContext()->urDdiTable.Enqueue.pfnUSMFill;
 
@@ -5847,9 +5849,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -5929,9 +5931,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMPrefetch = getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -5996,8 +5998,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   auto pfnUSMAdvise = getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
 
@@ -6062,9 +6064,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill2D = getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -6167,9 +6170,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy2D = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -6267,9 +6271,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableWrite =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -6347,9 +6352,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableRead =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -6428,10 +6434,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnReadHostPipe = getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
 
@@ -6510,10 +6517,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWriteHostPipe = getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
 
@@ -6975,9 +6983,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnImageCopyExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -7500,9 +7508,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWaitExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
@@ -7561,9 +7569,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnSignalExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -24,8 +24,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -311,8 +312,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_adapter_handle_t>(
-                context->factories.ur_adapter_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_adapter_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -391,7 +392,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -467,7 +468,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -559,8 +560,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_platform_handle_t>(
-                context->factories.ur_platform_factory.getInstance(handles[i],
-                                                                   dditable));
+                context->factories.ur_platform_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -571,8 +572,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -583,8 +584,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -595,8 +596,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -705,8 +706,8 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     // convert platform handles to loader handles
     for (size_t i = 0; (nullptr != phSubDevices) && (i < NumDevices); ++i)
       phSubDevices[i] = reinterpret_cast<ur_device_handle_t>(
-          context->factories.ur_device_factory.getInstance(phSubDevices[i],
-                                                           dditable));
+          context->factories.ur_device_factory.getInstanceNonOwning(
+              phSubDevices[i]));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -786,7 +787,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -859,7 +860,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1003,8 +1004,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -1095,8 +1096,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
   try {
     // convert platform handle to loader handle
     *phContext = reinterpret_cast<ur_context_handle_t>(
-        context->factories.ur_context_factory.getInstance(*phContext,
-                                                          dditable));
+        context->factories.ur_context_factory.getInstanceNonOwning(*phContext));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1170,7 +1170,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
   try {
     // convert platform handle to loader handle
     *phMem = reinterpret_cast<ur_mem_handle_t>(
-        context->factories.ur_mem_factory.getInstance(*phMem, dditable));
+        context->factories.ur_mem_factory.getInstanceNonOwning(*phMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1213,7 +1213,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
   try {
     // convert platform handle to loader handle
     *phBuffer = reinterpret_cast<ur_mem_handle_t>(
-        context->factories.ur_mem_factory.getInstance(*phBuffer, dditable));
+        context->factories.ur_mem_factory.getInstanceNonOwning(*phBuffer));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1310,7 +1310,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
   try {
     // convert platform handle to loader handle
     *phMem = reinterpret_cast<ur_mem_handle_t>(
-        context->factories.ur_mem_factory.getInstance(*phMem, dditable));
+        context->factories.ur_mem_factory.getInstanceNonOwning(*phMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1389,7 +1389,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
   try {
     // convert platform handle to loader handle
     *phMem = reinterpret_cast<ur_mem_handle_t>(
-        context->factories.ur_mem_factory.getInstance(*phMem, dditable));
+        context->factories.ur_mem_factory.getInstanceNonOwning(*phMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1436,7 +1436,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
   try {
     // convert platform handle to loader handle
     *phMem = reinterpret_cast<ur_mem_handle_t>(
-        context->factories.ur_mem_factory.getInstance(*phMem, dditable));
+        context->factories.ur_mem_factory.getInstanceNonOwning(*phMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1496,8 +1496,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -1581,8 +1581,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
   try {
     // convert platform handle to loader handle
     *phSampler = reinterpret_cast<ur_sampler_handle_t>(
-        context->factories.ur_sampler_factory.getInstance(*phSampler,
-                                                          dditable));
+        context->factories.ur_sampler_factory.getInstanceNonOwning(*phSampler));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1692,8 +1691,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -1772,8 +1771,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
   try {
     // convert platform handle to loader handle
     *phSampler = reinterpret_cast<ur_sampler_handle_t>(
-        context->factories.ur_sampler_factory.getInstance(*phSampler,
-                                                          dditable));
+        context->factories.ur_sampler_factory.getInstanceNonOwning(*phSampler));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -1976,8 +1974,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -1988,8 +1986,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_usm_pool_handle_t>(
-                context->factories.ur_usm_pool_factory.getInstance(handles[i],
-                                                                   dditable));
+                context->factories.ur_usm_pool_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -2012,7 +2010,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2146,8 +2144,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -2444,8 +2442,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
   try {
     // convert platform handle to loader handle
     *phPhysicalMem = reinterpret_cast<ur_physical_mem_handle_t>(
-        context->factories.ur_physical_mem_factory.getInstance(*phPhysicalMem,
-                                                               dditable));
+        context->factories.ur_physical_mem_factory.getInstanceNonOwning(
+            *phPhysicalMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -2565,8 +2563,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -2577,8 +2575,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -2604,7 +2602,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2655,7 +2653,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2768,7 +2766,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -2992,8 +2990,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3004,8 +3002,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3098,7 +3096,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3131,7 +3129,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3197,7 +3195,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
   try {
     // convert platform handle to loader handle
     *phKernel = reinterpret_cast<ur_kernel_handle_t>(
-        context->factories.ur_kernel_factory.getInstance(*phKernel, dditable));
+        context->factories.ur_kernel_factory.getInstanceNonOwning(*phKernel));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -3322,8 +3320,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3334,8 +3332,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_program_handle_t>(
-                context->factories.ur_program_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_program_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3685,7 +3683,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3817,8 +3815,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3829,8 +3827,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_device_handle_t>(
-                context->factories.ur_device_factory.getInstance(handles[i],
-                                                                 dditable));
+                context->factories.ur_device_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3841,8 +3839,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_queue_handle_t>(
-                context->factories.ur_queue_factory.getInstance(handles[i],
-                                                                dditable));
+                context->factories.ur_queue_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -3866,7 +3864,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3997,7 +3995,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4130,8 +4128,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_queue_handle_t>(
-                context->factories.ur_queue_factory.getInstance(handles[i],
-                                                                dditable));
+                context->factories.ur_queue_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -4142,8 +4140,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
         for (size_t i = 0; i < nelements; ++i) {
           if (handles[i] != nullptr) {
             handles[i] = reinterpret_cast<ur_context_handle_t>(
-                context->factories.ur_context_factory.getInstance(handles[i],
-                                                                  dditable));
+                context->factories.ur_context_factory.getInstanceNonOwning(
+                    handles[i]));
           }
         }
       } break;
@@ -4316,7 +4314,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4430,9 +4428,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4491,9 +4490,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4548,9 +4547,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4614,9 +4613,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4684,9 +4683,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4766,9 +4765,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4850,9 +4849,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4921,9 +4920,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5002,9 +5001,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5076,9 +5075,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5151,9 +5150,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5226,9 +5225,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5299,9 +5298,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5372,9 +5371,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5439,9 +5438,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5507,9 +5506,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5572,9 +5571,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5634,9 +5633,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5689,8 +5688,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5750,9 +5749,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5822,9 +5822,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5891,9 +5892,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5964,9 +5966,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6038,10 +6041,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6113,10 +6117,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6465,9 +6470,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6656,8 +6661,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
   try {
     // convert platform handle to loader handle
     *phExternalMem = reinterpret_cast<ur_exp_external_mem_handle_t>(
-        context->factories.ur_exp_external_mem_factory.getInstance(
-            *phExternalMem, dditable));
+        context->factories.ur_exp_external_mem_factory.getInstanceNonOwning(
+            *phExternalMem));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -6834,8 +6839,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
   try {
     // convert platform handle to loader handle
     *phExternalSemaphore = reinterpret_cast<ur_exp_external_semaphore_handle_t>(
-        context->factories.ur_exp_external_semaphore_factory.getInstance(
-            *phExternalSemaphore, dditable));
+        context->factories.ur_exp_external_semaphore_factory
+            .getInstanceNonOwning(*phExternalSemaphore));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -6907,9 +6912,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6979,9 +6984,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7065,8 +7070,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
   try {
     // convert platform handle to loader handle
     *phCommandBuffer = reinterpret_cast<ur_exp_command_buffer_handle_t>(
-        context->factories.ur_exp_command_buffer_factory.getInstance(
-            *phCommandBuffer, dditable));
+        context->factories.ur_exp_command_buffer_factory.getInstanceNonOwning(
+            *phCommandBuffer));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7259,7 +7264,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7268,8 +7273,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7345,7 +7350,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7354,8 +7359,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7432,7 +7437,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7441,8 +7446,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7528,7 +7533,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7537,8 +7542,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7619,7 +7624,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7628,8 +7633,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7710,7 +7715,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7719,8 +7724,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7815,7 +7820,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7824,8 +7829,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7920,7 +7925,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -7929,8 +7934,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8024,7 +8029,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8033,8 +8038,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8117,7 +8122,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8126,8 +8131,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8203,7 +8208,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8212,8 +8217,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8289,7 +8294,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8298,8 +8303,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     // convert platform handle to loader handle
     if (nullptr != phCommand)
       *phCommand = reinterpret_cast<ur_exp_command_buffer_command_handle_t>(
-          context->factories.ur_exp_command_buffer_command_factory.getInstance(
-              *phCommand, dditable));
+          context->factories.ur_exp_command_buffer_command_factory
+              .getInstanceNonOwning(*phCommand));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8364,7 +8369,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8529,8 +8534,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
   try {
     // convert platform handle to loader handle
     *phSignalEvent = reinterpret_cast<ur_event_handle_t>(
-        context->factories.ur_event_factory.getInstance(*phSignalEvent,
-                                                        dditable));
+        context->factories.ur_event_factory.getInstanceNonOwning(
+            *phSignalEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8729,7 +8734,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8840,7 +8845,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
   try {
     // convert platform handle to loader handle
     *phEvent = reinterpret_cast<ur_event_handle_t>(
-        context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+        context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -8924,7 +8929,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -9057,8 +9062,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     // convert platform handle to loader handle
     if (nullptr != phProgram)
       *phProgram = reinterpret_cast<ur_program_handle_t>(
-          context->factories.ur_program_factory.getInstance(*phProgram,
-                                                            dditable));
+          context->factories.ur_program_factory.getInstanceNonOwning(
+              *phProgram));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -9277,7 +9282,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -9355,7 +9360,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     // convert platform handle to loader handle
     if (nullptr != phEvent)
       *phEvent = reinterpret_cast<ur_event_handle_t>(
-          context->factories.ur_event_factory.getInstance(*phEvent, dditable));
+          context->factories.ur_event_factory.getInstanceNonOwning(*phEvent));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -9428,8 +9433,8 @@ __urdlllocal ur_result_t UR_APICALL urTensorMapEncodeIm2ColExp(
   try {
     // convert platform handle to loader handle
     *hTensorMap = reinterpret_cast<ur_exp_tensor_map_handle_t>(
-        context->factories.ur_exp_tensor_map_factory.getInstance(*hTensorMap,
-                                                                 dditable));
+        context->factories.ur_exp_tensor_map_factory.getInstanceNonOwning(
+            *hTensorMap));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }
@@ -9497,8 +9502,8 @@ __urdlllocal ur_result_t UR_APICALL urTensorMapEncodeTiledExp(
   try {
     // convert platform handle to loader handle
     *hTensorMap = reinterpret_cast<ur_exp_tensor_map_handle_t>(
-        context->factories.ur_exp_tensor_map_factory.getInstance(*hTensorMap,
-                                                                 dditable));
+        context->factories.ur_exp_tensor_map_factory.getInstanceNonOwning(
+            *hTensorMap));
   } catch (std::bad_alloc &) {
     result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   }

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -27,7 +27,7 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig) try {
   return ur_lib::urLoaderConfigCreate(phLoaderConfig);
 } catch (...) {
@@ -297,8 +297,9 @@ ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -686,7 +687,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -784,7 +785,7 @@ ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -1146,7 +1147,7 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -1235,7 +1236,7 @@ ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Context.pfnCreate;
   if (nullptr == pfnCreate)
@@ -2515,7 +2516,7 @@ ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) try {
   auto pfnPoolCreate = ur_lib::getContext()->urDdiTable.USM.pfnPoolCreate;
   if (nullptr == pfnPoolCreate)
@@ -3047,7 +3048,7 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithIL =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithIL;
@@ -3115,7 +3116,7 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithBinary =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -3256,7 +3257,7 @@ ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3620,7 +3621,7 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) try {
   auto pfnGetNativeHandle =
       ur_lib::getContext()->urDdiTable.Program.pfnGetNativeHandle;
@@ -3659,7 +3660,7 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -4268,7 +4269,7 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -4424,7 +4425,7 @@ ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Queue.pfnCreate;
   if (nullptr == pfnCreate)
@@ -4574,7 +4575,7 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4918,7 +4919,7 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -5037,9 +5038,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnKernelLaunch =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
@@ -5095,9 +5097,9 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEventsWait = ur_lib::getContext()->urDdiTable.Enqueue.pfnEventsWait;
   if (nullptr == pfnEventsWait)
@@ -5152,9 +5154,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEventsWaitWithBarrier =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -5221,9 +5223,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
@@ -5290,9 +5292,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
@@ -5386,9 +5388,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferReadRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -5485,9 +5487,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferWriteRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -5552,9 +5554,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferCopy =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
@@ -5639,9 +5641,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferCopyRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5712,9 +5714,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferFill =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
@@ -5787,9 +5789,9 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageRead;
@@ -5863,9 +5865,9 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
@@ -5931,9 +5933,9 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageCopy =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
@@ -6006,9 +6008,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -6068,9 +6070,9 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemUnmap = ur_lib::getContext()->urDdiTable.Enqueue.pfnMemUnmap;
   if (nullptr == pfnMemUnmap)
@@ -6130,9 +6132,9 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMFill = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMFill;
   if (nullptr == pfnUSMFill)
@@ -6189,9 +6191,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMMemcpy = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
   if (nullptr == pfnUSMMemcpy)
@@ -6252,9 +6254,9 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMPrefetch = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
   if (nullptr == pfnUSMPrefetch)
@@ -6302,8 +6304,8 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMAdvise = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
   if (nullptr == pfnUSMAdvise)
@@ -6371,9 +6373,10 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMFill2D = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
   if (nullptr == pfnUSMFill2D)
@@ -6443,9 +6446,10 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMMemcpy2D = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
   if (nullptr == pfnUSMMemcpy2D)
@@ -6500,9 +6504,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnDeviceGlobalVariableWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -6559,9 +6564,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnDeviceGlobalVariableRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -6618,10 +6624,11 @@ ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnReadHostPipe =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
@@ -6678,10 +6685,11 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnWriteHostPipe =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
@@ -7092,9 +7100,9 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnImageCopyExp =
       ur_lib::getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -7525,9 +7533,9 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnWaitExternalSemaphoreExp =
       ur_lib::getContext()
@@ -7580,9 +7588,9 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnSignalExternalSemaphoreExp =
       ur_lib::getContext()

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -25,7 +25,7 @@
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -284,8 +284,9 @@ ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -620,7 +621,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -705,7 +706,7 @@ ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -1027,7 +1028,7 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1103,7 +1104,7 @@ ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2227,7 +2228,7 @@ ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2681,7 +2682,7 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2743,7 +2744,7 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2867,7 +2868,7 @@ ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3180,7 +3181,7 @@ ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 ur_result_t UR_APICALL urProgramGetNativeHandle(
     /// [in] handle of the program.
     ur_program_handle_t hProgram,
-    /// [out] a pointer to the native handle of the program.
+    /// [out][alloc] a pointer to the native handle of the program.
     ur_native_handle_t *phNativeProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3213,7 +3214,7 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3736,7 +3737,7 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3872,7 +3873,7 @@ ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4001,7 +4002,7 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4295,7 +4296,7 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4402,9 +4403,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4452,9 +4454,9 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4504,9 +4506,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4566,9 +4568,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4628,9 +4630,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4717,9 +4719,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4807,9 +4809,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4865,9 +4867,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4945,9 +4947,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5009,9 +5011,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5077,9 +5079,9 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5145,9 +5147,9 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5205,9 +5207,9 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5273,9 +5275,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5327,9 +5329,9 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5383,9 +5385,9 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5436,9 +5438,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5493,9 +5495,9 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5537,8 +5539,8 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5601,9 +5603,10 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5667,9 +5670,10 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5718,9 +5722,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5769,9 +5774,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5820,10 +5826,11 @@ ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5873,10 +5880,11 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6230,9 +6238,9 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6588,9 +6596,9 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6634,9 +6642,9 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;


### PR DESCRIPTION
* The loader now checks that all handles have been released before
  dropping factories.
* Some arguments of functions have been marked as [alloc]. When the
  loader generates a handle from them, they will have an initial
  reference count that requires a single release.
* Handles that are assigned to non-alloc pointers must exist and their
  reference counts are not incremented.
