### PR TITLE
If ONEAPI_DEVICE_SELECTOR requested cpu/fpga devices, do NOT load L0/…

### DIFF
--- a/source/loader/ur_adapter_registry.hpp
+++ b/source/loader/ur_adapter_registry.hpp
@@ -263,7 +263,7 @@ class AdapterRegistry {
                         backend, platformBackendName);
                     acceptLibrary = false;
                     continue;
-                }else if ( backend.front() == '*' &&  ( hasDevice[cpu] or hasDevice[fpga] ) &&
+                }else if ( backend.front() == '*' &&  !( hasDevice[gpu] or hasDevice[any] ) &&
                   (platformBackendName.find("level_zero") != std::string::npos  ||
                    platformBackendName.find("cuda") != std::string::npos  ||
                    platformBackendName.find("hip") != std::string::npos  ) ){


### PR DESCRIPTION
…Cuda/Hip backends

Hi, there's an issue with the current implementation in UR, that even if ONEAPI_DEVICE_SELECTOR specified only cpu devices, like *:cpu , the gpu devices are still enumerated and processes are created on these devices which consume some unnecessary resources (a lot of vram in some cases). The issue is that UR only checks the backend types, but ignores device types. There's some customer complaining about this behavior of our runtime stack (reported JIRA already). please review. 