### PR TITLE
Enable cmd-buf local memory update CTS tests on L0

### DIFF
--- a/test/conformance/exp_command_buffer/update/local_memory_update.cpp
+++ b/test/conformance/exp_command_buffer/update/local_memory_update.cpp
@@ -17,11 +17,6 @@ struct LocalMemoryUpdateTestBase
     UUR_RETURN_ON_FATAL_FAILURE(
         urUpdatableCommandBufferExpExecutionTest::SetUp());
 
-    if (backend == UR_PLATFORM_BACKEND_LEVEL_ZERO) {
-      GTEST_SKIP()
-          << "Local memory argument update not supported on Level Zero.";
-    }
-
     // HIP has extra args for local memory so we define an offset for arg
     // indices here for updating
     hip_arg_offset = backend == UR_PLATFORM_BACKEND_HIP ? 3 : 0;
@@ -391,6 +386,8 @@ TEST_P(LocalMemoryUpdateTest, UpdateParametersEmptyLocalSize) {
 // Test updating A,X,Y parameters to new values and local memory parameters
 // to new smaller values.
 TEST_P(LocalMemoryUpdateTest, UpdateParametersSmallerLocalSize) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
+
   // Run command-buffer prior to update an verify output
   ASSERT_SUCCESS(urCommandBufferEnqueueExp(updatable_cmd_buf_handle, queue, 0,
                                            nullptr, nullptr));


### PR DESCRIPTION
The CTS tests for updating local memory in command-buffer kernel commands are currently skipped on Level-Zero. This feature is now available in L0 drivers so the tests can be enabled.

There is a failure in `LocalMemoryUpdateTest.UpdateParametersSmallerLocalSize` with incorrect results. Mark the individual test as failed as it needs further investigation.