### PR TITLE
In docs, mark "allocating" functions as such

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -934,7 +934,7 @@ typedef enum ur_device_init_flag_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 UR_APIEXPORT ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1207,8 +1207,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -1639,7 +1640,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1849,7 +1850,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -2725,7 +2726,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2893,7 +2894,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3110,7 +3111,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3432,7 +3433,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3537,7 +3538,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3731,7 +3732,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3766,7 +3767,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3979,7 +3980,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -4138,7 +4139,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler);
 
 #if !defined(__GNUC__)
@@ -4643,7 +4644,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5044,7 +5045,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5243,7 +5244,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5302,7 +5303,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5417,7 +5418,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -5853,7 +5854,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram);
 
 #if !defined(__GNUC__)
@@ -5887,7 +5888,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6535,7 +6536,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6775,7 +6776,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -6926,7 +6927,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7350,7 +7351,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7486,9 +7487,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7533,9 +7535,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7582,9 +7584,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7641,9 +7643,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7700,9 +7702,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7786,9 +7788,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7873,9 +7875,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -7928,9 +7930,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8005,9 +8007,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8066,9 +8068,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8131,9 +8133,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8196,9 +8198,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8253,9 +8255,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8348,9 +8350,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -8399,9 +8401,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8452,9 +8454,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8502,9 +8504,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8556,9 +8558,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8598,8 +8600,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8659,9 +8661,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8722,9 +8725,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8770,9 +8774,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8818,9 +8823,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8866,10 +8872,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -8916,10 +8923,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)
@@ -9313,7 +9321,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9378,7 +9386,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9422,7 +9430,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9489,9 +9497,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9619,7 +9627,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9751,7 +9759,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9817,9 +9825,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -9860,9 +9868,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)
@@ -10119,7 +10127,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10253,11 +10261,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
@@ -10316,11 +10324,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10382,11 +10390,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10444,11 +10452,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10505,11 +10513,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10566,11 +10574,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10636,11 +10644,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10710,11 +10718,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10848,11 +10856,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10916,11 +10924,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -10984,11 +10992,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11023,10 +11031,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11139,7 +11147,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11284,9 +11292,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -11519,10 +11528,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)
@@ -11663,7 +11672,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram);
 
 #if !defined(__GNUC__)
@@ -11970,9 +11979,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent);
 
 #if !defined(__GNUC__)
@@ -12059,7 +12068,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/scripts/YaML.md
+++ b/scripts/YaML.md
@@ -621,12 +621,13 @@ class ur_name_t(Structure):
       - `out` is used for params that are write-only; if the param is a pointer, then the memory being pointed to is also write-only
       - `in,out` is used for params that are both read and write; typically this is used for pointers to other data structures that contain both read and write params
       - `nocheck` is used to specify that no additional validation checks will be generated.
-    + `desc` may include one the following annotations: {`"[optional]"`, `"[range(start,end)]"`, `"[retain]"`, `"[release]"`, `"[typename(typeVarName)]"`, `"[bounds(offset,size)]"`}
+    + `desc` may include one or more of the following annotations: {`"[optional]"`, `"[range(start,end)]"`, `"[alloc]"`, `"[retain]"`, `"[release]"`, `"[typename(typeVarName)]"`, `"[bounds(offset,size)]"`}
       - `optional` is used for params that are handles or pointers where it is legal for the value to be `nullptr`
       - `range` is used for params that are array pointers to specify the valid range that the is valid to read
         + `start` and `end` must be an ISO-C standard identifier or literal
         + `start` is inclusive and `end` is exclusive
-      - `retain` is used for params that are handles or pointers to handles where the function will increment the reference counter associated with the handle(s).
+      - `alloc` is used for output params that are handles or pointers to handles where the function will either increase the reference count by one or create a new handle with an initial reference count of one.
+      - `retain` is used for params that are handles or pointers to handles where the function will increment the reference counter associated with the handle(s). The handle will not be created and must be valid.
       - `release` is used for params that are handles or pointers to handles where the function will decrement the handle's reference count, potentially leaving it in an invalid state if the reference count reaches zero.
       - `typename` is used to denote the type enum for params that are opaque pointers to values of tagged data types.
       - `bounds` is used for params that are memory objects or USM allocations. It specifies the range within the memory allocation represented by the param that will be accessed by the operation.

--- a/scripts/core/adapter.yml
+++ b/scripts/core/adapter.yml
@@ -34,7 +34,7 @@ params:
     - type: "$x_adapter_handle_t*"
       name: phAdapters
       desc: |
-            [out][optional][range(0, NumEntries)] array of handle of adapters.
+            [out][optional][range(0, NumEntries)][alloc] array of handle of adapters.
             If NumEntries is less than the number of adapters available, then $xAdapterGet shall only retrieve that number of adapters.
     - type: "uint32_t*"
       name: "pNumAdapters"

--- a/scripts/core/context.yml
+++ b/scripts/core/context.yml
@@ -59,7 +59,7 @@ params:
             [in][optional] pointer to context creation properties.
     - type: $x_context_handle_t*
       name: phContext
-      desc: "[out] pointer to handle of context object created"
+      desc: "[out][alloc] pointer to handle of context object created"
 returns:
     - $X_RESULT_ERROR_OUT_OF_HOST_MEMORY
     - $X_RESULT_ERROR_OUT_OF_DEVICE_MEMORY
@@ -243,7 +243,7 @@ params:
     - type: "$x_context_handle_t*"
       name: phContext
       desc: |
-            [out] pointer to the handle of the context object created.
+            [out][alloc] pointer to the handle of the context object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -136,7 +136,7 @@ params:
     - type: "$x_device_handle_t*"
       name: phDevices
       desc: |
-            [out][optional][range(0, NumEntries)] array of handle of devices.
+            [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
             If NumEntries is less than the number of devices available, then platform shall only retrieve that number of devices.
     - type: "uint32_t*"
       name: pNumDevices
@@ -834,7 +834,7 @@ params:
       desc: "[in][optional] pointer to native device properties struct."
     - type: "$x_device_handle_t*"
       name: phDevice
-      desc: "[out] pointer to the handle of the device object created."
+      desc: "[out][alloc] pointer to the handle of the device object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -51,7 +51,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_KERNEL
@@ -96,7 +96,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -137,7 +137,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -190,7 +190,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -245,7 +245,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -316,7 +316,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -394,7 +394,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -454,7 +454,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -520,7 +520,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -581,7 +581,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -647,7 +647,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -708,7 +708,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -761,7 +761,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -819,7 +819,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -897,7 +897,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
     - type: void**
       name: ppRetMap
       desc: "[out] return mapped pointer.  TODO: move it before numEventsInWaitList?"
@@ -969,7 +969,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1011,7 +1011,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1057,7 +1057,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1108,7 +1108,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1156,7 +1156,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1196,7 +1196,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance.
+            [out][optional][alloc] return an event object that identifies this particular command instance.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT
@@ -1245,7 +1245,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`pitch == 0`"
@@ -1309,7 +1309,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_SIZE:
       - "`srcPitch == 0`"
@@ -1368,7 +1368,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
@@ -1415,7 +1415,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
     - "`phEventWaitList == NULL && numEventsInWaitList > 0`"
@@ -1462,7 +1462,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] returns an event object that identifies this read command
+            [out][optional][alloc] returns an event object that identifies this read command
             and can be used to query or queue a wait for this command to complete. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:
@@ -1510,7 +1510,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] returns an event object that identifies this write command
+            [out][optional][alloc] returns an event object that identifies this write command
             and can be used to query or queue a wait for this command to complete. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
   - $X_RESULT_ERROR_INVALID_EVENT_WAIT_LIST:

--- a/scripts/core/event.yml
+++ b/scripts/core/event.yml
@@ -317,7 +317,7 @@ params:
     - type: "$x_event_handle_t*"
       name: phEvent
       desc: |
-            [out] pointer to the handle of the event object created.
+            [out][alloc] pointer to the handle of the event object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/exp-bindless-images.yml
+++ b/scripts/core/exp-bindless-images.yml
@@ -429,7 +429,7 @@ params:
       desc: "[in] pointer to image description"
     - type: $x_exp_image_mem_native_handle_t*
       name: phImageMem
-      desc: "[out] pointer to handle of image memory allocated"
+      desc: "[out][alloc] pointer to handle of image memory allocated"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -484,7 +484,7 @@ params:
       desc: "[in] pointer to image description"
     - type: $x_exp_image_native_handle_t*
       name: phImage
-      desc: "[out] pointer to handle of image object created"
+      desc: "[out][alloc] pointer to handle of image object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -522,7 +522,7 @@ params:
       desc: "[in] sampler to be used"
     - type: $x_exp_image_native_handle_t*
       name: phImage
-      desc: "[out] pointer to handle of image object created"
+      desc: "[out][alloc] pointer to handle of image object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -583,7 +583,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -699,7 +699,7 @@ params:
       desc: "[in] the external memory descriptor"
     - type: $x_exp_external_mem_handle_t*
       name: phExternalMem
-      desc: "[out] external memory handle to the external memory"
+      desc: "[out][alloc] external memory handle to the external memory"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -812,7 +812,7 @@ params:
       desc: "[in] the external semaphore descriptor"
     - type: $x_exp_external_semaphore_handle_t*
       name: phExternalSemaphore
-      desc: "[out] external semaphore handle to the external semaphore"
+      desc: "[out][alloc] external semaphore handle to the external semaphore"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -872,7 +872,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -911,7 +911,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_VALUE

--- a/scripts/core/exp-command-buffer.yml
+++ b/scripts/core/exp-command-buffer.yml
@@ -285,7 +285,7 @@ params:
       desc: "[in][optional] command-buffer descriptor."
     - type: "$x_exp_command_buffer_handle_t*"
       name: phCommandBuffer
-      desc: "[out] Pointer to command-Buffer handle."
+      desc: "[out][alloc] Pointer to command-Buffer handle."
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_DEVICE
@@ -386,10 +386,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command. Only available if the
+      desc: "[out][optional][alloc] Handle to this command. Only available if the
       command-buffer is updatable."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
@@ -451,10 +451,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_SIZE:
@@ -513,10 +513,10 @@ params:
       desc: "[out][optional] sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_SIZE:
@@ -580,10 +580,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -639,10 +639,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -698,10 +698,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -772,10 +772,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -846,10 +846,10 @@ params:
       desc: "[out][optional] Sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -982,10 +982,10 @@ params:
       desc: "[out][optional] sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -1043,10 +1043,10 @@ params:
       desc: "[out][optional] sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -1106,10 +1106,10 @@ params:
       desc: "[out][optional] sync point associated with this command."
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
+      desc: "[out][optional][alloc] return an event object that will be signaled by the completion of this command in the next execution of the command-buffer."
     - type: "$x_exp_command_buffer_command_handle_t*"
       name: phCommand
-      desc: "[out][optional] Handle to this command."
+      desc: "[out][optional][alloc] Handle to this command."
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_SYNC_POINT_EXP
@@ -1152,7 +1152,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command-buffer execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command-buffer execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_COMMAND_BUFFER_EXP
     - $X_RESULT_ERROR_INVALID_QUEUE
@@ -1213,7 +1213,7 @@ params:
       desc: "[in] Handle of the command-buffer command to update."
     - type: "$x_event_handle_t*"
       name: phSignalEvent
-      desc: "[out] Event to be signaled."
+      desc: "[out][alloc] Event to be signaled."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If $X_DEVICE_COMMAND_BUFFER_UPDATE_CAPABILITY_FLAG_EVENTS is not supported by the device associated with `hCommand`."

--- a/scripts/core/exp-cooperative-kernels.yml
+++ b/scripts/core/exp-cooperative-kernels.yml
@@ -55,7 +55,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_KERNEL

--- a/scripts/core/exp-launch-properties.yml
+++ b/scripts/core/exp-launch-properties.yml
@@ -111,7 +111,7 @@ params:
       desc: "[in][optional][range(0, numEventsInWaitList)] pointer to a list of events that must be complete before the kernel execution. If nullptr, the numEventsInWaitList must be 0, indicating that no wait event. "
     - type: $x_event_handle_t*
       name: phEvent
-      desc: "[out][optional] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array."
+      desc: "[out][optional][alloc] return an event object that identifies this particular kernel execution instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array."
 returns:
     - $X_RESULT_SUCCESS
     - $X_RESULT_ERROR_UNINITIALIZED

--- a/scripts/core/exp-low-power-events.yml
+++ b/scripts/core/exp-low-power-events.yml
@@ -99,7 +99,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
+            [out][optional][alloc] return an event object that identifies this particular command instance. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_QUEUE
     - $X_RESULT_ERROR_INVALID_EVENT

--- a/scripts/core/exp-multi-device-compile.yml
+++ b/scripts/core/exp-multi-device-compile.yml
@@ -116,7 +116,7 @@ params:
       desc: "[in][optional] pointer to linker options null-terminated string."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of program object created."
+      desc: "[out][alloc] pointer to handle of program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_PROGRAM:
       - "If one of the programs in `phPrograms` isn't a valid program object."

--- a/scripts/core/exp-native-enqueue.yml
+++ b/scripts/core/exp-native-enqueue.yml
@@ -111,7 +111,7 @@ params:
     - type: $x_event_handle_t*
       name: phEvent
       desc: |
-            [out][optional] return an event object that identifies the work that has
+            [out][optional][alloc] return an event object that identifies the work that has
             been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are not NULL, phEvent must not refer to an element of the phEventWaitList array.
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_HANDLE

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -30,7 +30,7 @@ params:
       desc: "[in] pointer to null-terminated string."
     - type: $x_kernel_handle_t*
       name: phKernel
-      desc: "[out] pointer to handle of kernel object created."
+      desc: "[out][alloc] pointer to handle of kernel object created."
 returns:
     - $X_RESULT_ERROR_INVALID_KERNEL_NAME:
         - "If `pKernelName` wasn't found in `hProgram`."
@@ -551,7 +551,7 @@ params:
     - type: "$x_kernel_handle_t*"
       name: phKernel
       desc: |
-            [out] pointer to the handle of the kernel object created.
+            [out][alloc] pointer to the handle of the kernel object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/loader.yml
+++ b/scripts/core/loader.yml
@@ -37,7 +37,7 @@ decl: static
 params:
     - type: $x_loader_config_handle_t*
       name: phLoaderConfig
-      desc: "[out] Pointer to handle of loader config object created."
+      desc: "[out][alloc] Pointer to handle of loader config object created."
 --- #--------------------------------------------------------------------------
 type: function
 desc: "Get a reference to the loader config object."

--- a/scripts/core/memory.yml
+++ b/scripts/core/memory.yml
@@ -247,7 +247,7 @@ params:
       desc: "[in][optional] pointer to the buffer data"
     - type: $x_mem_handle_t*
       name: phMem
-      desc: "[out] pointer to handle of image object created"
+      desc: "[out][alloc] pointer to handle of image object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -337,7 +337,7 @@ params:
       desc: "[in][optional] pointer to buffer creation properties"
     - type: $x_mem_handle_t*
       name: phBuffer
-      desc: "[out] pointer to handle of the memory buffer created"
+      desc: "[out][alloc] pointer to handle of the memory buffer created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -507,7 +507,7 @@ params:
       desc: "[in][optional] pointer to native memory creation properties."
     - type: $x_mem_handle_t*
       name: phMem
-      desc: "[out] pointer to handle of buffer memory object created."
+      desc: "[out][alloc] pointer to handle of buffer memory object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."
@@ -540,7 +540,7 @@ params:
       desc: "[in][optional] pointer to native memory creation properties."
     - type: $x_mem_handle_t*
       name: phMem
-      desc: "[out] pointer to handle of image memory object created."
+      desc: "[out][alloc pointer to handle of image memory object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/platform.yml
+++ b/scripts/core/platform.yml
@@ -229,7 +229,7 @@ params:
       desc: "[in][optional] pointer to native platform properties struct."
     - type: "$x_platform_handle_t*"
       name: phPlatform
-      desc: "[out] pointer to the handle of the platform object created."
+      desc: "[out][alloc] pointer to the handle of the platform object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/program.yml
+++ b/scripts/core/program.yml
@@ -105,7 +105,7 @@ params:
       desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of program object created."
+      desc: "[out][alloc] pointer to handle of program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_POINTER:
         - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
@@ -152,7 +152,7 @@ params:
       desc: "[in][optional] pointer to program creation properties."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of Program object created."
+      desc: "[out][alloc] pointer to handle of Program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_POINTER:
         - "`NULL != pProperties && pProperties->count > 0 && NULL == pProperties->pMetadatas`"
@@ -243,7 +243,7 @@ params:
       desc: "[in][optional] pointer to linker options null-terminated string."
     - type: $x_program_handle_t*
       name: phProgram
-      desc: "[out] pointer to handle of program object created."
+      desc: "[out][alloc] pointer to handle of program object created."
 returns:
     - $X_RESULT_ERROR_INVALID_PROGRAM:
       - "If one of the programs in `phPrograms` isn't a valid program object."
@@ -614,7 +614,7 @@ params:
       desc: "[in][optional] pointer to native program properties struct."
     - type: "$x_program_handle_t*"
       name: phProgram
-      desc: "[out] pointer to the handle of the program object created."
+      desc: "[out][alloc] pointer to the handle of the program object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/queue.yml
+++ b/scripts/core/queue.yml
@@ -161,7 +161,7 @@ params:
       desc: "[in][optional] pointer to queue creation properties."
     - type: $x_queue_handle_t*
       name: phQueue
-      desc: "[out] pointer to handle of queue object created"
+      desc: "[out][alloc] pointer to handle of queue object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_DEVICE
@@ -293,7 +293,7 @@ params:
     - type: "$x_queue_handle_t*"
       name: phQueue
       desc: |
-            [out] pointer to the handle of the queue object created.
+            [out][alloc] pointer to the handle of the queue object created.
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/sampler.yml
+++ b/scripts/core/sampler.yml
@@ -98,7 +98,7 @@ params:
       desc: "[in] pointer to the sampler description"
     - type: $x_sampler_handle_t*
       name: phSampler
-      desc: "[out] pointer to handle of sampler object created"
+      desc: "[out][alloc] pointer to handle of sampler object created"
 returns:
     - $X_RESULT_ERROR_INVALID_CONTEXT
     - $X_RESULT_ERROR_INVALID_VALUE
@@ -233,7 +233,7 @@ params:
       desc: "[in][optional] pointer to native sampler properties struct."
     - type: "$x_sampler_handle_t*"
       name: phSampler
-      desc: "[out] pointer to the handle of the sampler object created."
+      desc: "[out][alloc] pointer to the handle of the sampler object created."
 returns:
     - $X_RESULT_ERROR_UNSUPPORTED_FEATURE:
         - "If the adapter has no underlying equivalent handle."

--- a/scripts/core/usm.yml
+++ b/scripts/core/usm.yml
@@ -424,7 +424,7 @@ params:
       desc: "[in] pointer to USM pool descriptor. Can be chained with $x_usm_pool_limits_desc_t"
     - type: $x_usm_pool_handle_t*
       name: ppPool
-      desc: "[out] pointer to USM memory pool"
+      desc: "[out][alloc] pointer to USM memory pool"
 returns:
     - $X_RESULT_ERROR_INVALID_NULL_HANDLE
     - $X_RESULT_ERROR_INVALID_VALUE

--- a/scripts/core/virtual_memory.yml
+++ b/scripts/core/virtual_memory.yml
@@ -280,7 +280,7 @@ params:
       desc: "[in][optional] pointer to physical memory creation properties."
     - type: $x_physical_mem_handle_t*
       name: phPhysicalMem
-      desc: "[out] pointer to handle of physical memory object created."
+      desc: "[out][alloc] pointer to handle of physical memory object created."
 returns:
     - $X_RESULT_ERROR_INVALID_SIZE:
         - "If size is not a multiple of $X_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM."

--- a/source/adapters/mock/ur_mockddi.cpp
+++ b/source/adapters/mock/ur_mockddi.cpp
@@ -23,8 +23,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -477,7 +478,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -582,7 +583,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -935,7 +936,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1038,7 +1039,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1281,7 +1282,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1387,7 +1388,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1439,7 +1440,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1681,7 +1682,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1739,7 +1740,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1903,7 +1904,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2135,7 +2136,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2447,7 +2448,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3005,7 +3006,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3198,7 +3199,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3257,7 +3258,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3402,7 +3403,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -3860,7 +3861,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3912,7 +3913,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4613,7 +4614,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4781,7 +4782,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4967,7 +4968,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5385,7 +5386,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5507,9 +5508,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5573,9 +5575,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5632,9 +5634,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5703,9 +5705,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5773,9 +5775,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5855,9 +5857,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5939,9 +5941,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6010,9 +6012,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6087,9 +6089,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6158,9 +6160,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6238,9 +6240,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6314,9 +6316,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6388,9 +6390,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6457,9 +6459,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -6526,9 +6528,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6594,9 +6596,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6662,9 +6664,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6727,9 +6729,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6785,8 +6787,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6856,9 +6858,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6931,9 +6934,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7004,9 +7008,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7079,9 +7084,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7155,10 +7161,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7230,10 +7237,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7455,7 +7463,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7561,7 +7569,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7620,7 +7628,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7695,9 +7703,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7924,7 +7932,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8145,7 +8153,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8264,9 +8272,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8337,9 +8345,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8397,7 +8405,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8606,11 +8614,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
@@ -8701,11 +8709,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8793,11 +8801,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8888,11 +8896,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8982,11 +8990,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9075,11 +9083,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9178,11 +9186,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9289,11 +9297,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9499,11 +9507,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9591,11 +9599,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9681,11 +9689,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9761,10 +9769,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9863,7 +9871,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -10040,9 +10048,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -10264,10 +10273,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -10437,7 +10446,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -10739,9 +10748,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -10814,7 +10823,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -25,8 +25,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -389,7 +390,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -479,7 +480,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -762,7 +763,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -850,7 +851,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   auto pfnCreate = getContext()->urDdiTable.Context.pfnCreate;
 
@@ -1046,7 +1047,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Context.pfnCreateWithNativeHandle;
@@ -1136,7 +1137,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) {
   auto pfnImageCreate = getContext()->urDdiTable.Mem.pfnImageCreate;
 
@@ -1179,7 +1180,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) {
   auto pfnBufferCreate = getContext()->urDdiTable.Mem.pfnBufferCreate;
 
@@ -1363,7 +1364,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) {
   auto pfnBufferCreateWithNativeHandle =
       getContext()->urDdiTable.Mem.pfnBufferCreateWithNativeHandle;
@@ -1411,7 +1412,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) {
   auto pfnImageCreateWithNativeHandle =
       getContext()->urDdiTable.Mem.pfnImageCreateWithNativeHandle;
@@ -1548,7 +1549,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) {
   auto pfnCreate = getContext()->urDdiTable.Sampler.pfnCreate;
 
@@ -1732,7 +1733,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Sampler.pfnCreateWithNativeHandle;
@@ -1985,7 +1986,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   auto pfnPoolCreate = getContext()->urDdiTable.USM.pfnPoolCreate;
 
@@ -2442,7 +2443,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) {
   auto pfnCreate = getContext()->urDdiTable.PhysicalMem.pfnCreate;
 
@@ -2598,7 +2599,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithIL = getContext()->urDdiTable.Program.pfnCreateWithIL;
 
@@ -2648,7 +2649,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithBinary =
       getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -2769,7 +2770,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3152,7 +3153,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3194,7 +3195,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreate = getContext()->urDdiTable.Kernel.pfnCreate;
 
@@ -3773,7 +3774,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -3915,7 +3916,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   auto pfnCreate = getContext()->urDdiTable.Queue.pfnCreate;
 
@@ -4059,7 +4060,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4389,7 +4390,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -4493,9 +4494,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -4548,9 +4550,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWait = getContext()->urDdiTable.Enqueue.pfnEventsWait;
 
@@ -4595,9 +4597,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrier =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -4654,9 +4656,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferRead = getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -4714,9 +4716,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWrite = getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -4786,9 +4788,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferReadRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -4863,9 +4865,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWriteRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -4927,9 +4929,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopy = getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -4994,9 +4996,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopyRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5058,9 +5060,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferFill = getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -5128,9 +5130,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageRead = getContext()->urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -5193,9 +5195,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageWrite = getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -5257,9 +5259,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageCopy = getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -5315,9 +5317,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5371,9 +5373,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemUnmap = getContext()->urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -5427,9 +5429,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill = getContext()->urDdiTable.Enqueue.pfnUSMFill;
 
@@ -5484,9 +5486,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -5538,9 +5540,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMPrefetch = getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -5584,8 +5586,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   auto pfnUSMAdvise = getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
 
@@ -5642,9 +5644,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill2D = getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -5706,9 +5709,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy2D = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -5768,9 +5772,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableWrite =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -5832,9 +5837,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableRead =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -5897,10 +5903,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnReadHostPipe = getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
 
@@ -5961,10 +5968,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWriteHostPipe = getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
 
@@ -6159,7 +6167,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) {
   auto pfnImageAllocateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
@@ -6248,7 +6256,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   auto pfnUnsampledImageCreateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnUnsampledImageCreateExp;
@@ -6299,7 +6307,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   auto pfnSampledImageCreateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
@@ -6367,9 +6375,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnImageCopyExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -6562,7 +6570,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) {
   auto pfnImportExternalMemoryExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
@@ -6752,7 +6760,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   auto pfnImportExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalSemaphoreExp;
@@ -6858,9 +6866,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWaitExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
@@ -6921,9 +6929,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnSignalExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
@@ -6972,7 +6980,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) {
   auto pfnCreateExp = getContext()->urDdiTable.CommandBufferExp.pfnCreateExp;
 
@@ -7151,11 +7159,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendKernelLaunchExp =
@@ -7232,11 +7240,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMMemcpyExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMMemcpyExp;
@@ -7309,11 +7317,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMFillExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMFillExp;
@@ -7389,11 +7397,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferCopyExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferCopyExp;
@@ -7469,11 +7477,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferWriteExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferWriteExp;
@@ -7548,11 +7556,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferReadExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferReadExp;
@@ -7637,11 +7645,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferCopyRectExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferCopyRectExp;
@@ -7736,11 +7744,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferWriteRectExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferWriteRectExp;
@@ -7922,11 +7930,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferFillExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferFillExp;
@@ -8000,11 +8008,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMPrefetchExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMPrefetchExp;
@@ -8075,11 +8083,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMAdviseExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMAdviseExp;
@@ -8140,10 +8148,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEnqueueExp = getContext()->urDdiTable.CommandBufferExp.pfnEnqueueExp;
 
@@ -8223,7 +8231,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) {
   auto pfnUpdateSignalEventExp =
       getContext()->urDdiTable.CommandBufferExp.pfnUpdateSignalEventExp;
@@ -8376,9 +8384,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnCooperativeKernelLaunchExp =
       getContext()->urDdiTable.EnqueueExp.pfnCooperativeKernelLaunchExp;
@@ -8575,10 +8584,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunchCustomExp =
       getContext()->urDdiTable.EnqueueExp.pfnKernelLaunchCustomExp;
@@ -8720,7 +8729,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -8974,9 +8983,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrierExt =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrierExt;
@@ -9037,7 +9046,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -24,8 +24,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -345,7 +346,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -419,7 +420,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -693,7 +694,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -768,7 +769,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   auto pfnCreate = getContext()->urDdiTable.Context.pfnCreate;
 
@@ -945,7 +946,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Context.pfnCreateWithNativeHandle;
@@ -1024,7 +1025,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) {
   auto pfnImageCreate = getContext()->urDdiTable.Mem.pfnImageCreate;
 
@@ -1101,7 +1102,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) {
   auto pfnBufferCreate = getContext()->urDdiTable.Mem.pfnBufferCreate;
 
@@ -1301,7 +1302,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) {
   auto pfnBufferCreateWithNativeHandle =
       getContext()->urDdiTable.Mem.pfnBufferCreateWithNativeHandle;
@@ -1346,7 +1347,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) {
   auto pfnImageCreateWithNativeHandle =
       getContext()->urDdiTable.Mem.pfnImageCreateWithNativeHandle;
@@ -1495,7 +1496,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) {
   auto pfnCreate = getContext()->urDdiTable.Sampler.pfnCreate;
 
@@ -1672,7 +1673,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Sampler.pfnCreateWithNativeHandle;
@@ -1965,7 +1966,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   auto pfnPoolCreate = getContext()->urDdiTable.USM.pfnPoolCreate;
 
@@ -2414,7 +2415,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) {
   auto pfnCreate = getContext()->urDdiTable.PhysicalMem.pfnCreate;
 
@@ -2559,7 +2560,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithIL = getContext()->urDdiTable.Program.pfnCreateWithIL;
 
@@ -2622,7 +2623,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithBinary =
       getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -2762,7 +2763,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3136,7 +3137,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3175,7 +3176,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreate = getContext()->urDdiTable.Kernel.pfnCreate;
 
@@ -3721,7 +3722,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -3876,7 +3877,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   auto pfnCreate = getContext()->urDdiTable.Queue.pfnCreate;
 
@@ -4021,7 +4022,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4318,7 +4319,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -4420,9 +4421,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
@@ -4488,9 +4490,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWait = getContext()->urDdiTable.Enqueue.pfnEventsWait;
 
@@ -4541,9 +4543,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrier =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -4604,9 +4606,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferRead = getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
 
@@ -4685,9 +4687,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWrite = getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
 
@@ -4778,9 +4780,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferReadRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -4903,9 +4905,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWriteRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -5015,9 +5017,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopy = getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
 
@@ -5116,9 +5118,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopyRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5238,9 +5240,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferFill = getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
 
@@ -5339,9 +5341,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageRead = getContext()->urDdiTable.Enqueue.pfnMemImageRead;
 
@@ -5428,9 +5430,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageWrite = getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
 
@@ -5515,9 +5517,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemImageCopy = getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
 
@@ -5611,9 +5613,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5692,9 +5694,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnMemUnmap = getContext()->urDdiTable.Enqueue.pfnMemUnmap;
 
@@ -5764,9 +5766,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill = getContext()->urDdiTable.Enqueue.pfnUSMFill;
 
@@ -5847,9 +5849,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
 
@@ -5929,9 +5931,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMPrefetch = getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
 
@@ -5996,8 +5998,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   auto pfnUSMAdvise = getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
 
@@ -6062,9 +6064,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill2D = getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
 
@@ -6167,9 +6170,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy2D = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
 
@@ -6267,9 +6271,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableWrite =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -6347,9 +6352,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnDeviceGlobalVariableRead =
       getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -6428,10 +6434,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnReadHostPipe = getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
 
@@ -6510,10 +6517,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWriteHostPipe = getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
 
@@ -6734,7 +6742,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) {
   auto pfnImageAllocateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
@@ -6831,7 +6839,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   auto pfnUnsampledImageCreateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnUnsampledImageCreateExp;
@@ -6891,7 +6899,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   auto pfnSampledImageCreateExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSampledImageCreateExp;
@@ -6975,9 +6983,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnImageCopyExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -7183,7 +7191,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) {
   auto pfnImportExternalMemoryExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalMemoryExp;
@@ -7392,7 +7400,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   auto pfnImportExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnImportExternalSemaphoreExp;
@@ -7500,9 +7508,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnWaitExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnWaitExternalSemaphoreExp;
@@ -7561,9 +7569,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnSignalExternalSemaphoreExp =
       getContext()->urDdiTable.BindlessImagesExp.pfnSignalExternalSemaphoreExp;
@@ -7609,7 +7617,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) {
   auto pfnCreateExp = getContext()->urDdiTable.CommandBufferExp.pfnCreateExp;
 
@@ -7747,11 +7755,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendKernelLaunchExp =
@@ -7839,11 +7847,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMMemcpyExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMMemcpyExp;
@@ -7920,11 +7928,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMFillExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMFillExp;
@@ -8009,11 +8017,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferCopyExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferCopyExp;
@@ -8097,11 +8105,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferWriteExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferWriteExp;
@@ -8180,11 +8188,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferReadExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferReadExp;
@@ -8273,11 +8281,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferCopyRectExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferCopyRectExp;
@@ -8375,11 +8383,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferWriteRectExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferWriteRectExp;
@@ -8557,11 +8565,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendMemBufferFillExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendMemBufferFillExp;
@@ -8638,11 +8646,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMPrefetchExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMPrefetchExp;
@@ -8717,11 +8725,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   auto pfnAppendUSMAdviseExp =
       getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMAdviseExp;
@@ -8786,10 +8794,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEnqueueExp = getContext()->urDdiTable.CommandBufferExp.pfnEnqueueExp;
 
@@ -8867,7 +8875,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) {
   auto pfnUpdateSignalEventExp =
       getContext()->urDdiTable.CommandBufferExp.pfnUpdateSignalEventExp;
@@ -9004,9 +9012,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnCooperativeKernelLaunchExp =
       getContext()->urDdiTable.EnqueueExp.pfnCooperativeKernelLaunchExp;
@@ -9217,10 +9226,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunchCustomExp =
       getContext()->urDdiTable.EnqueueExp.pfnKernelLaunchCustomExp;
@@ -9357,7 +9366,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -9613,9 +9622,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnEventsWaitWithBarrierExt =
       getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrierExt;
@@ -9684,7 +9693,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/source/loader/ur_ldrddi.cpp
+++ b/source/loader/ur_ldrddi.cpp
@@ -24,8 +24,9 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -391,7 +392,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -467,7 +468,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -786,7 +787,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -859,7 +860,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1062,7 +1063,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1145,7 +1146,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1189,7 +1190,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1363,7 +1364,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1410,7 +1411,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1557,7 +1558,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -1746,7 +1747,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2012,7 +2013,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2417,7 +2418,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2604,7 +2605,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2655,7 +2656,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -2768,7 +2769,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -3131,7 +3132,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3173,7 +3174,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3685,7 +3686,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3866,7 +3867,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -3997,7 +3998,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4316,7 +4317,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4430,9 +4431,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4491,9 +4493,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4548,9 +4550,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4614,9 +4616,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4684,9 +4686,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4766,9 +4768,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4850,9 +4852,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -4921,9 +4923,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5002,9 +5004,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5076,9 +5078,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5151,9 +5153,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5226,9 +5228,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5299,9 +5301,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5372,9 +5374,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5439,9 +5441,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5507,9 +5509,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5572,9 +5574,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5634,9 +5636,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5689,8 +5691,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5750,9 +5752,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5822,9 +5825,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5891,9 +5895,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -5964,9 +5969,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6038,10 +6044,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6113,10 +6120,11 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6287,7 +6295,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6359,7 +6367,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6403,7 +6411,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6465,9 +6473,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6627,7 +6635,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6804,7 +6812,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6907,9 +6915,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -6979,9 +6987,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7038,7 +7046,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7203,11 +7211,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
@@ -7301,11 +7309,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7389,11 +7397,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7478,11 +7486,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7572,11 +7580,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7663,11 +7671,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7764,11 +7772,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -7872,11 +7880,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8070,11 +8078,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8159,11 +8167,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8245,11 +8253,11 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8321,10 +8329,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8437,7 +8445,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8585,9 +8593,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8779,10 +8788,10 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -8917,7 +8926,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   if (nullptr != phProgram) {
@@ -9138,9 +9147,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
@@ -9209,7 +9218,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -27,7 +27,7 @@ extern "C" {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig) try {
   return ur_lib::urLoaderConfigCreate(phLoaderConfig);
 } catch (...) {
@@ -297,8 +297,9 @@ ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -686,7 +687,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Platform.pfnCreateWithNativeHandle;
@@ -784,7 +785,7 @@ ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -1146,7 +1147,7 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Device.pfnCreateWithNativeHandle;
@@ -1235,7 +1236,7 @@ ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Context.pfnCreate;
   if (nullptr == pfnCreate)
@@ -1439,7 +1440,7 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Context.pfnCreateWithNativeHandle;
@@ -1557,7 +1558,7 @@ ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) try {
   auto pfnImageCreate = ur_lib::getContext()->urDdiTable.Mem.pfnImageCreate;
   if (nullptr == pfnImageCreate)
@@ -1615,7 +1616,7 @@ ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) try {
   auto pfnBufferCreate = ur_lib::getContext()->urDdiTable.Mem.pfnBufferCreate;
   if (nullptr == pfnBufferCreate)
@@ -1811,7 +1812,7 @@ ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) try {
   auto pfnBufferCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Mem.pfnBufferCreateWithNativeHandle;
@@ -1856,7 +1857,7 @@ ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) try {
   auto pfnImageCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Mem.pfnImageCreateWithNativeHandle;
@@ -2018,7 +2019,7 @@ ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Sampler.pfnCreate;
   if (nullptr == pfnCreate)
@@ -2203,7 +2204,7 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Sampler.pfnCreateWithNativeHandle;
@@ -2515,7 +2516,7 @@ ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) try {
   auto pfnPoolCreate = ur_lib::getContext()->urDdiTable.USM.pfnPoolCreate;
   if (nullptr == pfnPoolCreate)
@@ -2914,7 +2915,7 @@ ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.PhysicalMem.pfnCreate;
   if (nullptr == pfnCreate)
@@ -3047,7 +3048,7 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithIL =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithIL;
@@ -3115,7 +3116,7 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithBinary =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithBinary;
@@ -3256,7 +3257,7 @@ ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -3659,7 +3660,7 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
@@ -3696,7 +3697,7 @@ ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Kernel.pfnCreate;
   if (nullptr == pfnCreate)
@@ -4268,7 +4269,7 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Kernel.pfnCreateWithNativeHandle;
@@ -4424,7 +4425,7 @@ ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) try {
   auto pfnCreate = ur_lib::getContext()->urDdiTable.Queue.pfnCreate;
   if (nullptr == pfnCreate)
@@ -4574,7 +4575,7 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Queue.pfnCreateWithNativeHandle;
@@ -4918,7 +4919,7 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) try {
   auto pfnCreateWithNativeHandle =
       ur_lib::getContext()->urDdiTable.Event.pfnCreateWithNativeHandle;
@@ -5037,9 +5038,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnKernelLaunch =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
@@ -5095,9 +5097,9 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEventsWait = ur_lib::getContext()->urDdiTable.Enqueue.pfnEventsWait;
   if (nullptr == pfnEventsWait)
@@ -5152,9 +5154,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEventsWaitWithBarrier =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrier;
@@ -5221,9 +5223,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
@@ -5290,9 +5292,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
@@ -5386,9 +5388,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferReadRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
@@ -5485,9 +5487,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferWriteRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
@@ -5552,9 +5554,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferCopy =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
@@ -5639,9 +5641,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferCopyRect =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
@@ -5712,9 +5714,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemBufferFill =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
@@ -5787,9 +5789,9 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageRead;
@@ -5863,9 +5865,9 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageWrite;
@@ -5931,9 +5933,9 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemImageCopy =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnMemImageCopy;
@@ -6004,9 +6006,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -6066,9 +6068,9 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnMemUnmap = ur_lib::getContext()->urDdiTable.Enqueue.pfnMemUnmap;
   if (nullptr == pfnMemUnmap)
@@ -6128,9 +6130,9 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMFill = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMFill;
   if (nullptr == pfnUSMFill)
@@ -6187,9 +6189,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMMemcpy = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
   if (nullptr == pfnUSMMemcpy)
@@ -6250,9 +6252,9 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMPrefetch = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMPrefetch;
   if (nullptr == pfnUSMPrefetch)
@@ -6301,8 +6303,8 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMAdvise = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMAdvise;
   if (nullptr == pfnUSMAdvise)
@@ -6370,9 +6372,10 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMFill2D = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
   if (nullptr == pfnUSMFill2D)
@@ -6442,9 +6445,10 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnUSMMemcpy2D = ur_lib::getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
   if (nullptr == pfnUSMMemcpy2D)
@@ -6499,9 +6503,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnDeviceGlobalVariableWrite =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableWrite;
@@ -6558,9 +6563,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnDeviceGlobalVariableRead =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnDeviceGlobalVariableRead;
@@ -6617,10 +6623,11 @@ ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnReadHostPipe =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnReadHostPipe;
@@ -6677,10 +6684,11 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnWriteHostPipe =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnWriteHostPipe;
@@ -6874,7 +6882,7 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) try {
   auto pfnImageAllocateExp =
       ur_lib::getContext()->urDdiTable.BindlessImagesExp.pfnImageAllocateExp;
@@ -6958,7 +6966,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) try {
   auto pfnUnsampledImageCreateExp =
       ur_lib::getContext()
@@ -7013,7 +7021,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) try {
   auto pfnSampledImageCreateExp =
       ur_lib::getContext()
@@ -7091,9 +7099,9 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnImageCopyExp =
       ur_lib::getContext()->urDdiTable.BindlessImagesExp.pfnImageCopyExp;
@@ -7262,7 +7270,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) try {
   auto pfnImportExternalMemoryExp =
       ur_lib::getContext()
@@ -7436,7 +7444,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) try {
   auto pfnImportExternalSemaphoreExp =
       ur_lib::getContext()
@@ -7524,9 +7532,9 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnWaitExternalSemaphoreExp =
       ur_lib::getContext()
@@ -7579,9 +7587,9 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnSignalExternalSemaphoreExp =
       ur_lib::getContext()
@@ -7627,7 +7635,7 @@ ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) try {
   auto pfnCreateExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnCreateExp;
@@ -7797,11 +7805,11 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendKernelLaunchExp =
@@ -7874,11 +7882,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendUSMMemcpyExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMMemcpyExp;
@@ -7952,11 +7960,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendUSMFillExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMFillExp;
@@ -8026,11 +8034,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferCopyExp =
       ur_lib::getContext()
@@ -8100,11 +8108,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferWriteExp =
       ur_lib::getContext()
@@ -8174,11 +8182,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferReadExp =
       ur_lib::getContext()
@@ -8257,11 +8265,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferCopyRectExp =
       ur_lib::getContext()
@@ -8345,11 +8353,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferWriteRectExp =
       ur_lib::getContext()
@@ -8511,11 +8519,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendMemBufferFillExp =
       ur_lib::getContext()
@@ -8592,11 +8600,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendUSMPrefetchExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMPrefetchExp;
@@ -8672,11 +8680,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) try {
   auto pfnAppendUSMAdviseExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnAppendUSMAdviseExp;
@@ -8723,10 +8731,10 @@ ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEnqueueExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnEnqueueExp;
@@ -8859,7 +8867,7 @@ ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) try {
   auto pfnUpdateSignalEventExp =
       ur_lib::getContext()->urDdiTable.CommandBufferExp.pfnUpdateSignalEventExp;
@@ -9018,9 +9026,10 @@ ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnCooperativeKernelLaunchExp =
       ur_lib::getContext()->urDdiTable.EnqueueExp.pfnCooperativeKernelLaunchExp;
@@ -9209,10 +9218,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnKernelLaunchCustomExp =
       ur_lib::getContext()->urDdiTable.EnqueueExp.pfnKernelLaunchCustomExp;
@@ -9367,7 +9376,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) try {
   if (nullptr != phProgram) {
     *phProgram = nullptr;
@@ -9657,9 +9666,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) try {
   auto pfnEventsWaitWithBarrierExt =
       ur_lib::getContext()->urDdiTable.Enqueue.pfnEventsWaitWithBarrierExt;
@@ -9712,7 +9721,8 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -25,7 +25,7 @@
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_POINTER
 ///         + `NULL == phLoaderConfig`
 ur_result_t UR_APICALL urLoaderConfigCreate(
-    /// [out] Pointer to handle of loader config object created.
+    /// [out][alloc] Pointer to handle of loader config object created.
     ur_loader_config_handle_t *phLoaderConfig) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -284,8 +284,9 @@ ur_result_t UR_APICALL urAdapterGet(
     /// zero, otherwise ::UR_RESULT_ERROR_INVALID_SIZE,
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of adapters.
-    /// If NumEntries is less than the number of adapters available, then
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of
+    /// adapters. If NumEntries is less than the number of adapters available,
+    /// then
     /// ::urAdapterGet shall only retrieve that number of adapters.
     ur_adapter_handle_t *phAdapters,
     /// [out][optional] returns the total number of adapters available.
@@ -620,7 +621,7 @@ ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native platform properties struct.
     const ur_platform_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the platform object created.
+    /// [out][alloc] pointer to the handle of the platform object created.
     ur_platform_handle_t *phPlatform) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -705,7 +706,7 @@ ur_result_t UR_APICALL urDeviceGet(
     /// Otherwise ::UR_RESULT_ERROR_INVALID_SIZE
     /// will be returned.
     uint32_t NumEntries,
-    /// [out][optional][range(0, NumEntries)] array of handle of devices.
+    /// [out][optional][range(0, NumEntries)][alloc] array of handle of devices.
     /// If NumEntries is less than the number of devices available, then
     /// platform shall only retrieve that number of devices.
     ur_device_handle_t *phDevices,
@@ -1027,7 +1028,7 @@ ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_adapter_handle_t hAdapter,
     /// [in][optional] pointer to native device properties struct.
     const ur_device_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the device object created.
+    /// [out][alloc] pointer to the handle of the device object created.
     ur_device_handle_t *phDevice) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1103,7 +1104,7 @@ ur_result_t UR_APICALL urContextCreate(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to context creation properties.
     const ur_context_properties_t *pProperties,
-    /// [out] pointer to handle of context object created
+    /// [out][alloc] pointer to handle of context object created
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1281,7 +1282,7 @@ ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     const ur_device_handle_t *phDevices,
     /// [in][optional] pointer to native context properties struct
     const ur_context_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the context object created.
+    /// [out][alloc] pointer to the handle of the context object created.
     ur_context_handle_t *phContext) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1386,7 +1387,7 @@ ur_result_t UR_APICALL urMemImageCreate(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to the buffer data
     void *pHost,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1438,7 +1439,7 @@ ur_result_t UR_APICALL urMemBufferCreate(
     size_t size,
     /// [in][optional] pointer to buffer creation properties
     const ur_buffer_properties_t *pProperties,
-    /// [out] pointer to handle of the memory buffer created
+    /// [out][alloc] pointer to handle of the memory buffer created
     ur_mem_handle_t *phBuffer) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1607,7 +1608,7 @@ ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of buffer memory object created.
+    /// [out][alloc] pointer to handle of buffer memory object created.
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1645,7 +1646,7 @@ ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     const ur_image_desc_t *pImageDesc,
     /// [in][optional] pointer to native memory creation properties.
     const ur_mem_native_properties_t *pProperties,
-    /// [out] pointer to handle of image memory object created.
+    /// [out][alloc pointer to handle of image memory object created.
     ur_mem_handle_t *phMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1790,7 +1791,7 @@ ur_result_t UR_APICALL urSamplerCreate(
     ur_context_handle_t hContext,
     /// [in] pointer to the sampler description
     const ur_sampler_desc_t *pDesc,
-    /// [out] pointer to handle of sampler object created
+    /// [out][alloc] pointer to handle of sampler object created
     ur_sampler_handle_t *phSampler) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -1949,7 +1950,7 @@ ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native sampler properties struct.
     const ur_sampler_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the sampler object created.
+    /// [out][alloc] pointer to the handle of the sampler object created.
     ur_sampler_handle_t *phSampler) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2227,7 +2228,7 @@ ur_result_t UR_APICALL urUSMPoolCreate(
     /// [in] pointer to USM pool descriptor. Can be chained with
     /// ::ur_usm_pool_limits_desc_t
     ur_usm_pool_desc_t *pPoolDesc,
-    /// [out] pointer to USM memory pool
+    /// [out][alloc] pointer to USM memory pool
     ur_usm_pool_handle_t *ppPool) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2568,7 +2569,7 @@ ur_result_t UR_APICALL urPhysicalMemCreate(
     size_t size,
     /// [in][optional] pointer to physical memory creation properties.
     const ur_physical_mem_properties_t *pProperties,
-    /// [out] pointer to handle of physical memory object created.
+    /// [out][alloc] pointer to handle of physical memory object created.
     ur_physical_mem_handle_t *phPhysicalMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2681,7 +2682,7 @@ ur_result_t UR_APICALL urProgramCreateWithIL(
     size_t length,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2743,7 +2744,7 @@ ur_result_t UR_APICALL urProgramCreateWithBinary(
     const uint8_t **ppBinaries,
     /// [in][optional] pointer to program creation properties.
     const ur_program_properties_t *pProperties,
-    /// [out] pointer to handle of Program object created.
+    /// [out][alloc] pointer to handle of Program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -2867,7 +2868,7 @@ ur_result_t UR_APICALL urProgramLink(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3213,7 +3214,7 @@ ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native program properties struct.
     const ur_program_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the program object created.
+    /// [out][alloc] pointer to the handle of the program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3243,7 +3244,7 @@ ur_result_t UR_APICALL urKernelCreate(
     ur_program_handle_t hProgram,
     /// [in] pointer to null-terminated string.
     const char *pKernelName,
-    /// [out] pointer to handle of kernel object created.
+    /// [out][alloc] pointer to handle of kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3736,7 +3737,7 @@ ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     ur_program_handle_t hProgram,
     /// [in][optional] pointer to native kernel properties struct
     const ur_kernel_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the kernel object created.
+    /// [out][alloc] pointer to the handle of the kernel object created.
     ur_kernel_handle_t *phKernel) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -3872,7 +3873,7 @@ ur_result_t UR_APICALL urQueueCreate(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to queue creation properties.
     const ur_queue_properties_t *pProperties,
-    /// [out] pointer to handle of queue object created
+    /// [out][alloc] pointer to handle of queue object created
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4001,7 +4002,7 @@ ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice,
     /// [in][optional] pointer to native queue properties struct
     const ur_queue_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the queue object created.
+    /// [out][alloc] pointer to the handle of the queue object created.
     ur_queue_handle_t *phQueue) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4295,7 +4296,7 @@ ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     ur_context_handle_t hContext,
     /// [in][optional] pointer to native event properties struct
     const ur_event_native_properties_t *pProperties,
-    /// [out] pointer to the handle of the event object created.
+    /// [out][alloc] pointer to the handle of the event object created.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4402,9 +4403,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4452,9 +4454,9 @@ ur_result_t UR_APICALL urEnqueueEventsWait(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4504,9 +4506,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4566,9 +4568,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4628,9 +4630,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4717,9 +4719,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4807,9 +4809,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4865,9 +4867,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -4945,9 +4947,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5009,9 +5011,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5077,9 +5079,9 @@ ur_result_t UR_APICALL urEnqueueMemImageRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5145,9 +5147,9 @@ ur_result_t UR_APICALL urEnqueueMemImageWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5205,9 +5207,9 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5271,9 +5273,9 @@ ur_result_t UR_APICALL urEnqueueMemBufferMap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent,
     /// [out] return mapped pointer.  TODO: move it before
     /// numEventsInWaitList?
@@ -5325,9 +5327,9 @@ ur_result_t UR_APICALL urEnqueueMemUnmap(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5381,9 +5383,9 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5434,9 +5436,9 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5491,9 +5493,9 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that this
     /// command does not wait on any event to complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5536,8 +5538,8 @@ ur_result_t UR_APICALL urEnqueueUSMAdvise(
     size_t size,
     /// [in] USM memory advice
     ur_usm_advice_flags_t advice,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5600,9 +5602,10 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5666,9 +5669,10 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5717,9 +5721,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5768,9 +5773,10 @@ ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5819,10 +5825,11 @@ ur_result_t UR_APICALL urEnqueueReadHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this read
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// read command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -5872,10 +5879,11 @@ ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] returns an event object that identifies this write
-    /// command and can be used to query or queue a wait for this command to
-    /// complete. If phEventWaitList and phEvent are not NULL, phEvent must not
-    /// refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] returns an event object that identifies this
+    /// write command
+    /// and can be used to query or queue a wait for this command to complete.
+    /// If phEventWaitList and phEvent are not NULL, phEvent must not refer to
+    /// an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6041,7 +6049,7 @@ ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image memory allocated
+    /// [out][alloc] pointer to handle of image memory allocated
     ur_exp_image_mem_native_handle_t *phImageMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6112,7 +6120,7 @@ ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     const ur_image_format_t *pImageFormat,
     /// [in] pointer to image description
     const ur_image_desc_t *pImageDesc,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6159,7 +6167,7 @@ ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     const ur_image_desc_t *pImageDesc,
     /// [in] sampler to be used
     ur_sampler_handle_t hSampler,
-    /// [out] pointer to handle of image object created
+    /// [out][alloc] pointer to handle of image object created
     ur_exp_image_native_handle_t *phImage) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6229,9 +6237,9 @@ ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6371,7 +6379,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     /// [in] the external memory descriptor
     ur_exp_external_mem_desc_t *pExternalMemDesc,
-    /// [out] external memory handle to the external memory
+    /// [out][alloc] external memory handle to the external memory
     ur_exp_external_mem_handle_t *phExternalMem) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6515,7 +6523,7 @@ ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     /// [in] the external semaphore descriptor
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
-    /// [out] external semaphore handle to the external semaphore
+    /// [out][alloc] external semaphore handle to the external semaphore
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6587,9 +6595,9 @@ ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6633,9 +6641,9 @@ ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6672,7 +6680,7 @@ ur_result_t UR_APICALL urCommandBufferCreateExp(
     ur_device_handle_t hDevice,
     /// [in][optional] command-buffer descriptor.
     const ur_exp_command_buffer_desc_t *pCommandBufferDesc,
-    /// [out] Pointer to command-Buffer handle.
+    /// [out][alloc] Pointer to command-Buffer handle.
     ur_exp_command_buffer_handle_t *phCommandBuffer) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6818,11 +6826,11 @@ ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command. Only available if the
+    /// [out][optional][alloc] Handle to this command. Only available if the
     /// command-buffer is updatable.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
@@ -6884,11 +6892,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -6953,11 +6961,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7018,11 +7026,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7082,11 +7090,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7146,11 +7154,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7219,11 +7227,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7296,11 +7304,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] Sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7440,11 +7448,11 @@ ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7511,11 +7519,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7582,11 +7590,11 @@ ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     const ur_event_handle_t *phEventWaitList,
     /// [out][optional] sync point associated with this command.
     ur_exp_command_buffer_sync_point_t *pSyncPoint,
-    /// [out][optional] return an event object that will be signaled by the
-    /// completion of this command in the next execution of the
+    /// [out][optional][alloc] return an event object that will be signaled by
+    /// the completion of this command in the next execution of the
     /// command-buffer.
     ur_event_handle_t *phEvent,
-    /// [out][optional] Handle to this command.
+    /// [out][optional][alloc] Handle to this command.
     ur_exp_command_buffer_command_handle_t *phCommand) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7624,10 +7632,10 @@ ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command-buffer execution instance. If phEventWaitList and phEvent are
-    /// not NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command-buffer execution instance. If phEventWaitList and
+    /// phEvent are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7746,7 +7754,7 @@ ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
 ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     /// [in] Handle of the command-buffer command to update.
     ur_exp_command_buffer_command_handle_t hCommand,
-    /// [out] Event to be signaled.
+    /// [out][alloc] Event to be signaled.
     ur_event_handle_t *phSignalEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -7886,9 +7894,10 @@ ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating that no wait
     /// event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -8053,10 +8062,10 @@ ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     /// events that must be complete before the kernel execution. If nullptr,
     /// the numEventsInWaitList must be 0, indicating that no wait event.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// kernel execution instance. If phEventWaitList and phEvent are not
-    /// NULL, phEvent must not refer to an element of the phEventWaitList
-    /// array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular kernel execution instance. If phEventWaitList and phEvent
+    /// are not NULL, phEvent must not refer to an element of the
+    /// phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -8191,7 +8200,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
     const ur_program_handle_t *phPrograms,
     /// [in][optional] pointer to linker options null-terminated string.
     const char *pOptions,
-    /// [out] pointer to handle of program object created.
+    /// [out][alloc] pointer to handle of program object created.
     ur_program_handle_t *phProgram) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -8443,9 +8452,9 @@ ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     /// previously enqueued commands
     /// must be complete.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies this particular
-    /// command instance. If phEventWaitList and phEvent are not NULL, phEvent
-    /// must not refer to an element of the phEventWaitList array.
+    /// [out][optional][alloc] return an event object that identifies this
+    /// particular command instance. If phEventWaitList and phEvent are not
+    /// NULL, phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   ur_result_t result = UR_RESULT_SUCCESS;
   return result;
@@ -8491,7 +8500,8 @@ ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     /// If nullptr, the numEventsInWaitList must be 0, indicating no wait
     /// events.
     const ur_event_handle_t *phEventWaitList,
-    /// [out][optional] return an event object that identifies the work that has
+    /// [out][optional][alloc] return an event object that identifies the work
+    /// that has
     /// been enqueued in nativeEnqueueFunc. If phEventWaitList and phEvent are
     /// not NULL, phEvent must not refer to an element of the phEventWaitList
     /// array.


### PR DESCRIPTION
Mark all functions in the API who allocate handles (which must later be
free'd with `Release*` or similar with an `[alloc]` annotation.

----

I've marked the functions I feel should be free'd with the "Release" family of functions, mostly functions named "Create"
or that return events, but I'm not 100% sure I've not miscategorized any. Any feedback is appreciated.