### PR TITLE
[DeviceASAN] Bugfix for GetDeviceType

### DIFF
--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -159,7 +159,7 @@ DeviceType GetDeviceType(ur_context_handle_t Context,
 
     // L0 changes their VA layout.
     // TODO: update our shadow memory layout/algorithms to accordingly.
-    if (((Ptr >> 52) & 0xff0U) == 0xff0U) {
+    if (Ptr >> 52 == 0xff0U) {
       Type = DeviceType::GPU_PVC;
     } else {
       Type = DeviceType::GPU_DG2;


### PR DESCRIPTION
A logical error in `GetDeviceType()` is introduced with a recent PR. This fixes the bug.

Intel/llvm PR: https://github.com/intel/llvm/pull/16745