### PR TITLE
[L0] Enable Copy engine support with in-order command lists

### DIFF
--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -477,7 +477,7 @@ void ur_exp_command_buffer_handle_t_::registerSyncPoint(
 
 ze_command_list_handle_t
 ur_exp_command_buffer_handle_t_::chooseCommandList(bool PreferCopyEngine) {
-  if (PreferCopyEngine && this->useCopyEngine() && !this->IsInOrderCmdList) {
+  if (PreferCopyEngine && this->useCopyEngine()) {
     // We indicate that ZeCopyCommandList contains commands to be submitted.
     this->MCopyCommandListEmpty = false;
     return this->ZeCopyCommandList;
@@ -646,7 +646,7 @@ urCommandBufferCreateExp(ur_context_handle_t Context, ur_device_handle_t Device,
   // the current implementation only uses the main copy engine and does not use
   // the link engine even if available.
   if (Device->hasMainCopyEngine()) {
-    UR_CALL(createMainCommandList(Context, Device, false, false, true,
+    UR_CALL(createMainCommandList(Context, Device, IsInOrder, false, true,
                                   ZeCopyCommandList));
   }
 

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -110,6 +110,11 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // This flag must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
+  // This flag must be set to false if at least one copy command has been
+  // added to `ZeComputeCommandList`
+  bool MComputeCommandListEmpty = true;
+  // This flag tracks if the previous node submission was compute or copy type.
+  bool WasPrevCopyCommandList = false;
   // [WaitEvent Path only] Level Zero fences for each queue the command-buffer
   // has been enqueued to. These should be destroyed when the command-buffer is
   // released.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -45,6 +45,10 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
     return NextSyncPoint;
   }
 
+  bool isFirstNode() const {
+    return MComputeCommandListEmpty && MCopyCommandListEmpty;
+  }
+
   // Indicates if a copy engine is available for use
   bool useCopyEngine() const { return ZeCopyCommandList != nullptr; }
 
@@ -110,11 +114,11 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // This flag must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
-  // This flag must be set to false if at least one copy command has been
+  // This flag must be set to false if at least one compute command has been
   // added to `ZeComputeCommandList`
   bool MComputeCommandListEmpty = true;
   // This flag tracks if the previous node submission was compute or copy type.
-  bool WasPrevCopyCommandList = false;
+  bool MWasPrevCopyCommandList = false;
   // [WaitEvent Path only] Level Zero fences for each queue the command-buffer
   // has been enqueued to. These should be destroyed when the command-buffer is
   // released.

--- a/source/adapters/level_zero/command_buffer.hpp
+++ b/source/adapters/level_zero/command_buffer.hpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#include <optional>
 #include <ur/ur.hpp>
 #include <ur_api.h>
 #include <ze_api.h>
@@ -43,10 +44,6 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
 
   ur_exp_command_buffer_sync_point_t getNextSyncPoint() const {
     return NextSyncPoint;
-  }
-
-  bool isFirstNode() const {
-    return MComputeCommandListEmpty && MCopyCommandListEmpty;
   }
 
   // Indicates if a copy engine is available for use
@@ -114,11 +111,8 @@ struct ur_exp_command_buffer_handle_t_ : public _ur_object {
   // This flag must be set to false if at least one copy command has been
   // added to `ZeCopyCommandList`
   bool MCopyCommandListEmpty = true;
-  // This flag must be set to false if at least one compute command has been
-  // added to `ZeComputeCommandList`
-  bool MComputeCommandListEmpty = true;
-  // This flag tracks if the previous node submission was compute or copy type.
-  bool MWasPrevCopyCommandList = false;
+  // This flag tracks if the previous node submission was of a copy type.
+  std::optional<bool> MWasPrevCopyCommandList;
   // [WaitEvent Path only] Level Zero fences for each queue the command-buffer
   // has been enqueued to. These should be destroyed when the command-buffer is
   // released.


### PR DESCRIPTION
Currently, copy engine is only available to use for certain commands in the out-of-order command-buffer path. This PR adds required synchronization between the 2 command lists, when both are in-order. Hence, it enables using the copy engine with in-order path. 

For the immediateAppend path, this only works for now if the environment variable `UR_L0_USE_DRIVER_COUNTER_BASED_EVENTS=0` is set. 

[intel/llvm PR](https://github.com/intel/llvm/pull/16830)