### PR TITLE
Reorganised urEventGetProfilingInfo test into separate tests instead of a switch

### DIFF
--- a/test/conformance/adapter/urAdapterGetInfo.cpp
+++ b/test/conformance/adapter/urAdapterGetInfo.cpp
@@ -13,7 +13,7 @@ using urAdapterGetInfoTest = uur::urAdapterTest;
 UUR_INSTANTIATE_ADAPTER_TEST_SUITE(urAdapterGetInfoTest);
 
 TEST_P(urAdapterGetInfoTest, SuccessBackend) {
-  ur_adapter_info_t property_name = UR_ADAPTER_INFO_BACKEND;
+  const ur_adapter_info_t property_name = UR_ADAPTER_INFO_BACKEND;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -21,16 +21,16 @@ TEST_P(urAdapterGetInfoTest, SuccessBackend) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_adapter_backend_t));
 
-  ur_adapter_backend_t backend = UR_ADAPTER_BACKEND_UNKNOWN;
+  ur_adapter_backend_t property_value = UR_ADAPTER_BACKEND_UNKNOWN;
   ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
-                                  &backend, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_TRUE(backend >= UR_ADAPTER_BACKEND_LEVEL_ZERO &&
-              backend <= UR_ADAPTER_BACKEND_NATIVE_CPU);
+  ASSERT_TRUE(property_value >= UR_ADAPTER_BACKEND_LEVEL_ZERO &&
+              property_value <= UR_ADAPTER_BACKEND_NATIVE_CPU);
 }
 
 TEST_P(urAdapterGetInfoTest, SuccessReferenceCount) {
-  ur_adapter_info_t property_name = UR_ADAPTER_INFO_REFERENCE_COUNT;
+  const ur_adapter_info_t property_name = UR_ADAPTER_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -38,14 +38,16 @@ TEST_P(urAdapterGetInfoTest, SuccessReferenceCount) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t reference_count = 0;
-  ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
-                                  &reference_count, nullptr));
-  ASSERT_GE(reference_count, 0);
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urAdapterGetInfo(adapter, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
+  ASSERT_GE(property_value, 0);
 }
 
 TEST_P(urAdapterGetInfoTest, SuccessVersion) {
-  ur_adapter_info_t property_name = UR_ADAPTER_INFO_VERSION;
+  const ur_adapter_info_t property_name = UR_ADAPTER_INFO_VERSION;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -53,10 +55,11 @@ TEST_P(urAdapterGetInfoTest, SuccessVersion) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_version = 46;
-  ASSERT_SUCCESS(urAdapterGetInfo(adapter, property_name, property_size,
-                                  &returned_version, nullptr));
-  ASSERT_NE(42, returned_version);
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urAdapterGetInfo(adapter, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 }
 
 TEST_P(urAdapterGetInfoTest, InvalidNullHandleAdapter) {
@@ -89,7 +92,7 @@ TEST_P(urAdapterGetInfoTest, InvalidSizeSmall) {
 }
 
 TEST_P(urAdapterGetInfoTest, InvalidNullPointerPropValue) {
-  ur_adapter_backend_t backend = UR_ADAPTER_BACKEND_UNKNOWN;
+  const ur_adapter_backend_t backend = UR_ADAPTER_BACKEND_UNKNOWN;
   ASSERT_EQ_RESULT(urAdapterGetInfo(adapter, UR_ADAPTER_INFO_BACKEND,
                                     sizeof(backend), nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);

--- a/test/conformance/context/urContextGetInfo.cpp
+++ b/test/conformance/context/urContextGetInfo.cpp
@@ -9,7 +9,7 @@ using urContextGetInfoTest = uur::urContextTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urContextGetInfoTest);
 
 TEST_P(urContextGetInfoTest, SuccessNumDevices) {
-  ur_context_info_t property_name = UR_CONTEXT_INFO_NUM_DEVICES;
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_NUM_DEVICES;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -17,15 +17,15 @@ TEST_P(urContextGetInfoTest, SuccessNumDevices) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t nDevices = 0;
-  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
-                                  &nDevices, nullptr));
-
-  ASSERT_EQ(nDevices, 1);
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urContextGetInfo(context, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 }
 
 TEST_P(urContextGetInfoTest, SuccessDevices) {
-  ur_context_info_t property_name = UR_CONTEXT_INFO_DEVICES;
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_DEVICES;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -33,17 +33,17 @@ TEST_P(urContextGetInfoTest, SuccessDevices) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  ur_device_handle_t queried_device = nullptr;
+  ur_device_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
-                                  &queried_device, nullptr));
+                                  &property_value, nullptr));
 
   size_t devices_count = property_size / sizeof(ur_device_handle_t);
   ASSERT_EQ(devices_count, 1);
-  ASSERT_EQ(queried_device, device);
+  ASSERT_EQ(property_value, device);
 }
 
 TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
-  ur_context_info_t property_name = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -53,7 +53,7 @@ TEST_P(urContextGetInfoTest, SuccessUSMMemCpy2DSupport) {
 }
 
 TEST_P(urContextGetInfoTest, SuccessUSMFill2DSupport) {
-  ur_context_info_t property_name = UR_CONTEXT_INFO_USM_FILL2D_SUPPORT;
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_USM_FILL2D_SUPPORT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -63,7 +63,7 @@ TEST_P(urContextGetInfoTest, SuccessUSMFill2DSupport) {
 }
 
 TEST_P(urContextGetInfoTest, SuccessReferenceCount) {
-  ur_context_info_t property_name = UR_CONTEXT_INFO_REFERENCE_COUNT;
+  const ur_context_info_t property_name = UR_CONTEXT_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -71,14 +71,16 @@ TEST_P(urContextGetInfoTest, SuccessReferenceCount) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t reference_count = 0;
-  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
-                                  &reference_count, nullptr));
-  ASSERT_GT(reference_count, 0U);
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urContextGetInfo(context, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
-  ur_context_info_t property_name =
+  const ur_context_info_t property_name =
       UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES;
   size_t property_size = 0;
 
@@ -87,15 +89,15 @@ TEST_P(urContextGetInfoTest, SuccessAtomicMemoryOrderCapabilities) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
 
-  ur_memory_order_capability_flags_t flags = 0;
-  ASSERT_SUCCESS(
-      urContextGetInfo(context, property_name, property_size, &flags, nullptr));
+  ur_memory_order_capability_flags_t property_value = 0;
+  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+  ASSERT_EQ(property_value & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
-  ur_context_info_t property_name =
+  const ur_context_info_t property_name =
       UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES;
   size_t property_size = 0;
 
@@ -104,15 +106,15 @@ TEST_P(urContextGetInfoTest, SuccessAtomicMemoryScopeCapabilities) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
 
-  ur_memory_scope_capability_flags_t flags = 0;
-  ASSERT_SUCCESS(
-      urContextGetInfo(context, property_name, property_size, &flags, nullptr));
+  ur_memory_scope_capability_flags_t property_value = 0;
+  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+  ASSERT_EQ(property_value & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
-  ur_context_info_t property_name =
+  const ur_context_info_t property_name =
       UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES;
   size_t property_size = 0;
 
@@ -121,15 +123,15 @@ TEST_P(urContextGetInfoTest, SuccessAtomicFenceOrderCapabilities) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_memory_order_capability_flags_t));
 
-  ur_memory_order_capability_flags_t flags = 0;
-  ASSERT_SUCCESS(
-      urContextGetInfo(context, property_name, property_size, &flags, nullptr));
+  ur_memory_order_capability_flags_t property_value = 0;
+  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(flags & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
+  ASSERT_EQ(property_value & UR_MEMORY_ORDER_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
-  ur_context_info_t property_name =
+  const ur_context_info_t property_name =
       UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES;
   size_t property_size = 0;
 
@@ -138,11 +140,11 @@ TEST_P(urContextGetInfoTest, SuccessAtomicFenceScopeCapabilities) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_memory_scope_capability_flags_t));
 
-  ur_memory_scope_capability_flags_t flags = 0;
-  ASSERT_SUCCESS(
-      urContextGetInfo(context, property_name, property_size, &flags, nullptr));
+  ur_memory_scope_capability_flags_t property_value = 0;
+  ASSERT_SUCCESS(urContextGetInfo(context, property_name, property_size,
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(flags & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
+  ASSERT_EQ(property_value & UR_MEMORY_SCOPE_CAPABILITY_FLAGS_MASK, 0);
 }
 
 TEST_P(urContextGetInfoTest, InvalidNullHandleContext) {

--- a/test/conformance/event/urEventGetInfo.cpp
+++ b/test/conformance/event/urEventGetInfo.cpp
@@ -10,7 +10,7 @@
 using urEventGetInfoTest = uur::event::urEventTest;
 
 TEST_P(urEventGetInfoTest, SuccessCommandQueue) {
-  ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+  const ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -18,15 +18,15 @@ TEST_P(urEventGetInfoTest, SuccessCommandQueue) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_queue_handle_t));
 
-  ur_queue_handle_t returned_queue = nullptr;
+  ur_queue_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
-                                &returned_queue, nullptr));
+                                &property_value, nullptr));
 
-  ASSERT_EQ(queue, returned_queue);
+  ASSERT_EQ(queue, property_value);
 }
 
 TEST_P(urEventGetInfoTest, SuccessContext) {
-  ur_event_info_t property_name = UR_EVENT_INFO_CONTEXT;
+  const ur_event_info_t property_name = UR_EVENT_INFO_CONTEXT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -34,17 +34,17 @@ TEST_P(urEventGetInfoTest, SuccessContext) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
-                                &returned_context, nullptr));
+                                &property_value, nullptr));
 
-  ASSERT_EQ(context, returned_context);
+  ASSERT_EQ(context, property_value);
 }
 
 TEST_P(urEventGetInfoTest, SuccessCommandType) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_TYPE;
+  const ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_TYPE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -52,15 +52,15 @@ TEST_P(urEventGetInfoTest, SuccessCommandType) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_command_t));
 
-  ur_command_t returned_command_type = UR_COMMAND_FORCE_UINT32;
+  ur_command_t property_value = UR_COMMAND_FORCE_UINT32;
   ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
-                                &returned_command_type, nullptr));
+                                &property_value, nullptr));
 
-  ASSERT_EQ(UR_COMMAND_MEM_BUFFER_WRITE, returned_command_type);
+  ASSERT_EQ(UR_COMMAND_MEM_BUFFER_WRITE, property_value);
 }
 
 TEST_P(urEventGetInfoTest, SuccessCommandExecutionStatus) {
-  ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_EXECUTION_STATUS;
+  const ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_EXECUTION_STATUS;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -68,15 +68,15 @@ TEST_P(urEventGetInfoTest, SuccessCommandExecutionStatus) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_event_status_t));
 
-  ur_event_status_t returned_status = UR_EVENT_STATUS_FORCE_UINT32;
+  ur_event_status_t property_value = UR_EVENT_STATUS_FORCE_UINT32;
   ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
-                                &returned_status, nullptr));
+                                &property_value, nullptr));
 
-  ASSERT_EQ(UR_EVENT_STATUS_COMPLETE, returned_status);
+  ASSERT_EQ(UR_EVENT_STATUS_COMPLETE, property_value);
 }
 
 TEST_P(urEventGetInfoTest, SuccessReferenceCount) {
-  ur_event_info_t property_name = UR_EVENT_INFO_REFERENCE_COUNT;
+  const ur_event_info_t property_name = UR_EVENT_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -84,23 +84,22 @@ TEST_P(urEventGetInfoTest, SuccessReferenceCount) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urEventGetInfo(event, property_name, property_size,
-                                &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetInfo(event, property_name, property_size,
+                                            &property_value, nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0U);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urEventGetInfoTest, InvalidNullHandle) {
-  ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+  const ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
   size_t property_size;
 
   ASSERT_SUCCESS(
       urEventGetInfo(event, property_name, 0, nullptr, &property_size));
   ASSERT_NE(property_size, 0);
-  std::vector<uint8_t> data(property_size);
 
-  /* Invalid hEvent */
   ASSERT_EQ_RESULT(urEventGetInfo(nullptr, UR_EVENT_INFO_COMMAND_QUEUE, 0,
                                   nullptr, &property_size),
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
@@ -115,7 +114,7 @@ TEST_P(urEventGetInfoTest, InvalidEnumeration) {
 }
 
 TEST_P(urEventGetInfoTest, InvalidSizePropSize) {
-  ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
+  const ur_event_info_t property_name = UR_EVENT_INFO_COMMAND_QUEUE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS(
@@ -123,7 +122,6 @@ TEST_P(urEventGetInfoTest, InvalidSizePropSize) {
   ASSERT_NE(property_size, 0);
   std::vector<uint8_t> data(property_size);
 
-  /* Invalid propSize */
   ASSERT_EQ_RESULT(urEventGetInfo(event, UR_EVENT_INFO_COMMAND_QUEUE, 0,
                                   data.data(), nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);

--- a/test/conformance/event/urEventGetProfilingInfo.cpp
+++ b/test/conformance/event/urEventGetProfilingInfo.cpp
@@ -7,143 +7,170 @@
 #include "fixtures.h"
 #include "uur/known_failure.h"
 
-using urEventGetProfilingInfoTest =
-    uur::event::urEventTestWithParam<ur_profiling_info_t>;
+using urEventGetProfilingInfoTest = uur::event::urEventTest;
+UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetProfilingInfoTest);
 
-TEST_P(urEventGetProfilingInfoTest, Success) {
+TEST_P(urEventGetProfilingInfoTest, SuccessCommandQueued) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{}, uur::NativeCPU{});
 
-  ur_profiling_info_t info_type = getParam();
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_QUEUED;
+  size_t property_size = 0;
 
-  if (info_type == UR_PROFILING_INFO_COMMAND_COMPLETE) {
-    UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{}, uur::LevelZero{},
-                         uur::NativeCPU{});
-  }
-
-  if (info_type == UR_PROFILING_INFO_COMMAND_QUEUED) {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{},
-                         uur::NativeCPU{});
-  }
-
-  if (info_type == UR_PROFILING_INFO_COMMAND_SUBMIT) {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{},
-                         uur::NativeCPU{});
-  }
-
-  size_t size;
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
-      urEventGetProfilingInfo(event, info_type, 0, nullptr, &size), info_type);
-  ASSERT_EQ(size, 8);
+      urEventGetProfilingInfo(event, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
 
-  std::vector<uint8_t> data(size);
-  ASSERT_SUCCESS(
-      urEventGetProfilingInfo(event, info_type, size, data.data(), nullptr));
-
-  if (sizeof(size_t) == size) {
-    auto returned_value = reinterpret_cast<size_t *>(data.data());
-    ASSERT_NE(*returned_value, 0);
-  }
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetProfilingInfo(event, property_name,
+                                                     property_size,
+                                                     &property_value, nullptr),
+                             property_value);
 }
 
-UUR_DEVICE_TEST_SUITE_WITH_PARAM(
-    urEventGetProfilingInfoTest,
-    ::testing::Values(UR_PROFILING_INFO_COMMAND_QUEUED,
-                      UR_PROFILING_INFO_COMMAND_SUBMIT,
-                      UR_PROFILING_INFO_COMMAND_START,
-                      UR_PROFILING_INFO_COMMAND_END,
-                      UR_PROFILING_INFO_COMMAND_COMPLETE),
-    uur::deviceTestWithParamPrinter<ur_profiling_info_t>);
+TEST_P(urEventGetProfilingInfoTest, SuccessCommandSubmit) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{}, uur::NativeCPU{});
 
-using urEventGetProfilingInfoWithTimingComparisonTest = uur::event::urEventTest;
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_SUBMIT;
+  size_t property_size = 0;
 
-TEST_P(urEventGetProfilingInfoWithTimingComparisonTest, Success) {
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urEventGetProfilingInfo(event, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetProfilingInfo(event, property_name,
+                                                     property_size,
+                                                     &property_value, nullptr),
+                             property_value);
+}
+
+TEST_P(urEventGetProfilingInfoTest, SuccessCommandStart) {
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_START;
+  size_t property_size = 0;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urEventGetProfilingInfo(event, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetProfilingInfo(event, property_name,
+                                                     property_size,
+                                                     &property_value, nullptr),
+                             property_value);
+}
+
+TEST_P(urEventGetProfilingInfoTest, SuccessCommandEnd) {
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_END;
+  size_t property_size = 0;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urEventGetProfilingInfo(event, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetProfilingInfo(event, property_name,
+                                                     property_size,
+                                                     &property_value, nullptr),
+                             property_value);
+}
+
+TEST_P(urEventGetProfilingInfoTest, SuccessCommandComplete) {
+  UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{}, uur::LevelZero{},
+                       uur::NativeCPU{});
+
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_COMPLETE;
+  size_t property_size = 0;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urEventGetProfilingInfo(event, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint64_t));
+
+  uint64_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urEventGetProfilingInfo(event, property_name,
+                                                     property_size,
+                                                     &property_value, nullptr),
+                             property_value);
+}
+
+TEST_P(urEventGetProfilingInfoTest, Success) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{}, uur::LevelZero{},
                        uur::LevelZeroV2{}, uur::NativeCPU{});
 
   uint8_t size = 8;
 
-  std::vector<uint8_t> queued_data(size);
-  ASSERT_SUCCESS(urEventGetProfilingInfo(event,
-                                         UR_PROFILING_INFO_COMMAND_QUEUED, size,
-                                         queued_data.data(), nullptr));
-  auto queued_timing = reinterpret_cast<size_t *>(queued_data.data());
-  ASSERT_NE(*queued_timing, 0);
+  uint64_t queued_value = 0;
+  ASSERT_SUCCESS(urEventGetProfilingInfo(
+      event, UR_PROFILING_INFO_COMMAND_QUEUED, size, &queued_value, nullptr));
+  ASSERT_NE(queued_value, 0);
 
-  std::vector<uint8_t> submit_data(size);
-  ASSERT_SUCCESS(urEventGetProfilingInfo(event,
-                                         UR_PROFILING_INFO_COMMAND_SUBMIT, size,
-                                         submit_data.data(), nullptr));
-  auto submit_timing = reinterpret_cast<size_t *>(submit_data.data());
-  ASSERT_NE(*submit_timing, 0);
+  uint64_t submit_value = 0;
+  ASSERT_SUCCESS(urEventGetProfilingInfo(
+      event, UR_PROFILING_INFO_COMMAND_SUBMIT, size, &submit_value, nullptr));
+  ASSERT_NE(submit_value, 0);
 
-  std::vector<uint8_t> start_data(size);
+  uint64_t start_value = 0;
   ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_START,
-                                         size, start_data.data(), nullptr));
-  auto start_timing = reinterpret_cast<size_t *>(start_data.data());
-  ASSERT_NE(*start_timing, 0);
+                                         size, &start_value, nullptr));
+  ASSERT_NE(start_value, 0);
 
-  std::vector<uint8_t> end_data(size);
+  uint64_t end_value = 0;
   ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_END,
-                                         size, end_data.data(), nullptr));
-  auto end_timing = reinterpret_cast<size_t *>(end_data.data());
-  ASSERT_NE(*end_timing, 0);
+                                         size, &end_value, nullptr));
+  ASSERT_NE(end_value, 0);
 
-  std::vector<uint8_t> complete_data(size);
+  uint64_t complete_value = 0;
   ASSERT_SUCCESS(urEventGetProfilingInfo(event,
                                          UR_PROFILING_INFO_COMMAND_COMPLETE,
-                                         size, complete_data.data(), nullptr));
-  auto complete_timing = reinterpret_cast<size_t *>(complete_data.data());
-  ASSERT_NE(*complete_timing, 0);
+                                         size, &complete_value, nullptr));
+  ASSERT_NE(complete_value, 0);
 
-  ASSERT_LE(*queued_timing, *submit_timing);
-  ASSERT_LT(*submit_timing, *start_timing);
-  ASSERT_LT(*start_timing, *end_timing);
-  ASSERT_LE(*end_timing, *complete_timing);
+  ASSERT_LE(queued_value, submit_value);
+  ASSERT_LT(submit_value, start_value);
+  ASSERT_LT(start_value, end_value);
+  ASSERT_LE(end_value, complete_value);
 }
 
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(
-    urEventGetProfilingInfoWithTimingComparisonTest);
-
-using urEventGetProfilingInfoNegativeTest = uur::event::urEventTest;
-
-TEST_P(urEventGetProfilingInfoNegativeTest, InvalidNullHandle) {
+TEST_P(urEventGetProfilingInfoTest, InvalidNullHandle) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
-  size_t size;
-  ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
-  ASSERT_NE(size, 0);
-  std::vector<uint8_t> data(size);
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_QUEUED;
+  size_t property_size;
+  ASSERT_SUCCESS(urEventGetProfilingInfo(event, property_name, 0, nullptr,
+                                         &property_size));
+  ASSERT_NE(property_size, 0);
 
-  /* Invalid hEvent */
-  ASSERT_EQ_RESULT(
-      urEventGetProfilingInfo(nullptr, info_type, 0, nullptr, &size),
-      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  ASSERT_EQ_RESULT(urEventGetProfilingInfo(nullptr, property_name, 0, nullptr,
+                                           &property_size),
+                   UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
-TEST_P(urEventGetProfilingInfoNegativeTest, InvalidEnumeration) {
-  size_t size;
+TEST_P(urEventGetProfilingInfoTest, InvalidEnumeration) {
+  size_t property_size;
   ASSERT_EQ_RESULT(urEventGetProfilingInfo(event,
                                            UR_PROFILING_INFO_FORCE_UINT32, 0,
-                                           nullptr, &size),
+                                           nullptr, &property_size),
                    UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
-TEST_P(urEventGetProfilingInfoNegativeTest, InvalidValue) {
+TEST_P(urEventGetProfilingInfoTest, InvalidValue) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_profiling_info_t info_type = UR_PROFILING_INFO_COMMAND_QUEUED;
-  size_t size;
-  ASSERT_SUCCESS(urEventGetProfilingInfo(event, info_type, 0, nullptr, &size));
-  ASSERT_NE(size, 0);
-  std::vector<uint8_t> data(size);
+  const ur_profiling_info_t property_name = UR_PROFILING_INFO_COMMAND_QUEUED;
+  size_t property_size = 0;
+  ASSERT_SUCCESS(urEventGetProfilingInfo(event, property_name, 0, nullptr,
+                                         &property_size));
+  ASSERT_NE(property_size, 0);
 
-  /* Invalid propSize */
-  ASSERT_EQ_RESULT(
-      urEventGetProfilingInfo(event, info_type, 0, data.data(), nullptr),
-      UR_RESULT_ERROR_INVALID_VALUE);
+  uint64_t property_value = 0;
+  ASSERT_EQ_RESULT(urEventGetProfilingInfo(event, property_name, 0,
+                                           &property_value, nullptr),
+                   UR_RESULT_ERROR_INVALID_VALUE);
 }
-
-UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetProfilingInfoNegativeTest);
 
 struct urEventGetProfilingInfoForWaitWithBarrier : uur::urProfilingQueueTest {
   void SetUp() override {
@@ -176,17 +203,15 @@ struct urEventGetProfilingInfoForWaitWithBarrier : uur::urProfilingQueueTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventGetProfilingInfoForWaitWithBarrier);
 
 TEST_P(urEventGetProfilingInfoForWaitWithBarrier, Success) {
-  std::vector<uint8_t> submit_data(size);
+  uint64_t submit_value = 0;
   ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_START,
-                                         size, submit_data.data(), nullptr));
-  auto start_timing = reinterpret_cast<size_t *>(submit_data.data());
-  ASSERT_NE(*start_timing, 0);
+                                         size, &submit_value, nullptr));
+  ASSERT_NE(submit_value, 0);
 
-  std::vector<uint8_t> complete_data(size);
+  uint64_t complete_value = 0;
   ASSERT_SUCCESS(urEventGetProfilingInfo(event, UR_PROFILING_INFO_COMMAND_END,
-                                         size, complete_data.data(), nullptr));
-  auto end_timing = reinterpret_cast<size_t *>(complete_data.data());
-  ASSERT_NE(*end_timing, 0);
+                                         size, &complete_value, nullptr));
+  ASSERT_NE(complete_value, 0);
 
-  ASSERT_GE(*end_timing, *start_timing);
+  ASSERT_GE(complete_value, submit_value);
 }

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -26,7 +26,7 @@ TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest,
        SuccessCompileWorkGroupSize) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
 
-  ur_kernel_group_info_t property_name =
+  const ur_kernel_group_info_t property_name =
       UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE;
   size_t property_size = 0;
 
@@ -64,7 +64,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoMaxWorkGroupSizeTest);
 
 TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
        SuccessCompileMaxWorkGroupSize) {
-  ur_kernel_group_info_t property_name =
+  const ur_kernel_group_info_t property_name =
       UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE;
   size_t property_size = 0;
 
@@ -84,7 +84,7 @@ TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
 
 TEST_P(urKernelGetGroupInfoMaxWorkGroupSizeTest,
        SuccessCompileMaxLinearWorkGroupSize) {
-  ur_kernel_group_info_t property_name =
+  const ur_kernel_group_info_t property_name =
       UR_KERNEL_GROUP_INFO_COMPILE_MAX_LINEAR_WORK_GROUP_SIZE;
   size_t property_size = 0;
 
@@ -105,7 +105,8 @@ using urKernelGetGroupInfoTest = uur::urKernelTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetGroupInfoTest);
 
 TEST_P(urKernelGetGroupInfoTest, SuccessGlobalWorkSize) {
-  ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE;
+  const ur_kernel_group_info_t property_name =
+      UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -121,7 +122,8 @@ TEST_P(urKernelGetGroupInfoTest, SuccessGlobalWorkSize) {
 }
 
 TEST_P(urKernelGetGroupInfoTest, SuccessWorkGroupSize) {
-  ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE;
+  const ur_kernel_group_info_t property_name =
+      UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -130,14 +132,16 @@ TEST_P(urKernelGetGroupInfoTest, SuccessWorkGroupSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                      property_size, property_value.data(),
-                                      nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urKernelGetGroupInfo(kernel, device, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 }
 
 TEST_P(urKernelGetGroupInfoTest, SuccessLocalMemSize) {
-  ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE;
+  const ur_kernel_group_info_t property_name =
+      UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -146,14 +150,15 @@ TEST_P(urKernelGetGroupInfoTest, SuccessLocalMemSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                      property_size, property_value.data(),
-                                      nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urKernelGetGroupInfo(kernel, device, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 }
 
 TEST_P(urKernelGetGroupInfoTest, SuccessPreferredWorkGroupSizeMultiple) {
-  ur_kernel_group_info_t property_name =
+  const ur_kernel_group_info_t property_name =
       UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE;
   size_t property_size = 0;
 
@@ -163,14 +168,16 @@ TEST_P(urKernelGetGroupInfoTest, SuccessPreferredWorkGroupSizeMultiple) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                      property_size, property_value.data(),
-                                      nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urKernelGetGroupInfo(kernel, device, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 }
 
 TEST_P(urKernelGetGroupInfoTest, SuccessPrivateMemSize) {
-  ur_kernel_group_info_t property_name = UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE;
+  const ur_kernel_group_info_t property_name =
+      UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -179,16 +186,17 @@ TEST_P(urKernelGetGroupInfoTest, SuccessPrivateMemSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetGroupInfo(kernel, device, property_name,
-                                      property_size, property_value.data(),
-                                      nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urKernelGetGroupInfo(kernel, device, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 }
 
 TEST_P(urKernelGetGroupInfoTest, SuccessCompileWorkGroupSizeEmpty) {
   // Returns 0 by default when there is no specific information
   std::array<size_t, 3> read_dims{1, 1, 1};
-  std::array<size_t, 3> zero{0, 0, 0};
+  const std::array<size_t, 3> zero{0, 0, 0};
 
   ASSERT_SUCCESS(urKernelGetGroupInfo(
       kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
@@ -200,7 +208,7 @@ TEST_P(urKernelGetGroupInfoTest, SuccessCompileWorkGroupSizeEmpty) {
 TEST_P(urKernelGetGroupInfoTest, SuccessCompileMaxWorkGroupSizeEmpty) {
   // Returns 0 by default when there is no specific information
   std::array<size_t, 3> read_dims{1, 1, 1};
-  std::array<size_t, 3> zero{0, 0, 0};
+  const std::array<size_t, 3> zero{0, 0, 0};
 
   auto result = urKernelGetGroupInfo(
       kernel, device, UR_KERNEL_GROUP_INFO_COMPILE_MAX_WORK_GROUP_SIZE,

--- a/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
@@ -24,7 +24,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoFixedSubGroupSizeTest);
 
 TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
        SuccessCompileNumSubGroups) {
-  ur_kernel_sub_group_info_t property_name =
+  const ur_kernel_sub_group_info_t property_name =
       UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS;
   size_t property_size = 0;
 
@@ -34,9 +34,12 @@ TEST_P(urKernelGetSubGroupInfoFixedSubGroupSizeTest,
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t property_value;
-  ASSERT_SUCCESS(urKernelGetSubGroupInfo(
-      kernel, device, property_name, property_size, &property_value, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urKernelGetSubGroupInfo(kernel, device, property_name, property_size,
+                              &property_value, nullptr),
+      property_value);
+
   ASSERT_EQ(property_value, num_sub_groups);
 }
 
@@ -46,7 +49,7 @@ struct urKernelGetSubGroupInfoTest : uur::urKernelTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urKernelGetSubGroupInfoTest);
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxSubGroupSize) {
-  ur_kernel_sub_group_info_t property_name =
+  const ur_kernel_sub_group_info_t property_name =
       UR_KERNEL_SUB_GROUP_INFO_MAX_SUB_GROUP_SIZE;
   size_t property_size = 0;
 
@@ -56,14 +59,15 @@ TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxSubGroupSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
-                                         property_size, property_value.data(),
-                                         nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urKernelGetSubGroupInfo(kernel, device, property_name, property_size,
+                              &property_value, nullptr),
+      property_value);
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxNumSubGroups) {
-  ur_kernel_sub_group_info_t property_name =
+  const ur_kernel_sub_group_info_t property_name =
       UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS;
   size_t property_size = 0;
 
@@ -73,14 +77,15 @@ TEST_P(urKernelGetSubGroupInfoTest, SuccessMaxNumSubGroups) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
-                                         property_size, property_value.data(),
-                                         nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urKernelGetSubGroupInfo(kernel, device, property_name, property_size,
+                              &property_value, nullptr),
+      property_value);
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessSubGroupSizeIntel) {
-  ur_kernel_sub_group_info_t property_name =
+  const ur_kernel_sub_group_info_t property_name =
       UR_KERNEL_SUB_GROUP_INFO_SUB_GROUP_SIZE_INTEL;
   size_t property_size = 0;
 
@@ -90,43 +95,60 @@ TEST_P(urKernelGetSubGroupInfoTest, SuccessSubGroupSizeIntel) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  std::vector<char> property_value(property_size);
-  ASSERT_SUCCESS(urKernelGetSubGroupInfo(kernel, device, property_name,
-                                         property_size, property_value.data(),
-                                         nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urKernelGetSubGroupInfo(kernel, device, property_name, property_size,
+                              &property_value, nullptr),
+      property_value);
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, SuccessCompileNumSubgroupsIsZero) {
   // Returns 0 by default when there is no specific information
-  size_t subgroups = 1;
-  ASSERT_SUCCESS(urKernelGetSubGroupInfo(
-      kernel, device, UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS,
-      sizeof(subgroups), &subgroups, nullptr));
-  ASSERT_EQ(subgroups, 0);
+
+  const ur_kernel_sub_group_info_t property_name =
+      UR_KERNEL_SUB_GROUP_INFO_COMPILE_NUM_SUB_GROUPS;
+  size_t property_size = 0;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urKernelGetSubGroupInfo(kernel, device, property_name, 0, nullptr,
+                              &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urKernelGetSubGroupInfo(kernel, device, property_name, property_size,
+                              &property_value, nullptr),
+      property_value);
+
+  ASSERT_EQ(property_value, 0);
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, InvalidNullHandleKernel) {
-  uint32_t max_num_sub_groups = 0;
-  ASSERT_EQ_RESULT(
-      UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-      urKernelGetSubGroupInfo(
-          nullptr, device, UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS,
-          sizeof(max_num_sub_groups), &max_num_sub_groups, nullptr));
+  uint32_t property_value = 0;
+
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                   urKernelGetSubGroupInfo(
+                       nullptr, device,
+                       UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS,
+                       sizeof(property_value), &property_value, nullptr));
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, InvalidNullHandleDevice) {
-  uint32_t max_num_sub_groups = 0;
-  ASSERT_EQ_RESULT(
-      UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-      urKernelGetSubGroupInfo(
-          kernel, nullptr, UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS,
-          sizeof(max_num_sub_groups), &max_num_sub_groups, nullptr));
+  uint32_t property_value = 0;
+
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                   urKernelGetSubGroupInfo(
+                       kernel, nullptr,
+                       UR_KERNEL_SUB_GROUP_INFO_MAX_NUM_SUB_GROUPS,
+                       sizeof(property_value), &property_value, nullptr));
 }
 
 TEST_P(urKernelGetSubGroupInfoTest, InvalidEnumeration) {
-  size_t bad_enum_length = 0;
+  size_t property_size = 0;
+
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urKernelGetSubGroupInfo(
                        kernel, device, UR_KERNEL_SUB_GROUP_INFO_FORCE_UINT32, 0,
-                       nullptr, &bad_enum_length));
+                       nullptr, &property_size));
 }

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -14,7 +14,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetInfoTest);
 TEST_P(urMemGetInfoTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
+  const ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -22,17 +22,18 @@ TEST_P(urMemGetInfoTest, SuccessSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  size_t returned_size = 0;
-  ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
-                              &returned_size, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemGetInfo(buffer, property_name, property_size,
+                                          &property_value, nullptr),
+                             property_value);
 
-  ASSERT_GE(returned_size, allocation_size);
+  ASSERT_GE(property_value, allocation_size);
 }
 
 TEST_P(urMemGetInfoTest, SuccessContext) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
+  const ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -40,17 +41,17 @@ TEST_P(urMemGetInfoTest, SuccessContext) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
-                              &returned_context, nullptr));
+                              &property_value, nullptr));
 
-  ASSERT_EQ(context, returned_context);
+  ASSERT_EQ(context, property_value);
 }
 
 TEST_P(urMemGetInfoTest, SuccessReferenceCount) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
+  const ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -58,46 +59,50 @@ TEST_P(urMemGetInfoTest, SuccessReferenceCount) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urMemGetInfo(buffer, property_name, property_size,
-                              &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemGetInfo(buffer, property_name, property_size,
+                                          &property_value, nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0);
+  ASSERT_GT(property_value, 0);
 }
 
 TEST_P(urMemGetInfoTest, InvalidNullHandleMemory) {
-  size_t mem_size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                   urMemGetInfo(nullptr, UR_MEM_INFO_SIZE, sizeof(size_t),
-                                &mem_size, nullptr));
+                   urMemGetInfo(nullptr, UR_MEM_INFO_SIZE,
+                                sizeof(property_size), &property_size,
+                                nullptr));
 }
 
 TEST_P(urMemGetInfoTest, InvalidEnumerationMemInfoType) {
-  size_t mem_size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urMemGetInfo(buffer, UR_MEM_INFO_FORCE_UINT32,
-                                sizeof(size_t), &mem_size, nullptr));
+                                sizeof(property_size), &property_size,
+                                nullptr));
 }
 
 TEST_P(urMemGetInfoTest, InvalidSizeZero) {
-  size_t mem_size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(
-      urMemGetInfo(buffer, UR_MEM_INFO_SIZE, 0, &mem_size, nullptr),
+      urMemGetInfo(buffer, UR_MEM_INFO_SIZE, 0, &property_size, nullptr),
       UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urMemGetInfoTest, InvalidSizeSmall) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  size_t mem_size = 0;
-  ASSERT_EQ_RESULT(urMemGetInfo(buffer, UR_MEM_INFO_SIZE, sizeof(mem_size) - 1,
-                                &mem_size, nullptr),
+  size_t property_size = 0;
+  ASSERT_EQ_RESULT(urMemGetInfo(buffer, UR_MEM_INFO_SIZE,
+                                sizeof(property_size) - 1, &property_size,
+                                nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urMemGetInfoTest, InvalidNullPointerParamValue) {
-  size_t mem_size = 0;
-  ASSERT_EQ_RESULT(urMemGetInfo(buffer, UR_MEM_INFO_SIZE, sizeof(mem_size),
+  size_t property_size = 0;
+  ASSERT_EQ_RESULT(urMemGetInfo(buffer, UR_MEM_INFO_SIZE, sizeof(property_size),
                                 nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
@@ -118,7 +123,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urMemGetInfoImageTest);
 TEST_P(urMemGetInfoImageTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
+  const ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -126,9 +131,10 @@ TEST_P(urMemGetInfoImageTest, SuccessSize) {
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  size_t image_size_bytes = 0;
-  ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
-                              &image_size_bytes, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemGetInfo(image, property_name, property_size,
+                                          &property_value, nullptr),
+                             property_value);
 
   const size_t expected_pixel_size = sizeof(uint8_t) * 4;
   const size_t expected_image_size = expected_pixel_size *
@@ -137,11 +143,11 @@ TEST_P(urMemGetInfoImageTest, SuccessSize) {
 
   // Make sure the driver has allocated enough space to hold the image (the
   // actual size may be padded out to above the requested size)
-  ASSERT_GE(image_size_bytes, expected_image_size);
+  ASSERT_GE(property_value, expected_image_size);
 }
 
 TEST_P(urMemGetInfoImageTest, SuccessContext) {
-  ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
+  const ur_mem_info_t property_name = UR_MEM_INFO_CONTEXT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -149,15 +155,15 @@ TEST_P(urMemGetInfoImageTest, SuccessContext) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
-                              &returned_context, nullptr));
+                              &property_value, nullptr));
 
-  ASSERT_EQ(context, returned_context);
+  ASSERT_EQ(context, property_value);
 }
 
 TEST_P(urMemGetInfoImageTest, SuccessReferenceCount) {
-  ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
+  const ur_mem_info_t property_name = UR_MEM_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -165,9 +171,10 @@ TEST_P(urMemGetInfoImageTest, SuccessReferenceCount) {
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urMemGetInfo(image, property_name, property_size,
-                              &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemGetInfo(image, property_name, property_size,
+                                          &property_value, nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0);
+  ASSERT_GT(property_value, 0);
 }

--- a/test/conformance/memory/urMemImageGetInfo.cpp
+++ b/test/conformance/memory/urMemImageGetInfo.cpp
@@ -46,11 +46,11 @@ TEST_P(urMemImageGetInfoTest, SuccessElementSize) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
-
-  ASSERT_NE(property_value, 999);
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 }
 
 TEST_P(urMemImageGetInfoTest, SuccessRowPitch) {
@@ -64,9 +64,11 @@ TEST_P(urMemImageGetInfoTest, SuccessRowPitch) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_TRUE(property_value == image_desc.rowPitch ||
               property_value == (4 * sizeof(uint8_t)) * image_desc.width);
@@ -83,9 +85,11 @@ TEST_P(urMemImageGetInfoTest, SuccessSlicePitch) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_EQ(property_value, image_desc.slicePitch);
 }
@@ -101,9 +105,11 @@ TEST_P(urMemImageGetInfoTest, SuccessWidth) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_EQ(property_value, image_desc.width);
 }
@@ -119,9 +125,11 @@ TEST_P(urMemImageGetInfoTest, SuccessHeight) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_EQ(property_value, image_desc.height);
 }
@@ -137,9 +145,11 @@ TEST_P(urMemImageGetInfoTest, SuccessDepth) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_TRUE(property_value == image_desc.depth || property_value == 0);
 }
@@ -155,9 +165,11 @@ TEST_P(urMemImageGetInfoTest, SuccessArraySize) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_TRUE(property_value == image_desc.depth || property_value == 0);
 }
@@ -173,9 +185,11 @@ TEST_P(urMemImageGetInfoTest, SuccessNumMipMaps) {
       property_name);
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
-  uint32_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_EQ(property_value, image_desc.numMipLevel);
 }
@@ -191,9 +205,11 @@ TEST_P(urMemImageGetInfoTest, SuccessNumSamples) {
       property_name);
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
-  uint32_t property_value = 999;
-  ASSERT_SUCCESS(urMemImageGetInfo(image, property_name, property_size,
-                                   &property_value, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urMemImageGetInfo(image, property_name,
+                                               property_size, &property_value,
+                                               nullptr),
+                             property_value);
 
   ASSERT_EQ(property_value, image_desc.numSamples);
 }

--- a/test/conformance/platform/urPlatformGetInfo.cpp
+++ b/test/conformance/platform/urPlatformGetInfo.cpp
@@ -13,7 +13,7 @@ using urPlatformGetInfoTest = uur::urPlatformTest;
 UUR_INSTANTIATE_PLATFORM_TEST_SUITE(urPlatformGetInfoTest);
 
 TEST_P(urPlatformGetInfoTest, SuccessName) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_NAME;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_NAME;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -21,15 +21,15 @@ TEST_P(urPlatformGetInfoTest, SuccessName) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_name(property_size);
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   returned_name.data(), nullptr));
+                                   property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_name.size());
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessVendorName) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_VENDOR_NAME;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_VENDOR_NAME;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -37,15 +37,15 @@ TEST_P(urPlatformGetInfoTest, SuccessVendorName) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_vendor_name(property_size);
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   returned_vendor_name.data(), nullptr));
+                                   property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_vendor_name.size());
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessVersion) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_VERSION;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_VERSION;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -53,15 +53,15 @@ TEST_P(urPlatformGetInfoTest, SuccessVersion) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_version(property_size);
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   returned_version.data(), nullptr));
+                                   property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_version.size());
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessExtensions) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_EXTENSIONS;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_EXTENSIONS;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -69,15 +69,15 @@ TEST_P(urPlatformGetInfoTest, SuccessExtensions) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_extensions(property_size);
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   returned_extensions.data(), nullptr));
+                                   property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_extensions.size());
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessProfile) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_PROFILE;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_PROFILE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -85,15 +85,15 @@ TEST_P(urPlatformGetInfoTest, SuccessProfile) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_profile(property_size);
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   returned_profile.data(), nullptr));
+                                   property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_profile.size());
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessBackend) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_BACKEND;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_BACKEND;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -101,16 +101,16 @@ TEST_P(urPlatformGetInfoTest, SuccessBackend) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_platform_backend_t));
 
-  ur_platform_backend_t returned_backend = UR_PLATFORM_BACKEND_UNKNOWN;
+  ur_platform_backend_t property_value = UR_PLATFORM_BACKEND_UNKNOWN;
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   &returned_backend, nullptr));
+                                   &property_value, nullptr));
 
-  ASSERT_TRUE(returned_backend >= UR_PLATFORM_BACKEND_LEVEL_ZERO &&
-              returned_backend <= UR_PLATFORM_BACKEND_NATIVE_CPU);
+  ASSERT_TRUE(property_value >= UR_PLATFORM_BACKEND_LEVEL_ZERO &&
+              property_value <= UR_PLATFORM_BACKEND_NATIVE_CPU);
 }
 
 TEST_P(urPlatformGetInfoTest, SuccessAdapter) {
-  ur_platform_info_t property_name = UR_PLATFORM_INFO_ADAPTER;
+  const ur_platform_info_t property_name = UR_PLATFORM_INFO_ADAPTER;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -118,48 +118,49 @@ TEST_P(urPlatformGetInfoTest, SuccessAdapter) {
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_adapter_handle_t));
 
-  ur_adapter_handle_t returned_adapter = nullptr;
+  ur_adapter_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urPlatformGetInfo(platform, property_name, property_size,
-                                   &returned_adapter, nullptr));
+                                   &property_value, nullptr));
 
   auto adapter_found = std::find(
       uur::PlatformEnvironment::instance->adapters.begin(),
-      uur::PlatformEnvironment::instance->adapters.end(), returned_adapter);
+      uur::PlatformEnvironment::instance->adapters.end(), property_value);
   ASSERT_NE(adapter_found, uur::AdapterEnvironment::instance->adapters.end());
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidNullHandlePlatform) {
-  size_t size = 0;
-  ASSERT_EQ_RESULT(
-      UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-      urPlatformGetInfo(nullptr, UR_PLATFORM_INFO_NAME, 0, nullptr, &size));
+  size_t property_size = 0;
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
+                   urPlatformGetInfo(nullptr, UR_PLATFORM_INFO_NAME, 0, nullptr,
+                                     &property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidEnumerationPlatformInfoType) {
-  size_t size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urPlatformGetInfo(platform, UR_PLATFORM_INFO_FORCE_UINT32, 0,
-                                     nullptr, &size));
+                                     nullptr, &property_size));
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidSizeZero) {
-  ur_platform_backend_t backend = UR_PLATFORM_BACKEND_UNKNOWN;
+  ur_platform_backend_t property_value = UR_PLATFORM_BACKEND_UNKNOWN;
   ASSERT_EQ_RESULT(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND, 0,
-                                     &backend, nullptr),
+                                     &property_value, nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidSizeSmall) {
-  ur_platform_backend_t backend = UR_PLATFORM_BACKEND_UNKNOWN;
+  ur_platform_backend_t property_value = UR_PLATFORM_BACKEND_UNKNOWN;
   ASSERT_EQ_RESULT(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                     sizeof(backend) - 1, &backend, nullptr),
+                                     sizeof(property_value) - 1,
+                                     &property_value, nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urPlatformGetInfoTest, InvalidNullPointerPropValue) {
-  ur_platform_backend_t backend = UR_PLATFORM_BACKEND_UNKNOWN;
+  ur_platform_backend_t property_value = UR_PLATFORM_BACKEND_UNKNOWN;
   ASSERT_EQ_RESULT(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,
-                                     sizeof(backend), nullptr, nullptr),
+                                     sizeof(property_value), nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 

--- a/test/conformance/program/urProgramGetBuildInfo.cpp
+++ b/test/conformance/program/urProgramGetBuildInfo.cpp
@@ -19,7 +19,7 @@ TEST_P(urProgramGetBuildInfoTest, SuccessStatus) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_STATUS;
+  const ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_STATUS;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
@@ -27,19 +27,18 @@ TEST_P(urProgramGetBuildInfoTest, SuccessStatus) {
       property_name);
   ASSERT_EQ(sizeof(ur_program_build_status_t), property_size);
 
-  ur_program_build_status_t returned_status =
+  ur_program_build_status_t property_value =
       UR_PROGRAM_BUILD_STATUS_FORCE_UINT32;
-  ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
-                                       property_size, &returned_status,
-                                       nullptr));
+  ASSERT_SUCCESS(urProgramGetBuildInfo(
+      program, device, property_name, property_size, &property_value, nullptr));
 
-  ASSERT_GE(returned_status, UR_PROGRAM_BUILD_STATUS_NONE);
-  ASSERT_LE(returned_status, UR_PROGRAM_BUILD_STATUS_IN_PROGRESS);
+  ASSERT_GE(property_value, UR_PROGRAM_BUILD_STATUS_NONE);
+  ASSERT_LE(property_value, UR_PROGRAM_BUILD_STATUS_IN_PROGRESS);
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessOptions) {
   size_t property_size = 0;
-  ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_OPTIONS;
+  const ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_OPTIONS;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
@@ -47,21 +46,19 @@ TEST_P(urProgramGetBuildInfoTest, SuccessOptions) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_options(property_size);
-  returned_options[property_size - 1] = 'x';
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
-                                       property_size, returned_options.data(),
+                                       property_size, property_value.data(),
                                        nullptr));
 
-  ASSERT_EQ(property_size, returned_options.size());
-  ASSERT_EQ(returned_options[property_size - 1], '\0');
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessLog) {
   UUR_KNOWN_FAILURE_ON(uur::CUDA{});
 
   size_t property_size = 0;
-  ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_LOG;
+  const ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_LOG;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
@@ -69,19 +66,18 @@ TEST_P(urProgramGetBuildInfoTest, SuccessLog) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_log(property_size);
-  returned_log[property_size - 1] = 'x';
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
-                                       property_size, returned_log.data(),
+                                       property_size, property_value.data(),
                                        nullptr));
 
-  ASSERT_EQ(property_size, returned_log.size());
-  ASSERT_EQ(returned_log[property_size - 1], '\0');
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urProgramGetBuildInfoTest, SuccessBinaryType) {
   size_t property_size = 0;
-  ur_program_build_info_t property_name = UR_PROGRAM_BUILD_INFO_BINARY_TYPE;
+  const ur_program_build_info_t property_name =
+      UR_PROGRAM_BUILD_INFO_BINARY_TYPE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetBuildInfo(program, device, property_name, 0, nullptr,
@@ -89,38 +85,34 @@ TEST_P(urProgramGetBuildInfoTest, SuccessBinaryType) {
       property_name);
   ASSERT_EQ(sizeof(ur_program_binary_type_t), property_size);
 
-  ur_program_binary_type_t returned_binary_type =
-      UR_PROGRAM_BINARY_TYPE_FORCE_UINT32;
-  ASSERT_SUCCESS(urProgramGetBuildInfo(program, device, property_name,
-                                       property_size, &returned_binary_type,
-                                       nullptr));
+  ur_program_binary_type_t property_value = UR_PROGRAM_BINARY_TYPE_FORCE_UINT32;
+  ASSERT_SUCCESS(urProgramGetBuildInfo(
+      program, device, property_name, property_size, &property_value, nullptr));
 
-  ASSERT_GE(returned_binary_type, UR_PROGRAM_BINARY_TYPE_NONE);
-  ASSERT_LE(returned_binary_type, UR_PROGRAM_BINARY_TYPE_EXECUTABLE);
+  ASSERT_GE(property_value, UR_PROGRAM_BINARY_TYPE_NONE);
+  ASSERT_LE(property_value, UR_PROGRAM_BINARY_TYPE_EXECUTABLE);
 }
 
 TEST_P(urProgramGetBuildInfoTest, InvalidNullHandleProgram) {
-  ur_program_build_status_t programBuildStatus = UR_PROGRAM_BUILD_STATUS_ERROR;
-  ASSERT_EQ_RESULT(urProgramGetBuildInfo(nullptr, device,
-                                         UR_PROGRAM_BUILD_INFO_STATUS,
-                                         sizeof(programBuildStatus),
-                                         &programBuildStatus, nullptr),
-                   UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  ur_program_build_status_t property_value = UR_PROGRAM_BUILD_STATUS_ERROR;
+  ASSERT_EQ_RESULT(
+      urProgramGetBuildInfo(nullptr, device, UR_PROGRAM_BUILD_INFO_STATUS,
+                            sizeof(property_value), &property_value, nullptr),
+      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urProgramGetBuildInfoTest, InvalidNullHandleDevice) {
-  ur_program_build_status_t programBuildStatus = UR_PROGRAM_BUILD_STATUS_ERROR;
-  ASSERT_EQ_RESULT(urProgramGetBuildInfo(program, nullptr,
-                                         UR_PROGRAM_BUILD_INFO_STATUS,
-                                         sizeof(programBuildStatus),
-                                         &programBuildStatus, nullptr),
-                   UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  ur_program_build_status_t property_value = UR_PROGRAM_BUILD_STATUS_ERROR;
+  ASSERT_EQ_RESULT(
+      urProgramGetBuildInfo(program, nullptr, UR_PROGRAM_BUILD_INFO_STATUS,
+                            sizeof(property_value), &property_value, nullptr),
+      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urProgramGetBuildInfoTest, InvalidEnumeration) {
-  size_t propSizeOut = UR_PROGRAM_BUILD_STATUS_ERROR;
+  size_t property_size = UR_PROGRAM_BUILD_STATUS_ERROR;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urProgramGetBuildInfo(program, device,
                                          UR_PROGRAM_BUILD_INFO_FORCE_UINT32, 0,
-                                         nullptr, &propSizeOut));
+                                         nullptr, &property_size));
 }

--- a/test/conformance/program/urProgramGetInfo.cpp
+++ b/test/conformance/program/urProgramGetInfo.cpp
@@ -19,114 +19,123 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urProgramGetInfoTest);
 
 TEST_P(urProgramGetInfoTest, SuccessReferenceCount) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_REFERENCE_COUNT;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_REFERENCE_COUNT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urProgramGetInfo(program, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0U);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urProgramGetInfoTest, SuccessContext) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_CONTEXT;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_CONTEXT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  &returned_context, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(returned_context, context);
+  ASSERT_EQ(property_value, context);
 }
 
 TEST_P(urProgramGetInfoTest, SuccessNumDevices) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_DEVICES;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_DEVICES;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(property_size, sizeof(uint32_t));
 
-  uint32_t returned_num_devices = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  &returned_num_devices, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urProgramGetInfo(program, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 
-  ASSERT_GE(uur::DevicesEnvironment::instance->devices.size(),
-            returned_num_devices);
+  ASSERT_GE(uur::DevicesEnvironment::instance->devices.size(), property_value);
 }
 
 TEST_P(urProgramGetInfoTest, SuccessDevices) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_DEVICES;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_DEVICES;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(property_size, sizeof(ur_context_handle_t));
 
-  std::vector<ur_device_handle_t> returned_devices(property_size);
+  std::vector<ur_device_handle_t> property_value(property_size, nullptr);
   ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  returned_devices.data(), nullptr));
+                                  property_value.data(), nullptr));
 
   size_t devices_count = property_size / sizeof(ur_device_handle_t);
 
   ASSERT_EQ(devices_count, 1);
-  ASSERT_EQ(returned_devices[0], device);
+  ASSERT_EQ(property_value[0], device);
 }
 
 TEST_P(urProgramGetInfoTest, SuccessIL) {
+  // Some adapters only support ProgramCreateWithBinary, in those cases we
+  // expect a return size of 0 and an empty return value for INFO_IL.
+
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_IL;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_IL;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_GE(property_size, 0);
 
-  std::vector<char> returned_il(property_size);
-  // Some adapters only support ProgramCreateWithBinary, in those cases we
-  // expect a return size of 0 and an empty return value for INFO_IL.
+  std::vector<char> property_value(1, static_cast<char>(0xFF));
   if (property_size > 0) {
-    ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_IL, property_size,
-                                    returned_il.data(), nullptr));
-    ASSERT_EQ(returned_il, *il_binary.get());
+    property_value.resize(property_size, static_cast<char>(0xFF));
+    ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
+                                    property_value.data(), nullptr));
+    EXPECT_NE(property_value[0], static_cast<char>(0xFF));
+    EXPECT_EQ(property_value[property_size - 1], '\0');
+    ASSERT_EQ(property_value, *il_binary.get());
   } else {
-    ASSERT_TRUE(returned_il.empty());
+    ASSERT_EQ((urProgramGetInfo(program, property_name, property_size,
+                                property_value.data(), nullptr)),
+              UR_RESULT_ERROR_INVALID_SIZE);
   }
 }
 
 TEST_P(urProgramGetInfoTest, SuccessBinarySizes) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_BINARY_SIZES;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_BINARY_SIZES;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
-  ASSERT_NE(property_size, 0);
+  ASSERT_GT(property_size, 0);
 
-  std::vector<size_t> binary_sizes(property_size / sizeof(size_t));
-  ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES,
-                                  property_size, binary_sizes.data(), nullptr));
+  std::vector<size_t> property_value(property_size / sizeof(size_t), 0);
+  ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
+                                  property_value.data(), nullptr));
 
-  for (const auto &binary_size : binary_sizes) {
+  for (const auto &binary_size : property_value) {
     ASSERT_GT(binary_size, 0);
   }
 }
 
 TEST_P(urProgramGetInfoTest, SuccessBinaries) {
   size_t binary_sizes_len = 0;
-  std::vector<char> property_value;
+  std::vector<char> property_value(0);
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES, 0, nullptr,
@@ -139,8 +148,10 @@ TEST_P(urProgramGetInfoTest, SuccessBinaries) {
   size_t binary_sizes[1] = {binary_sizes_len};
   ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_BINARY_SIZES,
                                   binary_sizes_len, binary_sizes, nullptr));
+
   property_value.resize(binary_sizes[0]);
   char *binaries[1] = {property_value.data()};
+
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, UR_PROGRAM_INFO_BINARIES, sizeof(binaries[0]),
                        binaries, nullptr),
@@ -151,63 +162,65 @@ TEST_P(urProgramGetInfoTest, SuccessNumKernels) {
   UUR_KNOWN_FAILURE_ON(uur::HIP{});
 
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_KERNELS;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_KERNELS;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(property_size, sizeof(size_t));
 
-  size_t returned_num_kernels = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  &returned_num_kernels, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urProgramGetInfo(program, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_num_kernels, 0U);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urProgramGetInfoTest, SuccessKernelNames) {
   size_t property_size = 0;
-  ur_program_info_t property_name = UR_PROGRAM_INFO_KERNEL_NAMES;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_KERNEL_NAMES;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_GT(property_size, 0);
 
-  std::vector<char> returned_kernel_names(property_size);
-  returned_kernel_names[property_size - 1] = 'x';
+  std::vector<char> property_value(property_size, '\0');
   ASSERT_SUCCESS(urProgramGetInfo(program, property_name, property_size,
-                                  returned_kernel_names.data(), nullptr));
+                                  property_value.data(), nullptr));
 
-  ASSERT_EQ(property_size, returned_kernel_names.size());
-  ASSERT_EQ(returned_kernel_names[property_size - 1], '\0');
+  ASSERT_TRUE(uur::stringPropertyIsValid(property_value.data(), property_size));
 }
 
 TEST_P(urProgramGetInfoTest, InvalidNullHandleProgram) {
-  uint32_t ref_count = 0;
+  uint32_t property_value = 0;
   ASSERT_EQ_RESULT(urProgramGetInfo(nullptr, UR_PROGRAM_INFO_REFERENCE_COUNT,
-                                    sizeof(ref_count), &ref_count, nullptr),
+                                    sizeof(property_value), &property_value,
+                                    nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urProgramGetInfoTest, InvalidEnumeration) {
-  size_t prop_size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urProgramGetInfo(program, UR_PROGRAM_INFO_FORCE_UINT32, 0,
-                                    nullptr, &prop_size));
+                                    nullptr, &property_size));
 }
 
 TEST_P(urProgramGetInfoTest, InvalidSizeZero) {
-  uint32_t ref_count = 0;
+  uint32_t property_value = 0;
   ASSERT_EQ_RESULT(urProgramGetInfo(program, UR_PROGRAM_INFO_REFERENCE_COUNT, 0,
-                                    &ref_count, nullptr),
+                                    &property_value, nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urProgramGetInfoTest, InvalidSizeSmall) {
-  uint32_t ref_count = 0;
+  uint32_t property_value = 0;
   ASSERT_EQ_RESULT(urProgramGetInfo(program, UR_PROGRAM_INFO_REFERENCE_COUNT,
-                                    sizeof(ref_count) - 1, &ref_count, nullptr),
+                                    sizeof(property_value) - 1, &property_value,
+                                    nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
@@ -223,34 +236,52 @@ TEST_P(urProgramGetInfoTest, InvalidNullPointerPropValueRet) {
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
-TEST_P(urProgramGetInfoTest, NumDevicesIsNonzero) {
-  uint32_t count = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_NUM_DEVICES,
-                                  sizeof(uint32_t), &count, nullptr));
-  ASSERT_GE(count, 1);
+TEST_P(urProgramGetInfoTest, NumDevicesIsNonZero) {
+  size_t property_size = 0;
+  const ur_program_info_t property_name = UR_PROGRAM_INFO_NUM_DEVICES;
+
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urProgramGetInfo(program, property_name, 0, nullptr, &property_size),
+      property_name);
+  ASSERT_EQ(property_size, sizeof(uint32_t));
+
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urProgramGetInfo(program, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
+
+  ASSERT_GE(property_value, 1);
 }
 
 TEST_P(urProgramGetInfoTest, NumDevicesMatchesDeviceArray) {
-  uint32_t count = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_NUM_DEVICES,
-                                  sizeof(uint32_t), &count, nullptr));
+  uint32_t count;
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urProgramGetInfo(program, UR_PROGRAM_INFO_NUM_DEVICES, sizeof(uint32_t),
+                       &count, nullptr),
+      UR_PROGRAM_INFO_NUM_DEVICES);
 
-  size_t info_devices_size = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_DEVICES, 0, nullptr,
-                                  &info_devices_size));
+  size_t info_devices_size;
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urProgramGetInfo(program, UR_PROGRAM_INFO_DEVICES, 0, nullptr,
+                       &info_devices_size),
+      UR_PROGRAM_INFO_DEVICES);
   ASSERT_EQ(count, info_devices_size / sizeof(ur_device_handle_t));
 }
 
 TEST_P(urProgramGetInfoTest, NumDevicesMatchesContextNumDevices) {
   uint32_t count = 0;
-  ASSERT_SUCCESS(urProgramGetInfo(program, UR_PROGRAM_INFO_NUM_DEVICES,
-                                  sizeof(uint32_t), &count, nullptr));
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urProgramGetInfo(program, UR_PROGRAM_INFO_NUM_DEVICES, sizeof(uint32_t),
+                       &count, nullptr),
+      UR_PROGRAM_INFO_NUM_DEVICES);
 
   // The device count either matches the number of devices in the context or
   // is 1, depending on how it was built
   uint32_t info_context_devices_count = 0;
-  ASSERT_SUCCESS(urContextGetInfo(context, UR_CONTEXT_INFO_NUM_DEVICES,
-                                  sizeof(uint32_t), &info_context_devices_count,
-                                  nullptr));
+  ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
+      urContextGetInfo(context, UR_CONTEXT_INFO_NUM_DEVICES, sizeof(uint32_t),
+                       &info_context_devices_count, nullptr),
+      UR_CONTEXT_INFO_NUM_DEVICES);
   ASSERT_TRUE(count == 1 || count == info_context_devices_count);
 }

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -75,8 +75,9 @@ TEST_P(urQueueGetInfoTest, SuccessReferenceCount) {
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
   uint32_t property_value = 0;
-  ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
-                                &property_value, nullptr));
+  ASSERT_QUERY_RETURNS_VALUE(urQueueGetInfo(queue, property_name, property_size,
+                                            &property_value, nullptr),
+                             property_value);
 
   ASSERT_GT(property_value, 0U);
 }
@@ -90,7 +91,6 @@ TEST_P(urQueueGetInfoTest, SuccessEmptyQueue) {
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urQueueGetInfo(queue, property_name, 0, nullptr, &property_size),
       property_name);
-
   ASSERT_EQ(sizeof(ur_bool_t), property_size);
 }
 
@@ -196,8 +196,9 @@ TEST_P(urQueueGetInfoDeviceQueueTestWithInfoParam, SuccessSize) {
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
   uint32_t property_value = 0;
-  ASSERT_SUCCESS(urQueueGetInfo(queue, property_name, property_size,
-                                &property_value, nullptr));
+  ASSERT_QUERY_RETURNS_VALUE(urQueueGetInfo(queue, property_name, property_size,
+                                            &property_value, nullptr),
+                             property_value);
 
   ASSERT_GT(property_value, 0);
 }

--- a/test/conformance/sampler/urSamplerGetInfo.cpp
+++ b/test/conformance/sampler/urSamplerGetInfo.cpp
@@ -14,43 +14,45 @@ TEST_P(urSamplerGetInfoTest, SuccessReferenceCount) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_sampler_info_t property_name = UR_SAMPLER_INFO_REFERENCE_COUNT;
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_REFERENCE_COUNT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
-                                  &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urSamplerGetInfo(sampler, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0U);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urSamplerGetInfoTest, SuccessContext) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_sampler_info_t property_name = UR_SAMPLER_INFO_CONTEXT;
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_CONTEXT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(ur_context_handle_t), property_size);
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
-                                  &returned_context, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(returned_context, context);
+  ASSERT_EQ(property_value, context);
 }
 
 TEST_P(urSamplerGetInfoTest, SuccessNormalizedCoords) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_sampler_info_t property_name = UR_SAMPLER_INFO_NORMALIZED_COORDS;
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_NORMALIZED_COORDS;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
@@ -62,52 +64,53 @@ TEST_P(urSamplerGetInfoTest, SuccessAddressingMode) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_sampler_info_t property_name = UR_SAMPLER_INFO_ADDRESSING_MODE;
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_ADDRESSING_MODE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(ur_sampler_addressing_mode_t), property_size);
 
-  ur_sampler_addressing_mode_t returned_mode =
+  ur_sampler_addressing_mode_t property_value =
       UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32;
   ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
-                                  &returned_mode, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_GE(returned_mode, UR_SAMPLER_ADDRESSING_MODE_NONE);
-  ASSERT_LT(returned_mode, UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32);
+  ASSERT_GE(property_value, UR_SAMPLER_ADDRESSING_MODE_NONE);
+  ASSERT_LT(property_value, UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32);
 }
 
 TEST_P(urSamplerGetInfoTest, SuccessFilterMode) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_sampler_info_t property_name = UR_SAMPLER_INFO_FILTER_MODE;
+  const ur_sampler_info_t property_name = UR_SAMPLER_INFO_FILTER_MODE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urSamplerGetInfo(sampler, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(ur_sampler_filter_mode_t), property_size);
 
-  ur_sampler_filter_mode_t returned_mode = UR_SAMPLER_FILTER_MODE_FORCE_UINT32;
+  ur_sampler_filter_mode_t property_value = UR_SAMPLER_FILTER_MODE_FORCE_UINT32;
   ASSERT_SUCCESS(urSamplerGetInfo(sampler, property_name, property_size,
-                                  &returned_mode, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_GE(returned_mode, UR_SAMPLER_FILTER_MODE_NEAREST);
-  ASSERT_LT(returned_mode, UR_SAMPLER_FILTER_MODE_FORCE_UINT32);
+  ASSERT_GE(property_value, UR_SAMPLER_FILTER_MODE_NEAREST);
+  ASSERT_LT(property_value, UR_SAMPLER_FILTER_MODE_FORCE_UINT32);
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidNullHandleSampler) {
-  uint32_t refcount = 0;
+  uint32_t property_value = 0;
   ASSERT_EQ_RESULT(urSamplerGetInfo(nullptr, UR_SAMPLER_INFO_REFERENCE_COUNT,
-                                    sizeof(refcount), &refcount, nullptr),
+                                    sizeof(property_value), &property_value,
+                                    nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidEnumerationInfo) {
-  size_t size = 0;
+  size_t property_size = 0;
   ASSERT_EQ_RESULT(urSamplerGetInfo(sampler, UR_SAMPLER_INFO_FORCE_UINT32, 0,
-                                    nullptr, &size),
+                                    nullptr, &property_size),
                    UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
@@ -125,17 +128,18 @@ TEST_P(urSamplerGetInfoTest, InvalidNullPointerPropValue) {
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidSizePropSizeZero) {
-  ur_sampler_addressing_mode_t mode = UR_SAMPLER_ADDRESSING_MODE_NONE;
+  ur_sampler_addressing_mode_t property_value = UR_SAMPLER_ADDRESSING_MODE_NONE;
   ASSERT_EQ_RESULT(urSamplerGetInfo(sampler, UR_SAMPLER_INFO_ADDRESSING_MODE, 0,
-                                    &mode, nullptr),
+                                    &property_value, nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urSamplerGetInfoTest, InvalidSizePropSizeSmall) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::LevelZeroV2{});
-  ur_sampler_addressing_mode_t mode = UR_SAMPLER_ADDRESSING_MODE_NONE;
+  ur_sampler_addressing_mode_t property_value = UR_SAMPLER_ADDRESSING_MODE_NONE;
 
   ASSERT_EQ_RESULT(urSamplerGetInfo(sampler, UR_SAMPLER_INFO_ADDRESSING_MODE,
-                                    sizeof(mode) - 1, &mode, nullptr),
+                                    sizeof(property_value) - 1, &property_value,
+                                    nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
 }

--- a/test/conformance/testing/include/uur/checks.h
+++ b/test/conformance/testing/include/uur/checks.h
@@ -30,6 +30,29 @@ inline std::ostream &operator<<(std::ostream &out, const Result &result) {
   return out;
 }
 
+inline bool stringPropertyIsValid(const char *property,
+                                  const size_t property_size) {
+  if (!property) {
+    return property_size == 0;
+  }
+
+  if (property_size == 1) {
+    return property[0] == '\0';
+  }
+
+  if (property[property_size - 1] != '\0') {
+    return false;
+  }
+
+  for (size_t i = 0; i < property_size - 1; i++) {
+    if (property[i] == '\0') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 } // namespace uur
 
 #ifndef ASSERT_EQ_RESULT
@@ -68,5 +91,16 @@ inline std::ostream &operator<<(std::ostream &out,
   out << uur::GetDeviceName(device);
   return out;
 }
+
+#ifndef ASSERT_QUERY_RETURNS_VALUE
+#define ASSERT_QUERY_RETURNS_VALUE(CALL, PROPERTY_VALUE)                       \
+  do {                                                                         \
+    ASSERT_SUCCESS(CALL);                                                      \
+    auto returned_value = PROPERTY_VALUE;                                      \
+    PROPERTY_VALUE = 1;                                                        \
+    ASSERT_SUCCESS(CALL);                                                      \
+    ASSERT_EQ(PROPERTY_VALUE, returned_value);                                 \
+  } while (0)
+#endif
 
 #endif // UR_CONFORMANCE_INCLUDE_CHECKS_H_INCLUDED

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -28,7 +28,7 @@ TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
   size_t property_size = 0;
-  ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_POOL;
+  const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_POOL;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMGetMemAllocInfo(context, ptr, property_name, 0, nullptr,
@@ -36,11 +36,11 @@ TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
       property_name);
   ASSERT_EQ(sizeof(ur_usm_pool_handle_t), property_size);
 
-  ur_usm_pool_handle_t returned_pool = nullptr;
+  ur_usm_pool_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, property_name,
-                                      property_size, &returned_pool, nullptr));
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(returned_pool, pool);
+  ASSERT_EQ(property_value, pool);
 }
 
 using urUSMGetMemAllocInfoTest = uur::urUSMDeviceAllocTest;
@@ -50,7 +50,7 @@ TEST_P(urUSMGetMemAllocInfoTest, SuccessType) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
   size_t property_size = 0;
-  ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_TYPE;
+  const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_TYPE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMGetMemAllocInfo(context, ptr, property_name, 0, nullptr,
@@ -58,18 +58,18 @@ TEST_P(urUSMGetMemAllocInfoTest, SuccessType) {
       property_name);
   ASSERT_EQ(sizeof(ur_usm_type_t), property_size);
 
-  ur_usm_type_t returned_type = UR_USM_TYPE_FORCE_UINT32;
+  ur_usm_type_t property_value = UR_USM_TYPE_FORCE_UINT32;
   ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, property_name,
-                                      property_size, &returned_type, nullptr));
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(returned_type, UR_USM_TYPE_DEVICE);
+  ASSERT_EQ(property_value, UR_USM_TYPE_DEVICE);
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, SuccessBasePtr) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
   size_t property_size = 0;
-  ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_BASE_PTR;
+  const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_BASE_PTR;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMGetMemAllocInfo(context, ptr, property_name, 0, nullptr,
@@ -77,18 +77,18 @@ TEST_P(urUSMGetMemAllocInfoTest, SuccessBasePtr) {
       property_name);
   ASSERT_GT(property_size, 0);
 
-  void *returned_ptr = nullptr;
+  void *property_value = nullptr;
   ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, property_name,
-                                      property_size, &returned_ptr, nullptr));
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(returned_ptr, ptr);
+  ASSERT_EQ(property_value, ptr);
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
   size_t property_size = 0;
-  ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_SIZE;
+  const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_SIZE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMGetMemAllocInfo(context, ptr, property_name, 0, nullptr,
@@ -96,18 +96,20 @@ TEST_P(urUSMGetMemAllocInfoTest, SuccessSize) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  size_t returned_size = 0;
-  ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, property_name,
-                                      property_size, &returned_size, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urUSMGetMemAllocInfo(context, ptr, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 
-  ASSERT_GE(returned_size, allocation_size);
+  ASSERT_GE(property_value, allocation_size);
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, SuccessDevice) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
   size_t property_size = 0;
-  ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_DEVICE;
+  const ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_DEVICE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMGetMemAllocInfo(context, ptr, property_name, 0, nullptr,
@@ -115,49 +117,49 @@ TEST_P(urUSMGetMemAllocInfoTest, SuccessDevice) {
       property_name);
   ASSERT_EQ(sizeof(ur_device_handle_t), property_size);
 
-  ur_device_handle_t returned_device = nullptr;
-  ASSERT_SUCCESS(urUSMGetMemAllocInfo(
-      context, ptr, property_name, property_size, &returned_device, nullptr));
+  ur_device_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urUSMGetMemAllocInfo(context, ptr, property_name,
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(returned_device, device);
+  ASSERT_EQ(property_value, device);
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullHandleContext) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_usm_type_t USMType = UR_USM_TYPE_FORCE_UINT32;
+  ur_usm_type_t property_value = UR_USM_TYPE_FORCE_UINT32;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_NULL_HANDLE,
       urUSMGetMemAllocInfo(nullptr, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32,
-                           sizeof(ur_usm_type_t), &USMType, nullptr));
+                           sizeof(ur_usm_type_t), &property_value, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidNullPointerMem) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_usm_type_t USMType = UR_USM_TYPE_FORCE_UINT32;
+  ur_usm_type_t property_value = UR_USM_TYPE_FORCE_UINT32;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_NULL_POINTER,
       urUSMGetMemAllocInfo(context, nullptr, UR_USM_ALLOC_INFO_FORCE_UINT32,
-                           sizeof(ur_usm_type_t), &USMType, nullptr));
+                           sizeof(ur_usm_type_t), &property_value, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidEnumeration) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_usm_type_t USMType = UR_USM_TYPE_FORCE_UINT32;
+  ur_usm_type_t property_value = UR_USM_TYPE_FORCE_UINT32;
   ASSERT_EQ_RESULT(
       UR_RESULT_ERROR_INVALID_ENUMERATION,
       urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_FORCE_UINT32,
-                           sizeof(ur_usm_type_t), &USMType, nullptr));
+                           sizeof(ur_usm_type_t), &property_value, nullptr));
 }
 
 TEST_P(urUSMGetMemAllocInfoTest, InvalidValuePropSize) {
   UUR_KNOWN_FAILURE_ON(uur::NativeCPU{});
 
-  ur_usm_type_t USMType = UR_USM_TYPE_FORCE_UINT32;
+  ur_usm_type_t property_value = UR_USM_TYPE_FORCE_UINT32;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                    urUSMGetMemAllocInfo(context, ptr, UR_USM_ALLOC_INFO_TYPE,
-                                        sizeof(ur_usm_type_t) - 1, &USMType,
-                                        nullptr));
+                                        sizeof(ur_usm_type_t) - 1,
+                                        &property_value, nullptr));
 }

--- a/test/conformance/usm/urUSMPoolGetInfo.cpp
+++ b/test/conformance/usm/urUSMPoolGetInfo.cpp
@@ -11,65 +11,67 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urUSMPoolGetInfoTest);
 
 TEST_P(urUSMPoolGetInfoTest, SuccessReferenceCount) {
   size_t property_size = 0;
-  ur_usm_pool_info_t property_name = UR_USM_POOL_INFO_REFERENCE_COUNT;
+  const ur_usm_pool_info_t property_name = UR_USM_POOL_INFO_REFERENCE_COUNT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMPoolGetInfo(pool, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(uint32_t), property_size);
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urUSMPoolGetInfo(pool, property_name, property_size,
-                                  &returned_reference_count, nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urUSMPoolGetInfo(pool, property_name,
+                                              property_size, &property_value,
+                                              nullptr),
+                             property_value);
 
-  ASSERT_GT(returned_reference_count, 0U);
+  ASSERT_GT(property_value, 0U);
 }
 
 TEST_P(urUSMPoolGetInfoTest, SuccessContext) {
   size_t property_size = 0;
-  ur_usm_pool_info_t property_name = UR_USM_POOL_INFO_CONTEXT;
+  const ur_usm_pool_info_t property_name = UR_USM_POOL_INFO_CONTEXT;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
       urUSMPoolGetInfo(pool, property_name, 0, nullptr, &property_size),
       property_name);
   ASSERT_EQ(sizeof(ur_context_handle_t), property_size);
 
-  ur_context_handle_t returned_context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_SUCCESS(urUSMPoolGetInfo(pool, property_name, property_size,
-                                  &returned_context, nullptr));
+                                  &property_value, nullptr));
 
-  ASSERT_EQ(context, returned_context);
+  ASSERT_EQ(context, property_value);
 }
 
 TEST_P(urUSMPoolGetInfoTest, InvalidNullHandlePool) {
-  ur_context_handle_t context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
                    urUSMPoolGetInfo(nullptr, UR_USM_POOL_INFO_CONTEXT,
-                                    sizeof(ur_context_handle_t), &context,
-                                    nullptr));
+                                    sizeof(ur_context_handle_t),
+                                    &property_value, nullptr));
 }
 
 TEST_P(urUSMPoolGetInfoTest, InvalidEnumerationProperty) {
-  ur_context_handle_t context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,
                    urUSMPoolGetInfo(pool, UR_USM_POOL_INFO_FORCE_UINT32,
-                                    sizeof(ur_context_handle_t), &context,
-                                    nullptr));
+                                    sizeof(ur_context_handle_t),
+                                    &property_value, nullptr));
 }
 
 TEST_P(urUSMPoolGetInfoTest, InvalidSizeZero) {
-  ur_context_handle_t context = nullptr;
-  ASSERT_EQ_RESULT(
-      UR_RESULT_ERROR_INVALID_SIZE,
-      urUSMPoolGetInfo(pool, UR_USM_POOL_INFO_CONTEXT, 0, &context, nullptr));
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                   urUSMPoolGetInfo(pool, UR_USM_POOL_INFO_CONTEXT, 0,
+                                    &property_value, nullptr));
 }
 
 TEST_P(urUSMPoolGetInfoTest, InvalidSizeTooSmall) {
-  ur_context_handle_t context = nullptr;
+  ur_context_handle_t property_value = nullptr;
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
                    urUSMPoolGetInfo(pool, UR_USM_POOL_INFO_CONTEXT,
-                                    sizeof(ur_context_handle_t) - 1, &context,
-                                    nullptr));
+                                    sizeof(ur_context_handle_t) - 1,
+                                    &property_value, nullptr));
 }
 
 TEST_P(urUSMPoolGetInfoTest, InvalidNullPointerPropValue) {

--- a/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urPhysicalMemGetInfo.cpp
@@ -9,10 +9,16 @@
 using urPhysicalMemGetInfoTest = uur::urPhysicalMemTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urPhysicalMemGetInfoTest);
 
+bool operator==(ur_physical_mem_properties_t lhs,
+                ur_physical_mem_properties_t rhs) {
+  return lhs.flags == rhs.flags && lhs.pNext == rhs.pNext &&
+         lhs.stype == rhs.stype;
+}
+
 TEST_P(urPhysicalMemGetInfoTest, SuccessContext) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_CONTEXT;
+  const ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_CONTEXT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -21,17 +27,17 @@ TEST_P(urPhysicalMemGetInfoTest, SuccessContext) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  ur_context_handle_t returned_context = nullptr;
-  ASSERT_SUCCESS(urPhysicalMemGetInfo(
-      physical_mem, property_name, property_size, &returned_context, nullptr));
+  ur_context_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(context, returned_context);
+  ASSERT_EQ(context, property_value);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, SuccessDevice) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_DEVICE;
+  const ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_DEVICE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -40,17 +46,17 @@ TEST_P(urPhysicalMemGetInfoTest, SuccessDevice) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  ur_device_handle_t returned_device = nullptr;
-  ASSERT_SUCCESS(urPhysicalMemGetInfo(
-      physical_mem, property_name, property_size, &returned_device, nullptr));
+  ur_device_handle_t property_value = nullptr;
+  ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(device, returned_device);
+  ASSERT_EQ(device, property_value);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, SuccessSize) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_SIZE;
+  const ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_SIZE;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -59,17 +65,19 @@ TEST_P(urPhysicalMemGetInfoTest, SuccessSize) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  size_t returned_size = 0;
-  ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
-                                      property_size, &returned_size, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urPhysicalMemGetInfo(physical_mem, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 
-  ASSERT_EQ(size, returned_size);
+  ASSERT_EQ(size, property_value);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, SuccessProperties) {
   UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
-  ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_PROPERTIES;
+  const ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_PROPERTIES;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -78,18 +86,16 @@ TEST_P(urPhysicalMemGetInfoTest, SuccessProperties) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  ur_physical_mem_properties_t returned_properties = {};
+  ur_physical_mem_properties_t property_value = {};
   ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
-                                      property_size, &returned_properties,
-                                      nullptr));
+                                      property_size, &property_value, nullptr));
 
-  ASSERT_EQ(properties.stype, returned_properties.stype);
-  ASSERT_EQ(properties.pNext, returned_properties.pNext);
-  ASSERT_EQ(properties.flags, returned_properties.flags);
+  ASSERT_EQ(properties, property_value);
 }
 
 TEST_P(urPhysicalMemGetInfoTest, SuccessReferenceCount) {
-  ur_physical_mem_info_t property_name = UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT;
+  const ur_physical_mem_info_t property_name =
+      UR_PHYSICAL_MEM_INFO_REFERENCE_COUNT;
   size_t property_size = 0;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -98,10 +104,11 @@ TEST_P(urPhysicalMemGetInfoTest, SuccessReferenceCount) {
       property_name);
   ASSERT_NE(property_size, 0);
 
-  uint32_t returned_reference_count = 0;
-  ASSERT_SUCCESS(urPhysicalMemGetInfo(physical_mem, property_name,
-                                      property_size, &returned_reference_count,
-                                      nullptr));
+  uint32_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(urPhysicalMemGetInfo(physical_mem, property_name,
+                                                  property_size,
+                                                  &property_value, nullptr),
+                             property_value);
 
-  ASSERT_EQ(returned_reference_count, 1);
+  ASSERT_EQ(property_value, 1);
 }

--- a/test/conformance/virtual_memory/urVirtualMemGetInfo.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemGetInfo.cpp
@@ -10,7 +10,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemGetInfoTest);
 
 TEST_P(urVirtualMemGetInfoTest, SuccessAccessMode) {
   size_t property_size = 0;
-  ur_virtual_mem_info_t property_name = UR_VIRTUAL_MEM_INFO_ACCESS_MODE;
+  const ur_virtual_mem_info_t property_name = UR_VIRTUAL_MEM_INFO_ACCESS_MODE;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(urVirtualMemGetInfo(context, virtual_ptr,
                                                        size, property_name, 0,
@@ -18,27 +18,28 @@ TEST_P(urVirtualMemGetInfoTest, SuccessAccessMode) {
                                    property_name);
   ASSERT_NE(property_size, 0);
 
-  ur_virtual_mem_access_flags_t returned_flags =
+  ur_virtual_mem_access_flags_t property_value =
       UR_VIRTUAL_MEM_ACCESS_FLAG_FORCE_UINT32;
   ASSERT_SUCCESS(urVirtualMemGetInfo(context, virtual_ptr, size, property_name,
-                                     property_size, &returned_flags, nullptr));
+                                     property_size, &property_value, nullptr));
 
-  ASSERT_TRUE(returned_flags & UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE);
+  ASSERT_TRUE(property_value & UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE);
 }
 
 TEST_P(urVirtualMemGetInfoTest, InvalidNullHandleContext) {
-  ur_virtual_mem_access_flags_t flags = 0;
+  ur_virtual_mem_access_flags_t property_value = 0;
   ASSERT_EQ_RESULT(urVirtualMemGetInfo(nullptr, virtual_ptr, size,
                                        UR_VIRTUAL_MEM_INFO_ACCESS_MODE,
-                                       sizeof(flags), &flags, nullptr),
+                                       sizeof(property_value), &property_value,
+                                       nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
 TEST_P(urVirtualMemGetInfoTest, InvalidNullPointerStart) {
-  ur_virtual_mem_access_flags_t flags = 0;
-  ASSERT_EQ_RESULT(urVirtualMemGetInfo(context, nullptr, size,
-                                       UR_VIRTUAL_MEM_INFO_ACCESS_MODE,
-                                       sizeof(flags), &flags, nullptr),
+  ur_virtual_mem_access_flags_t property_value = 0;
+  ASSERT_EQ_RESULT(urVirtualMemGetInfo(
+                       context, nullptr, size, UR_VIRTUAL_MEM_INFO_ACCESS_MODE,
+                       sizeof(property_value), &property_value, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 

--- a/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
+++ b/test/conformance/virtual_memory/urVirtualMemGranularityGetInfo.cpp
@@ -24,7 +24,7 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urVirtualMemGranularityGetInfoTest);
 
 TEST_P(urVirtualMemGranularityGetInfoTest, SuccessMinimum) {
   size_t property_size = 0;
-  ur_virtual_mem_granularity_info_t property_name =
+  const ur_virtual_mem_granularity_info_t property_name =
       UR_VIRTUAL_MEM_GRANULARITY_INFO_MINIMUM;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -33,17 +33,18 @@ TEST_P(urVirtualMemGranularityGetInfoTest, SuccessMinimum) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  uint32_t returned_minimum = 0;
-  ASSERT_SUCCESS(urVirtualMemGranularityGetInfo(context, device, property_name,
-                                                property_size,
-                                                &returned_minimum, nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urVirtualMemGranularityGetInfo(context, device, property_name,
+                                     property_size, &property_value, nullptr),
+      property_value);
 
-  ASSERT_GT(returned_minimum, 0);
+  ASSERT_GT(property_value, 0);
 }
 
 TEST_P(urVirtualMemGranularityGetInfoTest, SuccessRecommended) {
   size_t property_size = 0;
-  ur_virtual_mem_granularity_info_t property_name =
+  const ur_virtual_mem_granularity_info_t property_name =
       UR_VIRTUAL_MEM_GRANULARITY_INFO_RECOMMENDED;
 
   ASSERT_SUCCESS_OR_OPTIONAL_QUERY(
@@ -52,12 +53,13 @@ TEST_P(urVirtualMemGranularityGetInfoTest, SuccessRecommended) {
       property_name);
   ASSERT_EQ(sizeof(size_t), property_size);
 
-  uint32_t returned_recommended = 0;
-  ASSERT_SUCCESS(urVirtualMemGranularityGetInfo(
-      context, device, property_name, property_size, &returned_recommended,
-      nullptr));
+  size_t property_value = 0;
+  ASSERT_QUERY_RETURNS_VALUE(
+      urVirtualMemGranularityGetInfo(context, device, property_name,
+                                     property_size, &property_value, nullptr),
+      property_value);
 
-  ASSERT_GT(returned_recommended, 0);
+  ASSERT_GT(property_value, 0);
 }
 
 TEST_P(urVirtualMemGranularityGetInfoTest, InvalidNullHandleContext) {


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/issues/2290

Also done a housekeeping pass across all urXGetInfo tests, renaming and adding consts where appropriate, and adding extra checks to tests with vectors.