### PR TITLE
Fix passing struct object by value

### DIFF
--- a/test/adapters/level_zero/event_cache_tests.cpp
+++ b/test/adapters/level_zero/event_cache_tests.cpp
@@ -30,7 +30,7 @@ static std::shared_ptr<_zel_tracer_handle_t> tracer = [] {
   zel_core_callbacks_t prologue_callbacks{};
   prologue_callbacks.Event.pfnCreateCb = OnEnterEventCreate;
   prologue_callbacks.Event.pfnDestroyCb = OnEnterEventDestroy;
-  return enableTracing(prologue_callbacks, {});
+  return enableTracing(std::move(prologue_callbacks), {});
 }();
 
 template <typename... Args> auto combineFlags(std::tuple<Args...> tuple) {

--- a/test/adapters/level_zero/multi_device_event_cache_tests.cpp
+++ b/test/adapters/level_zero/multi_device_event_cache_tests.cpp
@@ -20,7 +20,7 @@ static std::shared_ptr<_zel_tracer_handle_t> tracer = [] {
   zel_core_callbacks_t prologue_callbacks{};
   prologue_callbacks.CommandList.pfnAppendWaitOnEventsCb =
       OnAppendWaitOnEventsCb;
-  return enableTracing(prologue_callbacks, {});
+  return enableTracing(std::move(prologue_callbacks), {});
 }();
 
 using urMultiQueueMultiDeviceEventCacheTest = uur::urAllDevicesTest;

--- a/test/adapters/level_zero/ze_tracer_common.hpp
+++ b/test/adapters/level_zero/ze_tracer_common.hpp
@@ -11,9 +11,9 @@
 
 #include <memory>
 
-std::shared_ptr<_zel_tracer_handle_t>
-enableTracing(zel_core_callbacks_t prologueCallbacks,
-              zel_core_callbacks_t epilogueCallbacks) {
+inline std::shared_ptr<_zel_tracer_handle_t>
+enableTracing(zel_core_callbacks_t &&prologueCallbacks,
+              zel_core_callbacks_t &&epilogueCallbacks) {
   EXPECT_EQ(zeInit(ZE_INIT_FLAG_GPU_ONLY), ZE_RESULT_SUCCESS);
 
   zel_tracer_desc_t tracer_desc = {ZEL_STRUCTURE_TYPE_TRACER_EXP_DESC, nullptr,


### PR DESCRIPTION
Don't pass large objects by value, use a r-value reference instead. Also make function defined in header `inline`.
