### PR TITLE
Document CTS fixtures and macros.

### DIFF
--- a/test/adapters/cuda/context_tests.cpp
+++ b/test/adapters/cuda/context_tests.cpp
@@ -11,7 +11,7 @@
 #include <thread>
 
 using cudaUrContextCreateTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaUrContextCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(cudaUrContextCreateTest);
 
 constexpr unsigned int known_cuda_api_version = 3020;
 

--- a/test/adapters/cuda/event_tests.cpp
+++ b/test/adapters/cuda/event_tests.cpp
@@ -10,7 +10,7 @@
 #include "raii.h"
 
 using cudaEventTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaEventTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(cudaEventTest);
 
 // Testing the urEventGetInfo behaviour for natively constructed (Cuda) events.
 // Backend interop APIs can lead to creating event objects that are not fully

--- a/test/adapters/cuda/kernel_tests.cpp
+++ b/test/adapters/cuda/kernel_tests.cpp
@@ -9,7 +9,7 @@
 #include "uur/raii.h"
 
 using cudaKernelTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(cudaKernelTest);
 
 // The first argument stores the implicit global offset
 inline constexpr size_t NumberOfImplicitArgsCUDA = 1;

--- a/test/adapters/cuda/memory_tests.cpp
+++ b/test/adapters/cuda/memory_tests.cpp
@@ -8,7 +8,7 @@
 #include "uur/raii.h"
 
 using cudaMemoryTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(cudaMemoryTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(cudaMemoryTest);
 
 TEST_P(cudaMemoryTest, urMemBufferNoActiveContext) {
   constexpr size_t memSize = 1024u;

--- a/test/adapters/cuda/urContextGetNativeHandle.cpp
+++ b/test/adapters/cuda/urContextGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urCudaContextGetNativeHandle = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaContextGetNativeHandle);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaContextGetNativeHandle);
 
 TEST_P(urCudaContextGetNativeHandle, Success) {
   ur_native_handle_t native_context = 0;

--- a/test/adapters/cuda/urDeviceCreateWithNativeHandle.cpp
+++ b/test/adapters/cuda/urDeviceCreateWithNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urCudaDeviceCreateWithNativeHandle = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urCudaDeviceCreateWithNativeHandle);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urCudaDeviceCreateWithNativeHandle);
 
 TEST_P(urCudaDeviceCreateWithNativeHandle, Success) {
   // get a device from cuda

--- a/test/adapters/cuda/urDeviceGetNativeHandle.cpp
+++ b/test/adapters/cuda/urDeviceGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urCudaGetDeviceNativeHandle = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaGetDeviceNativeHandle);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaGetDeviceNativeHandle);
 
 TEST_P(urCudaGetDeviceNativeHandle, Success) {
   ur_native_handle_t native_handle;

--- a/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
+++ b/test/adapters/cuda/urEventCreateWithNativeHandle.cpp
@@ -8,7 +8,7 @@
 #include "raii.h"
 
 using urCudaEventCreateWithNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaEventCreateWithNativeHandleTest);
 
 TEST_P(urCudaEventCreateWithNativeHandleTest, Success) {
   RAIICUevent cuda_event;

--- a/test/adapters/cuda/urEventGetNativeHandle.cpp
+++ b/test/adapters/cuda/urEventGetNativeHandle.cpp
@@ -8,7 +8,7 @@
 #include "uur/raii.h"
 
 using urCudaEventGetNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEventGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaEventGetNativeHandleTest);
 
 TEST_P(urCudaEventGetNativeHandleTest, Success) {
   constexpr size_t buffer_size = 1024;

--- a/test/adapters/cuda/urQueueGetNativeHandle.cpp
+++ b/test/adapters/cuda/urQueueGetNativeHandle.cpp
@@ -8,7 +8,7 @@
 #include "queue.hpp"
 
 using urCudaQueueGetNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaQueueGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaQueueGetNativeHandleTest);
 
 TEST_P(urCudaQueueGetNativeHandleTest, Success) {
   CUstream Stream;

--- a/test/adapters/hip/test_context.cpp
+++ b/test/adapters/hip/test_context.cpp
@@ -12,7 +12,7 @@
 #include "uur/raii.h"
 
 using urHipContextTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipContextTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urHipContextTest);
 
 TEST_P(urHipContextTest, ActiveContexts) {
   uur::raii::Context context = nullptr;

--- a/test/adapters/hip/test_event.cpp
+++ b/test/adapters/hip/test_event.cpp
@@ -25,7 +25,7 @@ struct RAIIHipEvent {
 };
 
 using urHipEventTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipEventTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urHipEventTest);
 
 // Testing the urEventGetInfo behaviour for natively constructed (HIP) events.
 // Backend interop APIs can lead to creating event objects that are not fully

--- a/test/adapters/hip/urContextGetNativeHandle.cpp
+++ b/test/adapters/hip/urContextGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urHipContextGetNativeHandleTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipContextGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urHipContextGetNativeHandleTest);
 
 TEST_P(urHipContextGetNativeHandleTest, Success) {
   ur_native_handle_t native_context = 0;

--- a/test/adapters/hip/urDeviceGetNativeHandle.cpp
+++ b/test/adapters/hip/urDeviceGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urHipGetDeviceNativeHandle = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipGetDeviceNativeHandle);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urHipGetDeviceNativeHandle);
 
 TEST_P(urHipGetDeviceNativeHandle, Success) {
   ur_native_handle_t native_handle;

--- a/test/adapters/hip/urEventGetNativeHandle.cpp
+++ b/test/adapters/hip/urEventGetNativeHandle.cpp
@@ -8,7 +8,7 @@
 #include "uur/raii.h"
 
 using urHipEventGetNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urHipEventGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urHipEventGetNativeHandleTest);
 
 TEST_P(urHipEventGetNativeHandleTest, Success) {
   constexpr size_t buffer_size = 1024;

--- a/test/adapters/level_zero/event_cache_tests.cpp
+++ b/test/adapters/level_zero/event_cache_tests.cpp
@@ -183,18 +183,18 @@ printFlags(const testing::TestParamInfo<typename T::ParamType> &info) {
   return platform_device_name + "__" + str;
 }
 
-UUR_DEVICE_TEST_SUITE_P(urEventCacheTest,
-                        ::testing::
-                            Combine(
-                                testing::Values(0,
-                                                UR_QUEUE_FLAG_DISCARD_EVENTS),
-                                testing::Values(
-                                    0,
-                                    UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),
-                                // TODO: why the test fails with
-                                // UR_QUEUE_FLAG_SUBMISSION_BATCHED?
-                                testing::
-                                    Values(UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE /*, UR_QUEUE_FLAG_SUBMISSION_BATCHED */),
-                                testing::Values(
-                                    0, UR_QUEUE_FLAG_PROFILING_ENABLE)),
-                        printFlags<urEventCacheTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urEventCacheTest,
+                                 ::testing::Combine(
+                                     testing::Values(
+                                         0, UR_QUEUE_FLAG_DISCARD_EVENTS),
+                                     testing::Values(
+                                         0,
+                                         UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),
+                                     // TODO: why the test fails with
+                                     // UR_QUEUE_FLAG_SUBMISSION_BATCHED?
+                                     testing::
+                                         Values(
+                                             UR_QUEUE_FLAG_SUBMISSION_IMMEDIATE /*, UR_QUEUE_FLAG_SUBMISSION_BATCHED */),
+                                     testing::Values(
+                                         0, UR_QUEUE_FLAG_PROFILING_ENABLE)),
+                                 printFlags<urEventCacheTest>);

--- a/test/adapters/level_zero/ipc.cpp
+++ b/test/adapters/level_zero/ipc.cpp
@@ -13,7 +13,7 @@
 #endif
 
 using urL0IpcTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urL0IpcTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urL0IpcTest);
 
 TEST_P(urL0IpcTest, SuccessHostL0Ipc) {
   ur_device_usm_access_capability_flags_t hostUSMSupport = 0;

--- a/test/adapters/level_zero/multi_device_event_cache_tests.cpp
+++ b/test/adapters/level_zero/multi_device_event_cache_tests.cpp
@@ -24,7 +24,7 @@ static std::shared_ptr<_zel_tracer_handle_t> tracer = [] {
 }();
 
 using urMultiQueueMultiDeviceEventCacheTest = uur::urAllDevicesTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiQueueMultiDeviceEventCacheTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiQueueMultiDeviceEventCacheTest);
 
 TEST_P(urMultiQueueMultiDeviceEventCacheTest,
        GivenMultiSubDeviceWithQueuePerSubDeviceThenEventIsSharedBetweenQueues) {

--- a/test/adapters/level_zero/urEnqueueMemBufferMapHostPtr.cpp
+++ b/test/adapters/level_zero/urEnqueueMemBufferMapHostPtr.cpp
@@ -11,7 +11,7 @@
 using urEnqueueMemBufferMapTestWithParamL0 =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferMapTestWithParamL0,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferMapTestWithParamL0>);

--- a/test/adapters/level_zero/urEventCreateWithNativeHandle.cpp
+++ b/test/adapters/level_zero/urEventCreateWithNativeHandle.cpp
@@ -15,7 +15,7 @@
 
 using namespace std::chrono_literals;
 using urLevelZeroEventNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urLevelZeroEventNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroEventNativeHandleTest);
 
 #define TEST_MEMCPY_SIZE 4096
 

--- a/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
+++ b/test/adapters/level_zero/urKernelCreateWithNativeHandle.cpp
@@ -10,7 +10,7 @@
 #include <uur/fixtures.h>
 
 using urLevelZeroKernelNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urLevelZeroKernelNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroKernelNativeHandleTest);
 
 TEST_P(urLevelZeroKernelNativeHandleTest, OwnedHandleRelease) {
   ze_context_handle_t native_context;

--- a/test/adapters/level_zero/urProgramLink.cpp
+++ b/test/adapters/level_zero/urProgramLink.cpp
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urLevelZeroProgramLinkTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urLevelZeroProgramLinkTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urLevelZeroProgramLinkTest);
 
 TEST_P(urLevelZeroProgramLinkTest, InvalidLinkOptionsPrintedInLog) {
   ur_program_handle_t linked_program = nullptr;

--- a/test/adapters/level_zero/v2/command_list_cache_test.cpp
+++ b/test/adapters/level_zero/v2/command_list_cache_test.cpp
@@ -21,7 +21,7 @@
 
 struct CommandListCacheTest : public uur::urContextTest {};
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(CommandListCacheTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(CommandListCacheTest);
 
 TEST_P(CommandListCacheTest, CanStoreAndRetriveImmediateAndRegularCmdLists) {
   v2::command_list_cache_t cache(context->getZeHandle());

--- a/test/adapters/level_zero/v2/deferred_kernel.cpp
+++ b/test/adapters/level_zero/v2/deferred_kernel.cpp
@@ -22,7 +22,7 @@ struct urEnqueueKernelLaunchTest : uur::urKernelExecutionTest {
   size_t global_offset = 0;
   size_t n_dimensions = 1;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchTest);
 
 TEST_P(urEnqueueKernelLaunchTest, DeferredKernelRelease) {
   ur_mem_handle_t buffer = nullptr;
@@ -111,7 +111,7 @@ struct urMultiQueueLaunchKernelDeferFreeTest
   }
 };
 
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiQueueLaunchKernelDeferFreeTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiQueueLaunchKernelDeferFreeTest);
 
 TEST_P(urMultiQueueLaunchKernelDeferFreeTest, Success) {
   auto zeEvent1 = createZeEvent(context, devices[0]);

--- a/test/adapters/level_zero/v2/event_pool_test.cpp
+++ b/test/adapters/level_zero/v2/event_pool_test.cpp
@@ -147,8 +147,8 @@ static ProviderParams test_cases[] = {
     //{TEST_PROVIDER_COUNTER, EVENT_COUNTER, QUEUE_IMMEDIATE},
 };
 
-UUR_DEVICE_TEST_SUITE_P(EventPoolTest, testing::ValuesIn(test_cases),
-                        printParams<EventPoolTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(EventPoolTest, testing::ValuesIn(test_cases),
+                                 printParams<EventPoolTest>);
 
 TEST_P(EventPoolTest, InvalidDevice) {
   auto pool = cache->borrow(MAX_DEVICES, getParam().flags);
@@ -240,8 +240,9 @@ TEST_P(EventPoolTest, ProviderNormalUseMostFreePool) {
 
 using EventPoolTestWithQueue = uur::urQueueTestWithParam<ProviderParams>;
 
-UUR_DEVICE_TEST_SUITE_P(EventPoolTestWithQueue, testing::ValuesIn(test_cases),
-                        printParams<EventPoolTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(EventPoolTestWithQueue,
+                                 testing::ValuesIn(test_cases),
+                                 printParams<EventPoolTest>);
 
 // TODO: actual min version is unknown, retest after drivers on CI are
 // updated.

--- a/test/adapters/level_zero/v2/memory_residency.cpp
+++ b/test/adapters/level_zero/v2/memory_residency.cpp
@@ -8,7 +8,7 @@
 #include "uur/utils.h"
 
 using urMemoryResidencyTest = uur::urMultiDeviceContextTestTemplate<1>;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMemoryResidencyTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMemoryResidencyTest);
 
 TEST_P(urMemoryResidencyTest, allocatingDeviceMemoryWillResultInOOM) {
   static constexpr size_t allocSize = 1024 * 1024;

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -70,3 +70,82 @@ The following adapter matcher objects are available:
 * `uur::CUDA`
 * `uur::HIP`
 * `uur::NativeCPU`
+
+## Writing a new CTS test
+
+If you're writing a new CTS test you'll need to make use of the existing test
+fixtures and instantiation macros to access the adapters available for testing.
+The definitions for these can all be found in
+[fixtures.h](https://github.com/oneapi-src/unified-runtime/blob/main/test/conformance/testing/include/uur/fixtures.h).
+
+There are five "base" fixtures in that header that each correspond to an
+instantiation macro - specific macros are needed due to how gtest handles
+parameterization and printing. All of these make use of gtest's [value
+parameterization](http://google.github.io/googletest/advanced.html#how-to-write-value-parameterized-tests)
+to instantiate the tests for all the available backends. Two of the five base
+fixtures have a wrapper to allow for tests defining their own parameterization.
+
+The base fixtures and their macros are detailed below. Tests inheriting from
+fixtures other than the base ones (`urContextTest`, etc.) must be instantiated
+with the macro that corresponds to whatever base class is ultimately being
+inherited from. In the case of `urContextTest` we can see that it inherits
+directly from `urDeviceTest`, so we should use the `urDeviceTest` macro. For
+other fixtures you'll need to follow the inheritance back a few steps to figure
+it out.
+
+### `urAdapterTest`
+
+This fixture is intended for tests that will be run once for each adapter
+available. The only data member it provides is a `ur_adapter_handle_t`.
+
+Instantiated with the `UUR_INSTANTIATE_ADAPTER_TEST_SUITE` macro.
+
+### `urPlatformTest`
+
+This fixture is intended for tests that will be run once for each platform
+available (note the potentially one-to-many relationship between adapters and
+platforms). The only data member it provides is a `ur_platform_handle_t`.
+
+Instantiated with the `UUR_INSTANTIATE_PLATFORM_TEST_SUITE` macro.
+
+### `urDeviceTest`
+
+This fixture is intended for tests that will be run once for each device
+available. It provides a `ur_adapter_handle_t`, `ur_platform_handle_t` and a
+`ur_device_handle_t` (the former two corresponding to the latter).
+
+Instantiated with the `UUR_INSTANTIATE_DEVICE_TEST_SUITE` macro.
+
+### `urPlatformTestWithParam`
+
+This fixture functions the same as `urPlatformTest` except it allows value
+parameterization via a template parameter. Note the parameter you specify is
+accessed with `getParam()` rather than gtest's `GetParam()`. A platform handle
+is provided the same way it is in the non-parameterized variant.
+
+Instantiated with the `UUR_PLATFORM_TEST_SUITE_WITH_PARAM` macro, which, in
+addition to the fixture, takes a `::testing::Values` list of parameter values
+and a printer (more detail about that below).
+
+### `urDeviceTestWithParam`
+
+As with the parameterized platform fixture this functions identically to
+`urDeviceTest` with the addition of the template parameter for
+parameterization.
+
+Instantiated with the `UUR_DEVICE_TEST_SUITE_WITH_PARAM` macro.
+
+### Parameter printers
+
+When instantiating tests based on the parameterized fixtures you need to
+provide a printer function along with the value list. This determines how the
+parameter values are incorporated into the test name. If your parameter type
+has a `<<` operator defined for it, you can simply use the
+`platformTestWithParamPrinter`/`deviceTestWithParamPrinter` helper functions for
+this.
+
+If you find yourself needing to write a custom printer function, bear in mind
+that due to the parameterization wrapper it'll need to deal with a tuple
+containing the platform/device information and your parameter. You should
+reference the implementations of `platformTestWithParamPrinter` and
+`deviceTestWithParamPrinter` to see how this is handled.

--- a/test/conformance/adapter/urAdapterGetInfo.cpp
+++ b/test/conformance/adapter/urAdapterGetInfo.cpp
@@ -10,7 +10,7 @@
 
 using urAdapterGetInfoTest = uur::urAdapterTest;
 
-UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(urAdapterGetInfoTest);
+UUR_INSTANTIATE_ADAPTER_TEST_SUITE(urAdapterGetInfoTest);
 
 TEST_P(urAdapterGetInfoTest, SuccessBackend) {
   ur_adapter_info_t property_name = UR_ADAPTER_INFO_BACKEND;

--- a/test/conformance/adapter/urAdapterGetLastError.cpp
+++ b/test/conformance/adapter/urAdapterGetLastError.cpp
@@ -11,7 +11,7 @@ struct urAdapterGetLastErrorTest : uur::urAdapterTest {
   const char *message = nullptr;
 };
 
-UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(urAdapterGetLastErrorTest);
+UUR_INSTANTIATE_ADAPTER_TEST_SUITE(urAdapterGetLastErrorTest);
 
 TEST_P(urAdapterGetLastErrorTest, Success) {
   // We can't reliably generate a UR_RESULT_ERROR_ADAPTER_SPECIFIC error to

--- a/test/conformance/adapter/urAdapterRelease.cpp
+++ b/test/conformance/adapter/urAdapterRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urAdapterReleaseTest = uur::urAdapterTest;
-UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(urAdapterReleaseTest);
+UUR_INSTANTIATE_ADAPTER_TEST_SUITE(urAdapterReleaseTest);
 
 TEST_P(urAdapterReleaseTest, Success) {
   uint32_t referenceCountBefore = 0;

--- a/test/conformance/adapter/urAdapterRetain.cpp
+++ b/test/conformance/adapter/urAdapterRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urAdapterRetainTest = uur::urAdapterTest;
-UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(urAdapterRetainTest);
+UUR_INSTANTIATE_ADAPTER_TEST_SUITE(urAdapterRetainTest);
 
 TEST_P(urAdapterRetainTest, Success) {
   uint32_t referenceCountBefore = 0;

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -9,7 +9,7 @@
 
 using urContextCreateTest = uur::urDeviceTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextCreateTest);
 
 TEST_P(urContextCreateTest, Success) {
   uur::raii::Context context = nullptr;
@@ -46,7 +46,7 @@ TEST_P(urContextCreateTest, InvalidEnumeration) {
 }
 
 using urContextCreateMultiDeviceTest = uur::urAllDevicesTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urContextCreateMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urContextCreateMultiDeviceTest);
 
 TEST_P(urContextCreateMultiDeviceTest, Success) {
   if (devices.size() < 2) {

--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urContextCreateWithNativeHandleTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextCreateWithNativeHandleTest);
 
 TEST_P(urContextCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_context = 0;

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urContextGetInfoTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextGetInfoTest);
 
 TEST_P(urContextGetInfoTest, SuccessNumDevices) {
   ur_context_info_t property_name = UR_CONTEXT_INFO_NUM_DEVICES;

--- a/test/conformance/context/urContextGetNativeHandle.cpp
+++ b/test/conformance/context/urContextGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urContextGetNativeHandleTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextGetNativeHandleTest);
 
 TEST_P(urContextGetNativeHandleTest, Success) {
   ur_native_handle_t native_context = 0;

--- a/test/conformance/context/urContextRelease.cpp
+++ b/test/conformance/context/urContextRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urContextReleaseTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextReleaseTest);
 
 TEST_P(urContextReleaseTest, Success) {
   ASSERT_SUCCESS(urContextRetain(context));

--- a/test/conformance/context/urContextRetain.cpp
+++ b/test/conformance/context/urContextRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urContextRetainTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextRetainTest);
 
 TEST_P(urContextRetainTest, Success) {
   uint32_t prevRefCount = 0;

--- a/test/conformance/context/urContextSetExtendedDeleter.cpp
+++ b/test/conformance/context/urContextSetExtendedDeleter.cpp
@@ -10,7 +10,7 @@
 
 using urContextSetExtendedDeleterTest = uur::urDeviceTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urContextSetExtendedDeleterTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextSetExtendedDeleterTest);
 
 TEST_P(urContextSetExtendedDeleterTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{}, uur::NativeCPU{});

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urDeviceCreateWithNativeHandleTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceCreateWithNativeHandleTest);
 
 TEST_P(urDeviceCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/device/urDeviceGet.cpp
+++ b/test/conformance/device/urDeviceGet.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urDeviceGetTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urDeviceGetTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urDeviceGetTest);
 
 TEST_P(urDeviceGetTest, Success) {
   uint32_t count = 0;
@@ -71,7 +71,7 @@ TEST_P(urDeviceGetTest, InvalidNullPointerDevices) {
 using urDeviceGetTestWithDeviceTypeParam =
     uur::urPlatformTestWithParam<ur_device_type_t>;
 
-UUR_PLATFORM_TEST_SUITE_P(
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
     urDeviceGetTestWithDeviceTypeParam,
     ::testing::Values(UR_DEVICE_TYPE_DEFAULT, UR_DEVICE_TYPE_GPU,
                       UR_DEVICE_TYPE_CPU, UR_DEVICE_TYPE_FPGA,

--- a/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -28,7 +28,7 @@ T absolute_difference(T a, T b) {
 }
 
 using urDeviceGetGlobalTimestampTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceGetGlobalTimestampTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetGlobalTimestampTest);
 
 TEST_P(urDeviceGetGlobalTimestampTest, Success) {
   // See https://github.com/oneapi-src/unified-runtime/issues/2633

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -133,7 +133,7 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
 
 using urDeviceGetInfoTest = uur::urDeviceTestWithParam<ur_device_info_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urDeviceGetInfoTest,
     ::testing::Values(
 
@@ -260,7 +260,7 @@ UUR_DEVICE_TEST_SUITE_P(
     uur::deviceTestWithParamPrinter<ur_device_info_t>);
 
 using urDeviceGetInfoSingleTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceGetInfoSingleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetInfoSingleTest);
 
 bool doesReturnArray(ur_device_info_t info_type) {
   if (info_type == UR_DEVICE_INFO_SUPPORTED_PARTITIONS ||

--- a/test/conformance/device/urDeviceGetNativeHandle.cpp
+++ b/test/conformance/device/urDeviceGetNativeHandle.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urDeviceGetNativeHandleTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceGetNativeHandleTest);
 
 TEST_P(urDeviceGetNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/device/urDeviceGetSelected.cpp
+++ b/test/conformance/device/urDeviceGetSelected.cpp
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urDeviceGetSelectedTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urDeviceGetSelectedTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urDeviceGetSelectedTest);
 
 /* adpater agnostic tests -- none assume the existence or support of any
  * specific adapter */

--- a/test/conformance/device/urDevicePartition.cpp
+++ b/test/conformance/device/urDevicePartition.cpp
@@ -7,7 +7,7 @@
 #include <uur/utils.h>
 
 using urDevicePartitionTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDevicePartitionTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDevicePartitionTest);
 
 void getNumberComputeUnits(ur_device_handle_t device,
                            uint32_t &n_compute_units) {
@@ -208,7 +208,7 @@ TEST_P(urDevicePartitionTest, SuccessSubSet) {
 using urDevicePartitionAffinityDomainTest =
     uur::urDeviceTestWithParam<ur_device_affinity_domain_flags_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urDevicePartitionAffinityDomainTest,
     ::testing::Values(UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA,
                       UR_DEVICE_AFFINITY_DOMAIN_FLAG_L4_CACHE,
@@ -284,13 +284,13 @@ CountPrinter(const ::testing::TestParamInfo<
   return uur::GetPlatformAndDeviceName(device) + "__" + ss.str();
 }
 
-UUR_DEVICE_TEST_SUITE_P(urDevicePartitionByCountsTestWithParam,
-                        ::testing::Values(std::vector<size_t>{2, 4},
-                                          std::vector<size_t>{1, 4},
-                                          std::vector<size_t>{2, 3},
-                                          std::vector<size_t>{3, 2},
-                                          std::vector<size_t>{3, 1}),
-                        CountPrinter);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urDevicePartitionByCountsTestWithParam,
+                                 ::testing::Values(std::vector<size_t>{2, 4},
+                                                   std::vector<size_t>{1, 4},
+                                                   std::vector<size_t>{2, 3},
+                                                   std::vector<size_t>{3, 2},
+                                                   std::vector<size_t>{3, 1}),
+                                 CountPrinter);
 
 TEST_P(urDevicePartitionByCountsTestWithParam, CountsOrdering) {
   if (!uur::hasDevicePartitionSupport(device, UR_DEVICE_PARTITION_BY_COUNTS)) {

--- a/test/conformance/device/urDeviceRelease.cpp
+++ b/test/conformance/device/urDeviceRelease.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 struct urDeviceReleaseTest : uur::urDeviceTest {};
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceReleaseTest);
 
 TEST_P(urDeviceReleaseTest, Success) {
   uint32_t prevRefCount = 0;

--- a/test/conformance/device/urDeviceRetain.cpp
+++ b/test/conformance/device/urDeviceRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urDeviceRetainTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceRetainTest);
 
 TEST_P(urDeviceRetainTest, Success) {
   uint32_t prevRefCount = 0;

--- a/test/conformance/device/urDeviceSelectBinary.cpp
+++ b/test/conformance/device/urDeviceSelectBinary.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urDeviceSelectBinaryTest = uur::urDeviceTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceSelectBinaryTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urDeviceSelectBinaryTest);
 
 static constexpr ur_device_binary_t binaries[] = {
     {UR_STRUCTURE_TYPE_DEVICE_BINARY, nullptr, UR_DEVICE_BINARY_TARGET_UNKNOWN},

--- a/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
+++ b/test/conformance/enqueue/urEnqueueDeviceGlobalVariableRead.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urEnqueueDeviceGetGlobalVariableReadTest = uur::urGlobalVariableTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueDeviceGetGlobalVariableReadTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueDeviceGetGlobalVariableReadTest);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableReadTest, Success) {
 

--- a/test/conformance/enqueue/urEnqueueDeviceGlobalVariableWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueDeviceGlobalVariableWrite.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urEnqueueDeviceGetGlobalVariableWriteTest = uur::urGlobalVariableTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueDeviceGetGlobalVariableWriteTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueDeviceGetGlobalVariableWriteTest);
 
 TEST_P(urEnqueueDeviceGetGlobalVariableWriteTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(urEnqueueDeviceGlobalVariableWrite(

--- a/test/conformance/enqueue/urEnqueueEventsWait.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWait.cpp
@@ -36,7 +36,7 @@ struct urEnqueueEventsWaitTest : uur::urMultiQueueTest {
   std::vector<uint32_t> input;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueEventsWaitTest);
 
 TEST_P(urEnqueueEventsWaitTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::NativeCPU{});

--- a/test/conformance/enqueue/urEnqueueEventsWaitMultiDevice.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitMultiDevice.cpp
@@ -68,7 +68,7 @@ struct urEnqueueEventsWaitMultiDeviceTest
 
   std::vector<void *> ptrs;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueEventsWaitMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueEventsWaitMultiDeviceTest);
 
 TEST_P(urEnqueueEventsWaitMultiDeviceTest, EmptyWaitList) {
   initData();
@@ -167,7 +167,7 @@ struct urEnqueueEventsWaitMultiDeviceMTTest
   std::vector<void *> ptrs;
 };
 
-UUR_PLATFORM_TEST_SUITE_P(
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
     urEnqueueEventsWaitMultiDeviceMTTest,
     testing::ValuesIn(uur::BoolTestParam::makeBoolParam("MultiThread")),
     uur::platformTestWithParamPrinter<uur::BoolTestParam>);

--- a/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
+++ b/test/conformance/enqueue/urEnqueueEventsWaitWithBarrier.cpp
@@ -72,10 +72,10 @@ struct urEnqueueEventsWaitWithBarrierTest
   std::vector<uint32_t> input;
 };
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitWithBarrierTest,
-                        ::testing::Values(BarrierType::Normal,
-                                          BarrierType::ExtLowPower),
-                        uur::deviceTestWithParamPrinter<BarrierType>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urEnqueueEventsWaitWithBarrierTest,
+                                 ::testing::Values(BarrierType::Normal,
+                                                   BarrierType::ExtLowPower),
+                                 uur::deviceTestWithParamPrinter<BarrierType>);
 
 struct urEnqueueEventsWaitWithBarrierOrderingTest : uur::urProgramTest {
   void SetUp() override {
@@ -101,7 +101,7 @@ struct urEnqueueEventsWaitWithBarrierOrderingTest : uur::urProgramTest {
   ur_mem_handle_t buffer = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueEventsWaitWithBarrierOrderingTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueEventsWaitWithBarrierOrderingTest);
 
 TEST_P(urEnqueueEventsWaitWithBarrierTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::NativeCPU{});

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -20,7 +20,7 @@ struct urEnqueueKernelLaunchTest : uur::urKernelExecutionTest {
   size_t global_offset = 0;
   size_t n_dimensions = 1;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchTest);
 
 struct urEnqueueKernelLaunchKernelWgSizeTest : uur::urKernelExecutionTest {
   void SetUp() override {
@@ -36,7 +36,7 @@ struct urEnqueueKernelLaunchKernelWgSizeTest : uur::urKernelExecutionTest {
   std::array<size_t, 3> wg_size{2, 4, 8};
   size_t n_dimensions = 3;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchKernelWgSizeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchKernelWgSizeTest);
 
 // Note: Due to an issue with HIP, the subgroup test is not generated
 struct urEnqueueKernelLaunchKernelSubGroupTest : uur::urKernelExecutionTest {
@@ -53,7 +53,7 @@ struct urEnqueueKernelLaunchKernelSubGroupTest : uur::urKernelExecutionTest {
   std::array<size_t, 3> global_offset{0, 0, 0};
   size_t n_dimensions = 3;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchKernelSubGroupTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchKernelSubGroupTest);
 
 struct urEnqueueKernelLaunchKernelStandardTest : uur::urKernelExecutionTest {
   void SetUp() override {
@@ -65,7 +65,7 @@ struct urEnqueueKernelLaunchKernelStandardTest : uur::urKernelExecutionTest {
   size_t global_size = 1;
   size_t offset = 0;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchKernelStandardTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchKernelStandardTest);
 
 TEST_P(urEnqueueKernelLaunchTest, Success) {
   ur_mem_handle_t buffer = nullptr;
@@ -302,7 +302,7 @@ static std::vector<testParametersEnqueueKernel> test_cases{// 1D
                                                            {1027, 1, 19, 3},
                                                            {1, 53, 19, 3},
                                                            {256, 79, 8, 3}};
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueKernelLaunchTestWithParam, testing::ValuesIn(test_cases),
     printKernelLaunchTestString<urEnqueueKernelLaunchTestWithParam>);
 
@@ -349,7 +349,7 @@ struct urEnqueueKernelLaunchWithUSM : uur::urKernelExecutionTest {
   size_t alloc_size = 0;
   void *usmPtr = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchWithUSM);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchWithUSM);
 
 TEST_P(urEnqueueKernelLaunchWithUSM, Success) {
   size_t work_dim = 1;
@@ -438,7 +438,7 @@ struct urEnqueueKernelLaunchWithVirtualMemory : uur::urKernelExecutionTest {
   ur_physical_mem_handle_t physical_mem = nullptr;
   void *virtual_ptr = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchWithVirtualMemory);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchWithVirtualMemory);
 
 TEST_P(urEnqueueKernelLaunchWithVirtualMemory, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
@@ -515,7 +515,7 @@ struct urEnqueueKernelLaunchMultiDeviceTest
   size_t global_offset = 0;
   size_t n_dimensions = 1;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueKernelLaunchMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueKernelLaunchMultiDeviceTest);
 
 // TODO: rewrite this test, right now it only works for a single queue
 // (the context is only created for one device)
@@ -603,7 +603,7 @@ struct urEnqueueKernelLaunchUSMLinkedList
   ur_queue_handle_t queue = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueKernelLaunchUSMLinkedList,
     testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
     uur::deviceTestWithParamPrinter<uur::BoolTestParam>);

--- a/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunchAndMemcpyInOrder.cpp
@@ -173,7 +173,7 @@ struct urEnqueueKernelLaunchIncrementTest
   }
 };
 
-UUR_PLATFORM_TEST_SUITE_P(
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
     urEnqueueKernelLaunchIncrementTest,
     testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UseEvents")),
     uur::platformTestWithParamPrinter<uur::BoolTestParam>);
@@ -258,7 +258,7 @@ using urEnqueueKernelLaunchIncrementMultiDeviceTest =
     urEnqueueKernelLaunchIncrementMultiDeviceTestWithParam<
         std::tuple<uur::BoolTestParam, uur::BoolTestParam>>;
 
-UUR_PLATFORM_TEST_SUITE_P(
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
     urEnqueueKernelLaunchIncrementMultiDeviceTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UseEventWait")),
@@ -348,7 +348,7 @@ using urEnqueueKernelLaunchIncrementMultiDeviceMultiThreadTest =
     urEnqueueKernelLaunchIncrementMultiDeviceTestWithParam<
         std::tuple<uur::BoolTestParam, uur::BoolTestParam>>;
 
-UUR_PLATFORM_TEST_SUITE_P(
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
     urEnqueueKernelLaunchIncrementMultiDeviceMultiThreadTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UseEvents")),

--- a/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopy.cpp
@@ -39,9 +39,9 @@ struct urEnqueueMemBufferCopyTestWithParam : uur::urQueueTestWithParam<size_t> {
 
 static std::vector<size_t> test_parameters{1024, 2500, 4096, 6000};
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueMemBufferCopyTestWithParam,
-                        ::testing::ValuesIn(test_parameters),
-                        uur::deviceTestWithParamPrinter<size_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urEnqueueMemBufferCopyTestWithParam,
+                                 ::testing::ValuesIn(test_parameters),
+                                 uur::deviceTestWithParamPrinter<size_t>);
 
 TEST_P(urEnqueueMemBufferCopyTestWithParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -107,7 +107,7 @@ TEST_P(urEnqueueMemBufferCopyTestWithParam, InvalidSize) {
 
 using urEnqueueMemBufferCopyMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemBufferCopyMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferCopyMultiDeviceTest, CopyReadDifferentQueues) {
   // First queue does a fill.

--- a/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferCopyRect.cpp
@@ -72,7 +72,7 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 struct urEnqueueMemBufferCopyRectTestWithParam
     : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferCopyRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
     uur::printRectTestString<urEnqueueMemBufferCopyRectTestWithParam>);
@@ -178,7 +178,7 @@ struct urEnqueueMemBufferCopyRectTest : uur::urQueueTest {
   ur_mem_handle_t dst_buffer = nullptr;
   std::vector<uint32_t> input;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferCopyRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferCopyRectTest);
 
 TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullHandleQueue) {
   ur_rect_region_t src_region{size, 1, 1};
@@ -245,8 +245,7 @@ TEST_P(urEnqueueMemBufferCopyRectTest, InvalidNullPtrEventWaitList) {
 
 using urEnqueueMemBufferCopyRectMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(
-    urEnqueueMemBufferCopyRectMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferCopyRectMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferCopyRectMultiDeviceTest, CopyRectReadDifferentQueues) {
   // First queue does a fill.

--- a/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferFill.cpp
@@ -69,9 +69,9 @@ static std::vector<testParametersFill> test_cases{
     {256, 16},
     {256, 32}};
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueMemBufferFillTest,
-                        testing::ValuesIn(test_cases),
-                        uur::printFillTestString<urEnqueueMemBufferFillTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueMemBufferFillTest, testing::ValuesIn(test_cases),
+    uur::printFillTestString<urEnqueueMemBufferFillTest>);
 
 TEST_P(urEnqueueMemBufferFillTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -147,7 +147,7 @@ TEST_P(urEnqueueMemBufferFillTest, SuccessOffset) {
 
 using urEnqueueMemBufferFillNegativeTest = uur::urMemBufferQueueTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferFillNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferFillNegativeTest);
 
 TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidNullHandleQueue) {
   const uint32_t pattern = 0xdeadbeef;
@@ -208,7 +208,7 @@ TEST_P(urEnqueueMemBufferFillNegativeTest, InvalidSize) {
 
 using urEnqueueMemBufferFillMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemBufferFillMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferFillMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferFillMultiDeviceTest, FillReadDifferentQueues) {
   // First queue does a fill.

--- a/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferMap.cpp
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferMapTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferMapTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferMapTestWithParam>);
@@ -41,10 +41,11 @@ using urEnqueueMemBufferMapTestWithWriteFlagParam =
     uur::urMemBufferQueueTestWithParam<
         uur::mem_buffer_map_write_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueMemBufferMapTestWithWriteFlagParam,
-                        ::testing::ValuesIn(map_write_test_parameters),
-                        uur::printMemBufferMapWriteTestString<
-                            urEnqueueMemBufferMapTestWithWriteFlagParam>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueMemBufferMapTestWithWriteFlagParam,
+    ::testing::ValuesIn(map_write_test_parameters),
+    uur::printMemBufferMapWriteTestString<
+        urEnqueueMemBufferMapTestWithWriteFlagParam>);
 
 TEST_P(urEnqueueMemBufferMapTestWithWriteFlagParam, SuccessWrite) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -312,7 +313,7 @@ TEST_P(urEnqueueMemBufferMapTestWithParam, InvalidSize) {
 
 using urEnqueueMemBufferMapMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemBufferMapMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferMapMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferMapMultiDeviceTest, WriteMapDifferentQueues) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferRead.cpp
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferReadTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferReadTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferReadTestWithParam>);
@@ -137,7 +137,7 @@ TEST_P(urEnqueueMemBufferReadTestWithParam, NonBlocking) {
 
 using urEnqueueMemBufferReadMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemBufferReadMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadMultiDeviceTest, WriteReadDifferentQueues) {
   // First queue does a blocking write of 42 into the buffer.

--- a/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferReadRect.cpp
@@ -73,7 +73,7 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 struct urEnqueueMemBufferReadRectTestWithParam
     : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferReadRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
     uur::printRectTestString<urEnqueueMemBufferReadRectTestWithParam>);
@@ -123,7 +123,7 @@ TEST_P(urEnqueueMemBufferReadRectTestWithParam, Success) {
 }
 
 using urEnqueueMemBufferReadRectTest = uur::urMemBufferQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferReadRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferReadRectTest);
 TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullHandleQueue) {
   std::vector<uint32_t> dst(count);
   ur_rect_region_t region{size, 1, 1};
@@ -192,8 +192,7 @@ TEST_P(urEnqueueMemBufferReadRectTest, InvalidNullPtrEventWaitList) {
 
 using urEnqueueMemBufferReadRectMultiDeviceTest =
     uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(
-    urEnqueueMemBufferReadRectMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemBufferReadRectMultiDeviceTest);
 
 TEST_P(urEnqueueMemBufferReadRectMultiDeviceTest,
        WriteRectReadDifferentQueues) {

--- a/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWrite.cpp
@@ -10,7 +10,7 @@
 using urEnqueueMemBufferWriteTestWithParam =
     uur::urMemBufferQueueTestWithParam<uur::mem_buffer_test_parameters_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferWriteTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemBufferWriteTestWithParam>);

--- a/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
+++ b/test/conformance/enqueue/urEnqueueMemBufferWriteRect.cpp
@@ -72,7 +72,7 @@ static std::vector<uur::test_parameters_t> generateParameterizations() {
 struct urEnqueueMemBufferWriteRectTestWithParam
     : public uur::urQueueTestWithParam<uur::test_parameters_t> {};
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemBufferWriteRectTestWithParam,
     testing::ValuesIn(generateParameterizations()),
     uur::printRectTestString<urEnqueueMemBufferWriteRectTestWithParam>);
@@ -139,7 +139,7 @@ TEST_P(urEnqueueMemBufferWriteRectTestWithParam, Success) {
 }
 
 using urEnqueueMemBufferWriteRectTest = uur::urMemBufferQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemBufferWriteRectTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemBufferWriteRectTest);
 
 TEST_P(urEnqueueMemBufferWriteRectTest, InvalidNullHandleQueue) {
   std::vector<uint32_t> src(count);

--- a/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageCopy.cpp
@@ -122,11 +122,11 @@ inline std::string printImageCopyTestString(
   return platform_device_name + "__" + test_name;
 }
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueMemImageCopyTest,
-                        testing::ValuesIn({UR_MEM_TYPE_IMAGE1D,
-                                           UR_MEM_TYPE_IMAGE2D,
-                                           UR_MEM_TYPE_IMAGE3D}),
-                        printImageCopyTestString<urEnqueueMemImageCopyTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueMemImageCopyTest,
+    testing::ValuesIn({UR_MEM_TYPE_IMAGE1D, UR_MEM_TYPE_IMAGE2D,
+                       UR_MEM_TYPE_IMAGE3D}),
+    printImageCopyTestString<urEnqueueMemImageCopyTest>);
 
 TEST_P(urEnqueueMemImageCopyTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -266,7 +266,7 @@ TEST_P(urEnqueueMemImageCopyTest, InvalidSize) {
 
 using urEnqueueMemImageCopyMultiDeviceTest =
     uur::urMultiDeviceMemImageWriteTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemImageCopyMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemImageCopyMultiDeviceTest);
 
 TEST_P(urEnqueueMemImageCopyMultiDeviceTest, CopyReadDifferentQueues) {
   ur_mem_handle_t dstImage1D = nullptr;

--- a/test/conformance/enqueue/urEnqueueMemImageRead.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageRead.cpp
@@ -12,7 +12,7 @@ struct urEnqueueMemImageReadTest : uur::urMemImageQueueTest {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urMemImageQueueTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemImageReadTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemImageReadTest);
 
 // Note that for each test, we multiply the size in pixels by 4 to account for
 // each channel in the RGBA image
@@ -153,7 +153,7 @@ TEST_P(urEnqueueMemImageReadTest, InvalidRegion3D) {
 
 using urEnqueueMemImageReadMultiDeviceTest =
     uur::urMultiDeviceMemImageWriteTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueMemImageReadMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueMemImageReadMultiDeviceTest);
 
 TEST_P(urEnqueueMemImageReadMultiDeviceTest, WriteReadDifferentQueues) {
   // The remaining queues do blocking reads from the image1D/2D/3D. Since the

--- a/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
+++ b/test/conformance/enqueue/urEnqueueMemImageWrite.cpp
@@ -12,7 +12,7 @@ struct urEnqueueMemImageWriteTest : uur::urMemImageQueueTest {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urMemImageQueueTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueMemImageWriteTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueMemImageWriteTest);
 
 TEST_P(urEnqueueMemImageWriteTest, Success1D) {
   std::vector<uint32_t> input(width * 4, 42);

--- a/test/conformance/enqueue/urEnqueueMemUnmap.cpp
+++ b/test/conformance/enqueue/urEnqueueMemUnmap.cpp
@@ -24,7 +24,7 @@ struct urEnqueueMemUnmapTestWithParam
   uint32_t *map = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueMemUnmapTestWithParam,
     ::testing::ValuesIn(uur::mem_buffer_test_parameters),
     uur::printMemBufferTestString<urEnqueueMemUnmapTestWithParam>);

--- a/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueReadHostPipe.cpp
@@ -7,7 +7,7 @@
 
 using urEnqueueReadHostPipeTest = uur::urHostPipeTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueReadHostPipeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueReadHostPipeTest);
 
 TEST_P(urEnqueueReadHostPipeTest, InvalidNullHandleQueue) {
   uint32_t numEventsInWaitList = 0;

--- a/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
+++ b/test/conformance/enqueue/urEnqueueTimestampRecording.cpp
@@ -20,7 +20,7 @@ struct urEnqueueTimestampRecordingExpTest : uur::urQueueTest {
 
   void TearDown() override { urQueueTest::TearDown(); }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueTimestampRecordingExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueTimestampRecordingExpTest);
 
 void common_check(ur_event_handle_t event) {
   // All successful runs should return a non-zero profiling results.

--- a/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMAdvise.cpp
@@ -18,9 +18,10 @@ struct urEnqueueUSMAdviseWithParamTest
         uur::urUSMDeviceAllocTestWithParam<ur_usm_advice_flag_t>::SetUp());
   }
 };
-UUR_DEVICE_TEST_SUITE_P(urEnqueueUSMAdviseWithParamTest,
-                        ::testing::Values(UR_USM_ADVICE_FLAG_DEFAULT),
-                        uur::deviceTestWithParamPrinter<ur_usm_advice_flag_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueUSMAdviseWithParamTest,
+    ::testing::Values(UR_USM_ADVICE_FLAG_DEFAULT),
+    uur::deviceTestWithParamPrinter<ur_usm_advice_flag_t>);
 
 TEST_P(urEnqueueUSMAdviseWithParamTest, Success) {
   // HIP and CUDA return UR_RESULT_ERROR_ADAPTER_SPECIFIC to issue a warning
@@ -50,7 +51,7 @@ struct urEnqueueUSMAdviseTest : uur::urUSMDeviceAllocTest {
     uur::urUSMDeviceAllocTest::SetUp();
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMAdviseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMAdviseTest);
 
 TEST_P(urEnqueueUSMAdviseTest, MultipleParamsSuccess) {
   // HIP and CUDA return UR_RESULT_ERROR_ADAPTER_SPECIFIC to issue a warning

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -92,9 +92,9 @@ static std::vector<testParametersFill> test_cases{
     {256, 16},
     {256, 32}};
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueUSMFillTestWithParam,
-                        testing::ValuesIn(test_cases),
-                        printFillTestString<urEnqueueUSMFillTestWithParam>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueUSMFillTestWithParam, testing::ValuesIn(test_cases),
+    printFillTestString<urEnqueueUSMFillTestWithParam>);
 
 TEST_P(urEnqueueUSMFillTestWithParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -145,7 +145,7 @@ struct urEnqueueUSMFillNegativeTest : uur::urQueueTest {
   void *ptr{nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMFillNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMFillNegativeTest);
 
 TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullQueueHandle) {
   ASSERT_EQ_RESULT(urEnqueueUSMFill(nullptr, ptr, pattern_size, pattern.data(),

--- a/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill2D.cpp
@@ -130,9 +130,9 @@ static std::vector<testParametersFill2D> test_cases{
     /* Height != power_of_2 && width == power_of_2 && pattern_size == 128 */
     {1024, 256, 35, 128}};
 
-UUR_DEVICE_TEST_SUITE_P(urEnqueueUSMFill2DTestWithParam,
-                        testing::ValuesIn(test_cases),
-                        printFill2DTestString<urEnqueueUSMFill2DTestWithParam>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEnqueueUSMFill2DTestWithParam, testing::ValuesIn(test_cases),
+    printFill2DTestString<urEnqueueUSMFill2DTestWithParam>);
 
 TEST_P(urEnqueueUSMFill2DTestWithParam, Success) {
 
@@ -191,7 +191,7 @@ struct urEnqueueUSMFill2DNegativeTest : uur::urQueueTest {
   void *ptr{nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMFill2DNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMFill2DNegativeTest);
 
 TEST_P(urEnqueueUSMFill2DNegativeTest, InvalidNullQueueHandle) {
   ASSERT_EQ_RESULT(urEnqueueUSMFill2D(nullptr, ptr, pitch, pattern_size,

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy.cpp
@@ -174,7 +174,7 @@ TEST_P(urEnqueueUSMMemcpyTest, InvalidNullPtrEventWaitList) {
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMMemcpyTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMMemcpyTest);
 
 struct urEnqueueUSMMemcpyMultiDeviceTest : uur::urAllDevicesTest {
   void SetUp() override {
@@ -250,7 +250,7 @@ struct urEnqueueUSMMemcpyMultiDeviceTest : uur::urAllDevicesTest {
   size_t alloc_size = 64;
   uint8_t fill_pattern = 42;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urEnqueueUSMMemcpyMultiDeviceTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urEnqueueUSMMemcpyMultiDeviceTest);
 
 TEST_P(urEnqueueUSMMemcpyMultiDeviceTest, DeviceToDeviceCopyBlocking) {
   ASSERT_SUCCESS(urEnqueueUSMMemcpy(src_queue, true, dst_alloc, src_alloc,

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -113,7 +113,7 @@ static std::vector<uur::TestParameters2D> test_sizes{
     /* Height == 1 && Pitch == width + 1 */
     {234, 233, 1}};
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMMemcpy2DTestWithParam,
     ::testing::Combine(::testing::ValuesIn(test_sizes),
                        ::testing::Values(ur_usm_type_t::UR_USM_TYPE_DEVICE,
@@ -147,7 +147,7 @@ TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessNonBlocking) {
 }
 
 using urEnqueueUSMMemcpy2DNegativeTest = urEnqueueUSMMemcpy2DTestWithParam;
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMMemcpy2DNegativeTest,
     ::testing::Values(TestParametersMemcpy2D{
         {1, 1, 1},

--- a/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMPrefetch.cpp
@@ -17,7 +17,7 @@ struct urEnqueueUSMPrefetchWithParamTest
   }
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urEnqueueUSMPrefetchWithParamTest,
     ::testing::Values(UR_USM_MIGRATION_FLAG_DEFAULT),
     uur::deviceTestWithParamPrinter<ur_usm_migration_flag_t>);
@@ -101,7 +101,7 @@ struct urEnqueueUSMPrefetchTest : uur::urUSMDeviceAllocTest {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urUSMDeviceAllocTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueUSMPrefetchTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueUSMPrefetchTest);
 
 TEST_P(urEnqueueUSMPrefetchTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
+++ b/test/conformance/enqueue/urEnqueueWriteHostPipe.cpp
@@ -7,7 +7,7 @@
 
 using urEnqueueWriteHostPipeTest = uur::urHostPipeTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueWriteHostPipeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueWriteHostPipeTest);
 
 TEST_P(urEnqueueWriteHostPipeTest, InvalidNullHandleQueue) {
   uint32_t numEventsInWaitList = 0;

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@
 #include "uur/raii.h"
 
 using urEventCreateWithNativeHandleTest = uur::event::urEventTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventCreateWithNativeHandleTest);
 
 TEST_P(urEventCreateWithNativeHandleTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -149,4 +149,4 @@ TEST_P(urEventGetInfoTest, InvalidNullPointerPropSizeRet) {
       UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetInfoTest);

--- a/test/conformance/event/urEventGetNativeHandle.cpp
+++ b/test/conformance/event/urEventGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urEventGetNativeHandleTest = uur::event::urEventTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetNativeHandleTest);
 
 TEST_P(urEventGetNativeHandleTest, Success) {
   ur_native_handle_t native_event = 0;

--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -44,13 +44,14 @@ TEST_P(urEventGetProfilingInfoTest, Success) {
   }
 }
 
-UUR_DEVICE_TEST_SUITE_P(urEventGetProfilingInfoTest,
-                        ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED,
-                                          UR_PROFILING_INFO_COMMAND_SUBMIT,
-                                          UR_PROFILING_INFO_COMMAND_START,
-                                          UR_PROFILING_INFO_COMMAND_END,
-                                          UR_PROFILING_INFO_COMMAND_COMPLETE),
-                        uur::deviceTestWithParamPrinter<ur_profiling_info_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urEventGetProfilingInfoTest,
+    ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED,
+                      UR_PROFILING_INFO_COMMAND_SUBMIT,
+                      UR_PROFILING_INFO_COMMAND_START,
+                      UR_PROFILING_INFO_COMMAND_END,
+                      UR_PROFILING_INFO_COMMAND_COMPLETE),
+    uur::deviceTestWithParamPrinter<ur_profiling_info_t>);
 
 using urEventGetProfilingInfoWithTimingComparisonTest = uur::event::urEventTest;
 
@@ -99,7 +100,7 @@ TEST_P(urEventGetProfilingInfoWithTimingComparisonTest, Success) {
   ASSERT_LE(*end_timing, *complete_timing);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(
     urEventGetProfilingInfoWithTimingComparisonTest);
 
 using urEventGetProfilingInfoNegativeTest = uur::event::urEventTest;
@@ -142,7 +143,7 @@ TEST_P(urEventGetProfilingInfoNegativeTest, InvalidValue) {
       UR_RESULT_ERROR_INVALID_VALUE);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetProfilingInfoNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetProfilingInfoNegativeTest);
 
 struct urEventGetProfilingInfoForWaitWithBarrier : uur::urProfilingQueueTest {
   void SetUp() override {
@@ -172,7 +173,7 @@ struct urEventGetProfilingInfoForWaitWithBarrier : uur::urProfilingQueueTest {
   std::vector<uint32_t> input;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventGetProfilingInfoForWaitWithBarrier);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetProfilingInfoForWaitWithBarrier);
 
 TEST_P(urEventGetProfilingInfoForWaitWithBarrier, Success) {
   std::vector<uint8_t> submit_data(size);

--- a/test/conformance/event/urEventRelease.cpp
+++ b/test/conformance/event/urEventRelease.cpp
@@ -8,7 +8,7 @@
 
 using urEventReleaseTest = uur::event::urEventTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventReleaseTest);
 
 TEST_P(urEventReleaseTest, Success) {
   ASSERT_SUCCESS(urEventRetain(event));

--- a/test/conformance/event/urEventRetain.cpp
+++ b/test/conformance/event/urEventRetain.cpp
@@ -7,7 +7,7 @@
 #include "fixtures.h"
 
 using urEventRetainTest = uur::event::urEventTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventRetainTest);
 
 TEST_P(urEventRetainTest, Success) {
   uint32_t prevRefCount = 0;

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -160,7 +160,7 @@ TEST_P(urEventSetCallbackTest, EventAlreadyCompleted) {
   ASSERT_TRUE(didRun);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventSetCallbackTest);
 
 /* Negative tests */
 using urEventSetCallbackNegativeTest = uur::event::urEventTest;
@@ -189,4 +189,4 @@ TEST_P(urEventSetCallbackNegativeTest, InvalidEnumeration) {
       UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventSetCallbackNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventSetCallbackNegativeTest);

--- a/test/conformance/event/urEventWait.cpp
+++ b/test/conformance/event/urEventWait.cpp
@@ -40,7 +40,7 @@ struct urEventWaitTest : uur::urQueueTest {
   ur_event_handle_t event = nullptr;
   std::vector<uint32_t> input;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventWaitTest);
 
 TEST_P(urEventWaitTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -64,7 +64,7 @@ TEST_P(urEventWaitTest, Success) {
 
 using urEventWaitNegativeTest = uur::urQueueTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEventWaitNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventWaitNegativeTest);
 
 TEST_P(urEventWaitNegativeTest, ZeroSize) {
   ur_event_handle_t event = nullptr;

--- a/test/conformance/exp_command_buffer/commands.cpp
+++ b/test/conformance/exp_command_buffer/commands.cpp
@@ -53,7 +53,7 @@ struct urCommandBufferCommandsTest
   std::array<ur_mem_handle_t, 2> buffers = {nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferCommandsTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferCommandsTest);
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMMemcpyExp) {
   ASSERT_SUCCESS(urCommandBufferAppendUSMMemcpyExp(
@@ -181,7 +181,7 @@ struct urCommandBufferAppendKernelLaunchExpTest
   std::array<void *, 3> shared_ptrs = {nullptr, nullptr, nullptr};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferAppendKernelLaunchExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferAppendKernelLaunchExpTest);
 TEST_P(urCommandBufferAppendKernelLaunchExpTest, Basic) {
   ASSERT_SUCCESS(urCommandBufferAppendKernelLaunchExp(
       cmd_buf_handle, kernel, n_dimensions, &global_offset, &global_size,

--- a/test/conformance/exp_command_buffer/event_sync.cpp
+++ b/test/conformance/exp_command_buffer/event_sync.cpp
@@ -9,7 +9,7 @@
 // Tests non-kernel commands using ur events for synchronization work as
 // expected
 using CommandEventSyncTest = uur::command_buffer::urCommandEventSyncTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(CommandEventSyncTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(CommandEventSyncTest);
 
 TEST_P(CommandEventSyncTest, USMMemcpyExp) {
   // Get wait event from queue fill on ptr 0

--- a/test/conformance/exp_command_buffer/fill.cpp
+++ b/test/conformance/exp_command_buffer/fill.cpp
@@ -99,9 +99,9 @@ printFillTestString(const testing::TestParamInfo<typename T::ParamType> &info) {
   return test_name.str();
 }
 
-UUR_DEVICE_TEST_SUITE_P(urCommandBufferFillCommandsTest,
-                        testing::ValuesIn(test_cases),
-                        printFillTestString<urCommandBufferFillCommandsTest>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urCommandBufferFillCommandsTest, testing::ValuesIn(test_cases),
+    printFillTestString<urCommandBufferFillCommandsTest>);
 
 TEST_P(urCommandBufferFillCommandsTest, Buffer) {
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(

--- a/test/conformance/exp_command_buffer/invalid.cpp
+++ b/test/conformance/exp_command_buffer/invalid.cpp
@@ -14,7 +14,7 @@ struct InvalidCreationTest : uur::urContextTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(InvalidCreationTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(InvalidCreationTest);
 
 // Check correct error is reported when trying to create a
 // command-buffer with update enabled on a device that doesn't

--- a/test/conformance/exp_command_buffer/kernel_event_sync.cpp
+++ b/test/conformance/exp_command_buffer/kernel_event_sync.cpp
@@ -77,7 +77,7 @@ struct KernelCommandEventSyncTest
   static constexpr size_t A = 2;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(KernelCommandEventSyncTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(KernelCommandEventSyncTest);
 
 // Tests using a regular enqueue event as a dependency of a command-buffer
 // command, and having the signal event of that command-buffer command being

--- a/test/conformance/exp_command_buffer/release.cpp
+++ b/test/conformance/exp_command_buffer/release.cpp
@@ -9,7 +9,7 @@
 using urCommandBufferReleaseExpTest =
     uur::command_buffer::urCommandBufferExpTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferReleaseExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferReleaseExpTest);
 
 TEST_P(urCommandBufferReleaseExpTest, Success) {
   EXPECT_SUCCESS(urCommandBufferRetainExp(cmd_buf_handle));

--- a/test/conformance/exp_command_buffer/retain.cpp
+++ b/test/conformance/exp_command_buffer/retain.cpp
@@ -9,7 +9,7 @@
 using urCommandBufferRetainExpTest =
     uur::command_buffer::urCommandBufferExpTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferRetainExpTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferRetainExpTest);
 
 TEST_P(urCommandBufferRetainExpTest, Success) {
   uint32_t prev_ref_count = 0;

--- a/test/conformance/exp_command_buffer/update/buffer_fill_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/update/buffer_fill_kernel_update.cpp
@@ -76,7 +76,7 @@ struct BufferFillCommandTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(BufferFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(BufferFillCommandTest);
 
 // Update kernel arguments to fill with a new scalar value to a new output
 // buffer.

--- a/test/conformance/exp_command_buffer/update/buffer_saxpy_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/update/buffer_saxpy_kernel_update.cpp
@@ -129,7 +129,7 @@ struct BufferSaxpyKernelTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(BufferSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(BufferSaxpyKernelTest);
 
 TEST_P(BufferSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output

--- a/test/conformance/exp_command_buffer/update/event_sync.cpp
+++ b/test/conformance/exp_command_buffer/update/event_sync.cpp
@@ -10,7 +10,7 @@
 // updated
 using CommandEventSyncUpdateTest =
     uur::command_buffer::urCommandEventSyncUpdateTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(CommandEventSyncUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(CommandEventSyncUpdateTest);
 
 TEST_P(CommandEventSyncUpdateTest, USMMemcpyExp) {
   // Get wait event from queue fill on ptr 0

--- a/test/conformance/exp_command_buffer/update/invalid_update.cpp
+++ b/test/conformance/exp_command_buffer/update/invalid_update.cpp
@@ -68,7 +68,7 @@ struct InvalidUpdateTest
   bool finalized = false;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(InvalidUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(InvalidUpdateTest);
 
 // Test error code is returned if command-buffer not finalized
 TEST_P(InvalidUpdateTest, NotFinalizedCommandBuffer) {
@@ -301,7 +301,7 @@ struct InvalidUpdateCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
       0;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(InvalidUpdateCommandBufferExpExecutionTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(InvalidUpdateCommandBufferExpExecutionTest);
 
 // Test error reported if device doesn't support updating kernel args
 TEST_P(InvalidUpdateCommandBufferExpExecutionTest, KernelArg) {

--- a/test/conformance/exp_command_buffer/update/kernel_event_sync.cpp
+++ b/test/conformance/exp_command_buffer/update/kernel_event_sync.cpp
@@ -64,7 +64,7 @@ struct KernelCommandEventSyncUpdateTest
   static constexpr size_t A = 2;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(KernelCommandEventSyncUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(KernelCommandEventSyncUpdateTest);
 
 // Tests updating the signal and wait event dependencies of the saxpy
 // command in a command-buffer.

--- a/test/conformance/exp_command_buffer/update/kernel_handle_update.cpp
+++ b/test/conformance/exp_command_buffer/update/kernel_handle_update.cpp
@@ -251,7 +251,7 @@ struct urCommandBufferKernelHandleUpdateTest
   std::shared_ptr<TestFill2DKernel> FillUSM2DKernel;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferKernelHandleUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferKernelHandleUpdateTest);
 
 /* Tests that it is possible to update the kernel handle of a command-buffer
  * node. This test launches a Saxpy kernel using a command-buffer and then
@@ -399,7 +399,7 @@ TEST_P(urCommandBufferKernelHandleUpdateTest,
 
 using urCommandBufferValidUpdateParametersTest =
     urCommandBufferKernelHandleUpdateTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCommandBufferValidUpdateParametersTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferValidUpdateParametersTest);
 
 // Test that updating the dimensions of a kernel command does not cause an
 // error.

--- a/test/conformance/exp_command_buffer/update/local_memory_update.cpp
+++ b/test/conformance/exp_command_buffer/update/local_memory_update.cpp
@@ -134,7 +134,7 @@ struct LocalMemoryUpdateTest : LocalMemoryUpdateTestBase {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(LocalMemoryUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryUpdateTest);
 
 // Test updating A,X,Y parameters to new values and local memory parameters
 // to original values.
@@ -882,7 +882,7 @@ struct LocalMemoryMultiUpdateTest : LocalMemoryUpdateTestBase {
   std::array<ur_exp_command_buffer_command_handle_t, nodes> command_handles{};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(LocalMemoryMultiUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryMultiUpdateTest);
 
 // Test updating A,X,Y parameters to new values and local memory parameters
 // to original values.
@@ -1180,7 +1180,7 @@ struct LocalMemoryUpdateTestOutOfOrder : LocalMemoryUpdateTestBaseOutOfOrder {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(LocalMemoryUpdateTestOutOfOrder);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(LocalMemoryUpdateTestOutOfOrder);
 
 // Test updating A,X,Y parameters to new values and local memory to larger
 // values when the kernel arguments were added out of order.

--- a/test/conformance/exp_command_buffer/update/ndrange_update.cpp
+++ b/test/conformance/exp_command_buffer/update/ndrange_update.cpp
@@ -101,7 +101,7 @@ struct NDRangeUpdateTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(NDRangeUpdateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(NDRangeUpdateTest);
 
 // Add a 3 dimension kernel command to the command-buffer and update the
 // local size and global offset

--- a/test/conformance/exp_command_buffer/update/usm_fill_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/update/usm_fill_kernel_update.cpp
@@ -75,7 +75,7 @@ struct USMFillCommandTest
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(USMFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMFillCommandTest);
 
 // Test using a different global size to fill and larger USM output buffer
 TEST_P(USMFillCommandTest, UpdateParameters) {
@@ -314,7 +314,7 @@ struct USMMultipleFillCommandTest
       command_handles;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(USMMultipleFillCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMMultipleFillCommandTest);
 
 // Test updating all the kernels commands in the command-buffer
 TEST_P(USMMultipleFillCommandTest, UpdateAllKernels) {

--- a/test/conformance/exp_command_buffer/update/usm_saxpy_kernel_update.cpp
+++ b/test/conformance/exp_command_buffer/update/usm_saxpy_kernel_update.cpp
@@ -90,7 +90,7 @@ struct USMSaxpyKernelTest : USMSaxpyKernelTestBase {
   ur_exp_command_buffer_command_handle_t command_handle = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(USMSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMSaxpyKernelTest);
 
 TEST_P(USMSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output
@@ -187,7 +187,7 @@ struct USMMultiSaxpyKernelTest : USMSaxpyKernelTestBase {
   std::array<ur_exp_command_buffer_command_handle_t, nodes> command_handles{};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(USMMultiSaxpyKernelTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(USMMultiSaxpyKernelTest);
 
 TEST_P(USMMultiSaxpyKernelTest, UpdateParameters) {
   // Run command-buffer prior to update an verify output

--- a/test/conformance/exp_enqueue_native/enqueue_native_cuda.cpp
+++ b/test/conformance/exp_enqueue_native/enqueue_native_cuda.cpp
@@ -38,7 +38,7 @@ struct urCudaEnqueueNativeCommandTest : uur::urQueueTest {
   static constexpr size_t allocation_size = sizeof(val) * global_size;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urCudaEnqueueNativeCommandTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCudaEnqueueNativeCommandTest);
 
 struct InteropData1 {
   void *fill_ptr;

--- a/test/conformance/exp_launch_properties/launch_properties.cpp
+++ b/test/conformance/exp_launch_properties/launch_properties.cpp
@@ -17,7 +17,7 @@ struct urEnqueueKernelLaunchCustomTest : uur::urKernelExecutionTest {
   size_t global_offset = 0;
   size_t n_dimensions = 1;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urEnqueueKernelLaunchCustomTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEnqueueKernelLaunchCustomTest);
 
 TEST_P(urEnqueueKernelLaunchCustomTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/exp_usm_p2p/usm_p2p.cpp
+++ b/test/conformance/exp_usm_p2p/usm_p2p.cpp
@@ -6,7 +6,7 @@
 #include "uur/fixtures.h"
 
 using urP2PTest = uur::urAllDevicesTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urP2PTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urP2PTest);
 
 TEST_P(urP2PTest, Success) {
 

--- a/test/conformance/integration/QueueBuffer.cpp
+++ b/test/conformance/integration/QueueBuffer.cpp
@@ -35,7 +35,7 @@ struct QueueBufferTestWithParam : uur::IntegrationQueueTestWithParam {
   ur_mem_handle_t Buffer2 = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     QueueBufferTestWithParam,
     testing::Values(0, /* In-Order */
                     UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),

--- a/test/conformance/integration/QueueEmptyStatus.cpp
+++ b/test/conformance/integration/QueueEmptyStatus.cpp
@@ -98,7 +98,7 @@ struct QueueEmptyStatusTestWithParam : uur::IntegrationQueueTestWithParam {
   void *SharedMem = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     QueueEmptyStatusTestWithParam,
     testing::Values(0, /* In-Order */
                     UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),

--- a/test/conformance/integration/QueueUSM.cpp
+++ b/test/conformance/integration/QueueUSM.cpp
@@ -56,7 +56,7 @@ struct QueueUSMTestWithParam : uur::IntegrationQueueTestWithParam {
   void *DeviceMem2 = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     QueueUSMTestWithParam,
     testing::Values(0, /* In-Order */
                     UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE),

--- a/test/conformance/kernel/urKernelCreate.cpp
+++ b/test/conformance/kernel/urKernelCreate.cpp
@@ -26,7 +26,7 @@ struct urKernelCreateTest : uur::urProgramTest {
   std::string kernel_name;
   ur_kernel_handle_t kernel = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelCreateTest);
 
 TEST_P(urKernelCreateTest, Success) {
   ASSERT_SUCCESS(urKernelCreate(program, kernel_name.data(), &kernel));
@@ -54,7 +54,7 @@ TEST_P(urKernelCreateTest, InvalidKernelName) {
 }
 
 using urMultiDeviceKernelCreateTest = uur::urMultiDeviceQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiDeviceKernelCreateTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceKernelCreateTest);
 
 TEST_P(urMultiDeviceKernelCreateTest, WithProgramBuild) {
   constexpr size_t global_offset = 0;

--- a/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelCreateWithNativeHandle.cpp
@@ -25,7 +25,7 @@ struct urKernelCreateWithNativeHandleTest : uur::urKernelTest {
       false                                       /*isNativeHandleOwned*/
   };
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelCreateWithNativeHandleTest);
 
 TEST_P(urKernelCreateWithNativeHandleTest, Success) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urKernelCreateWithNativeHandle(

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -20,7 +20,7 @@ struct urKernelGetGroupInfoFixedWorkGroupSizeTest : uur::urKernelTest {
   // In UR, this is on the left, so we reverse the order of these values.
   std::array<size_t, 3> work_group_size{2, 4, 8};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoFixedWorkGroupSizeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoFixedWorkGroupSizeTest);
 
 TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest,
        SuccessCompileWorkGroupSize) {
@@ -60,7 +60,7 @@ struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
   std::array<size_t, 3> max_work_group_size{2, 4, 8};
   size_t max_linear_work_group_size{64};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoMaxWorkGroupSizeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoMaxWorkGroupSizeTest);
 
 TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
        SuccessCompileMaxWorkGroupSize) {
@@ -102,7 +102,7 @@ TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
 }
 
 using urKernelGetGroupInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetGroupInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoTest);
 
 TEST_P(urKernelGetGroupInfoTest, SuccessGlobalWorkSize) {
   ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE;

--- a/test/conformance/kernel/urKernelGetInfo.cpp
+++ b/test/conformance/kernel/urKernelGetInfo.cpp
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 using urKernelGetInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetInfoTest);
 
 TEST_P(urKernelGetInfoTest, SuccessFunctionName) {
   ur_kernel_info_t property_name = UR_KERNEL_INFO_FUNCTION_NAME;

--- a/test/conformance/kernel/urKernelGetNativeHandle.cpp
+++ b/test/conformance/kernel/urKernelGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urKernelGetNativeHandleTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetNativeHandleTest);
 
 TEST_P(urKernelGetNativeHandleTest, Success) {
   ur_native_handle_t native_kernel_handle = 0;

--- a/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
@@ -20,8 +20,7 @@ struct urKernelGetSubGroupInfoFixedSubGroupSizeTest : uur::urKernelTest {
   // This value correlates to sub_group_size<8> in fixed_sg_size.cpp.
   uint32_t num_sub_groups{8};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
-    urKernelGetSubGroupInfoFixedSubGroupSizeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoFixedSubGroupSizeTest);
 
 TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
        SuccessCompileNumSubGroups) {
@@ -44,7 +43,7 @@ TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
 struct urKernelGetSubGroupInfoTest : uur::urKernelTest {
   void SetUp() override { UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp()); }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetSubGroupInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoTest);
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxSubGroupSize) {
   ur_kernel_sub_group_info_t property_name =

--- a/test/conformance/kernel/urKernelGetSuggestedLocalWorkSize.cpp
+++ b/test/conformance/kernel/urKernelGetSuggestedLocalWorkSize.cpp
@@ -17,7 +17,7 @@ struct urKernelGetSuggestedLocalWorkSizeTest : uur::urKernelExecutionTest {
 
   size_t suggested_local_work_size;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelGetSuggestedLocalWorkSizeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSuggestedLocalWorkSizeTest);
 
 TEST_P(urKernelGetSuggestedLocalWorkSizeTest, Success) {
   suggested_local_work_size = SIZE_MAX;

--- a/test/conformance/kernel/urKernelRelease.cpp
+++ b/test/conformance/kernel/urKernelRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urKernelReleaseTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelReleaseTest);
 
 TEST_P(urKernelReleaseTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));

--- a/test/conformance/kernel/urKernelRetain.cpp
+++ b/test/conformance/kernel/urKernelRetain.cpp
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urKernelRetainTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelRetainTest);
 
 TEST_P(urKernelRetainTest, Success) {
   ASSERT_SUCCESS(urKernelRetain(kernel));

--- a/test/conformance/kernel/urKernelSetArgLocal.cpp
+++ b/test/conformance/kernel/urKernelSetArgLocal.cpp
@@ -15,7 +15,7 @@ struct urKernelSetArgLocalTest : uur::urKernelTest {
   }
   size_t local_mem_size = 4 * sizeof(uint32_t);
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgLocalTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgLocalTest);
 
 TEST_P(urKernelSetArgLocalTest, Success) {
   ASSERT_SUCCESS(urKernelSetArgLocal(kernel, 1, local_mem_size, nullptr));
@@ -147,7 +147,7 @@ struct urKernelSetArgLocalMultiTest : uur::urKernelExecutionTest {
   static constexpr uint64_t hip_local_offset = 0;
   ur_platform_backend_t backend{};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgLocalMultiTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgLocalMultiTest);
 
 TEST_P(urKernelSetArgLocalMultiTest, Basic) {
   ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
@@ -324,7 +324,7 @@ struct urKernelSetArgLocalOutOfOrder : urKernelSetArgLocalMultiTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgLocalOutOfOrder);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgLocalOutOfOrder);
 TEST_P(urKernelSetArgLocalOutOfOrder, Success) {
   ASSERT_SUCCESS(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
                                        &global_offset, &global_size,

--- a/test/conformance/kernel/urKernelSetArgMemObj.cpp
+++ b/test/conformance/kernel/urKernelSetArgMemObj.cpp
@@ -25,7 +25,7 @@ struct urKernelSetArgMemObjTest : uur::urKernelTest {
 
   ur_mem_handle_t buffer = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgMemObjTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgMemObjTest);
 
 TEST_P(urKernelSetArgMemObjTest, Success) {
   ASSERT_SUCCESS(urKernelSetArgMemObj(kernel, 0, nullptr, buffer));

--- a/test/conformance/kernel/urKernelSetArgPointer.cpp
+++ b/test/conformance/kernel/urKernelSetArgPointer.cpp
@@ -31,7 +31,7 @@ struct urKernelSetArgPointerTest : uur::urKernelExecutionTest {
   size_t allocation_size = array_size * sizeof(uint32_t);
   uint32_t data = 42;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgPointerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgPointerTest);
 
 TEST_P(urKernelSetArgPointerTest, SuccessHost) {
   ur_device_usm_access_capability_flags_t host_usm_flags = 0;
@@ -132,7 +132,7 @@ struct urKernelSetArgPointerNegativeTest : urKernelSetArgPointerTest {
     ASSERT_NE(allocation, nullptr);
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgPointerNegativeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgPointerNegativeTest);
 
 TEST_P(urKernelSetArgPointerNegativeTest, InvalidNullHandleKernel) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,

--- a/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -56,7 +56,7 @@ struct urKernelSetArgSamplerTestWithParam
   ur_sampler_handle_t sampler = nullptr;
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urKernelSetArgSamplerTestWithParam,
     ::testing::Combine(
         ::testing::Values(true, false),
@@ -114,7 +114,7 @@ struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
   ur_sampler_handle_t sampler = nullptr;
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgSamplerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgSamplerTest);
 
 TEST_P(urKernelSetArgSamplerTest, SuccessWithProps) {
   ur_kernel_arg_sampler_properties_t props{

--- a/test/conformance/kernel/urKernelSetArgValue.cpp
+++ b/test/conformance/kernel/urKernelSetArgValue.cpp
@@ -15,7 +15,7 @@ struct urKernelSetArgValueTest : uur::urKernelTest {
 
   uint32_t arg_value = 42;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetArgValueTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetArgValueTest);
 
 TEST_P(urKernelSetArgValueTest, Success) {
   ASSERT_SUCCESS(

--- a/test/conformance/kernel/urKernelSetExecInfo.cpp
+++ b/test/conformance/kernel/urKernelSetExecInfo.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urKernelSetExecInfoTest = uur::urKernelTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetExecInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetExecInfoTest);
 
 TEST_P(urKernelSetExecInfoTest, SuccessIndirectAccess) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -59,7 +59,7 @@ struct urKernelSetExecInfoUSMPointersTest : uur::urKernelTest {
   size_t allocation_size = 16;
   void *allocation = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetExecInfoUSMPointersTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetExecInfoUSMPointersTest);
 
 TEST_P(urKernelSetExecInfoUSMPointersTest, SuccessHost) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
@@ -119,7 +119,7 @@ TEST_P(urKernelSetExecInfoUSMPointersTest, SuccessShared) {
 using urKernelSetExecInfoCacheConfigTest =
     uur::urKernelTestWithParam<ur_kernel_cache_config_t>;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urKernelSetExecInfoCacheConfigTest,
     ::testing::Values(UR_KERNEL_CACHE_CONFIG_DEFAULT,
                       UR_KERNEL_CACHE_CONFIG_LARGE_SLM,

--- a/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
+++ b/test/conformance/kernel/urKernelSetSpecializationConstants.cpp
@@ -24,7 +24,7 @@ struct urKernelSetSpecializationConstantsTest : uur::urBaseKernelExecutionTest {
   uint32_t spec_value = 42;
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urKernelSetSpecializationConstantsTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelSetSpecializationConstantsTest);
 
 struct urKernelSetSpecializationConstantsNegativeTest
     : uur::urBaseKernelExecutionTest {
@@ -44,7 +44,7 @@ struct urKernelSetSpecializationConstantsNegativeTest
   uint32_t spec_value = 42;
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(
     urKernelSetSpecializationConstantsNegativeTest);
 
 TEST_P(urKernelSetSpecializationConstantsTest, Success) {

--- a/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
+++ b/test/conformance/memory-migrate/urMemBufferMigrateAcrossDevices.cpp
@@ -144,7 +144,7 @@ struct urMultiDeviceContextMemBufferTest : urMultiDeviceContextTest {
   std::vector<ur_kernel_handle_t> kernels;
   std::vector<ur_program_metadata_t> metadatas{};
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiDeviceContextMemBufferTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceContextMemBufferTest);
 
 TEST_P(urMultiDeviceContextMemBufferTest, WriteRead) {
   if (num_devices == 1) {

--- a/test/conformance/memory/urMemBufferCreate.cpp
+++ b/test/conformance/memory/urMemBufferCreate.cpp
@@ -11,12 +11,11 @@ using urMemBufferCreateTestWithFlagsParam =
     uur::urContextTestWithParam<ur_mem_flag_t>;
 
 using urMemBufferCreateWithFlagsTest = urMemBufferCreateTestWithFlagsParam;
-UUR_DEVICE_TEST_SUITE_P(urMemBufferCreateWithFlagsTest,
-                        ::testing::Values(UR_MEM_FLAG_READ_WRITE,
-                                          UR_MEM_FLAG_WRITE_ONLY,
-                                          UR_MEM_FLAG_READ_ONLY,
-                                          UR_MEM_FLAG_ALLOC_HOST_POINTER),
-                        uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemBufferCreateWithFlagsTest,
+    ::testing::Values(UR_MEM_FLAG_READ_WRITE, UR_MEM_FLAG_WRITE_ONLY,
+                      UR_MEM_FLAG_READ_ONLY, UR_MEM_FLAG_ALLOC_HOST_POINTER),
+    uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithFlagsTest, Success) {
   uur::raii::Mem buffer = nullptr;
@@ -46,7 +45,7 @@ TEST_P(urMemBufferCreateWithFlagsTest, InvalidBufferSizeZero) {
 }
 
 using urMemBufferCreateTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemBufferCreateTest);
 
 TEST_P(urMemBufferCreateTest, InvalidEnumerationFlags) {
   uur::raii::Mem buffer = nullptr;
@@ -88,10 +87,11 @@ TEST_P(urMemBufferCreateTest, InvalidHostPtrValidHost) {
 
 using urMemBufferCreateWithHostPtrFlagsTest =
     urMemBufferCreateTestWithFlagsParam;
-UUR_DEVICE_TEST_SUITE_P(urMemBufferCreateWithHostPtrFlagsTest,
-                        ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
-                                          UR_MEM_FLAG_USE_HOST_POINTER),
-                        uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemBufferCreateWithHostPtrFlagsTest,
+    ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
+                      UR_MEM_FLAG_USE_HOST_POINTER),
+    uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferCreateWithHostPtrFlagsTest, SUCCESS) {
   uur::raii::Mem host_ptr_buffer = nullptr;

--- a/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@
 #include <uur/raii.h>
 
 using urMemBufferCreateWithNativeHandleTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemBufferCreateWithNativeHandleTest);
 
 TEST_P(urMemBufferCreateWithNativeHandleTest, Success) {
   ur_native_handle_t hNativeMem = 0;
@@ -113,7 +113,7 @@ TEST_P(urMemBufferCreateWithNativeHandleTest, InvalidNullPointer) {
 }
 
 using urMemBufferMultiQueueMemBufferTest = uur::urMultiDeviceMemBufferQueueTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMemBufferMultiQueueMemBufferTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMemBufferMultiQueueMemBufferTest);
 
 TEST_P(urMemBufferMultiQueueMemBufferTest, WriteBack) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/test/conformance/memory/urMemBufferPartition.cpp
+++ b/test/conformance/memory/urMemBufferPartition.cpp
@@ -10,11 +10,11 @@
 
 using urMemBufferPartitionWithFlagsTest =
     uur::urContextTestWithParam<ur_mem_flag_t>;
-UUR_DEVICE_TEST_SUITE_P(urMemBufferPartitionWithFlagsTest,
-                        ::testing::Values(UR_MEM_FLAG_READ_WRITE,
-                                          UR_MEM_FLAG_WRITE_ONLY,
-                                          UR_MEM_FLAG_READ_ONLY),
-                        uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemBufferPartitionWithFlagsTest,
+    ::testing::Values(UR_MEM_FLAG_READ_WRITE, UR_MEM_FLAG_WRITE_ONLY,
+                      UR_MEM_FLAG_READ_ONLY),
+    uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemBufferPartitionWithFlagsTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
@@ -42,7 +42,7 @@ TEST_P(urMemBufferPartitionWithFlagsTest, Success) {
 }
 
 using urMemBufferPartitionTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemBufferPartitionTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemBufferPartitionTest);
 
 TEST_P(urMemBufferPartitionTest, InvalidNullHandleBuffer) {
   ur_buffer_region_t region{UR_STRUCTURE_TYPE_BUFFER_REGION, nullptr, 0, 1024};

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 using urMemGetInfoTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetInfoTest);
 
 TEST_P(urMemGetInfoTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -113,7 +113,7 @@ struct urMemGetInfoImageTest : uur::urMemImageTest {
     uur::urMemImageTest::SetUp();
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetInfoImageTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetInfoImageTest);
 
 TEST_P(urMemGetInfoImageTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/test/conformance/memory/urMemGetNativeHandle.cpp
+++ b/test/conformance/memory/urMemGetNativeHandle.cpp
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urMemGetNativeHandleTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetNativeHandleTest);
 
 TEST_P(urMemGetNativeHandleTest, Success) {
   ur_native_handle_t hNativeMem = 0;

--- a/test/conformance/memory/urMemImageCreate.cpp
+++ b/test/conformance/memory/urMemImageCreate.cpp
@@ -50,7 +50,7 @@ struct urMemImageCreateTest : public uur::urContextTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemImageCreateTest);
 
 template <typename Param>
 struct urMemImageCreateTestWithParam
@@ -84,10 +84,10 @@ struct urMemImageCreateTestWithParam
 using urMemImageCreateTestWith1DMemoryTypeParam =
     urMemImageCreateTestWithParam<ur_mem_type_t>;
 
-UUR_DEVICE_TEST_SUITE_P(urMemImageCreateTestWith1DMemoryTypeParam,
-                        ::testing::Values(UR_MEM_TYPE_IMAGE1D,
-                                          UR_MEM_TYPE_IMAGE1D_ARRAY),
-                        uur::deviceTestWithParamPrinter<ur_mem_type_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemImageCreateTestWith1DMemoryTypeParam,
+    ::testing::Values(UR_MEM_TYPE_IMAGE1D, UR_MEM_TYPE_IMAGE1D_ARRAY),
+    uur::deviceTestWithParamPrinter<ur_mem_type_t>);
 
 TEST_P(urMemImageCreateTestWith1DMemoryTypeParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
@@ -120,10 +120,10 @@ TEST_P(urMemImageCreateTestWith1DMemoryTypeParam, Success) {
 using urMemImageCreateTestWith2DMemoryTypeParam =
     urMemImageCreateTestWithParam<ur_mem_type_t>;
 
-UUR_DEVICE_TEST_SUITE_P(urMemImageCreateTestWith2DMemoryTypeParam,
-                        ::testing::Values(UR_MEM_TYPE_IMAGE2D,
-                                          UR_MEM_TYPE_IMAGE2D_ARRAY),
-                        uur::deviceTestWithParamPrinter<ur_mem_type_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemImageCreateTestWith2DMemoryTypeParam,
+    ::testing::Values(UR_MEM_TYPE_IMAGE2D, UR_MEM_TYPE_IMAGE2D_ARRAY),
+    uur::deviceTestWithParamPrinter<ur_mem_type_t>);
 
 TEST_P(urMemImageCreateTestWith2DMemoryTypeParam, Success) {
   UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
@@ -341,10 +341,11 @@ TEST_P(urMemImageCreateTest, InvalidHostPtrValidHost) {
 using urMemImageCreateWithHostPtrFlagsTest =
     urMemImageCreateTestWithParam<ur_mem_flag_t>;
 
-UUR_DEVICE_TEST_SUITE_P(urMemImageCreateWithHostPtrFlagsTest,
-                        ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
-                                          UR_MEM_FLAG_USE_HOST_POINTER),
-                        uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urMemImageCreateWithHostPtrFlagsTest,
+    ::testing::Values(UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER,
+                      UR_MEM_FLAG_USE_HOST_POINTER),
+    uur::deviceTestWithParamPrinter<ur_mem_flag_t>);
 
 TEST_P(urMemImageCreateWithHostPtrFlagsTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});

--- a/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
+++ b/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
@@ -90,7 +90,7 @@ struct urMemImageCreateTestWithImageFormatParam
   }
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urMemImageCreateTestWithImageFormatParam,
     ::testing::ValuesIn(
         urMemImageCreateTestWithImageFormatParam::makeImageFormats()),

--- a/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
@@ -13,7 +13,7 @@ struct urMemImageCreateWithNativeHandleTest : uur::urMemImageTest {
     UUR_RETURN_ON_FATAL_FAILURE(urMemImageTest::SetUp());
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemImageCreateWithNativeHandleTest);
 
 TEST_P(urMemImageCreateWithNativeHandleTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::HIP{}, uur::LevelZero{});

--- a/test/conformance/memory/urMemImageGetInfo.cpp
+++ b/test/conformance/memory/urMemImageGetInfo.cpp
@@ -8,7 +8,7 @@
 #include <uur/optional_queries.h>
 
 using urMemImageGetInfoTest = uur::urMemImageTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemImageGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemImageGetInfoTest);
 
 bool operator==(ur_image_format_t lhs, ur_image_format_t rhs) {
   return lhs.channelOrder == rhs.channelOrder &&

--- a/test/conformance/memory/urMemRelease.cpp
+++ b/test/conformance/memory/urMemRelease.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urMemReleaseTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemReleaseTest);
 
 TEST_P(urMemReleaseTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/memory/urMemRetain.cpp
+++ b/test/conformance/memory/urMemRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urMemRetainTest = uur::urMemBufferTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemRetainTest);
 
 TEST_P(urMemRetainTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -15,7 +15,7 @@ struct urPlatformCreateWithNativeHandleTest : uur::urPlatformTest {
   }
   ur_adapter_handle_t adapter = nullptr;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformCreateWithNativeHandleTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformCreateWithNativeHandleTest);
 
 TEST_P(urPlatformCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/platform/urPlatformGetApiVersion.cpp
+++ b/test/conformance/platform/urPlatformGetApiVersion.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urPlatformGetApiVersionTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformGetApiVersionTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformGetApiVersionTest);
 
 TEST_P(urPlatformGetApiVersionTest, Success) {
   ur_api_version_t version;

--- a/test/conformance/platform/urPlatformGetBackendOption.cpp
+++ b/test/conformance/platform/urPlatformGetBackendOption.cpp
@@ -9,9 +9,10 @@
 using urPlatformGetBackendOptionTest =
     uur::urPlatformTestWithParam<std::string>;
 
-UUR_PLATFORM_TEST_SUITE_P(urPlatformGetBackendOptionTest,
-                          ::testing::Values("-O0", "-O1", "-O2", "-O3"),
-                          uur::platformTestWithParamPrinter<std::string>);
+UUR_PLATFORM_TEST_SUITE_WITH_PARAM(
+    urPlatformGetBackendOptionTest,
+    ::testing::Values("-O0", "-O1", "-O2", "-O3"),
+    uur::platformTestWithParamPrinter<std::string>);
 
 TEST_P(urPlatformGetBackendOptionTest, Success) {
   const char *platformOption = nullptr;
@@ -21,7 +22,7 @@ TEST_P(urPlatformGetBackendOptionTest, Success) {
 }
 
 using urPlatformGetBackendOptionNegativeTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformGetBackendOptionNegativeTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformGetBackendOptionNegativeTest);
 
 TEST_P(urPlatformGetBackendOptionNegativeTest, InvalidNullHandle) {
   const char *platformOption = nullptr;

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -10,7 +10,7 @@
 #include <cstring>
 
 using urPlatformGetInfoTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformGetInfoTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformGetInfoTest);
 
 TEST_P(urPlatformGetInfoTest, SuccessName) {
   ur_platform_info_t property_name = UR_PLATFORM_INFO_NAME;

--- a/test/conformance/platform/urPlatformGetNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urPlatformGetNativeHandleTest = uur::urPlatformTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urPlatformGetNativeHandleTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformGetNativeHandleTest);
 
 TEST_P(urPlatformGetNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/program/urMultiDeviceProgramCreateWithBinary.cpp
+++ b/test/conformance/program/urMultiDeviceProgramCreateWithBinary.cpp
@@ -53,7 +53,7 @@ struct urMultiDeviceProgramCreateWithBinaryTest
   std::vector<size_t> binary_sizes;
   ur_program_handle_t binary_program = nullptr;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiDeviceProgramCreateWithBinaryTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceProgramCreateWithBinaryTest);
 
 // Create the kernel using the program created with multiple binaries and run it
 // on all devices.
@@ -301,7 +301,7 @@ struct urMultiDeviceCommandBufferExpTest
   static constexpr size_t global_size = 64;
   static constexpr size_t local_size = 4;
 };
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiDeviceCommandBufferExpTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceCommandBufferExpTest);
 
 TEST_P(urMultiDeviceCommandBufferExpTest, Enqueue) {
   for (size_t i = 0; i < devices.size(); i++) {

--- a/test/conformance/program/urMultiDeviceProgramCreateWithIL.cpp
+++ b/test/conformance/program/urMultiDeviceProgramCreateWithIL.cpp
@@ -9,7 +9,7 @@
 #include <uur/raii.h>
 
 using urMultiDeviceProgramTest = uur::urMultiDeviceProgramTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urMultiDeviceProgramTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urMultiDeviceProgramTest);
 
 // Test binary sizes and binaries obtained from urProgramGetInfo when program is
 // built for a subset of devices in the context.

--- a/test/conformance/program/urProgramBuild.cpp
+++ b/test/conformance/program/urProgramBuild.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urProgramBuildTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramBuildTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramBuildTest);
 
 TEST_P(urProgramBuildTest, Success) {
   ASSERT_SUCCESS(urProgramBuild(context, program, nullptr));

--- a/test/conformance/program/urProgramCompile.cpp
+++ b/test/conformance/program/urProgramCompile.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramCompileTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramCompileTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCompileTest);
 
 TEST_P(urProgramCompileTest, Success) {
   ASSERT_SUCCESS(urProgramCompile(context, program, nullptr));

--- a/test/conformance/program/urProgramCreateWithBinary.cpp
+++ b/test/conformance/program/urProgramCreateWithBinary.cpp
@@ -35,7 +35,7 @@ struct urProgramCreateWithBinaryTest : uur::urProgramTest {
   std::vector<uint8_t> binary;
   ur_program_handle_t binary_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramCreateWithBinaryTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCreateWithBinaryTest);
 
 TEST_P(urProgramCreateWithBinaryTest, Success) {
   auto size = binary.size();

--- a/test/conformance/program/urProgramCreateWithIL.cpp
+++ b/test/conformance/program/urProgramCreateWithIL.cpp
@@ -31,7 +31,7 @@ struct urProgramCreateWithILTest : uur::urContextTest {
 
   std::shared_ptr<std::vector<char>> il_binary;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramCreateWithILTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCreateWithILTest);
 
 TEST_P(urProgramCreateWithILTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});

--- a/test/conformance/program/urProgramCreateWithNativeHandle.cpp
+++ b/test/conformance/program/urProgramCreateWithNativeHandle.cpp
@@ -33,7 +33,7 @@ struct urProgramCreateWithNativeHandleTest : uur::urProgramTest {
   ur_native_handle_t native_program_handle = 0;
   ur_program_handle_t native_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramCreateWithNativeHandleTest);
 
 TEST_P(urProgramCreateWithNativeHandleTest, Success) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urProgramCreateWithNativeHandle(

--- a/test/conformance/program/urProgramGetBuildInfo.cpp
+++ b/test/conformance/program/urProgramGetBuildInfo.cpp
@@ -13,7 +13,7 @@ struct urProgramGetBuildInfoTest : uur::urProgramTest {
     ASSERT_SUCCESS(urProgramBuild(this->context, program, nullptr));
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetBuildInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetBuildInfoTest);
 
 TEST_P(urProgramGetBuildInfoTest, SuccessStatus) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});

--- a/test/conformance/program/urProgramGetFunctionPointer.cpp
+++ b/test/conformance/program/urProgramGetFunctionPointer.cpp
@@ -18,7 +18,7 @@ struct urProgramGetFunctionPointerTest : uur::urProgramTest {
 
   std::string function_name;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetFunctionPointerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetFunctionPointerTest);
 
 TEST_P(urProgramGetFunctionPointerTest, Success) {
   void *function_pointer = nullptr;

--- a/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
+++ b/test/conformance/program/urProgramGetGlobalVariablePointer.cpp
@@ -8,7 +8,7 @@
 
 using urProgramGetGlobalVariablePointerTest = uur::urGlobalVariableTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetGlobalVariablePointerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetGlobalVariablePointerTest);
 
 TEST_P(urProgramGetGlobalVariablePointerTest, Success) {
   size_t global_variable_size = 0;

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -15,7 +15,7 @@ struct urProgramGetInfoTest : uur::urProgramTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetInfoTest);
 
 TEST_P(urProgramGetInfoTest, SuccessReferenceCount) {
   size_t property_size = 0;

--- a/test/conformance/program/urProgramGetNativeHandle.cpp
+++ b/test/conformance/program/urProgramGetNativeHandle.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramGetNativeHandleTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetNativeHandleTest);
 
 TEST_P(urProgramGetNativeHandleTest, Success) {
   ur_platform_backend_t backend;

--- a/test/conformance/program/urProgramLink.cpp
+++ b/test/conformance/program/urProgramLink.cpp
@@ -31,7 +31,7 @@ struct urProgramLinkTest : uur::urProgramTest {
 
   ur_program_handle_t linked_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramLinkTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramLinkTest);
 
 struct urProgramLinkErrorTest : uur::urQueueTest {
   const std::string linker_error_program_name = "linker_error";
@@ -73,7 +73,7 @@ struct urProgramLinkErrorTest : uur::urQueueTest {
   ur_program_handle_t program = nullptr;
   ur_program_handle_t linked_program = nullptr;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramLinkErrorTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramLinkErrorTest);
 
 TEST_P(urProgramLinkTest, Success) {
   // This entry point isn't implemented for HIP.

--- a/test/conformance/program/urProgramRelease.cpp
+++ b/test/conformance/program/urProgramRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramReleaseTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramReleaseTest);
 
 TEST_P(urProgramReleaseTest, Success) {
   ASSERT_SUCCESS(urProgramRetain(program));

--- a/test/conformance/program/urProgramRetain.cpp
+++ b/test/conformance/program/urProgramRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urProgramRetainTest = uur::urProgramTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramRetainTest);
 
 TEST_P(urProgramRetainTest, Success) {
   ASSERT_SUCCESS(urProgramRetain(program));

--- a/test/conformance/program/urProgramSetSpecializationConstants.cpp
+++ b/test/conformance/program/urProgramSetSpecializationConstants.cpp
@@ -26,7 +26,7 @@ struct urProgramSetSpecializationConstantsTest : uur::urKernelExecutionTest {
   uint32_t default_spec_value = 1000; // Must match the one in the SYCL source
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urProgramSetSpecializationConstantsTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramSetSpecializationConstantsTest);
 
 struct urProgramSetSpecializationConstantsNegativeTest
     : uur::urKernelExecutionTest {
@@ -48,7 +48,7 @@ struct urProgramSetSpecializationConstantsNegativeTest
   uint32_t default_spec_value = 1000; // Must match the one in the SYCL source
   ur_specialization_constant_info_t info = {0, sizeof(spec_value), &spec_value};
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(
     urProgramSetSpecializationConstantsNegativeTest);
 
 struct urProgramSetMultipleSpecializationConstantsTest
@@ -68,7 +68,7 @@ struct urProgramSetMultipleSpecializationConstantsTest
     }
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(
     urProgramSetMultipleSpecializationConstantsTest);
 
 TEST_P(urProgramSetSpecializationConstantsTest, Success) {

--- a/test/conformance/queue/urQueueCreate.cpp
+++ b/test/conformance/queue/urQueueCreate.cpp
@@ -9,7 +9,7 @@
 #include <uur/known_failure.h>
 
 using urQueueCreateTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueCreateTest);
 
 TEST_P(urQueueCreateTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -28,7 +28,7 @@ TEST_P(urQueueCreateTest, Success) {
 }
 
 using urQueueCreateWithParamTest = uur::urContextTestWithParam<ur_queue_flag_t>;
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urQueueCreateWithParamTest,
     testing::Values(UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE,
                     UR_QUEUE_FLAG_PROFILING_ENABLE, UR_QUEUE_FLAG_ON_DEVICE,
@@ -132,7 +132,7 @@ TEST_P(urQueueCreateTest, CheckContext) {
 }
 
 using urQueueCreateTestMultipleDevices = uur::urAllDevicesTest;
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urQueueCreateTestMultipleDevices);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urQueueCreateTestMultipleDevices);
 
 /* Create a queue using a context from a different device */
 TEST_P(urQueueCreateTestMultipleDevices, ContextFromWrongDevice) {

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urQueueCreateWithNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueCreateWithNativeHandleTest);
 
 TEST_P(urQueueCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/queue/urQueueFinish.cpp
+++ b/test/conformance/queue/urQueueFinish.cpp
@@ -8,7 +8,7 @@
 #include "uur/raii.h"
 
 using urQueueFinishTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFinishTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueFinishTest);
 
 TEST_P(urQueueFinishTest, Success) {
   constexpr size_t buffer_size = 1024;

--- a/test/conformance/queue/urQueueFlush.cpp
+++ b/test/conformance/queue/urQueueFlush.cpp
@@ -9,7 +9,7 @@
 #include "uur/raii.h"
 
 using urQueueFlushTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueFlushTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueFlushTest);
 
 TEST_P(urQueueFlushTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urQueueGetInfoTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueGetInfoTest);
 
 TEST_P(urQueueGetInfoTest, SuccessContext) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -168,7 +168,7 @@ struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
           UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE};
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetInfoDeviceQueueTestWithInfoParam);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueGetInfoDeviceQueueTestWithInfoParam);
 
 TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, SuccessDeviceDefault) {
   size_t property_size = 0;

--- a/test/conformance/queue/urQueueGetNativeHandle.cpp
+++ b/test/conformance/queue/urQueueGetNativeHandle.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urQueueGetNativeHandleTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueGetNativeHandleTest);
 
 TEST_P(urQueueGetNativeHandleTest, Success) {
   ur_native_handle_t native_handle = 0;

--- a/test/conformance/queue/urQueueRelease.cpp
+++ b/test/conformance/queue/urQueueRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urQueueReleaseTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueReleaseTest);
 
 TEST_P(urQueueReleaseTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/queue/urQueueRetain.cpp
+++ b/test/conformance/queue/urQueueRetain.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urQueueRetainTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urQueueRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urQueueRetainTest);
 
 TEST_P(urQueueRetainTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/sampler/urSamplerCreate.cpp
+++ b/test/conformance/sampler/urSamplerCreate.cpp
@@ -43,7 +43,7 @@ struct urSamplerCreateTestWithParam
   }
 };
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urSamplerCreateTestWithParam,
     ::testing::Combine(
         ::testing::Values(true, false),
@@ -77,7 +77,7 @@ TEST_P(urSamplerCreateTestWithParam, Success) {
 }
 
 using urSamplerCreateTest = uur::urContextTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerCreateTest);
 
 TEST_P(urSamplerCreateTest, InvalidNullHandleContext) {
   ur_sampler_desc_t sampler_desc{

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -9,7 +9,7 @@
 
 using urSamplerCreateWithNativeHandleTest = uur::urSamplerTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerCreateWithNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerCreateWithNativeHandleTest);
 
 TEST_P(urSamplerCreateWithNativeHandleTest, Success) {
   ur_native_handle_t native_sampler = 0;

--- a/test/conformance/sampler/urSamplerGetInfo.cpp
+++ b/test/conformance/sampler/urSamplerGetInfo.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urSamplerGetInfoTest = uur::urSamplerTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerGetInfoTest);
 
 TEST_P(urSamplerGetInfoTest, SuccessReferenceCount) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});

--- a/test/conformance/sampler/urSamplerGetNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerGetNativeHandle.cpp
@@ -8,7 +8,7 @@
 
 using urSamplerGetNativeHandleTest = uur::urSamplerTest;
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerGetNativeHandleTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerGetNativeHandleTest);
 
 TEST_P(urSamplerGetNativeHandleTest, Success) {
   ur_native_handle_t native_sampler = 0;

--- a/test/conformance/sampler/urSamplerRelease.cpp
+++ b/test/conformance/sampler/urSamplerRelease.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urSamplerReleaseTest = uur::urSamplerTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerReleaseTest);
 
 TEST_P(urSamplerReleaseTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});

--- a/test/conformance/sampler/urSamplerRetain.cpp
+++ b/test/conformance/sampler/urSamplerRetain.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urSamplerRetainTest = uur::urSamplerTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urSamplerRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerRetainTest);
 
 TEST_P(urSamplerRetainTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -45,7 +45,7 @@ struct urAdapterTest : ::testing::Test,
 
 // In the vein of urAdapterTest and urDeviceTest this is a parameterized
 // platform fixture which can be instantiated via
-// UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P to run tests on each discovered
+// UUR_INSTANTIATE_PLATFORM_TEST_SUITE to run tests on each discovered
 // platform.
 struct urPlatformTest : ::testing::Test,
                         ::testing::WithParamInterface<ur_platform_handle_t> {
@@ -113,7 +113,7 @@ struct urDeviceTest : ::testing::Test,
 };
 } // namespace uur
 
-#define UUR_INSTANTIATE_ADAPTER_TEST_SUITE_P(FIXTURE)                          \
+#define UUR_INSTANTIATE_ADAPTER_TEST_SUITE(FIXTURE)                            \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE,                                                               \
       ::testing::ValuesIn(uur::AdapterEnvironment::instance->adapters),        \
@@ -121,7 +121,7 @@ struct urDeviceTest : ::testing::Test,
         return uur::GetAdapterBackendName(info.param);                         \
       })
 
-#define UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(FIXTURE)                         \
+#define UUR_INSTANTIATE_PLATFORM_TEST_SUITE(FIXTURE)                           \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE,                                                               \
       ::testing::ValuesIn(uur::PlatformEnvironment::instance->platforms),      \
@@ -129,7 +129,7 @@ struct urDeviceTest : ::testing::Test,
         return uur::GetPlatformNameWithID(info.param);                         \
       })
 
-#define UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(FIXTURE)                           \
+#define UUR_INSTANTIATE_DEVICE_TEST_SUITE(FIXTURE)                             \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE,                                                               \
       ::testing::ValuesIn(uur::DevicesEnvironment::instance->devices),         \
@@ -301,7 +301,7 @@ struct urMemImageTest : urContextTest {
 
 } // namespace uur
 
-#define UUR_PLATFORM_TEST_SUITE_P(FIXTURE, VALUES, PRINTER)                    \
+#define UUR_PLATFORM_TEST_SUITE_WITH_PARAM(FIXTURE, VALUES, PRINTER)           \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE,                                                               \
       testing::Combine(                                                        \
@@ -309,7 +309,7 @@ struct urMemImageTest : urContextTest {
           VALUES),                                                             \
       PRINTER)
 
-#define UUR_DEVICE_TEST_SUITE_P(FIXTURE, VALUES, PRINTER)                      \
+#define UUR_DEVICE_TEST_SUITE_WITH_PARAM(FIXTURE, VALUES, PRINTER)             \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE,                                                               \
       testing::Combine(                                                        \

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -45,7 +45,7 @@ struct urUSMDeviceAllocTest
 // The 0 value parameters are not relevant for urUSMDeviceAllocTest tests, they
 // are used below in urUSMDeviceAllocAlignmentTest for allocation size and
 // alignment values
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMDeviceAllocTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
@@ -138,7 +138,7 @@ TEST_P(urUSMDeviceAllocTest, InvalidValueAlignPowerOfTwo) {
 
 using urUSMDeviceAllocAlignmentTest = urUSMDeviceAllocTest;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMDeviceAllocAlignmentTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),

--- a/test/conformance/usm/urUSMFree.cpp
+++ b/test/conformance/usm/urUSMFree.cpp
@@ -8,7 +8,7 @@
 #include <uur/known_failure.h>
 
 using urUSMFreeTest = uur::urQueueTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMFreeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMFreeTest);
 
 TEST_P(urUSMFreeTest, SuccessDeviceAlloc) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
@@ -117,7 +117,7 @@ struct urUSMFreeDuringExecutionTest : uur::urKernelExecutionTest {
   uint32_t data = 42;
   size_t wg_offset = 0;
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMFreeDuringExecutionTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMFreeDuringExecutionTest);
 
 TEST_P(urUSMFreeDuringExecutionTest, SuccessHost) {
   ur_device_usm_access_capability_flags_t host_usm_flags = 0;

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -20,9 +20,9 @@ struct urUSMGetMemAllocInfoPoolTest
   }
 };
 
-UUR_DEVICE_TEST_SUITE_P(urUSMGetMemAllocInfoPoolTest,
-                        ::testing::Values(UR_USM_ALLOC_INFO_POOL),
-                        uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
+    urUSMGetMemAllocInfoPoolTest, ::testing::Values(UR_USM_ALLOC_INFO_POOL),
+    uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
@@ -44,7 +44,7 @@ TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
 }
 
 using urUSMGetMemAllocInfoTest = uur::urUSMDeviceAllocTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMGetMemAllocInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMGetMemAllocInfoTest);
 
 TEST_P(urUSMGetMemAllocInfoTest, SuccessType) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -46,7 +46,7 @@ struct urUSMHostAllocTest
 // The 0 value parameters are not relevant for urUSMHostAllocTest tests, they
 // are used below in urUSMHostAllocAlignmentTest for allocation size and
 // alignment values
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMHostAllocTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
@@ -148,7 +148,7 @@ TEST_P(urUSMHostAllocTest, InvalidValueAlignPowerOfTwo) {
 
 using urUSMHostAllocAlignmentTest = urUSMHostAllocTest;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMHostAllocAlignmentTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),

--- a/test/conformance/usm/urUSMPoolCreate.cpp
+++ b/test/conformance/usm/urUSMPoolCreate.cpp
@@ -18,7 +18,7 @@ struct urUSMPoolCreateTest : uur::urContextTest {
     }
   }
 };
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMPoolCreateTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMPoolCreateTest);
 
 TEST_P(urUSMPoolCreateTest, Success) {
   ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr, 0};

--- a/test/conformance/usm/urUSMPoolGetInfo.cpp
+++ b/test/conformance/usm/urUSMPoolGetInfo.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urUSMPoolGetInfoTest = uur::urUSMPoolTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMPoolGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMPoolGetInfoTest);
 
 TEST_P(urUSMPoolGetInfoTest, SuccessReferenceCount) {
   size_t property_size = 0;

--- a/test/conformance/usm/urUSMPoolRelease.cpp
+++ b/test/conformance/usm/urUSMPoolRelease.cpp
@@ -7,7 +7,7 @@
 #include <uur/fixtures.h>
 
 using urUSMPoolDestroyTest = uur::urUSMPoolTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMPoolDestroyTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMPoolDestroyTest);
 
 TEST_P(urUSMPoolDestroyTest, Success) {
   ASSERT_SUCCESS(urUSMPoolRelease(pool));

--- a/test/conformance/usm/urUSMPoolRetain.cpp
+++ b/test/conformance/usm/urUSMPoolRetain.cpp
@@ -8,7 +8,7 @@
 #include <uur/fixtures.h>
 
 using urUSMPoolRetainTest = uur::urUSMPoolTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUSMPoolRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMPoolRetainTest);
 
 TEST_P(urUSMPoolRetainTest, Success) {
   uint32_t prevRefCount = 0;

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -52,7 +52,7 @@ struct urUSMSharedAllocTest
 // The 0 value parameters are not relevant for urUSMSharedAllocTest tests, they
 // are used below in urUSMSharedAllocAlignmentTest for allocation size and
 // alignment values
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMSharedAllocTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
@@ -159,7 +159,7 @@ TEST_P(urUSMSharedAllocTest, InvalidValueAlignPowerOfTwo) {
 
 using urUSMSharedAllocAlignmentTest = urUSMSharedAllocTest;
 
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urUSMSharedAllocAlignmentTest,
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),

--- a/test/conformance/virtual_memory/urPhysicalMemCreate.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemCreate.cpp
@@ -28,9 +28,9 @@ struct urPhysicalMemCreateTest
 };
 
 using urPhysicalMemCreateWithSizeParamTest = urPhysicalMemCreateTest;
-UUR_DEVICE_TEST_SUITE_P(urPhysicalMemCreateWithSizeParamTest,
-                        ::testing::Values(1, 2, 3, 7, 12, 44),
-                        uur::deviceTestWithParamPrinter<size_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urPhysicalMemCreateWithSizeParamTest,
+                                 ::testing::Values(1, 2, 3, 7, 12, 44),
+                                 uur::deviceTestWithParamPrinter<size_t>);
 
 TEST_P(urPhysicalMemCreateWithSizeParamTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
@@ -54,7 +54,7 @@ TEST_P(urPhysicalMemCreateWithSizeParamTest, InvalidSize) {
 
 using urPhysicalMemCreateWithFlagsParamTest =
     uur::urPhysicalMemTestWithParam<ur_physical_mem_flags_t>;
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urPhysicalMemCreateWithFlagsParamTest,
     ::testing::Values(UR_PHYSICAL_MEM_FLAG_TBD),
     uur::deviceTestWithParamPrinter<ur_physical_mem_flags_t>);
@@ -71,8 +71,8 @@ TEST_P(urPhysicalMemCreateWithFlagsParamTest, Success) {
 }
 
 using urPhysicalMemCreateTest = urPhysicalMemCreateTest;
-UUR_DEVICE_TEST_SUITE_P(urPhysicalMemCreateTest, ::testing::Values(1),
-                        uur::deviceTestWithParamPrinter<size_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urPhysicalMemCreateTest, ::testing::Values(1),
+                                 uur::deviceTestWithParamPrinter<size_t>);
 
 TEST_P(urPhysicalMemCreateTest, InvalidNullHandleContext) {
   ASSERT_EQ_RESULT(

--- a/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
@@ -7,7 +7,7 @@
 #include <uur/known_failure.h>
 
 using urPhysicalMemGetInfoTest = uur::urPhysicalMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urPhysicalMemGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urPhysicalMemGetInfoTest);
 
 TEST_P(urPhysicalMemGetInfoTest, SuccessContext) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});

--- a/test/conformance/virtual_memory/urPhysicalMemRelease.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemRelease.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urPhysicalMemReleaseTest = uur::urPhysicalMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urPhysicalMemReleaseTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urPhysicalMemReleaseTest);
 
 TEST_P(urPhysicalMemReleaseTest, Success) {
   uint32_t referenceCount = 0;

--- a/test/conformance/virtual_memory/urPhysicalMemRetain.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemRetain.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urPhysicalMemRetainTest = uur::urPhysicalMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urPhysicalMemRetainTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urPhysicalMemRetainTest);
 
 TEST_P(urPhysicalMemRetainTest, Success) {
   uint32_t referenceCount = 0;

--- a/test/conformance/virtual_memory/urVirtualMemFree.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemFree.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urVirtualMemFreeTest = uur::urVirtualMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemFreeTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemFreeTest);
 
 TEST_P(urVirtualMemFreeTest, Success) {
   ASSERT_SUCCESS(urVirtualMemFree(context, virtual_ptr, size));

--- a/test/conformance/virtual_memory/urVirtualMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemGetInfo.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urVirtualMemGetInfoTest = uur::urVirtualMemMappedTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemGetInfoTest);
 
 TEST_P(urVirtualMemGetInfoTest, SuccessAccessMode) {
   size_t property_size = 0;

--- a/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
@@ -20,7 +20,7 @@ struct urVirtualMemGranularityGetInfoTest : uur::urContextTest {
   }
 };
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemGranularityGetInfoTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemGranularityGetInfoTest);
 
 TEST_P(urVirtualMemGranularityGetInfoTest, SuccessMinimum) {
   size_t property_size = 0;

--- a/test/conformance/virtual_memory/urVirtualMemMap.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemMap.cpp
@@ -7,7 +7,7 @@
 
 using urVirtualMemMapWithFlagsTest =
     uur::urVirtualMemTestWithParam<ur_virtual_mem_access_flag_t>;
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urVirtualMemMapWithFlagsTest,
     ::testing::Values(UR_VIRTUAL_MEM_ACCESS_FLAG_NONE,
                       UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE,
@@ -21,7 +21,7 @@ TEST_P(urVirtualMemMapWithFlagsTest, Success) {
 }
 
 using urVirtualMemMapTest = uur::urVirtualMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemMapTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemMapTest);
 
 TEST_P(urVirtualMemMapTest, InvalidNullHandleContext) {
   ASSERT_EQ_RESULT(urVirtualMemMap(nullptr, virtual_ptr, size, physical_mem, 0,

--- a/test/conformance/virtual_memory/urVirtualMemReserve.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemReserve.cpp
@@ -7,10 +7,11 @@
 
 using urVirtualMemReserveTestWithParam =
     uur::urVirtualMemGranularityTestWithParam<size_t>;
-UUR_DEVICE_TEST_SUITE_P(urVirtualMemReserveTestWithParam,
-                        ::testing::Values(2, 4, 8, 16, 32, 64, 128, 256, 512,
-                                          1024, 2048, 5000, 100000),
-                        uur::deviceTestWithParamPrinter<size_t>);
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(urVirtualMemReserveTestWithParam,
+                                 ::testing::Values(2, 4, 8, 16, 32, 64, 128,
+                                                   256, 512, 1024, 2048, 5000,
+                                                   100000),
+                                 uur::deviceTestWithParamPrinter<size_t>);
 
 TEST_P(urVirtualMemReserveTestWithParam, SuccessNoStartPointer) {
   // round up to nearest granularity
@@ -45,7 +46,7 @@ TEST_P(urVirtualMemReserveTestWithParam, SuccessWithStartPointer) {
 }
 
 using urVirtualMemReserveTest = uur::urVirtualMemGranularityTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemReserveTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemReserveTest);
 
 TEST_P(urVirtualMemReserveTest, InvalidNullHandleContext) {
   size_t page_size = uur::RoundUpToNearestFactor(1024, granularity);

--- a/test/conformance/virtual_memory/urVirtualMemSetAccess.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemSetAccess.cpp
@@ -7,7 +7,7 @@
 
 using urVirtualMemSetAccessWithFlagsTest =
     uur::urVirtualMemMappedTestWithParam<ur_virtual_mem_access_flag_t>;
-UUR_DEVICE_TEST_SUITE_P(
+UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     urVirtualMemSetAccessWithFlagsTest,
     ::testing::Values(UR_VIRTUAL_MEM_ACCESS_FLAG_NONE,
                       UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE,
@@ -29,7 +29,7 @@ TEST_P(urVirtualMemSetAccessWithFlagsTest, Success) {
 }
 
 using urVirtualMemSetAccessTest = uur::urVirtualMemMappedTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemSetAccessTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemSetAccessTest);
 
 TEST_P(urVirtualMemSetAccessTest, InvalidNullHandleContext) {
   ASSERT_EQ_RESULT(urVirtualMemSetAccess(nullptr, virtual_ptr, size,

--- a/test/conformance/virtual_memory/urVirtualMemUnmap.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemUnmap.cpp
@@ -6,7 +6,7 @@
 #include <uur/fixtures.h>
 
 using urVirtualMemUnmapTest = uur::urVirtualMemTest;
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urVirtualMemUnmapTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemUnmapTest);
 
 TEST_P(urVirtualMemUnmapTest, Success) {
   ASSERT_SUCCESS(urVirtualMemMap(context, virtual_ptr, size, physical_mem, 0,

--- a/test/usm/usmPoolManager.cpp
+++ b/test/usm/usmPoolManager.cpp
@@ -11,7 +11,7 @@
 
 using urUsmPoolDescriptorTest = uur::urMultiDeviceContextTest;
 
-UUR_INSTANTIATE_PLATFORM_TEST_SUITE_P(urUsmPoolDescriptorTest);
+UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urUsmPoolDescriptorTest);
 
 auto createMockPoolHandle() {
   static uintptr_t uniqueAddress = 0x1;
@@ -177,4 +177,4 @@ TEST_P(urUsmPoolManagerTest, config) {
   ASSERT_EQ(compareConfigs(test, parsed3), true);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urUsmPoolManagerTest);
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUsmPoolManagerTest);


### PR DESCRIPTION
Also rename the macros to be a little more intuitive.