### PR TITLE
[L0]: fix missing destroy of event given enqueue wait out event

### DIFF
--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -887,7 +887,14 @@ ur_result_t
 
 urEventRelease(/** [in] handle of the event object */ ur_event_handle_t Event) {
   Event->RefCountExternal--;
+  bool isEventsWaitCompleted =
+      Event->CommandType == UR_COMMAND_EVENTS_WAIT && Event->Completed;
   UR_CALL(urEventReleaseInternal(Event));
+  // If this is a Completed Event Wait Out Event, then we need to cleanup the
+  // event at user release and not at the time of completion.
+  if (isEventsWaitCompleted) {
+    UR_CALL(CleanupCompletedEvent((Event), false, false));
+  }
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
- Added check during event handle release to perform an additional
  cleanup of an enqueue wait event once the user has released their
usage of the out event.