### PR TITLE
Add UR_KERNEL_INFO_SPILL_MEM_SIZE kernel info prop

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -5995,6 +5995,9 @@ typedef enum ur_kernel_info_t {
   /// [uint32_t][optional-query] Return the number of registers used by the
   /// compiled kernel.
   UR_KERNEL_INFO_NUM_REGS = 6,
+  /// [uint32_t][optional-query] Return the spill memory size allocated by
+  /// the compiler.
+  UR_KERNEL_INFO_SPILL_MEM_SIZE = 7,
   /// @cond
   UR_KERNEL_INFO_FORCE_UINT32 = 0x7fffffff
   /// @endcond
@@ -6095,7 +6098,7 @@ typedef enum ur_kernel_exec_info_t {
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_KERNEL_INFO_NUM_REGS < propName`
+///         + `::UR_KERNEL_INFO_SPILL_MEM_SIZE < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -8764,6 +8764,9 @@ inline std::ostream &operator<<(std::ostream &os, enum ur_kernel_info_t value) {
   case UR_KERNEL_INFO_NUM_REGS:
     os << "UR_KERNEL_INFO_NUM_REGS";
     break;
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
+    os << "UR_KERNEL_INFO_SPILL_MEM_SIZE";
+    break;
   default:
     os << "unknown enumerator";
     break;
@@ -8844,6 +8847,19 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     printPtr(os, tptr);
   } break;
   case UR_KERNEL_INFO_NUM_REGS: {
+    const uint32_t *tptr = (const uint32_t *)ptr;
+    if (sizeof(uint32_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)
+         << ")";
+      return UR_RESULT_ERROR_INVALID_SIZE;
+    }
+    os << (const void *)(tptr) << " (";
+
+    os << *tptr;
+
+    os << ")";
+  } break;
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE: {
     const uint32_t *tptr = (const uint32_t *)ptr;
     if (sizeof(uint32_t) > size) {
       os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)

--- a/scripts/core/kernel.yml
+++ b/scripts/core/kernel.yml
@@ -125,6 +125,8 @@ etors:
       desc: "[char[]] Return null-terminated kernel attributes string."
     - name: NUM_REGS
       desc: "[uint32_t][optional-query] Return the number of registers used by the compiled kernel."
+    - name: SPILL_MEM_SIZE
+      desc: "[uint32_t][optional-query] Return the spill memory size allocated by the compiler."
 --- #--------------------------------------------------------------------------
 type: enum
 desc: "Get Kernel Work Group information"

--- a/source/adapters/cuda/kernel.cpp
+++ b/source/adapters/cuda/kernel.cpp
@@ -299,6 +299,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
                                       hKernel->get()));
     return ReturnValue(static_cast<uint32_t>(NumRegs));
   }
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
   default:
     break;
   }

--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -234,6 +234,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
                                        hKernel->get()));
     return ReturnValue(static_cast<uint32_t>(NumRegs));
   }
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
   default:
     break;
   }

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -751,6 +751,8 @@ ur_result_t urKernelGetInfo(
   case UR_KERNEL_INFO_NUM_REGS:
   case UR_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(uint32_t{Kernel->ZeKernelProperties->numKernelArgs});
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
+    return ReturnValue(uint32_t{Kernel->ZeKernelProperties->spillMemSize});
   case UR_KERNEL_INFO_REFERENCE_COUNT:
     return ReturnValue(uint32_t{Kernel->RefCount.load()});
   case UR_KERNEL_INFO_ATTRIBUTES:

--- a/source/adapters/level_zero/v2/kernel.cpp
+++ b/source/adapters/level_zero/v2/kernel.cpp
@@ -624,6 +624,8 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
   case UR_KERNEL_INFO_NUM_REGS:
   case UR_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(uint32_t{hKernel->getCommonProperties().numKernelArgs});
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
+    return ReturnValue(uint32_t{hKernel->getProperties().spillMemSize});
   case UR_KERNEL_INFO_REFERENCE_COUNT:
     return ReturnValue(uint32_t{hKernel->RefCount.load()});
   case UR_KERNEL_INFO_ATTRIBUTES: {

--- a/source/adapters/opencl/kernel.cpp
+++ b/source/adapters/opencl/kernel.cpp
@@ -64,6 +64,7 @@ static cl_int mapURKernelInfoToCL(ur_kernel_info_t URPropName) {
     return CL_KERNEL_ATTRIBUTES;
   // NUM_REGS doesn't have a CL equivalent
   case UR_KERNEL_INFO_NUM_REGS:
+  case UR_KERNEL_INFO_SPILL_MEM_SIZE:
   default:
     return -1;
   }
@@ -76,6 +77,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
                                                     size_t *pPropSizeRet) {
   // OpenCL doesn't have a way to support this.
   if (propName == UR_KERNEL_INFO_NUM_REGS) {
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+  if (propName == UR_KERNEL_INFO_SPILL_MEM_SIZE) {
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
   size_t CheckPropSize = 0;

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -3315,7 +3315,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     if (pPropValue == NULL && pPropSizeRet == NULL)
       return UR_RESULT_ERROR_INVALID_NULL_POINTER;
 
-    if (UR_KERNEL_INFO_NUM_REGS < propName)
+    if (UR_KERNEL_INFO_SPILL_MEM_SIZE < propName)
       return UR_RESULT_ERROR_INVALID_ENUMERATION;
 
     if (propSize == 0 && pPropValue != NULL)

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -3798,7 +3798,7 @@ ur_result_t UR_APICALL urKernelSetArgLocal(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_KERNEL_INFO_NUM_REGS < propName`
+///         + `::UR_KERNEL_INFO_SPILL_MEM_SIZE < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -3330,7 +3330,7 @@ ur_result_t UR_APICALL urKernelSetArgLocal(
 ///     - ::UR_RESULT_ERROR_INVALID_NULL_HANDLE
 ///         + `NULL == hKernel`
 ///     - ::UR_RESULT_ERROR_INVALID_ENUMERATION
-///         + `::UR_KERNEL_INFO_NUM_REGS < propName`
+///         + `::UR_KERNEL_INFO_SPILL_MEM_SIZE < propName`
 ///     - ::UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION
 ///         + If `propName` is not supported by the adapter.
 ///     - ::UR_RESULT_ERROR_INVALID_SIZE

--- a/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/test/conformance/kernel/urKernelGetInfo.cpp
@@ -136,6 +136,22 @@ TEST_P(urKernelGetInfoTest, SuccessNumRegs) {
                                  property_value.data(), nullptr));
 }
 
+TEST_P(urKernelGetInfoTest, SuccessSpillMemSize) {
+  UUR_KNOWN_FAILURE_ON(uur::HIP{}, uur::OpenCL{});
+
+  ur_kernel_info_t property_name = UR_KERNEL_INFO_SPILL_MEM_SIZE;
+  size_t property_size = 0;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urKernelGetInfo(kernel, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  std::vector<char> property_value(property_size);
+  ASSERT_SUCCESS(urKernelGetInfo(kernel, property_name, property_size,
+                                 property_value.data(), nullptr));
+}
+
 TEST_P(urKernelGetInfoTest, InvalidNullHandleKernel) {
   size_t kernel_name_length = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/test/conformance/testing/include/uur/optional_queries.h
+++ b/test/conformance/testing/include/uur/optional_queries.h
@@ -86,6 +86,7 @@ template <> inline bool isQueryOptional(ur_program_info_t query) {
 
 constexpr std::array optional_ur_kernel_info_t = {
     UR_KERNEL_INFO_NUM_REGS,
+    UR_KERNEL_INFO_SPILL_MEM_SIZE,
 };
 
 template <> inline bool isQueryOptional(ur_kernel_info_t query) {


### PR DESCRIPTION
This allows for querying the information about produced register spills during kernel compilation. The query is optional and is only implemented for L0 now. The direct counterpart for the query is [spillMemSize](https://spec.oneapi.io/level-zero/1.9.3/core/api.html#_CPPv4N22ze_kernel_properties_t12spillMemSizeE) property returned by `zeKernelGetProperties`.