### PR TITLE
[benchmarks] use manifest to build compute-runtime dependencies

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -205,6 +205,7 @@ jobs:
         --umf ${{ github.workspace }}/umf_build
         --adapter ${{ matrix.adapter.str_name }}
         --compute-runtime ${{ inputs.compute_runtime_commit }}
+        --build-igc
         ${{ inputs.upload_report && '--output-html' || '' }}
         ${{ inputs.bench_script_params }}
 

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -9,11 +9,11 @@ Scripts for running performance tests on SYCL and Unified Runtime.
 
 ## Running
 
-`$ ./main.py ~/benchmarks_workdir/ ~/llvm/build/ ~/ur adapter_name`
+`$ ./main.py ~/benchmarks_workdir/ --sycl ~/llvm/build/ --ur ~/ur --adapter adapter_name`
 
 This will download and build everything in `~/benchmarks_workdir/` using the compiler in `~/llvm/build/`, UR source from `~/ur` and then run the benchmarks for `adapter_name` adapter. The results will be stored in `benchmark_results.md`.
 
-The scripts will try to reuse the files stored in `~/benchmarks_workdir/`, but the benchmarks will be rebuilt every time. To avoid that, use `-no-rebuild` option.
+The scripts will try to reuse the files stored in `~/benchmarks_workdir/`, but the benchmarks will be rebuilt every time. To avoid that, use `--no-rebuild` option.
 
 ## Running in CI
 
@@ -47,7 +47,27 @@ are stored [here](https://oneapi-src.github.io/unified-runtime/benchmark_results
 ### Python
 
 dataclasses-json==0.6.7
+PyYAML==6.0.2
+Mako==1.3.0
 
 ### System
 
-libopencv-dev
+Sobel Filter benchmark:
+
+`$ sudo apt-get install libopencv-dev`
+
+### Compute-runtime and IGC
+
+The scripts have an option to build compute-runtime and all related components from source:
+
+`$ ./main.py ~/benchmarks_workdir/ --compute-runtime [tag] --build-igc`
+
+For this to work, the system needs to have the appropriate dependencies installed.
+
+compute-runtime (Ubuntu):
+
+`$ sudo apt-get install cmake g++ git pkg-config`
+
+IGC (Ubuntu):
+
+`$ sudo apt-get install flex bison libz-dev cmake libc6 libstdc++6 python3-pip`

--- a/scripts/benchmarks/main.py
+++ b/scripts/benchmarks/main.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
     parser.add_argument('--ur', type=str, help='UR install prefix path', default=None)
     parser.add_argument('--umf', type=str, help='UMF install prefix path', default=None)
     parser.add_argument('--adapter', type=str, help='Options to build the Unified Runtime as part of the benchmark', default="level_zero")
-    parser.add_argument("--no-rebuild", help='Rebuild the benchmarks from scratch.', action="store_true")
+    parser.add_argument("--no-rebuild", help='Do not rebuild the benchmarks from scratch.', action="store_true")
     parser.add_argument("--env", type=str, help='Use env variable for a benchmark run.', action="append", default=[])
     parser.add_argument("--save", type=str, help='Save the results for comparison under a specified name.')
     parser.add_argument("--compare", type=str, help='Compare results against previously saved data.', action="append", default=["baseline"])
@@ -262,6 +262,7 @@ if __name__ == "__main__":
     parser.add_argument("--dry-run", help='Do not run any actual benchmarks', action="store_true", default=False)
     parser.add_argument("--compute-runtime", nargs='?', const=options.compute_runtime_tag, help="Fetch and build compute runtime")
     parser.add_argument("--iterations-stddev", type=int, help="Max number of iterations of the loop calculating stddev after completed benchmark runs", default=options.iterations_stddev)
+    parser.add_argument("--build-igc", help="Build IGC from source instead of using the OS-installed version", action="store_true", default=options.build_igc)
 
     args = parser.parse_args()
     additional_env_vars = validate_and_parse_env_args(args.env)
@@ -283,6 +284,10 @@ if __name__ == "__main__":
     options.dry_run = args.dry_run
     options.umf = args.umf
     options.iterations_stddev = args.iterations_stddev
+    options.build_igc = args.build_igc
+
+    if args.build_igc and args.compute_runtime is None:
+        parser.error("--build-igc requires --compute-runtime to be set")
     if args.compute_runtime is not None:
         options.build_compute_runtime = True
         options.compute_runtime_tag = args.compute_runtime

--- a/scripts/benchmarks/options.py
+++ b/scripts/benchmarks/options.py
@@ -30,7 +30,8 @@ class Options:
     build_compute_runtime: bool = False
     extra_ld_libraries: list[str] = field(default_factory=list)
     extra_env_vars: dict = field(default_factory=dict)
-    compute_runtime_tag: str = 'c1ed0334d65f6ce86d7273fe4137d1d4a5b5fa7c'
+    compute_runtime_tag: str = '24.52.32224.8'
+    build_igc: bool = False
 
 options = Options()
 

--- a/scripts/benchmarks/utils/utils.py
+++ b/scripts/benchmarks/utils/utils.py
@@ -13,7 +13,7 @@ import urllib # nosec B404
 from options import options
 from pathlib import Path
 
-def run(command, env_vars={}, cwd=None, add_sycl=False, ld_library=[]):
+def run(command, env_vars={}, cwd=None, add_sycl=False, ld_library=[], timeout=options.timeout):
     try:
         if isinstance(command, str):
             command = command.split()
@@ -32,7 +32,7 @@ def run(command, env_vars={}, cwd=None, add_sycl=False, ld_library=[]):
 
         env.update(env_vars)
 
-        result = subprocess.run(command, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, timeout=options.timeout) # nosec B603
+        result = subprocess.run(command, cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, timeout=timeout) # nosec B603
 
         if options.verbose:
             print(result.stdout.decode())

--- a/third_party/benchmark_requirements.txt
+++ b/third_party/benchmark_requirements.txt
@@ -41,3 +41,4 @@ sphinxcontrib-websupport==1.2.4
 sphinx-rtd-theme==1.0.0
 urllib3==2.2.2
 dataclasses-json==0.6.7
+PyYAML==6.0.1


### PR DESCRIPTION
Instead of hardcoding compute runtime dependencies, scripts will now fetch its manifest file to see what are the correct versions of dependencies to build them.
This patch also adds an option to build IGC from source.