### PR TITLE
[HIP] Implement urKernelSuggestMaxCooperativeGroupCountExp for HIP

### DIFF
--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -58,11 +58,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(VendorId);
   }
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
-    int ComputeUnits = 0;
-    UR_CHECK_ERROR(hipDeviceGetAttribute(
-        &ComputeUnits, hipDeviceAttributeMultiprocessorCount, hDevice->get()));
-    detail::ur::assertion(ComputeUnits >= 0);
-    return ReturnValue(static_cast<uint32_t>(ComputeUnits));
+    return ReturnValue(hDevice->getNumComputeUnits());
   }
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS: {
     return ReturnValue(MaxWorkItemDimensions);

--- a/source/adapters/hip/device.hpp
+++ b/source/adapters/hip/device.hpp
@@ -26,6 +26,7 @@ private:
   ur_platform_handle_t Platform;
   hipEvent_t EvBase; // HIP event used as base counter
   uint32_t DeviceIndex;
+  uint32_t NumComputeUnits{0};
 
   int MaxWorkGroupSize{0};
   int MaxBlockDimX{0};
@@ -41,6 +42,9 @@ public:
       : HIPDevice(HipDevice), RefCount{1}, Platform(Platform), EvBase(EvBase),
         DeviceIndex(DeviceIndex) {
 
+    UR_CHECK_ERROR(hipDeviceGetAttribute(
+        reinterpret_cast<int *>(&NumComputeUnits),
+        hipDeviceAttributeMultiprocessorCount, HIPDevice));
     UR_CHECK_ERROR(hipDeviceGetAttribute(
         &MaxWorkGroupSize, hipDeviceAttributeMaxThreadsPerBlock, HIPDevice));
     UR_CHECK_ERROR(hipDeviceGetAttribute(
@@ -84,6 +88,8 @@ public:
   int getDeviceMaxLocalMem() const noexcept { return DeviceMaxLocalMem; };
 
   int getManagedMemSupport() const noexcept { return ManagedMemSupport; };
+
+  uint32_t getNumComputeUnits() const noexcept { return NumComputeUnits; };
 
   int getConcurrentManagedAccess() const noexcept {
     return ConcurrentManagedAccess;

--- a/source/adapters/hip/kernel.cpp
+++ b/source/adapters/hip/kernel.cpp
@@ -185,9 +185,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
         &MaxNumActiveGroupsPerCU, hKernel->get(), localWorkSize,
         dynamicSharedMemorySize));
     detail::ur::assertion(MaxNumActiveGroupsPerCU >= 0);
-    // Handle the case where we can't have all SMs active with at least 1 group
-    // per SM. In that case, the device is still able to run 1 work-group, hence
-    // we will manually check if it is possible with the available HW resources.
+    // Handle the case where we can't have all work-group processors (WGPs)
+    // active with at least 1 group per WGP. In that case, the device is still
+    // able to run 1 work-group, hence we will manually check if it is possible
+    // with the available HW resources.
     if (MaxNumActiveGroupsPerCU == 0) {
       size_t MaxWorkGroupSize{};
       urKernelGetGroupInfo(
@@ -202,8 +203,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
       else
         *pGroupCountRet = 1;
     } else {
-      // Multiply by the number of SMs (CUs = compute units) on the device in
-      // order to retreive the total number of groups/blocks that can be
+      // Multiply by the number of WGPs (CUs = compute units) on the device in
+      // order to retrieve the total number of groups/blocks that can be
       // launched.
       *pGroupCountRet = Device->getNumComputeUnits() * MaxNumActiveGroupsPerCU;
     }


### PR DESCRIPTION
This commit follows the implementation https://github.com/oneapi-src/unified-runtime/pull/1796 to support the experimental urKernelSuggestMaxCooperativeGroupCountExp, for the HIP adapter, to retrieve the maximum number of cooperative groups that can be launched on the device.

Additionally, the changes also cache the result of the hipDeviceAttributeMultiprocessorCount query which is used to calculate the device-wide maximum cooperative groups, because the HIP occupancy query used has per multiprocessor semantics.