### PR TITLE
added filename and line number to logs

### DIFF
--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -48,7 +48,7 @@ namespace ur_tracing_layer
         uint64_t instance = getContext()->notify_begin(${th.make_func_etor(n, tags, obj)}, "${th.make_func_name(n, tags, obj)}", &params);
 
         auto &logger = getContext()->logger;
-        logger.info("   ---> ${th.make_func_name(n, tags, obj)}\n");
+        URLOG_(logger, INFO, "   ---> ${th.make_func_name(n, tags, obj)}\n");
 
         ${x}_result_t result = ${th.make_pfn_name(n, tags, obj)}( ${", ".join(th.make_param_lines(n, tags, obj, format=["name"]))} );
 
@@ -57,7 +57,7 @@ namespace ur_tracing_layer
         if (logger.getLevel() <= logger::Level::INFO) {
             std::ostringstream args_str;
             ur::extras::printFunctionParams(args_str, ${th.make_func_etor(n, tags, obj)}, &params);
-            logger.info("   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);
+            URLOG_(logger, INFO "   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);
         }
 
         return result;

--- a/scripts/templates/trcddi.cpp.mako
+++ b/scripts/templates/trcddi.cpp.mako
@@ -57,7 +57,7 @@ namespace ur_tracing_layer
         if (logger.getLevel() <= logger::Level::INFO) {
             std::ostringstream args_str;
             ur::extras::printFunctionParams(args_str, ${th.make_func_etor(n, tags, obj)}, &params);
-            URLOG_(logger, INFO "   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);
+            URLOG_(logger, INFO, "   <--- ${th.make_func_name(n, tags, obj)}({}) -> {};\n", args_str.str(), result);
         }
 
         return result;

--- a/scripts/templates/valddi.cpp.mako
+++ b/scripts/templates/valddi.cpp.mako
@@ -91,7 +91,7 @@ namespace ur_validation_layer
             %>
             %if tp_input_handle_funcs and not is_related_create_get_retain_release_func:
             if (getContext()->enableLifetimeValidation && !getContext()->refCountContext->isReferenceValid(${tp['name']})) {
-                getContext()->refCountContext->logInvalidReference(${tp['name']});
+                URLOG_CTX_INVALID_REFERENCE(${tp['name']});
             }
             %endif
             %endfor
@@ -232,7 +232,7 @@ namespace ur_validation_layer
 
     ${x}_result_t context_t::tearDown() {
         if (enableLeakChecking) {
-            getContext()->refCountContext->logInvalidReferences();
+            URLOG_CTX_INVALID_REFERENCES();
         }
         
         return ${X}_RESULT_SUCCESS;

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 add_definitions(-DUR_VERSION="${PROJECT_VERSION_MAJOR}")
 add_definitions(-DUR_VALIDATION_LAYER_SUPPORTED_VERSION="${PROJECT_VERSION_MAJOR}")
+string(LENGTH "${CMAKE_SOURCE_DIR}/" SRC_PATH_SIZE)
+add_definitions("-DSRC_PATH_SIZE=${SRC_PATH_SIZE}")  # for nicer log messages
 
 add_subdirectory(common)
 add_subdirectory(loader)

--- a/source/adapters/cuda/command_buffer.hpp
+++ b/source/adapters/cuda/command_buffer.hpp
@@ -29,10 +29,10 @@
 #define UR_CALL(Call, Result)                                                  \
   {                                                                            \
     if (PrintTrace)                                                            \
-      logger::always("UR ---> {}", #Call);                                     \
+      URLOG_ALWAYS("UR ---> {}", #Call);                                       \
     Result = (Call);                                                           \
     if (PrintTrace)                                                            \
-      logger::always("UR <--- {}({})", #Call, Result);                         \
+      URLOG_ALWAYS("UR <--- {}({})", #Call, Result);                           \
   }
 
 enum class CommandType {

--- a/source/adapters/cuda/common.cpp
+++ b/source/adapters/cuda/common.cpp
@@ -53,7 +53,7 @@ void checkErrorUR(CUresult Result, const char *Function, int Line,
      << "\n\tDescription:     " << ErrorString
      << "\n\tFunction:        " << Function << "\n\tSource Location: " << File
      << ":" << Line << "\n";
-  logger::error("{}", SS.str());
+  URLOG(ERR, "{}", SS.str());
 
   if (std::getenv("PI_CUDA_ABORT") != nullptr ||
       std::getenv("UR_CUDA_ABORT") != nullptr) {
@@ -73,7 +73,7 @@ void checkErrorUR(ur_result_t Result, const char *Function, int Line,
   SS << "\nUR ERROR:"
      << "\n\tValue:           " << Result << "\n\tFunction:        " << Function
      << "\n\tSource Location: " << File << ":" << Line << "\n";
-  logger::error("{}", SS.str());
+  URLOG(ERR, "{}", SS.str());
 
   if (std::getenv("PI_CUDA_ABORT") != nullptr) {
     std::abort();
@@ -93,7 +93,7 @@ std::string getCudaVersionString() {
 }
 
 void detail::ur::die(const char *Message) {
-  logger::always("ur_die:{}", Message);
+  URLOG_ALWAYS("ur_die:{}", Message);
   std::terminate();
 }
 

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -290,7 +290,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
         std::getenv("UR_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
       Enabled = true;
     } else {
-      logger::always(
+      URLOG_ALWAYS(
           "Images are not fully supported by the CUDA BE, their support is "
           "disabled by default. Their partial support can be activated by "
           "setting UR_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "

--- a/source/adapters/cuda/image.cpp
+++ b/source/adapters/cuda/image.cpp
@@ -801,8 +801,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
       // we don't support copying between different image types.
       if (pSrcImageDesc->type != pDstImageDesc->type) {
-        logger::error(
-            "Unsupported copy operation between different type of images");
+        URLOG(ERR,
+              "Unsupported copy operation between different type of images");
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
       }
 

--- a/source/adapters/hip/common.cpp
+++ b/source/adapters/hip/common.cpp
@@ -86,7 +86,7 @@ void checkErrorUR(amd_comgr_status_t Result, const char *Function, int Line,
      << "\n\tDescription:     " << ErrorString
      << "\n\tFunction:        " << Function << "\n\tSource Location: " << File
      << ":" << Line << "\n";
-  logger::error("{}", SS.str());
+  URLOG(ERR, "{}", SS.str());
 
   if (std::getenv("PI_HIP_ABORT") != nullptr ||
       std::getenv("UR_HIP_ABORT") != nullptr) {
@@ -113,7 +113,7 @@ void checkErrorUR(hipError_t Result, const char *Function, int Line,
      << "\n\tDescription:     " << ErrorString
      << "\n\tFunction:        " << Function << "\n\tSource Location: " << File
      << ":" << Line << "\n";
-  logger::error("{}", SS.str());
+  URLOG(ERR, "{}", SS.str());
 
   if (std::getenv("PI_HIP_ABORT") != nullptr ||
       std::getenv("UR_HIP_ABORT") != nullptr) {
@@ -133,7 +133,7 @@ void checkErrorUR(ur_result_t Result, const char *Function, int Line,
   SS << "\nUR HIP ERROR:"
      << "\n\tValue:           " << Result << "\n\tFunction:        " << Function
      << "\n\tSource Location: " << File << ":" << Line << "\n";
-  logger::error("{}", SS.str());
+  URLOG(ERR, "{}", SS.str());
 
   if (std::getenv("PI_HIP_ABORT") != nullptr ||
       std::getenv("UR_HIP_ABORT") != nullptr) {
@@ -157,7 +157,7 @@ hipError_t getHipVersionString(std::string &Version) {
 }
 
 void detail::ur::die(const char *pMessage) {
-  logger::always("ur_die: {}", pMessage);
+  URLOG_ALWAYS("ur_die: {}", pMessage);
   std::terminate();
 }
 

--- a/source/adapters/hip/device.cpp
+++ b/source/adapters/hip/device.cpp
@@ -231,7 +231,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     if (std::getenv("UR_HIP_ENABLE_IMAGE_SUPPORT") != nullptr) {
       Enabled = true;
     } else {
-      logger::always(
+      URLOG_ALWAYS(
           "Images are not fully supported by the HIP BE, their support is "
           "disabled by default. Their partial support can be activated by "
           "setting UR_HIP_ENABLE_IMAGE_SUPPORT environment variable at "

--- a/source/adapters/hip/image.cpp
+++ b/source/adapters/hip/image.cpp
@@ -825,8 +825,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
       // we don't support copying between different image types.
       if (pSrcImageDesc->type != pDstImageDesc->type) {
-        logger::error(
-            "Unsupported copy operation between different type of images");
+        URLOG(ERR,
+              "Unsupported copy operation between different type of images");
         return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
       }
 

--- a/source/adapters/level_zero/adapter.cpp
+++ b/source/adapters/level_zero/adapter.cpp
@@ -163,7 +163,7 @@ ur_result_t initPlatforms(PlatformVec &platforms,
     ZE2UR_CALL(zeDriverGet, (&ZeDriverGetCount, ZeDriverGetHandles.data()));
   }
   if (ZeDriverGetCount == 0 && GlobalAdapter->ZeInitDriversCount == 0) {
-    logger::error("\nNo Valid L0 Drivers found.\n");
+    URLOG(ERR, "\nNo Valid L0 Drivers found.\n");
     return UR_RESULT_SUCCESS;
   }
 
@@ -188,9 +188,10 @@ ur_result_t initPlatforms(PlatformVec &platforms,
           // newer drivers.
           if (ZeDriverGetProperties.driverVersion !=
               ZeInitDriverProperties.driverVersion) {
-            logger::debug("\nzeDriverHandle {} added to the zeInitDrivers list "
-                          "of possible handles.\n",
-                          ZeDriverGetHandles[Y]);
+            URLOG(DEBUG,
+                  "\nzeDriverHandle {} added to the zeInitDrivers list "
+                  "of possible handles.\n",
+                  ZeDriverGetHandles[Y]);
             ZeDrivers.push_back(ZeDriverGetHandles[Y]);
           }
         }
@@ -201,7 +202,7 @@ ur_result_t initPlatforms(PlatformVec &platforms,
     ZeDrivers.assign(ZeDriverGetHandles.begin(), ZeDriverGetHandles.end());
   }
   ZeDriverCount = ZeDrivers.size();
-  logger::debug("\n{} L0 Drivers found.\n", ZeDriverCount);
+  URLOG(DEBUG, "\n{} L0 Drivers found.\n", ZeDriverCount);
   for (uint32_t I = 0; I < ZeDriverCount; ++I) {
     // Keep track of the first platform init for this Driver
     bool DriverPlatformInit = false;
@@ -351,8 +352,8 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
       }
 
       if (getenv("SYCL_ENABLE_PCI") != nullptr) {
-        logger::warning(
-            "WARNING: SYCL_ENABLE_PCI is deprecated and no longer needed.\n");
+        URLOG(WARN,
+              "WARNING: SYCL_ENABLE_PCI is deprecated and no longer needed.\n");
       }
 
       // TODO: We can still safely recover if something goes wrong during the
@@ -373,13 +374,13 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
       if (UrL0InitAllDrivers) {
         L0InitFlags |= ZE_INIT_FLAG_VPU_ONLY;
       }
-      logger::debug("\nzeInit with flags value of {}\n",
-                    static_cast<int>(L0InitFlags));
+      URLOG(DEBUG, "\nzeInit with flags value of {}\n",
+            static_cast<int>(L0InitFlags));
       GlobalAdapter->ZeInitResult = ZE_CALL_NOCHECK(zeInit, (L0InitFlags));
       if (GlobalAdapter->ZeInitResult != ZE_RESULT_SUCCESS) {
         const char *ErrorString = "Unknown";
         zeParseError(GlobalAdapter->ZeInitResult, ErrorString);
-        logger::error("\nzeInit failed with {}\n", ErrorString);
+        URLOG(ERR, "\nzeInit failed with {}\n", ErrorString);
       }
 
       bool useInitDrivers = false;
@@ -395,9 +396,9 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
             if (strncmp(versions[i].component_name, "loader",
                         strlen("loader")) == 0) {
               loader_version = versions[i].component_lib_version;
-              logger::debug("\nLevel Zero Loader Version: {}.{}.{}\n",
-                            loader_version.major, loader_version.minor,
-                            loader_version.patch);
+              URLOG(DEBUG, "\nLevel Zero Loader Version: {}.{}.{}\n",
+                    loader_version.major, loader_version.minor,
+                    loader_version.patch);
               break;
             }
           }
@@ -416,8 +417,8 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
             (ze_pfnInitDrivers_t)ur_loader::LibLoader::getFunctionPtr(
                 processHandle, "zeInitDrivers");
         if (GlobalAdapter->initDriversFunctionPtr) {
-          logger::debug("\nzeInitDrivers with flags value of {}\n",
-                        static_cast<int>(GlobalAdapter->InitDriversDesc.flags));
+          URLOG(DEBUG, "\nzeInitDrivers with flags value of {}\n",
+                static_cast<int>(GlobalAdapter->InitDriversDesc.flags));
           GlobalAdapter->ZeInitDriversResult =
               ZE_CALL_NOCHECK(GlobalAdapter->initDriversFunctionPtr,
                               (&GlobalAdapter->ZeInitDriversCount, nullptr,
@@ -427,7 +428,7 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
           } else {
             const char *ErrorString = "Unknown";
             zeParseError(GlobalAdapter->ZeInitDriversResult, ErrorString);
-            logger::error("\nzeInitDrivers failed with {}\n", ErrorString);
+            URLOG(ERR, "\nzeInitDrivers failed with {}\n", ErrorString);
           }
         }
       }
@@ -445,12 +446,12 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
 
     // Absorb the ZE_RESULT_ERROR_UNINITIALIZED and just return 0 Platforms.
     if (*GlobalAdapter->ZeResult == ZE_RESULT_ERROR_UNINITIALIZED) {
-      logger::error("Level Zero Uninitialized\n");
+      URLOG(ERR, "Level Zero Uninitialized\n");
       result = std::move(platforms);
       return;
     }
     if (*GlobalAdapter->ZeResult != ZE_RESULT_SUCCESS) {
-      logger::error("Level Zero initialization failure\n");
+      URLOG(ERR, "Level Zero initialization failure\n");
       result = ze2urResult(*GlobalAdapter->ZeResult);
 
       return;
@@ -499,8 +500,8 @@ ur_adapter_handle_t_::ur_adapter_handle_t_()
         GlobalAdapter->getSysManDriversFunctionPtr &&
         GlobalAdapter->sysManInitFunctionPtr) {
       ze_init_flags_t L0ZesInitFlags = 0;
-      logger::debug("\nzesInit with flags value of {}\n",
-                    static_cast<int>(L0ZesInitFlags));
+      URLOG(DEBUG, "\nzesInit with flags value of {}\n",
+            static_cast<int>(L0ZesInitFlags));
       GlobalAdapter->ZesResult = ZE_CALL_NOCHECK(
           GlobalAdapter->sysManInitFunctionPtr, (L0ZesInitFlags));
     } else {

--- a/source/adapters/level_zero/command_buffer.cpp
+++ b/source/adapters/level_zero/command_buffer.cpp
@@ -18,7 +18,7 @@ https://github.com/intel/llvm/blob/sycl/sycl/doc/design/CommandGraph.md#level-ze
 */
 
 // Print the name of a variable and its value in the L0 debug log
-#define DEBUG_LOG(VAR) logger::debug(#VAR " {}", VAR);
+#define DEBUG_LOG(VAR) URLOG(DEBUG, #VAR " {}", VAR);
 
 namespace {
 
@@ -44,17 +44,19 @@ bool checkImmediateAppendSupport(ur_context_handle_t Context,
     const bool EnableAppendPath = std::atoi(UrRet) == 1;
 
     if (EnableAppendPath && !Device->ImmCommandListUsed) {
-      logger::error("{} is set but immediate command-lists are currently "
-                    "disabled. Immediate command-lists are "
-                    "required to use the immediate append path.",
-                    AppendEnvVarName);
+      URLOG(ERR,
+            "{} is set but immediate command-lists are currently "
+            "disabled. Immediate command-lists are "
+            "required to use the immediate append path.",
+            AppendEnvVarName);
       std::abort();
     }
     if (EnableAppendPath && !DriverSupportsImmediateAppend) {
-      logger::error("{} is set but "
-                    "the current driver does not support the "
-                    "zeCommandListImmediateAppendCommandListsExp entrypoint.",
-                    AppendEnvVarName);
+      URLOG(ERR,
+            "{} is set but "
+            "the current driver does not support the "
+            "zeCommandListImmediateAppendCommandListsExp entrypoint.",
+            AppendEnvVarName);
       std::abort();
     }
 
@@ -1775,7 +1777,7 @@ ur_result_t validateCommandDesc(
   auto SupportedFeatures =
       Command->CommandBuffer->Device->ZeDeviceMutableCmdListsProperties
           ->mutableCommandFlags;
-  logger::debug("Mutable features supported by device {}", SupportedFeatures);
+  URLOG(DEBUG, "Mutable features supported by device {}", SupportedFeatures);
 
   UR_ASSERT(
       !CommandDesc->hNewKernel ||
@@ -1801,7 +1803,7 @@ ur_result_t validateCommandDesc(
   if (NewGlobalWorkOffset) {
     if (!CommandBuffer->Context->getPlatform()
              ->ZeDriverGlobalOffsetExtensionFound) {
-      logger::error("No global offset extension found on this driver");
+      URLOG(ERR, "No global offset extension found on this driver");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }

--- a/source/adapters/level_zero/common.cpp
+++ b/source/adapters/level_zero/common.cpp
@@ -77,8 +77,8 @@ bool setEnvVar(const char *name, const char *value) {
   int Res = setenv(name, value, 1);
 #endif
   if (Res != 0) {
-    logger::debug(
-        "UR L0 Adapter was unable to set the environment variable: {}", name);
+    URLOG(DEBUG, "UR L0 Adapter was unable to set the environment variable: {}",
+          name);
     return false;
   }
   return true;
@@ -139,7 +139,7 @@ void zeParseError(ze_result_t ZeError, const char *&ErrorString) {
 
 ze_result_t ZeCall::doCall(ze_result_t ZeResult, const char *ZeName,
                            const char *ZeArgs, bool TraceError) {
-  logger::debug("ZE ---> {}{}", ZeName, ZeArgs);
+  URLOG(DEBUG, "ZE ---> {}{}", ZeName, ZeArgs);
 
   if (ZeResult == ZE_RESULT_SUCCESS) {
     if (UrL0LeaksDebug) {
@@ -151,7 +151,7 @@ ze_result_t ZeCall::doCall(ze_result_t ZeResult, const char *ZeName,
   if (TraceError) {
     const char *ErrorString = "Unknown";
     zeParseError(ZeResult, ErrorString);
-    logger::error("Error ({}) in {}", ErrorString, ZeName);
+    URLOG(ERR, "Error ({}) in {}", ErrorString, ZeName);
   }
   return ZeResult;
 }

--- a/source/adapters/level_zero/common.hpp
+++ b/source/adapters/level_zero/common.hpp
@@ -174,10 +174,10 @@ static auto getUrResultString = [](ur_result_t Result) {
 #define UR_CALL(Call)                                                          \
   {                                                                            \
     if (PrintTrace)                                                            \
-      logger::always("UR ---> {}", #Call);                                     \
+      URLOG_ALWAYS("UR ---> {}", #Call);                                       \
     ur_result_t Result = (Call);                                               \
     if (PrintTrace)                                                            \
-      logger::always("UR <--- {}({})", #Call, getUrResultString(Result));      \
+      URLOG_ALWAYS("UR <--- {}({})", #Call, getUrResultString(Result));        \
     if (Result != UR_RESULT_SUCCESS)                                           \
       return Result;                                                           \
   }
@@ -186,10 +186,10 @@ static auto getUrResultString = [](ur_result_t Result) {
 #define UR_CALL_THROWS(Call)                                                   \
   {                                                                            \
     if (PrintTrace)                                                            \
-      logger::always("UR ---> {}", #Call);                                     \
+      URLOG_ALWAYS("UR ---> {}", #Call);                                       \
     ur_result_t Result = (Call);                                               \
     if (PrintTrace)                                                            \
-      logger::always("UR <--- {}({})", #Call, getUrResultString(Result));      \
+      URLOG_ALWAYS("UR <--- {}({})", #Call, getUrResultString(Result));        \
     if (Result != UR_RESULT_SUCCESS)                                           \
       throw Result;                                                            \
   }

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -185,8 +185,10 @@ ur_result_t urContextSetExtendedDeleter(
   std::ignore = Context;
   std::ignore = Deleter;
   std::ignore = UserData;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 } // namespace ur::level_zero

--- a/source/adapters/level_zero/context.cpp
+++ b/source/adapters/level_zero/context.cpp
@@ -331,7 +331,8 @@ ur_result_t ur_context_handle_t_::initialize() {
   ZeCommandQueueDesc.mode = ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS;
   if (Device->useDriverInOrderLists() &&
       Device->useDriverCounterBasedEvents()) {
-    logger::debug(
+    URLOG(
+        DEBUG,
         "L0 Synchronous Immediate Command List needed with In Order property.");
     ZeCommandQueueDesc.flags |= ZE_COMMAND_LIST_FLAG_IN_ORDER;
   }
@@ -550,8 +551,8 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
       ZeEventPoolDesc.flags |= ZE_EVENT_POOL_FLAG_HOST_VISIBLE;
     if (ProfilingEnabled)
       ZeEventPoolDesc.flags |= ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP;
-    logger::debug("ze_event_pool_desc_t flags set to: {}",
-                  ZeEventPoolDesc.flags);
+    URLOG(DEBUG, "ze_event_pool_desc_t flags set to: {}",
+          ZeEventPoolDesc.flags);
     if (CounterBasedEventEnabled) {
       if (UsingImmCmdList) {
         counterBasedExt.flags = ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_IMMEDIATE;
@@ -559,8 +560,8 @@ ur_result_t ur_context_handle_t_::getFreeSlotInExistingOrNewPool(
         counterBasedExt.flags =
             ZE_EVENT_POOL_COUNTER_BASED_EXP_FLAG_NON_IMMEDIATE;
       }
-      logger::debug("ze_event_pool_desc_t counter based flags set to: {}",
-                    counterBasedExt.flags);
+      URLOG(DEBUG, "ze_event_pool_desc_t counter based flags set to: {}",
+            counterBasedExt.flags);
       if (InterruptBasedEventEnabled) {
         counterBasedExt.pNext = &eventSyncMode;
       }
@@ -600,10 +601,11 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
       getEventCache(HostVisible, WithProfiling, Device,
                     CounterBasedEventEnabled, InterruptBasedEventEnabled);
   if (Cache->empty()) {
-    logger::info("Cache empty (Host Visible: {}, Profiling: {}, Counter: {}, "
-                 "Interrupt: {}, Device: {})",
-                 HostVisible, WithProfiling, CounterBasedEventEnabled,
-                 InterruptBasedEventEnabled, Device);
+    URLOG(INFO,
+          "Cache empty (Host Visible: {}, Profiling: {}, Counter: {}, "
+          "Interrupt: {}, Device: {})",
+          HostVisible, WithProfiling, CounterBasedEventEnabled,
+          InterruptBasedEventEnabled, Device);
     return nullptr;
   }
 
@@ -614,11 +616,12 @@ ur_event_handle_t ur_context_handle_t_::getEventFromContextCache(
   // We have to reset event before using it.
   Event->reset();
 
-  logger::info("Using {} event (Host Visible: {}, Profiling: {}, Counter: {}, "
-               "Interrupt: {}, Device: {}) from cache {}",
-               Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
-               Event->CounterBasedEventsEnabled,
-               Event->InterruptBasedEventsEnabled, Device, Cache);
+  URLOG(INFO,
+        "Using {} event (Host Visible: {}, Profiling: {}, Counter: {}, "
+        "Interrupt: {}, Device: {}) from cache {}",
+        Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
+        Event->CounterBasedEventsEnabled, Event->InterruptBasedEventsEnabled,
+        Device, Cache);
 
   return Event;
 }
@@ -634,10 +637,11 @@ void ur_context_handle_t_::addEventToContextCache(ur_event_handle_t Event) {
   auto Cache = getEventCache(
       Event->isHostVisible(), Event->isProfilingEnabled(), Device,
       Event->CounterBasedEventsEnabled, Event->InterruptBasedEventsEnabled);
-  logger::info("Inserting {} event (Host Visible: {}, Profiling: {}, Counter: "
-               "{}, Device: {}) into cache {}",
-               Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
-               Event->CounterBasedEventsEnabled, Device, Cache);
+  URLOG(INFO,
+        "Inserting {} event (Host Visible: {}, Profiling: {}, Counter: "
+        "{}, Device: {}) into cache {}",
+        Event, Event->HostVisibleEvent, Event->isProfilingEnabled(),
+        Event->CounterBasedEventsEnabled, Device, Cache);
   Cache->emplace_back(Event);
 }
 

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -52,8 +52,8 @@ getRangeOfAllowedCopyEngines(const ur_device_handle_t &Device) {
   int UpperCopyEngineIndex = std::stoi(CopyEngineRange.substr(pos + 1));
   if ((LowerCopyEngineIndex > UpperCopyEngineIndex) ||
       (LowerCopyEngineIndex < -1) || (UpperCopyEngineIndex < -1)) {
-    logger::error("UR_L0_LEVEL_ZERO_USE_COPY_ENGINE: invalid value provided, "
-                  "default set.");
+    URLOG(ERR, "UR_L0_LEVEL_ZERO_USE_COPY_ENGINE: invalid value provided, "
+               "default set.");
     LowerCopyEngineIndex = 0;
     UpperCopyEngineIndex = INT_MAX;
   }
@@ -141,7 +141,7 @@ ur_result_t urDeviceGet(
       break;
     default:
       Matched = false;
-      logger::warning("Unknown device type");
+      URLOG(WARN, "Unknown device type");
       break;
     }
 
@@ -217,7 +217,7 @@ ur_result_t urDeviceGetInfo(
     case ZE_DEVICE_TYPE_FPGA:
       return ReturnValue(UR_DEVICE_TYPE_FPGA);
     default:
-      logger::error("This device type is not supported");
+      URLOG(ERR, "This device type is not supported");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }
@@ -765,8 +765,8 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_GLOBAL_MEM_FREE: {
     bool SysManEnv = getenv_tobool("ZES_ENABLE_SYSMAN", false);
     if ((Device->Platform->ZedeviceToZesDeviceMap.size() == 0) && !SysManEnv) {
-      logger::error("SysMan support is unavailable on this system. Please "
-                    "check your level zero driver installation.");
+      URLOG(ERR, "SysMan support is unavailable on this system. Please "
+                 "check your level zero driver installation.");
       return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     }
     // Calculate the global memory size as the max limit that can be reported as
@@ -1103,8 +1103,8 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_WIDTH_EXP:
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_HEIGHT_EXP:
   case UR_DEVICE_INFO_MAX_IMAGE_LINEAR_PITCH_EXP:
-    logger::error("Unsupported ParamName in urGetDeviceInfo");
-    logger::error("ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
+    URLOG(ERR, "Unsupported ParamName in urGetDeviceInfo");
+    URLOG(ERR, "ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   case UR_DEVICE_INFO_MIPMAP_SUPPORT_EXP: {
     // L0 does not support mipmaps.
@@ -1115,8 +1115,8 @@ ur_result_t urDeviceGetInfo(
     return ReturnValue(false);
   }
   case UR_DEVICE_INFO_MIPMAP_MAX_ANISOTROPY_EXP:
-    logger::error("Unsupported ParamName in urGetDeviceInfo");
-    logger::error("ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
+    URLOG(ERR, "Unsupported ParamName in urGetDeviceInfo");
+    URLOG(ERR, "ParamName=%{}(0x{})", ParamName, logger::toHex(ParamName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   case UR_DEVICE_INFO_MIPMAP_LEVEL_REFERENCE_SUPPORT_EXP: {
     // L0 does not support creation of images from individual mipmap levels.
@@ -1211,9 +1211,9 @@ ur_result_t urDeviceGetInfo(
   case UR_DEVICE_INFO_HOST_PIPE_READ_WRITE_SUPPORTED:
     return ReturnValue(false);
   default:
-    logger::error("Unsupported ParamName in urGetDeviceInfo");
-    logger::error("ParamNameParamName={}(0x{})", ParamName,
-                  logger::toHex(ParamName));
+    URLOG(ERR, "Unsupported ParamName in urGetDeviceInfo");
+    URLOG(ERR, "ParamNameParamName={}(0x{})", ParamName,
+          logger::toHex(ParamName));
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   }
 

--- a/source/adapters/level_zero/device.cpp
+++ b/source/adapters/level_zero/device.cpp
@@ -1672,8 +1672,10 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
   if (numQueueGroups == 0) {
     return UR_RESULT_ERROR_UNKNOWN;
   }
-  logger::info(logger::LegacyMessage("NOTE: Number of queue groups = {}"),
-               "Number of queue groups = {}", numQueueGroups);
+  logger::get_logger().log(
+      logger::LegacyMessage("NOTE: Number of queue groups = {}"),
+      logger::Level::INFO, SHORT_FILE, UR_STR(__LINE__),
+      "Number of queue groups = {}", numQueueGroups);
   std::vector<ZeStruct<ze_command_queue_group_properties_t>>
       QueueGroupProperties(numQueueGroups);
   ZE2UR_CALL(zeDeviceGetCommandQueueGroupProperties,
@@ -1726,22 +1728,30 @@ ur_result_t ur_device_handle_t_::initialize(int SubSubDeviceOrdinal,
         }
       }
       if (QueueGroup[queue_group_info_t::MainCopy].ZeOrdinal < 0)
-        logger::info(logger::LegacyMessage(
-                         "NOTE: main blitter/copy engine is not available"),
-                     "main blitter/copy engine is not available");
+        logger::get_logger().log(
+            logger::LegacyMessage(
+                "NOTE: main blitter/copy engine is not available"),
+            logger::Level::INFO, SHORT_FILE, UR_STR(__LINE__),
+            "main blitter/copy engine is not available");
       else
-        logger::info(logger::LegacyMessage(
-                         "NOTE: main blitter/copy engine is available"),
-                     "main blitter/copy engine is available");
+        logger::get_logger().log(
+            logger::LegacyMessage(
+                "NOTE: main blitter/copy engine is available"),
+            logger::Level::INFO, SHORT_FILE, UR_STR(__LINE__),
+            "main blitter/copy engine is available");
 
       if (QueueGroup[queue_group_info_t::LinkCopy].ZeOrdinal < 0)
-        logger::info(logger::LegacyMessage(
-                         "NOTE: link blitter/copy engines are not available"),
-                     "link blitter/copy engines are not available");
+        logger::get_logger().log(
+            logger::LegacyMessage(
+                "NOTE: link blitter/copy engines are not available"),
+            logger::Level::INFO, SHORT_FILE, UR_STR(__LINE__),
+            "link blitter/copy engines are not available");
       else
-        logger::info(logger::LegacyMessage(
-                         "NOTE: link blitter/copy engines are available"),
-                     "link blitter/copy engines are available");
+        logger::get_logger().log(
+            logger::LegacyMessage(
+                "NOTE: link blitter/copy engines are available"),
+            logger::Level::INFO, SHORT_FILE, UR_STR(__LINE__),
+            "link blitter/copy engines are available");
     }
   }
 

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -29,7 +29,7 @@ void printZeEventList(const _ur_ze_event_list_t &UrZeEventList) {
     for (uint32_t I = 0; I < UrZeEventList.Length; I++) {
       ss << " " << ur_cast<std::uintptr_t>(UrZeEventList.ZeEventList[I]);
     }
-    logger::debug(ss.str().c_str());
+    URLOG(DEBUG, "{}", ss.str().c_str());
   }
 }
 
@@ -523,7 +523,8 @@ ur_result_t urEventGetInfo(
     return ReturnValue(Event->RefCount.load());
   }
   default:
-    logger::error(
+    URLOG(
+        ERR,
         "Unsupported ParamName in urEventGetInfo: ParamName=ParamName={}(0x{})",
         PropName, logger::toHex(PropName));
     return UR_RESULT_ERROR_INVALID_VALUE;
@@ -610,7 +611,7 @@ ur_result_t urEventGetProfilingInfo(
       return ReturnValue(ContextEndTime);
     }
     default:
-      logger::error("urEventGetProfilingInfo: not supported ParamName");
+      URLOG(ERR, "urEventGetProfilingInfo: not supported ParamName");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }
@@ -673,7 +674,7 @@ ur_result_t urEventGetProfilingInfo(
         return ReturnValue(ContextEndTime);
       }
       default:
-        logger::error("urEventGetProfilingInfo: not supported ParamName");
+        URLOG(ERR, "urEventGetProfilingInfo: not supported ParamName");
         return UR_RESULT_ERROR_INVALID_VALUE;
       }
     } else {
@@ -716,7 +717,7 @@ ur_result_t urEventGetProfilingInfo(
     //
     return ReturnValue(uint64_t{0});
   default:
-    logger::error("urEventGetProfilingInfo: not supported ParamName");
+    URLOG(ERR, "urEventGetProfilingInfo: not supported ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -831,7 +832,7 @@ urEventWait(uint32_t NumEvents,
             die("The host-visible proxy event missing");
 
           ze_event_handle_t ZeEvent = HostVisibleEvent->ZeEvent;
-          logger::debug("ZeEvent = {}", ur_cast<std::uintptr_t>(ZeEvent));
+          URLOG(DEBUG, "ZeEvent = {}", ur_cast<std::uintptr_t>(ZeEvent));
           // If this event was an inner batched event, then sync with
           // the Queue instead of waiting on the event.
           if (HostVisibleEvent->IsInnerBatchedEvent && Event->ZeBatchedQueue) {

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -1007,8 +1007,10 @@ ur_result_t urEventSetCallback(
   std::ignore = ExecStatus;
   std::ignore = Notify;
   std::ignore = UserData;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/helpers/kernel_helpers.cpp
+++ b/source/adapters/level_zero/helpers/kernel_helpers.cpp
@@ -52,15 +52,15 @@ ur_result_t getSuggestedLocalWorkSize(ur_device_handle_t hDevice,
         --GroupSize[I];
       }
       if (GlobalWorkSize3D[I] / GroupSize[I] > UINT32_MAX) {
-        logger::error("getSuggestedLocalWorkSize: can't find a WG size "
-                      "suitable for global work size > UINT32_MAX");
+        URLOG(ERR, "getSuggestedLocalWorkSize: can't find a WG size "
+                   "suitable for global work size > UINT32_MAX");
         return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
       }
       WG[I] = GroupSize[I];
     }
-    logger::debug(
-        "getSuggestedLocalWorkSize: using computed WG size = {{{}, {}, {}}}",
-        WG[0], WG[1], WG[2]);
+    URLOG(DEBUG,
+          "getSuggestedLocalWorkSize: using computed WG size = {{{}, {}, {}}}",
+          WG[0], WG[1], WG[2]);
   }
 
   return UR_RESULT_SUCCESS;
@@ -70,7 +70,7 @@ ur_result_t setKernelGlobalOffset(ur_context_handle_t Context,
                                   ze_kernel_handle_t Kernel, uint32_t WorkDim,
                                   const size_t *GlobalWorkOffset) {
   if (!Context->getPlatform()->ZeDriverGlobalOffsetExtensionFound) {
-    logger::debug("No global offset extension found on this driver");
+    URLOG(DEBUG, "No global offset extension found on this driver");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -130,27 +130,27 @@ ur_result_t calculateKernelWorkDimensions(
     break;
 
   default:
-    logger::error("calculateKernelWorkDimensions: unsupported work_dim");
+    URLOG(ERR, "calculateKernelWorkDimensions: unsupported work_dim");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
   // Error handling for non-uniform group size case
   if (GlobalWorkSize3D[0] !=
       size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 1st dimension");
+    URLOG(ERR, "calculateKernelWorkDimensions: invalid work_dim. The range "
+               "is not a multiple of the group size in the 1st dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
   if (GlobalWorkSize3D[1] !=
       size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 2nd dimension");
+    URLOG(ERR, "calculateKernelWorkDimensions: invalid work_dim. The range "
+               "is not a multiple of the group size in the 2nd dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
   if (GlobalWorkSize3D[2] !=
       size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
-    logger::error("calculateKernelWorkDimensions: invalid work_dim. The range "
-                  "is not a multiple of the group size in the 3rd dimension");
+    URLOG(ERR, "calculateKernelWorkDimensions: invalid work_dim. The range "
+               "is not a multiple of the group size in the 3rd dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
 

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -56,9 +56,8 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
     ZeImageFormatTypeSize = 32;
     break;
   default:
-    logger::error(
-        "ze2urImageFormat: unsupported image format layout: layout = {}",
-        ZeImageFormat.layout);
+    URLOG(ERR, "ze2urImageFormat: unsupported image format layout: layout = {}",
+          ZeImageFormat.layout);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -75,9 +74,8 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_A;
       break;
     default:
-      logger::error(
-          "ze2urImageFormat: unexpected image format channel x: x = {}",
-          ZeImageFormat.x);
+      URLOG(ERR, "ze2urImageFormat: unexpected image format channel x: x = {}",
+            ZeImageFormat.x);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -85,9 +83,8 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
   case ZE_IMAGE_FORMAT_LAYOUT_16_16:
   case ZE_IMAGE_FORMAT_LAYOUT_32_32:
     if (ZeImageFormat.x != ZE_IMAGE_FORMAT_SWIZZLE_R) {
-      logger::error(
-          "ze2urImageFormat: unexpected image format channel x: x = {}",
-          ZeImageFormat.x);
+      URLOG(ERR, "ze2urImageFormat: unexpected image format channel x: x = {}",
+            ZeImageFormat.x);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     switch (ZeImageFormat.y) {
@@ -101,9 +98,9 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RX;
       break;
     default:
-      logger::error(
-          "ze2urImageFormat: unexpected image format channel y: y = {}\n",
-          ZeImageFormat.y);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format channel y: y = {}\n",
+            ZeImageFormat.y);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -120,13 +117,13 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
         ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RGX;
         break;
       default:
-        logger::error(
-            "ze2urImageFormat: unexpected image format channel z: z = {}\n",
-            ZeImageFormat.z);
+        URLOG(ERR,
+              "ze2urImageFormat: unexpected image format channel z: z = {}\n",
+              ZeImageFormat.z);
         return UR_RESULT_ERROR_INVALID_VALUE;
       }
     } else {
-      logger::error("ze2urImageFormat: unexpected image format channel");
+      URLOG(ERR, "ze2urImageFormat: unexpected image format channel");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -144,9 +141,10 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
         ChannelOrder = UR_IMAGE_CHANNEL_ORDER_RGBA;
         break;
       default:
-        logger::error("ze2urImageFormat: unexpected image format channel w: w "
-                      "= {}",
-                      ZeImageFormat.x);
+        URLOG(ERR,
+              "ze2urImageFormat: unexpected image format channel w: w "
+              "= {}",
+              ZeImageFormat.x);
         return UR_RESULT_ERROR_INVALID_VALUE;
       }
     } else if (ZeImageFormat.x == ZE_IMAGE_FORMAT_SWIZZLE_A &&
@@ -160,14 +158,13 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
                ZeImageFormat.w == ZE_IMAGE_FORMAT_SWIZZLE_A) {
       ChannelOrder = UR_IMAGE_CHANNEL_ORDER_BGRA;
     } else {
-      logger::error("ze2urImageFormat: unexpected image format channel");
+      URLOG(ERR, "ze2urImageFormat: unexpected image format channel");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
   default:
-    logger::error(
-        "ze2urImageFormat: unsupported image format layout: layout = {}",
-        ZeImageFormat.layout);
+    URLOG(ERR, "ze2urImageFormat: unsupported image format layout: layout = {}",
+          ZeImageFormat.layout);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -185,9 +182,10 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelType = UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32;
       break;
     default:
-      logger::error("ze2urImageFormat: unexpected image format type size: size "
-                    "= {}",
-                    ZeImageFormatTypeSize);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format type size: size "
+            "= {}",
+            ZeImageFormatTypeSize);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -203,9 +201,10 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelType = UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32;
       break;
     default:
-      logger::error("ze2urImageFormat: unexpected image format type size: size "
-                    "= {}",
-                    ZeImageFormatTypeSize);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format type size: size "
+            "= {}",
+            ZeImageFormatTypeSize);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -218,9 +217,10 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelType = UR_IMAGE_CHANNEL_TYPE_UNORM_INT16;
       break;
     default:
-      logger::error("ze2urImageFormat: unexpected image format type size: size "
-                    "= {}",
-                    ZeImageFormatTypeSize);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format type size: size "
+            "= {}",
+            ZeImageFormatTypeSize);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -233,9 +233,10 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelType = UR_IMAGE_CHANNEL_TYPE_SNORM_INT16;
       break;
     default:
-      logger::error("ze2urImageFormat: unexpected image format type size: size "
-                    "= {}",
-                    ZeImageFormatTypeSize);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format type size: size "
+            "= {}",
+            ZeImageFormatTypeSize);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -248,15 +249,16 @@ ur_result_t ze2urImageFormat(const ze_image_desc_t *ZeImageDesc,
       ChannelType = UR_IMAGE_CHANNEL_TYPE_FLOAT;
       break;
     default:
-      logger::error("ze2urImageFormat: unexpected image format type size: size "
-                    "= {}",
-                    ZeImageFormatTypeSize);
+      URLOG(ERR,
+            "ze2urImageFormat: unexpected image format type size: size "
+            "= {}",
+            ZeImageFormatTypeSize);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
   default:
-    logger::error("ze2urImageFormat: unsupported image format type: type = {}",
-                  ZeImageFormat.type);
+    URLOG(ERR, "ze2urImageFormat: unsupported image format type: type = {}",
+          ZeImageFormat.type);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -300,7 +302,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
       ZeImageFormatLayout = ZE_IMAGE_FORMAT_LAYOUT_32;
       break;
     default:
-      logger::error("ur2zeImageDesc: unexpected data type size");
+      URLOG(ERR, "ur2zeImageDesc: unexpected data type size");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -319,7 +321,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
       ZeImageFormatLayout = ZE_IMAGE_FORMAT_LAYOUT_32_32;
       break;
     default:
-      logger::error("ur2zeImageDesc: unexpected data type size");
+      URLOG(ERR, "ur2zeImageDesc: unexpected data type size");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -339,7 +341,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
       ZeImageFormatLayout = ZE_IMAGE_FORMAT_LAYOUT_32_32_32_32;
       break;
     default:
-      logger::error("ur2zeImageDesc: unexpected data type size");
+      URLOG(ERR, "ur2zeImageDesc: unexpected data type size");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
@@ -357,13 +359,13 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
       ZeImageFormatLayout = ZE_IMAGE_FORMAT_LAYOUT_32_32_32;
       break;
     default:
-      logger::error("ur2zeImageDesc: unexpected data type size");
+      URLOG(ERR, "ur2zeImageDesc: unexpected data type size");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     break;
   }
   default:
-    logger::error("format channel order = {}", ImageFormat->channelOrder);
+    URLOG(ERR, "format channel order = {}", ImageFormat->channelOrder);
     die("ur2zeImageDesc: unsupported image channel order\n");
     break;
   }
@@ -392,7 +394,7 @@ ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
     ZeImageType = ZE_IMAGE_TYPE_2DARRAY;
     break;
   default:
-    logger::error("ur2zeImageDesc: unsupported image type");
+    URLOG(ERR, "ur2zeImageDesc: unsupported image type");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -542,9 +544,10 @@ ur_result_t bindlessImagesCreateImpl(ur_context_handle_t hContext,
         DriverHandle, "zeImageGetDeviceOffsetExp",
         (void **)&zeImageGetDeviceOffsetExpFunctionPtr);
     if (Result != ZE_RESULT_SUCCESS)
-      logger::error("zeDriverGetExtensionFunctionAddress "
-                    "zeImageGetDeviceOffsetExpv failed, err = {}",
-                    Result);
+      URLOG(ERR,
+            "zeDriverGetExtensionFunctionAddress "
+            "zeImageGetDeviceOffsetExpv failed, err = {}",
+            Result);
   });
   if (!zeImageGetDeviceOffsetExpFunctionPtr)
     return UR_RESULT_ERROR_INVALID_OPERATION;
@@ -684,9 +687,8 @@ getImageFormatTypeAndSize(const ur_image_format_t *ImageFormat) {
     break;
   }
   default:
-    logger::error(
-        "urMemImageCreate: unsupported image data type: data type = {}",
-        ImageFormat->channelType);
+    URLOG(ERR, "urMemImageCreate: unsupported image data type: data type = {}",
+          ImageFormat->channelType);
     ZeImageFormatType = ZE_IMAGE_FORMAT_TYPE_FORCE_UINT32;
     ZeImageFormatTypeSize = 0;
   }
@@ -714,10 +716,10 @@ ur_result_t urUSMPitchedAllocExp(ur_context_handle_t hContext,
         DriverHandle, "zeMemGetPitchFor2dImage",
         (void **)&zeMemGetPitchFor2dImageFunctionPtr);
     if (Result != ZE_RESULT_SUCCESS)
-      logger::error(
-          "zeDriverGetExtensionFunctionAddress zeMemGetPitchFor2dImage "
-          "failed, err = {}",
-          Result);
+      URLOG(ERR,
+            "zeDriverGetExtensionFunctionAddress zeMemGetPitchFor2dImage "
+            "failed, err = {}",
+            Result);
   });
   if (!zeMemGetPitchFor2dImageFunctionPtr)
     return UR_RESULT_ERROR_INVALID_OPERATION;
@@ -985,7 +987,7 @@ ur_result_t urBindlessImagesImageCopyExp(
                 &DstRegion, &SrcRegion, ZeEvent, WaitList.Length,
                 WaitList.ZeEventList));
   } else {
-    logger::error("urBindlessImagesImageCopyExp: unexpected imageCopyFlags");
+    URLOG(ERR, "urBindlessImagesImageCopyExp: unexpected imageCopyFlags");
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
@@ -1169,8 +1171,8 @@ ur_result_t urBindlessImagesMapExternalLinearMemoryExp(
   std::ignore = offset;
   std::ignore = hExternalMem;
   std::ignore = phRetMem;
-  logger::error("[UR][L0] {} function not implemented!",
-                "{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "[UR][L0] {} function not implemented!",
+        "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/image.cpp
+++ b/source/adapters/level_zero/image.cpp
@@ -1055,8 +1055,10 @@ ur_result_t urBindlessImagesMipmapGetLevelExp(
   std::ignore = hImageMem;
   std::ignore = mipmapLevel;
   std::ignore = phImageMem;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -1214,8 +1216,9 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
 
   auto UrPlatform = hContext->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
-    logger::error(logger::LegacyMessage("[UR][L0] "),
-                  " {} function not supported!", __FUNCTION__);
+    logger::get_logger().log(logger::LegacyMessage("[UR][L0] "),
+                             logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+                             " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
   ze_intel_external_semaphore_exp_desc_t SemDesc = {
@@ -1271,8 +1274,9 @@ ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
   std::ignore = hDevice;
   auto UrPlatform = hContext->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
-    logger::error(logger::LegacyMessage("[UR][L0] "),
-                  " {} function not supported!", __FUNCTION__);
+    logger::get_logger().log(logger::LegacyMessage("[UR][L0] "),
+                             logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+                             " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
   ZE2UR_CALL(
@@ -1288,8 +1292,9 @@ ur_result_t urBindlessImagesWaitExternalSemaphoreExp(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   auto UrPlatform = hQueue->Context->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
-    logger::error(logger::LegacyMessage("[UR][L0] "),
-                  " {} function not supported!", __FUNCTION__);
+    logger::get_logger().log(logger::LegacyMessage("[UR][L0] "),
+                             logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+                             " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
@@ -1350,8 +1355,9 @@ ur_result_t urBindlessImagesSignalExternalSemaphoreExp(
   std::ignore = phEvent;
   auto UrPlatform = hQueue->Context->getPlatform();
   if (UrPlatform->ZeExternalSemaphoreExt.Supported == false) {
-    logger::error(logger::LegacyMessage("[UR][L0] "),
-                  " {} function not supported!", __FUNCTION__);
+    logger::get_logger().log(logger::LegacyMessage("[UR][L0] "),
+                             logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+                             " {} function not supported!", __FUNCTION__);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -189,9 +189,10 @@ ur_result_t urEnqueueKernelLaunch(
                 (*Event)->WaitList.Length, (*Event)->WaitList.ZeEventList));
   }
 
-  logger::debug("calling zeCommandListAppendLaunchKernel() with"
-                "  ZeEvent {}",
-                ur_cast<std::uintptr_t>(ZeEvent));
+  URLOG(DEBUG,
+        "calling zeCommandListAppendLaunchKernel() with"
+        "  ZeEvent {}",
+        ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList((*Event)->WaitList);
 
   // Execute command list asynchronously, as the event will be used
@@ -317,16 +318,17 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
         }
 
         if (GlobalWorkSize3D[I] / GroupSize[I] > UINT32_MAX) {
-          logger::error(
-              "urEnqueueCooperativeKernelLaunchExp: can't find a WG size "
-              "suitable for global work size > UINT32_MAX");
+          URLOG(ERR,
+                "urEnqueueCooperativeKernelLaunchExp: can't find a WG size "
+                "suitable for global work size > UINT32_MAX");
           return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
         }
         WG[I] = GroupSize[I];
       }
-      logger::debug("urEnqueueCooperativeKernelLaunchExp: using computed WG "
-                    "size = {{{}, {}, {}}}",
-                    WG[0], WG[1], WG[2]);
+      URLOG(DEBUG,
+            "urEnqueueCooperativeKernelLaunchExp: using computed WG "
+            "size = {{{}, {}, {}}}",
+            WG[0], WG[1], WG[2]);
     }
   }
 
@@ -355,30 +357,30 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
     break;
 
   default:
-    logger::error("urEnqueueCooperativeKernelLaunchExp: unsupported work_dim");
+    URLOG(ERR, "urEnqueueCooperativeKernelLaunchExp: unsupported work_dim");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
   // Error handling for non-uniform group size case
   if (GlobalWorkSize3D[0] !=
       size_t(ZeThreadGroupDimensions.groupCountX) * WG[0]) {
-    logger::error("urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
-                  "range is not a "
-                  "multiple of the group size in the 1st dimension");
+    URLOG(ERR, "urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
+               "range is not a "
+               "multiple of the group size in the 1st dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
   if (GlobalWorkSize3D[1] !=
       size_t(ZeThreadGroupDimensions.groupCountY) * WG[1]) {
-    logger::error("urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
-                  "range is not a "
-                  "multiple of the group size in the 2nd dimension");
+    URLOG(ERR, "urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
+               "range is not a "
+               "multiple of the group size in the 2nd dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
   if (GlobalWorkSize3D[2] !=
       size_t(ZeThreadGroupDimensions.groupCountZ) * WG[2]) {
-    logger::debug("urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
-                  "range is not a "
-                  "multiple of the group size in the 3rd dimension");
+    URLOG(DEBUG, "urEnqueueCooperativeKernelLaunchExp: invalid work_dim. The "
+                 "range is not a "
+                 "multiple of the group size in the 3rd dimension");
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
 
@@ -449,9 +451,10 @@ ur_result_t urEnqueueCooperativeKernelLaunchExp(
                 (*Event)->WaitList.Length, (*Event)->WaitList.ZeEventList));
   }
 
-  logger::debug("calling zeCommandListAppendLaunchCooperativeKernel() with"
-                "  ZeEvent {}",
-                ur_cast<std::uintptr_t>(ZeEvent));
+  URLOG(DEBUG,
+        "calling zeCommandListAppendLaunchCooperativeKernel() with"
+        "  ZeEvent {}",
+        ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList((*Event)->WaitList);
 
   // Execute command list asynchronously, as the event will be used
@@ -776,9 +779,8 @@ ur_result_t urKernelGetInfo(
       return UR_RESULT_ERROR_UNKNOWN;
     }
   default:
-    logger::error(
-        "Unsupported ParamName in urKernelGetInfo: ParamName={}(0x{})",
-        ParamName, logger::toHex(ParamName));
+    URLOG(ERR, "Unsupported ParamName in urKernelGetInfo: ParamName={}(0x{})",
+          ParamName, logger::toHex(ParamName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 
@@ -865,9 +867,8 @@ ur_result_t urKernelGetGroupInfo(
     // No corresponding enumeration in Level Zero
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default: {
-    logger::error(
-        "Unknown ParamName in urKernelGetGroupInfo: ParamName={}(0x{})",
-        ParamName, logger::toHex(ParamName));
+    URLOG(ERR, "Unknown ParamName in urKernelGetGroupInfo: ParamName={}(0x{})",
+          ParamName, logger::toHex(ParamName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   }
@@ -1005,7 +1006,7 @@ ur_result_t urKernelSetExecInfo(
         return UR_RESULT_ERROR_INVALID_VALUE;
       ZE2UR_CALL(zeKernelSetCacheConfig, (ZeKernel, ZeCacheConfig););
     } else {
-      logger::error("urKernelSetExecInfo: unsupported ParamName");
+      URLOG(ERR, "urKernelSetExecInfo: unsupported ParamName");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -1158,8 +1158,10 @@ ur_result_t urKernelSetSpecializationConstants(
   std::ignore = Kernel;
   std::ignore = Count;
   std::ignore = SpecConstants;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -1445,8 +1445,10 @@ ur_result_t urEnqueueUSMFill2D(
   std::ignore = NumEventsInWaitList;
   std::ignore = EventWaitList;
   std::ignore = OutEvent;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -1967,8 +1969,10 @@ ur_result_t urMemImageGetInfo(
   std::ignore = PropSize;
   std::ignore = ImgInfo;
   std::ignore = PropSizeRet;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -2021,8 +2025,10 @@ ur_result_t urEnqueueReadHostPipe(ur_queue_handle_t hQueue,
   std::ignore = numEventsInWaitList;
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -2042,8 +2048,10 @@ ur_result_t urEnqueueWriteHostPipe(ur_queue_handle_t hQueue,
   std::ignore = numEventsInWaitList;
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -117,9 +117,10 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  logger::debug("calling zeCommandListAppendMemoryCopy() with"
-                "  ZeEvent {}",
-                ur_cast<std::uintptr_t>(ZeEvent));
+  URLOG(DEBUG,
+        "calling zeCommandListAppendMemoryCopy() with"
+        "  ZeEvent {}",
+        ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList(WaitList);
 
   ZE2UR_CALL(zeCommandListAppendMemoryCopy,
@@ -170,9 +171,10 @@ ur_result_t enqueueMemCopyRectHelper(
   const auto &ZeCommandList = CommandList->first;
   const auto &WaitList = (*Event)->WaitList;
 
-  logger::debug("calling zeCommandListAppendMemoryCopy() with"
-                "  ZeEvent {}",
-                ur_cast<std::uintptr_t>(ZeEvent));
+  URLOG(DEBUG,
+        "calling zeCommandListAppendMemoryCopy() with"
+        "  ZeEvent {}",
+        ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList(WaitList);
 
   auto ZeParams = ur2zeRegionParams(SrcOrigin, DstOrigin, Region, SrcRowPitch,
@@ -184,7 +186,7 @@ ur_result_t enqueueMemCopyRectHelper(
               ZeParams.srcPitch, ZeParams.srcSlicePitch, ZeEvent,
               WaitList.Length, WaitList.ZeEventList));
 
-  logger::debug("calling zeCommandListAppendMemoryCopyRegion()");
+  URLOG(DEBUG, "calling zeCommandListAppendMemoryCopyRegion()");
 
   UR_CALL(Queue->executeCommandList(CommandList, Blocking, OkToBatch));
 
@@ -259,9 +261,10 @@ static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
                (ZeCommandList, Ptr, Pattern, PatternSize, Size, ZeEvent,
                 WaitList.Length, WaitList.ZeEventList));
 
-    logger::debug("calling zeCommandListAppendMemoryFill() with"
-                  "  ZeEvent {}",
-                  ur_cast<uint64_t>(ZeEvent));
+    URLOG(DEBUG,
+          "calling zeCommandListAppendMemoryFill() with"
+          "  ZeEvent {}",
+          ur_cast<uint64_t>(ZeEvent));
     printZeEventList(WaitList);
 
     // Execute command list asynchronously, as the event will be used
@@ -281,9 +284,10 @@ static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
                   WaitList.Length, WaitList.ZeEventList));
     }
 
-    logger::debug("calling zeCommandListAppendMemoryCopy() with"
-                  "  ZeEvent {}",
-                  ur_cast<uint64_t>(ZeEvent));
+    URLOG(DEBUG,
+          "calling zeCommandListAppendMemoryCopy() with"
+          "  ZeEvent {}",
+          ur_cast<uint64_t>(ZeEvent));
     printZeEventList(WaitList);
 
     // Execute command list synchronously.
@@ -466,7 +470,7 @@ static ur_result_t enqueueMemImageCommandHelper(
                 ur_cast<ze_image_handle_t>(ZeHandleSrc), &ZeDstRegion,
                 &ZeSrcRegion, ZeEvent, 0, nullptr));
   } else {
-    logger::error("enqueueMemImageUpdate: unsupported image command type");
+    URLOG(ERR, "enqueueMemImageUpdate: unsupported image command type");
     return UR_RESULT_ERROR_INVALID_OPERATION;
   }
 
@@ -1043,7 +1047,7 @@ ur_result_t urEnqueueMemBufferMap(
     // False as the second value in pair means that mapping was not inserted
     // because mapping already exists.
     if (!Res.second) {
-      logger::error("urEnqueueMemBufferMap: duplicate mapping detected");
+      URLOG(ERR, "urEnqueueMemBufferMap: duplicate mapping detected");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
 
@@ -1104,7 +1108,7 @@ ur_result_t urEnqueueMemBufferMap(
   // False as the second value in pair means that mapping was not inserted
   // because mapping already exists.
   if (!Res.second) {
-    logger::error("urEnqueueMemBufferMap: duplicate mapping detected");
+    URLOG(ERR, "urEnqueueMemBufferMap: duplicate mapping detected");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   return UR_RESULT_SUCCESS;
@@ -1158,7 +1162,7 @@ ur_result_t urEnqueueMemUnmap(
     std::scoped_lock<ur_shared_mutex> Guard(Buffer->Mutex);
     auto It = Buffer->Mappings.find(MappedPtr);
     if (It == Buffer->Mappings.end()) {
-      logger::error("urEnqueueMemUnmap: unknown memory mapping");
+      URLOG(ERR, "urEnqueueMemUnmap: unknown memory mapping");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     MapInfo = It->second;
@@ -1513,13 +1517,13 @@ static ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
       ZeImageFormatLayout = ZE_IMAGE_FORMAT_LAYOUT_32_32_32_32;
       break;
     default:
-      logger::error("urMemImageCreate: unexpected data type Size\n");
+      URLOG(ERR, "urMemImageCreate: unexpected data type Size\n");
       return UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
     }
     break;
   }
   default:
-    logger::error("format layout = {}", ImageFormat->channelOrder);
+    URLOG(ERR, "format layout = {}", ImageFormat->channelOrder);
     return UR_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT;
     break;
   }
@@ -1548,7 +1552,7 @@ static ur_result_t ur2zeImageDesc(const ur_image_format_t *ImageFormat,
     ZeImageType = ZE_IMAGE_TYPE_2DARRAY;
     break;
   default:
-    logger::error("urMemImageCreate: unsupported image type");
+    URLOG(ERR, "urMemImageCreate: unsupported image type");
     return UR_RESULT_ERROR_INVALID_IMAGE_FORMAT_DESCRIPTOR;
   }
 
@@ -2339,8 +2343,8 @@ ur_result_t _ur_buffer::getBufferZeHandle(char *&ZeHandle,
     }
   }
 
-  logger::debug("getZeHandle(pi_device{{{}}}) = {}", (void *)Device,
-                (void *)Allocation.ZeHandle);
+  URLOG(DEBUG, "getZeHandle(pi_device{{{}}}) = {}", (void *)Device,
+        (void *)Allocation.ZeHandle);
   return UR_RESULT_SUCCESS;
 }
 

--- a/source/adapters/level_zero/platform.cpp
+++ b/source/adapters/level_zero/platform.cpp
@@ -98,7 +98,7 @@ ur_result_t urPlatformGetInfo(
   case UR_PLATFORM_INFO_ADAPTER:
     return ReturnValue(GlobalAdapter);
   default:
-    logger::debug("urPlatformGetInfo: unrecognized ParamName");
+    URLOG(DEBUG, "urPlatformGetInfo: unrecognized ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -913,8 +913,10 @@ ur_result_t urProgramSetSpecializationConstant(
   std::ignore = SpecId;
   std::ignore = SpecSize;
   std::ignore = SpecValue;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!");
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!");
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/program.cpp
+++ b/source/adapters/level_zero/program.cpp
@@ -440,9 +440,9 @@ ur_result_t urProgramLinkExp(
         ZeModuleDesc.pInputModule = ZeExtModuleDesc.pInputModules[0];
         ZeModuleDesc.pConstants = ZeExtModuleDesc.pConstants[0];
       } else {
-        logger::error(
-            "urProgramLink: level_zero driver does not have static linking "
-            "support.");
+        URLOG(ERR,
+              "urProgramLink: level_zero driver does not have static linking "
+              "support.");
         return UR_RESULT_ERROR_INVALID_VALUE;
       }
     }
@@ -894,7 +894,7 @@ ur_result_t urProgramGetBuildInfo(
     // program.
     return ReturnValue("");
   } else {
-    logger::error("urProgramGetBuildInfo: unsupported ParamName");
+    URLOG(ERR, "urProgramGetBuildInfo: unsupported ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   return UR_RESULT_SUCCESS;

--- a/source/adapters/level_zero/queue.cpp
+++ b/source/adapters/level_zero/queue.cpp
@@ -455,7 +455,8 @@ ur_result_t urQueueGetInfo(
     return ReturnValue(true);
   }
   default:
-    logger::error(
+    URLOG(
+        ERR,
         "Unsupported ParamName in urQueueGetInfo: ParamName=ParamName={}(0x{})",
         ParamName, logger::toHex(ParamName));
     return UR_RESULT_ERROR_INVALID_ENUMERATION;
@@ -924,8 +925,8 @@ ur_result_t urEnqueueKernelLaunchCustomExp(
   std::ignore = phEventWaitList;
   std::ignore = phEvent;
 
-  logger::error("[UR][L0] {} function not implemented!",
-                "{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "[UR][L0] {} function not implemented!",
+        "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -1005,9 +1006,9 @@ static const zeCommandListBatchConfig ZeCommandListBatchConfig(bool IsCopy) {
           Val = std::stoi(BatchConfig.substr(Pos));
         } catch (...) {
           if (IsCopy)
-            logger::error("UR_L0_COPY_BATCH_SIZE: failed to parse value");
+            URLOG(ERR, "UR_L0_COPY_BATCH_SIZE: failed to parse value")
           else
-            logger::error("UR_L0_BATCH_SIZE: failed to parse value");
+            URLOG(ERR, "UR_L0_BATCH_SIZE: failed to parse value")
           break;
         }
         switch (Ord) {
@@ -1030,20 +1031,21 @@ static const zeCommandListBatchConfig ZeCommandListBatchConfig(bool IsCopy) {
           die("Unexpected batch config");
         }
         if (IsCopy)
-          logger::error("UR_L0_COPY_BATCH_SIZE: dynamic batch param "
-                        "#{}: {}",
-                        (int)Ord, (int)Val);
+          URLOG(ERR,
+                "UR_L0_COPY_BATCH_SIZE: dynamic batch param "
+                "#{}: {}",
+                (int)Ord, (int)Val)
         else
-          logger::error("UR_L0_BATCH_SIZE: dynamic batch param #{}: {}",
-                        (int)Ord, (int)Val);
+          URLOG(ERR, "UR_L0_BATCH_SIZE: dynamic batch param #{}: {}", (int)Ord,
+                (int)Val)
       };
 
     } else {
       // Negative batch sizes are silently ignored.
       if (IsCopy)
-        logger::warning("UR_L0_COPY_BATCH_SIZE: ignored negative value");
+        URLOG(WARN, "UR_L0_COPY_BATCH_SIZE: ignored negative value")
       else
-        logger::warning("UR_L0_BATCH_SIZE: ignored negative value");
+        URLOG(WARN, "UR_L0_BATCH_SIZE: ignored negative value")
     }
   }
   return Config;
@@ -1219,7 +1221,7 @@ void ur_queue_handle_t_::adjustBatchSizeForFullBatch(bool IsCopy) {
           ZeCommandListBatchConfig.NumTimesClosedFullThreshold) {
     if (QueueBatchSize < ZeCommandListBatchConfig.DynamicSizeMax) {
       QueueBatchSize += ZeCommandListBatchConfig.DynamicSizeStep;
-      logger::debug("Raising QueueBatchSize to {}", QueueBatchSize);
+      URLOG(DEBUG, "Raising QueueBatchSize to {}", QueueBatchSize);
     }
     CommandBatch.NumTimesClosedEarly = 0;
     CommandBatch.NumTimesClosedFull = 0;
@@ -1246,7 +1248,7 @@ void ur_queue_handle_t_::adjustBatchSizeForPartialBatch(bool IsCopy) {
     QueueBatchSize = CommandBatch.OpenCommandList->second.size() - 1;
     if (QueueBatchSize < 1)
       QueueBatchSize = 1;
-    logger::debug("Lowering QueueBatchSize to {}", QueueBatchSize);
+    URLOG(DEBUG, "Lowering QueueBatchSize to {}", QueueBatchSize);
     CommandBatch.NumTimesClosedEarly = 0;
     CommandBatch.NumTimesClosedFull = 0;
   }
@@ -1608,14 +1610,15 @@ ur_result_t urQueueReleaseInternal(ur_queue_handle_t Queue) {
 
   Queue->clearEndTimeRecordings();
 
-  logger::debug("urQueueRelease(compute) NumTimesClosedFull {}, "
-                "NumTimesClosedEarly {}",
-                Queue->ComputeCommandBatch.NumTimesClosedFull,
-                Queue->ComputeCommandBatch.NumTimesClosedEarly);
-  logger::debug(
-      "urQueueRelease(copy) NumTimesClosedFull {}, NumTimesClosedEarly {}",
-      Queue->CopyCommandBatch.NumTimesClosedFull,
-      Queue->CopyCommandBatch.NumTimesClosedEarly);
+  URLOG(DEBUG,
+        "urQueueRelease(compute) NumTimesClosedFull {}, "
+        "NumTimesClosedEarly {}",
+        Queue->ComputeCommandBatch.NumTimesClosedFull,
+        Queue->ComputeCommandBatch.NumTimesClosedEarly);
+  URLOG(DEBUG,
+        "urQueueRelease(copy) NumTimesClosedFull {}, NumTimesClosedEarly {}",
+        Queue->CopyCommandBatch.NumTimesClosedFull,
+        Queue->CopyCommandBatch.NumTimesClosedEarly);
 
   delete Queue;
 
@@ -2232,10 +2235,11 @@ ur_queue_handle_t_::ur_queue_group_t::getZeQueue(uint32_t *QueueGroupOrdinal) {
     ZeCommandQueueDesc.flags = ZE_COMMAND_QUEUE_FLAG_EXPLICIT_ONLY;
   }
 
-  logger::debug("[getZeQueue]: create queue ordinal = {}, index = {} "
-                "(round robin in [{}, {}]) priority = {}",
-                ZeCommandQueueDesc.ordinal, ZeCommandQueueDesc.index,
-                LowerIndex, UpperIndex, Priority);
+  URLOG(DEBUG,
+        "[getZeQueue]: create queue ordinal = {}, index = {} "
+        "(round robin in [{}, {}]) priority = {}",
+        ZeCommandQueueDesc.ordinal, ZeCommandQueueDesc.index, LowerIndex,
+        UpperIndex, Priority);
 
   auto ZeResult = ZE_CALL_NOCHECK(
       zeCommandQueueCreate, (Queue->Context->ZeContext, Queue->Device->ZeDevice,
@@ -2293,7 +2297,8 @@ ur_result_t ur_queue_handle_t_::createCommandList(
     IsInOrderList = true;
   }
 
-  logger::debug(
+  URLOG(
+      DEBUG,
       "create command list ordinal: {}, type: regular, device: {}, inOrder: {}",
       QueueGroupOrdinal, Device->ZeDevice, IsInOrderList);
 
@@ -2459,14 +2464,15 @@ ur_command_list_ptr_t &ur_queue_handle_t_::ur_queue_group_t::getImmCmdList() {
 
   // If cache didn't contain a command list, create one.
   if (!ZeCommandList) {
-    logger::debug("[getZeQueue]: create queue ordinal = {}, index = {} "
-                  "(round robin in [{}, {}]) priority = {}",
-                  ZeCommandQueueDesc.ordinal, ZeCommandQueueDesc.index,
-                  LowerIndex, UpperIndex, Priority);
-    logger::debug("create command list ordinal: {}, type: immediate, device: "
-                  "{}, inOrder: {}",
-                  ZeCommandQueueDesc.ordinal, Queue->Device->ZeDevice,
-                  isInOrderList);
+    URLOG(DEBUG,
+          "[getZeQueue]: create queue ordinal = {}, index = {} "
+          "(round robin in [{}, {}]) priority = {}",
+          ZeCommandQueueDesc.ordinal, ZeCommandQueueDesc.index, LowerIndex,
+          UpperIndex, Priority);
+    URLOG(DEBUG,
+          "create command list ordinal: {}, type: immediate, device: "
+          "{}, inOrder: {}",
+          ZeCommandQueueDesc.ordinal, Queue->Device->ZeDevice, isInOrderList);
 
     ZE_CALL_NOCHECK(zeCommandListCreateImmediate,
                     (Queue->Context->ZeContext, Queue->Device->ZeDevice,

--- a/source/adapters/level_zero/sampler.cpp
+++ b/source/adapters/level_zero/sampler.cpp
@@ -78,9 +78,9 @@ ur_result_t urSamplerCreate(
       ZeSamplerDesc.addressMode = ZE_SAMPLER_ADDRESS_MODE_MIRROR;
       break;
     default:
-      logger::error("urSamplerCreate: unsupported "
-                    "UR_SAMPLER_PROPERTIES_ADDRESSING_MODEE "
-                    "value");
+      URLOG(ERR, "urSamplerCreate: unsupported "
+                 "UR_SAMPLER_PROPERTIES_ADDRESSING_MODEE "
+                 "value");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
 
@@ -89,8 +89,7 @@ ur_result_t urSamplerCreate(
     else if (Props->filterMode == UR_SAMPLER_FILTER_MODE_LINEAR)
       ZeSamplerDesc.filterMode = ZE_SAMPLER_FILTER_MODE_LINEAR;
     else {
-      logger::error(
-          "urSamplerCreate: unsupported UR_SAMPLER_FILTER_MODE value");
+      URLOG(ERR, "urSamplerCreate: unsupported UR_SAMPLER_FILTER_MODE value");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }

--- a/source/adapters/level_zero/sampler.cpp
+++ b/source/adapters/level_zero/sampler.cpp
@@ -148,8 +148,10 @@ ur_result_t urSamplerGetInfo(
   std::ignore = PropValueSize;
   std::ignore = PropValue;
   std::ignore = PropSizeRet;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -160,8 +162,10 @@ ur_result_t urSamplerGetNativeHandle(
     ur_native_handle_t *NativeSampler) {
   std::ignore = Sampler;
   std::ignore = NativeSampler;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -178,8 +182,10 @@ ur_result_t urSamplerCreateWithNativeHandle(
   std::ignore = Context;
   std::ignore = Properties;
   std::ignore = Sampler;
-  logger::error(logger::LegacyMessage("[UR][L0] {} function not implemented!"),
-                "{} function not implemented!", __FUNCTION__);
+  logger::get_logger().log(
+      logger::LegacyMessage("[UR][L0] {} function not implemented!"),
+      logger::Level::ERR, SHORT_FILE, UR_STR(__LINE__),
+      "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 } // namespace ur::level_zero

--- a/source/adapters/level_zero/usm.cpp
+++ b/source/adapters/level_zero/usm.cpp
@@ -636,7 +636,7 @@ ur_result_t urUSMGetMemAllocInfo(
       MemAllocaType = UR_USM_TYPE_SHARED;
       break;
     default:
-      logger::error("urUSMGetMemAllocInfo: unexpected usm memory type");
+      URLOG(ERR, "urUSMGetMemAllocInfo: unexpected usm memory type");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     return ReturnValue(MemAllocaType);
@@ -694,7 +694,7 @@ ur_result_t urUSMGetMemAllocInfo(
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   default:
-    logger::error("urUSMGetMemAllocInfo: unsupported ParamName");
+    URLOG(ERR, "urUSMGetMemAllocInfo: unsupported ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   return UR_RESULT_SUCCESS;
@@ -975,7 +975,7 @@ umf_result_t L0MemoryProvider::open_ipc_handle(void *IpcData, void **Ptr) {
     memcpy(&fdRemote, &zeIpcData->zeHandle, sizeof(fdRemote));
     fdLocal = ur_duplicate_fd(zeIpcData->pid, fdRemote);
     if (fdLocal == -1) {
-      logger::error("duplicating file descriptor from IPC handle failed");
+      URLOG(ERR, "duplicating file descriptor from IPC handle failed");
       return UMF_RESULT_ERROR_MEMORY_PROVIDER_SPECIFIC;
     }
 
@@ -1056,7 +1056,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
       break;
     }
     default: {
-      logger::error("urUSMPoolCreate: unexpected chained stype");
+      URLOG(ERR, "urUSMPoolCreate: unexpected chained stype");
       throw UsmAllocationException(UR_RESULT_ERROR_INVALID_ARGUMENT);
     }
     }

--- a/source/adapters/level_zero/v2/api.cpp
+++ b/source/adapters/level_zero/v2/api.cpp
@@ -23,7 +23,7 @@ ur_result_t
 urContextSetExtendedDeleter(ur_context_handle_t hContext,
                             ur_context_extended_deleter_t pfnDeleter,
                             void *pUserData) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -31,7 +31,7 @@ ur_result_t urMemImageCreate(ur_context_handle_t hContext, ur_mem_flags_t flags,
                              const ur_image_format_t *pImageFormat,
                              const ur_image_desc_t *pImageDesc, void *pHost,
                              ur_mem_handle_t *phMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -39,44 +39,44 @@ ur_result_t urMemImageCreateWithNativeHandle(
     ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urMemImageGetInfo(ur_mem_handle_t hMemory, ur_image_info_t propName,
                               size_t propSize, void *pPropValue,
                               size_t *pPropSizeRet) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urSamplerCreate(ur_context_handle_t hContext,
                             const ur_sampler_desc_t *pDesc,
                             ur_sampler_handle_t *phSampler) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urSamplerRetain(ur_sampler_handle_t hSampler) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urSamplerGetInfo(ur_sampler_handle_t hSampler,
                              ur_sampler_info_t propName, size_t propSize,
                              void *pPropValue, size_t *pPropSizeRet) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urSamplerGetNativeHandle(ur_sampler_handle_t hSampler,
                                      ur_native_handle_t *phNativeSampler) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -84,7 +84,7 @@ ur_result_t urSamplerCreateWithNativeHandle(
     ur_native_handle_t hNativeSampler, ur_context_handle_t hContext,
     const ur_sampler_native_properties_t *pProperties,
     ur_sampler_handle_t *phSampler) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -92,21 +92,21 @@ ur_result_t
 urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
                       const ur_kernel_arg_sampler_properties_t *pProperties,
                       ur_sampler_handle_t hArgValue) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urKernelSetSpecializationConstants(
     ur_kernel_handle_t hKernel, uint32_t count,
     const ur_specialization_constant_info_t *pSpecConstants) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urEventSetCallback(ur_event_handle_t hEvent,
                                ur_execution_info_t execStatus,
                                ur_event_callback_t pfnNotify, void *pUserData) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -116,21 +116,21 @@ ur_result_t urUSMPitchedAllocExp(ur_context_handle_t hContext,
                                  ur_usm_pool_handle_t pool, size_t widthInBytes,
                                  size_t height, size_t elementSizeBytes,
                                  void **ppMem, size_t *pResultPitch) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesUnsampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_image_native_handle_t hImage) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesSampledImageHandleDestroyExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_image_native_handle_t hImage) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -138,7 +138,7 @@ ur_result_t urBindlessImagesImageAllocateExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_image_mem_native_handle_t *phImageMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -146,7 +146,7 @@ ur_result_t
 urBindlessImagesImageFreeExp(ur_context_handle_t hContext,
                              ur_device_handle_t hDevice,
                              ur_exp_image_mem_native_handle_t hImageMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -155,7 +155,7 @@ ur_result_t urBindlessImagesUnsampledImageCreateExp(
     ur_exp_image_mem_native_handle_t hImageMem,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_image_native_handle_t *phImage) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -164,14 +164,14 @@ ur_result_t urBindlessImagesSampledImageCreateExp(
     ur_exp_image_mem_native_handle_t hImageMem,
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_sampler_handle_t hSampler, ur_exp_image_native_handle_t *phImage) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesImageGetInfoExp(
     ur_context_handle_t hContext, ur_exp_image_mem_native_handle_t hImageMem,
     ur_image_info_t propName, void *pPropValue, size_t *pPropSizeRet) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -179,7 +179,7 @@ ur_result_t urBindlessImagesMipmapGetLevelExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_image_mem_native_handle_t hImageMem, uint32_t mipmapLevel,
     ur_exp_image_mem_native_handle_t *phImageMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -187,7 +187,7 @@ ur_result_t
 urBindlessImagesMipmapFreeExp(ur_context_handle_t hContext,
                               ur_device_handle_t hDevice,
                               ur_exp_image_mem_native_handle_t hMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -196,7 +196,7 @@ ur_result_t urBindlessImagesImportExternalMemoryExp(
     ur_exp_external_mem_type_t memHandleType,
     ur_exp_external_mem_desc_t *pExternalMemDesc,
     ur_exp_external_mem_handle_t *phExternalMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -205,21 +205,21 @@ ur_result_t urBindlessImagesMapExternalArrayExp(
     const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
     ur_exp_external_mem_handle_t hExternalMem,
     ur_exp_image_mem_native_handle_t *phImageMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesMapExternalLinearMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice, uint64_t offset,
     uint64_t size, ur_exp_external_mem_handle_t hExternalMem, void **ppRetMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesReleaseExternalMemoryExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_external_mem_handle_t hExternalMem) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -228,14 +228,14 @@ ur_result_t urBindlessImagesImportExternalSemaphoreExp(
     ur_exp_external_semaphore_type_t semHandleType,
     ur_exp_external_semaphore_desc_t *pExternalSemaphoreDesc,
     ur_exp_external_semaphore_handle_t *phExternalSemaphore) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urBindlessImagesReleaseExternalSemaphoreExp(
     ur_context_handle_t hContext, ur_device_handle_t hDevice,
     ur_exp_external_semaphore_handle_t hExternalSemaphore) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -247,7 +247,7 @@ ur_result_t urCommandBufferAppendUSMFillExp(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
     ur_exp_command_buffer_command_handle_t *phCommand) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -259,7 +259,7 @@ ur_result_t urCommandBufferAppendMemBufferFillExp(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
     ur_exp_command_buffer_command_handle_t *phCommand) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -271,7 +271,7 @@ ur_result_t urCommandBufferAppendUSMPrefetchExp(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
     ur_exp_command_buffer_command_handle_t *phCommand) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -282,7 +282,7 @@ ur_result_t urCommandBufferAppendUSMAdviseExp(
     uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList,
     ur_exp_command_buffer_sync_point_t *pSyncPoint, ur_event_handle_t *phEvent,
     ur_exp_command_buffer_command_handle_t *phCommand) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
@@ -290,21 +290,21 @@ ur_result_t urCommandBufferUpdateKernelLaunchExp(
     ur_exp_command_buffer_command_handle_t hCommand,
     const ur_exp_command_buffer_update_kernel_launch_desc_t
         *pUpdateKernelLaunch) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urCommandBufferUpdateSignalEventExp(
     ur_exp_command_buffer_command_handle_t hCommand,
     ur_event_handle_t *phEvent) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 
 ur_result_t urCommandBufferUpdateWaitEventsExp(
     ur_exp_command_buffer_command_handle_t hCommand,
     uint32_t NumEventsInWaitList, const ur_event_handle_t *phEventWaitList) {
-  logger::error("{} function not implemented!", __FUNCTION__);
+  URLOG(ERR, "{} function not implemented!", __FUNCTION__);
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/source/adapters/level_zero/v2/command_buffer.cpp
@@ -20,9 +20,9 @@ namespace {
 // given context.
 void checkImmediateAppendSupport(ur_context_handle_t context) {
   if (!context->getPlatform()->ZeCommandListImmediateAppendExt.Supported) {
-    logger::error("Adapter v2 is used but "
-                  "the current driver does not support the "
-                  "zeCommandListImmediateAppendCommandListsExp entrypoint.");
+    URLOG(ERR, "Adapter v2 is used but "
+               "the current driver does not support the "
+               "zeCommandListImmediateAppendCommandListsExp entrypoint.");
     throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 }

--- a/source/adapters/level_zero/v2/command_list_cache.cpp
+++ b/source/adapters/level_zero/v2/command_list_cache.cpp
@@ -70,10 +70,10 @@ command_list_cache_t::createCommandList(const command_list_descriptor_t &desc) {
     }
     QueueDesc.pNext = &offloadDesc;
 
-    logger::debug("create command list ordinal: {}, type: immediate, device: "
-                  "{}, inOrder: {}",
-                  ImmCmdDesc->Ordinal, ImmCmdDesc->ZeDevice,
-                  ImmCmdDesc->IsInOrder);
+    URLOG(DEBUG,
+          "create command list ordinal: {}, type: immediate, device: "
+          "{}, inOrder: {}",
+          ImmCmdDesc->Ordinal, ImmCmdDesc->ZeDevice, ImmCmdDesc->IsInOrder);
 
     ZE2UR_CALL_THROWS(
         zeCommandListCreateImmediate,
@@ -87,10 +87,10 @@ command_list_cache_t::createCommandList(const command_list_descriptor_t &desc) {
     CmdListDesc.commandQueueGroupOrdinal = RegCmdDesc.Ordinal;
     CmdListDesc.pNext = &offloadDesc;
 
-    logger::debug("create command list ordinal: {}, type: immediate, device: "
-                  "{}, inOrder: {}",
-                  RegCmdDesc.Ordinal, RegCmdDesc.ZeDevice,
-                  RegCmdDesc.IsInOrder);
+    URLOG(DEBUG,
+          "create command list ordinal: {}, type: immediate, device: "
+          "{}, inOrder: {}",
+          RegCmdDesc.Ordinal, RegCmdDesc.ZeDevice, RegCmdDesc.IsInOrder);
 
     ze_command_list_handle_t ZeCommandList;
     ZE2UR_CALL_THROWS(zeCommandListCreate, (ZeContext, RegCmdDesc.ZeDevice,

--- a/source/adapters/level_zero/v2/event.cpp
+++ b/source/adapters/level_zero/v2/event.cpp
@@ -271,7 +271,8 @@ ur_result_t urEventGetInfo(ur_event_handle_t hEvent, ur_event_info_t propName,
     return returnValue(hEvent->getCommandType());
   }
   default:
-    logger::error(
+    URLOG(
+        ERR,
         "Unsupported ParamName in urEventGetInfo: ParamName=ParamName={}(0x{})",
         propName, logger::toHex(propName));
     return UR_RESULT_ERROR_INVALID_VALUE;
@@ -318,7 +319,7 @@ ur_result_t urEventGetProfilingInfo(
       return returnValue(hEvent->getEventEndTimestamp());
     }
     default:
-      logger::error("urEventGetProfilingInfo: not supported ParamName");
+      URLOG(ERR, "urEventGetProfilingInfo: not supported ParamName");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }
@@ -368,7 +369,7 @@ ur_result_t urEventGetProfilingInfo(
     //
     return returnValue(uint64_t{0});
   default:
-    logger::error("urEventGetProfilingInfo: not supported ParamName");
+    URLOG(ERR, "urEventGetProfilingInfo: not supported ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 

--- a/source/adapters/level_zero/v2/event_provider_normal.cpp
+++ b/source/adapters/level_zero/v2/event_provider_normal.cpp
@@ -50,7 +50,7 @@ provider_pool::provider_pool(ur_context_handle_t context, queue_type queue,
     devices.push_back(d->ZeDevice);
   }
 
-  logger::debug("ze_event_pool_desc_t flags set to: {}", desc.flags);
+  URLOG(DEBUG, "ze_event_pool_desc_t flags set to: {}", desc.flags);
 
   ZE2UR_CALL_THROWS(zeEventPoolCreate,
                     (context->getZeHandle(), &desc, devices.size(),

--- a/source/adapters/level_zero/v2/kernel.cpp
+++ b/source/adapters/level_zero/v2/kernel.cpp
@@ -263,7 +263,7 @@ ur_result_t ur_kernel_handle_t_::setExecInfo(ur_kernel_exec_info_t propName,
       ZE2UR_CALL(zeKernelSetCacheConfig,
                  (kernel->hKernel.get(), zeCacheConfig););
     } else {
-      logger::error("urKernelSetExecInfo: unsupported ParamName");
+      URLOG(ERR, "urKernelSetExecInfo: unsupported ParamName");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
   }
@@ -557,9 +557,8 @@ ur_result_t urKernelGetGroupInfo(
     // No corresponding enumeration in Level Zero
     return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default: {
-    logger::error(
-        "Unknown ParamName in urKernelGetGroupInfo: ParamName={}(0x{})",
-        paramName, logger::toHex(paramName));
+    URLOG(ERR, "Unknown ParamName in urKernelGetGroupInfo: ParamName={}(0x{})",
+          paramName, logger::toHex(paramName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   }
@@ -642,9 +641,8 @@ ur_result_t urKernelGetInfo(ur_kernel_handle_t hKernel,
     return ReturnValue(static_cast<const char *>(attributes.data()));
   }
   default:
-    logger::error(
-        "Unsupported ParamName in urKernelGetInfo: ParamName={}(0x{})",
-        paramName, logger::toHex(paramName));
+    URLOG(ERR, "Unsupported ParamName in urKernelGetInfo: ParamName={}(0x{})",
+          paramName, logger::toHex(paramName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 

--- a/source/adapters/level_zero/v2/memory.cpp
+++ b/source/adapters/level_zero/v2/memory.cpp
@@ -97,7 +97,7 @@ ur_integrated_mem_handle_t::ur_integrated_mem_handle_t(
     this->ptr = usm_unique_ptr_t(rawPtr, [hContext](void *ptr) {
       auto ret = hContext->getDefaultUSMPool()->free(ptr);
       if (ret != UR_RESULT_SUCCESS) {
-        logger::error("Failed to free host memory: {}", ret);
+        URLOG(ERR, "Failed to free host memory: {}", ret);
       }
     });
 
@@ -178,7 +178,7 @@ void *ur_discrete_mem_handle_t::allocateOnDevice(ur_device_handle_t hDevice,
       usm_unique_ptr_t(ptr, [hContext = this->hContext](void *ptr) {
         auto ret = hContext->getDefaultUSMPool()->free(ptr);
         if (ret != UR_RESULT_SUCCESS) {
-          logger::error("Failed to free device memory: {}", ret);
+          URLOG(ERR, "Failed to free device memory: {}", ret);
         }
       });
 
@@ -306,7 +306,7 @@ void *ur_discrete_mem_handle_t::mapHostPtr(
         if (ownsAlloc) {
           auto ret = hContext->getDefaultUSMPool()->free(p);
           if (ret != UR_RESULT_SUCCESS) {
-            logger::error("Failed to mapped memory: {}", ret);
+            URLOG(ERR, "Failed to mapped memory: {}", ret);
           }
         }
       });

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -185,7 +185,7 @@ ur_queue_immediate_in_order_t::~ur_queue_immediate_in_order_t() {
   try {
     UR_CALL_THROWS(queueFinish());
   } catch (...) {
-    logger::error("Failed to finish queue on destruction");
+    URLOG(ERR, "Failed to finish queue on destruction");
   }
 }
 

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.cpp
@@ -122,9 +122,10 @@ ur_queue_immediate_in_order_t::queueGetInfo(ur_queue_info_t propName,
     }
   }
   default:
-    logger::error("Unsupported ParamName in urQueueGetInfo: "
-                  "ParamName=ParamName={}(0x{})",
-                  propName, logger::toHex(propName));
+    URLOG(ERR,
+          "Unsupported ParamName in urQueueGetInfo: "
+          "ParamName=ParamName={}(0x{})",
+          propName, logger::toHex(propName));
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 

--- a/source/adapters/level_zero/v2/usm.cpp
+++ b/source/adapters/level_zero/v2/usm.cpp
@@ -171,7 +171,7 @@ ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t hContext,
     }
   } else {
     // If pooling is disabled, do nothing.
-    logger::info("USM pooling is disabled. Skiping pool limits adjustment.");
+    URLOG(INFO, "USM pooling is disabled. Skiping pool limits adjustment.");
   }
 
   auto [result, descriptors] = usm::pool_descriptor::create(this, hContext);

--- a/source/adapters/level_zero/v2/usm.cpp
+++ b/source/adapters/level_zero/v2/usm.cpp
@@ -245,7 +245,7 @@ ur_result_t ur_usm_pool_handle_t_::free(void *ptr) {
   if (umfPool) {
     return umf::umf2urResult(umfPoolFree(umfPool, ptr));
   } else {
-    logger::error("Failed to find pool for pointer: {}", ptr);
+    URLOG(ERR, "Failed to find pool for pointer: {}", ptr);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 }
@@ -449,7 +449,7 @@ ur_result_t urUSMGetMemAllocInfo(
       memAllocType = UR_USM_TYPE_SHARED;
       break;
     default:
-      logger::error("urUSMGetMemAllocInfo: unexpected usm memory type");
+      URLOG(ERR, "urUSMGetMemAllocInfo: unexpected usm memory type");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     return ReturnValue(memAllocType);
@@ -478,7 +478,7 @@ ur_result_t urUSMGetMemAllocInfo(
     // TODO
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   default:
-    logger::error("urUSMGetMemAllocInfo: unsupported ParamName");
+    URLOG(ERR, "urUSMGetMemAllocInfo: unsupported ParamName");
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   }

--- a/source/adapters/level_zero/virtual_mem.cpp
+++ b/source/adapters/level_zero/virtual_mem.cpp
@@ -38,8 +38,8 @@ ur_result_t urVirtualMemGranularityGetInfo(
     return ReturnValue(PageSize);
   }
   default:
-    logger::error("Unsupported propName in urQueueGetInfo: propName={}({})",
-                  propName, propName);
+    URLOG(ERR, "Unsupported propName in urQueueGetInfo: propName={}({})",
+          propName, propName);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
   return UR_RESULT_SUCCESS;
@@ -120,8 +120,8 @@ ur_result_t urVirtualMemGetInfo(ur_context_handle_t hContext,
     return ReturnValue(RetFlags);
   }
   default:
-    logger::error("Unsupported propName in urQueueGetInfo: propName={}({})",
-                  propName, propName);
+    URLOG(ERR, "Unsupported propName in urQueueGetInfo: propName={}({})",
+          propName, propName);
     return UR_RESULT_ERROR_INVALID_VALUE;
   }
 

--- a/source/adapters/native_cpu/common.cpp
+++ b/source/adapters/native_cpu/common.cpp
@@ -31,6 +31,6 @@ ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
 }
 
 void detail::ur::die(const char *pMessage) {
-  logger::always("ur_die: {}", pMessage);
+  URLOG_ALWAYS("ur_die: {}", pMessage);
   std::terminate();
 }

--- a/source/adapters/native_cpu/common.hpp
+++ b/source/adapters/native_cpu/common.hpp
@@ -21,23 +21,23 @@ extern thread_local char ErrorMessage[MaxMessageSize];
 
 #define DIE_NO_IMPLEMENTATION                                                  \
   do {                                                                         \
-    logger::error("Not Implemented : {} - File : {} / Line : {}",              \
-                  __FUNCTION__, __FILE__, __LINE__);                           \
+    URLOG(ERR, "Not Implemented : {} - File : {} / Line : {}", __FUNCTION__,   \
+          __FILE__, __LINE__);                                                 \
                                                                                \
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;                                \
   } while (false);
 
 #define CONTINUE_NO_IMPLEMENTATION                                             \
   do {                                                                         \
-    logger::warning("Not Implemented : {} - File : {} / Line : {}",            \
-                    __FUNCTION__, __FILE__, __LINE__);                         \
+    URLOG(WARN, "Not Implemented : {} - File : {} / Line : {}", __FUNCTION__,  \
+          __FILE__, __LINE__);                                                 \
     return UR_RESULT_SUCCESS;                                                  \
   } while (false);
 
 #define CASE_UR_UNSUPPORTED(not_supported)                                     \
   case not_supported:                                                          \
-    logger::error("Unsupported UR case : {} in {}:{}({})", #not_supported,     \
-                  __FUNCTION__, __LINE__, __FILE__);                           \
+    URLOG(ERR, "Unsupported UR case : {} in {}:{}({})", #not_supported,        \
+          __FUNCTION__, __LINE__, __FILE__);                                   \
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
 /// ------ Error handling, matching OpenCL plugin semantics.

--- a/source/adapters/native_cpu/device.cpp
+++ b/source/adapters/native_cpu/device.cpp
@@ -99,7 +99,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
   if (NumEntries == 0) {
     /// Runtime queries number of devices
     if (phDevices != nullptr) {
-      logger::error("Invalid Arguments for urDevicesGet");
+      URLOG(ERR, "Invalid Arguments for urDevicesGet");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     return UR_RESULT_SUCCESS;

--- a/source/adapters/native_cpu/platform.cpp
+++ b/source/adapters/native_cpu/platform.cpp
@@ -29,7 +29,7 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
 
   if (NumEntries == 0) {
     if (phPlatforms != nullptr) {
-      logger::error("Invalid argument combination for urPlatformsGet");
+      URLOG(ERR, "Invalid argument combination for urPlatformsGet");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     return UR_RESULT_SUCCESS;

--- a/source/adapters/opencl/common.cpp
+++ b/source/adapters/opencl/common.cpp
@@ -106,7 +106,7 @@ ur_result_t mapCLErrorToUR(cl_int Result) {
 }
 
 void cl_adapter::die(const char *Message) {
-  logger::always("ur_die: {}", Message);
+  URLOG_ALWAYS("ur_die: {}", Message);
   std::terminate();
 }
 

--- a/source/adapters/opencl/context.cpp
+++ b/source/adapters/opencl/context.cpp
@@ -171,9 +171,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
     ur_context_handle_t hContext, ur_context_extended_deleter_t pfnDeleter,
     void *pUserData) {
   if (!ur::cl::getAdapter()->clSetContextDestructorCallback) {
-    ur::cl::getAdapter()->log.warning(
-        "clSetContextDestructorCallback not found, consider upgrading the "
-        "OpenCL-ICD-Loader to the latest version.");
+    URLOG_(ur::cl::getAdapter()->log, WARN,
+           "clSetContextDestructorCallback not found, consider upgrading the "
+           "OpenCL-ICD-Loader to the latest version.");
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 

--- a/source/common/latency_tracker.hpp
+++ b/source/common/latency_tracker.hpp
@@ -64,7 +64,7 @@ static inline latencyValues getValues(const struct hdr_histogram *histogram) {
   auto ret = hdr_value_at_percentiles(histogram, percentiles,
                                       values.percentileValues, numPercentiles);
   if (ret != 0) {
-    logger::error("Failed to get percentiles from latency histogram");
+    URLOG(ERR, "Failed to get percentiles from latency histogram");
   }
 
   return values;
@@ -137,7 +137,7 @@ public:
       auto ret = hdr_init(lowestDiscernibleValue, highestTrackableValue,
                           significantFigures, &cHistogram);
       if (ret != 0) {
-        logger::error("Failed to initialize latency histogram");
+        URLOG(ERR, "Failed to initialize latency histogram");
       }
       histogram = std::unique_ptr<struct hdr_histogram, decltype(&hdr_close)>(
           cHistogram, &hdr_close);
@@ -153,7 +153,7 @@ public:
     }
 
     if (hdr_min(histogram.get()) == std::numeric_limits<int64_t>::max()) {
-      logger::info("[{}] latency: no data", name);
+      URLOG(INFO, "[{}] latency: no data", name);
       return;
     }
 

--- a/source/common/linux/ur_lib_loader.cpp
+++ b/source/common/linux/ur_lib_loader.cpp
@@ -25,10 +25,10 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
   if (handle) {
     int res = dlclose(handle);
     if (res) {
-      logger::error(
-          "Failed to unload the library with the handle at address {}", handle);
+      URLOG(ERR, "Failed to unload the library with the handle at address {}",
+            handle);
     } else {
-      logger::info("unloaded adapter 0x{}", handle);
+      URLOG(INFO, "unloaded adapter 0x{}", handle);
     }
   }
 }
@@ -40,10 +40,10 @@ LibLoader::loadAdapterLibrary(const char *name) {
   bool deepbind = getenv_tobool(DEEP_BIND_ENV);
   if (deepbind) {
 #if defined(SANITIZER_ANY)
-    logger::warning(
-        "Enabling RTLD_DEEPBIND while running under a sanitizer is likely "
-        "to cause issues. Consider disabling {} environment variable.",
-        DEEP_BIND_ENV);
+    URLOG(WARN,
+          "Enabling RTLD_DEEPBIND while running under a sanitizer is likely "
+          "to cause issues. Consider disabling {} environment variable.",
+          DEEP_BIND_ENV);
 #endif
     mode |= RTLD_DEEPBIND;
   }
@@ -51,17 +51,17 @@ LibLoader::loadAdapterLibrary(const char *name) {
   HMODULE handle = dlopen(name, mode);
   if (!handle) {
     char *err = dlerror();
-    logger::info("failed to load adapter '{}' with error: {}", name,
-                 err ? err : "unknown error");
+    URLOG(INFO, "failed to load adapter '{}' with error: {}", name,
+          err ? err : "unknown error");
   } else {
 #if defined(ADD_FULL_PATH_LOG)
     struct link_map *dlinfo_map;
     if (dlinfo(handle, RTLD_DI_LINKMAP, &dlinfo_map) == 0) {
-      logger::info("loaded adapter 0x{} ({}) from {}", handle, name,
-                   dlinfo_map->l_name);
+      URLOG(INFO, "loaded adapter 0x{} ({}) from {}", handle, name,
+            dlinfo_map->l_name);
     } else
 #endif
-      logger::info("loaded adapter 0x{} ({})", handle, name);
+      URLOG(INFO, "loaded adapter 0x{} ({})", handle, name);
   }
   return std::unique_ptr<HMODULE, LibLoader::lib_dtor>(handle);
 }

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -28,53 +28,10 @@ inline Logger &get_logger(std::string name = "common",
 
 inline void init(const std::string &name) { get_logger(name.c_str()); }
 
-template <typename... Args>
-inline void debug(const char *format, Args &&...args) {
-  get_logger().log(Level::DEBUG, format, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-inline void info(const char *format, Args &&...args) {
-  get_logger().log(Level::INFO, format, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-inline void warning(const char *format, Args &&...args) {
-  get_logger().log(Level::WARN, format, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-inline void error(const char *format, Args &&...args) {
-  get_logger().log(Level::ERR, format, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-inline void always(const char *format, Args &&...args) {
-  get_logger().always(format, std::forward<Args>(args)...);
-}
-
 #define URLOG(...) URLOG_(::logger::get_logger(), __VA_ARGS__)
 #define URLOG_ALWAYS(...) URLOG_ALWAYS_(::logger::get_logger(), __VA_ARGS__)
 #define URLOG_CTX(...) URLOG_(getContext()->logger, __VA_ARGS__)
 #define URLOG_CTX_ALWAYS(...) URLOG_(getContext()->logger, QUIET, __VA_ARGS__)
-
-template <typename... Args>
-inline void debug(const LegacyMessage &p, Args &&...args) {
-  get_logger().log(p, Level::DEBUG, std::forward<Args>(args)...);
-}
-
-template <typename... Args> inline void info(LegacyMessage p, Args &&...args) {
-  get_logger().log(p, Level::INFO, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-inline void warning(LegacyMessage p, Args &&...args) {
-  get_logger().log(p, Level::WARN, std::forward<Args>(args)...);
-}
-
-template <typename... Args> inline void error(LegacyMessage p, Args &&...args) {
-  get_logger().log(p, Level::ERR, std::forward<Args>(args)...);
-}
 
 inline void setLevel(Level level) { get_logger().setLevel(level); }
 

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -53,6 +53,22 @@ template <typename... Args>
 inline void always(const char *format, Args &&...args) {
   get_logger().always(format, std::forward<Args>(args)...);
 }
+#ifdef SRC_PATH_SIZE
+#define SHORT_FILE ((__FILE__) + (SRC_PATH_SIZE))
+#else
+#define SHORT_FILE __FILE__
+#endif
+
+#define URLOG_IMPL(level, format, ...)                                         \
+  {                                                                            \
+    ::logger::get_logger().log(logger::Level::level, format " <{}:{}>",        \
+                               __VA_ARGS__);                                   \
+  }
+#define URLOG(...) URLOG_IMPL(__VA_ARGS__, SHORT_FILE, __LINE__)
+
+#define URLOG_ALWAYS_IMPL(format, ...)                                         \
+  { ::logger::get_logger().always(format " <{}:{}>", __VA_ARGS__); }
+#define URLOG_ALWAYS(...) URLOG_ALWAYS_IMPL(__VA_ARGS__, SHORT_FILE, __LINE__)
 
 template <typename... Args>
 inline void debug(const logger::LegacyMessage &p, const char *format,

--- a/source/common/logger/ur_logger.hpp
+++ b/source/common/logger/ur_logger.hpp
@@ -16,11 +16,10 @@ namespace logger {
 
 Logger create_logger(std::string logger_name, bool skip_prefix = false,
                      bool skip_linebreak = false,
-                     logger::Level default_log_level = logger::Level::QUIET);
+                     Level default_log_level = Level::QUIET);
 
-inline Logger &
-get_logger(std::string name = "common",
-           logger::Level default_log_level = logger::Level::QUIET) {
+inline Logger &get_logger(std::string name = "common",
+                          Level default_log_level = Level::QUIET) {
   static Logger logger =
       create_logger(std::move(name), /*skip_prefix*/ false,
                     /*slip_linebreak*/ false, default_log_level);
@@ -31,73 +30,55 @@ inline void init(const std::string &name) { get_logger(name.c_str()); }
 
 template <typename... Args>
 inline void debug(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::DEBUG, format, std::forward<Args>(args)...);
+  get_logger().log(Level::DEBUG, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::INFO, format, std::forward<Args>(args)...);
+  get_logger().log(Level::INFO, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warning(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::WARN, format, std::forward<Args>(args)...);
+  get_logger().log(Level::WARN, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(const char *format, Args &&...args) {
-  get_logger().log(logger::Level::ERR, format, std::forward<Args>(args)...);
+  get_logger().log(Level::ERR, format, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void always(const char *format, Args &&...args) {
   get_logger().always(format, std::forward<Args>(args)...);
 }
-#ifdef SRC_PATH_SIZE
-#define SHORT_FILE ((__FILE__) + (SRC_PATH_SIZE))
-#else
-#define SHORT_FILE __FILE__
-#endif
 
-#define URLOG_IMPL(level, format, ...)                                         \
-  {                                                                            \
-    ::logger::get_logger().log(logger::Level::level, format " <{}:{}>",        \
-                               __VA_ARGS__);                                   \
-  }
-#define URLOG(...) URLOG_IMPL(__VA_ARGS__, SHORT_FILE, __LINE__)
-
-#define URLOG_ALWAYS_IMPL(format, ...)                                         \
-  { ::logger::get_logger().always(format " <{}:{}>", __VA_ARGS__); }
-#define URLOG_ALWAYS(...) URLOG_ALWAYS_IMPL(__VA_ARGS__, SHORT_FILE, __LINE__)
+#define URLOG(...) URLOG_(::logger::get_logger(), __VA_ARGS__)
+#define URLOG_ALWAYS(...) URLOG_ALWAYS_(::logger::get_logger(), __VA_ARGS__)
+#define URLOG_CTX(...) URLOG_(getContext()->logger, __VA_ARGS__)
+#define URLOG_CTX_ALWAYS(...) URLOG_(getContext()->logger, QUIET, __VA_ARGS__)
 
 template <typename... Args>
-inline void debug(const logger::LegacyMessage &p, const char *format,
-                  Args &&...args) {
-  get_logger().log(p, logger::Level::DEBUG, format,
-                   std::forward<Args>(args)...);
+inline void debug(const LegacyMessage &p, Args &&...args) {
+  get_logger().log(p, Level::DEBUG, std::forward<Args>(args)...);
+}
+
+template <typename... Args> inline void info(LegacyMessage p, Args &&...args) {
+  get_logger().log(p, Level::INFO, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
-inline void info(logger::LegacyMessage p, const char *format, Args &&...args) {
-  get_logger().log(p, logger::Level::INFO, format, std::forward<Args>(args)...);
+inline void warning(LegacyMessage p, Args &&...args) {
+  get_logger().log(p, Level::WARN, std::forward<Args>(args)...);
 }
 
-template <typename... Args>
-inline void warning(logger::LegacyMessage p, const char *format,
-                    Args &&...args) {
-  get_logger().log(p, logger::Level::WARN, format, std::forward<Args>(args)...);
+template <typename... Args> inline void error(LegacyMessage p, Args &&...args) {
+  get_logger().log(p, Level::ERR, std::forward<Args>(args)...);
 }
 
-template <typename... Args>
-inline void error(logger::LegacyMessage p, const char *format, Args &&...args) {
-  get_logger().log(p, logger::Level::ERR, format, std::forward<Args>(args)...);
-}
+inline void setLevel(Level level) { get_logger().setLevel(level); }
 
-inline void setLevel(logger::Level level) { get_logger().setLevel(level); }
-
-inline void setFlushLevel(logger::Level level) {
-  get_logger().setFlushLevel(level);
-}
+inline void setFlushLevel(Level level) { get_logger().setFlushLevel(level); }
 
 template <typename T> inline std::string toHex(T t) {
   std::stringstream s;
@@ -131,23 +112,22 @@ template <typename T> inline std::string toHex(T t) {
 ///                            to be printed immediately as they occur
 ///             - output: stderr
 inline Logger create_logger(std::string logger_name, bool skip_prefix,
-                            bool skip_linebreak,
-                            logger::Level default_log_level) {
+                            bool skip_linebreak, Level default_log_level) {
   std::transform(logger_name.begin(), logger_name.end(), logger_name.begin(),
                  ::toupper);
-  const auto default_flush_level = logger::Level::ERR;
+  const auto default_flush_level = Level::ERR;
   const std::string default_output = "stderr";
   auto level = default_log_level;
   auto flush_level = default_flush_level;
-  std::unique_ptr<logger::Sink> sink;
+  std::unique_ptr<Sink> sink;
 
   auto env_var_name = "UR_LOG_" + logger_name;
   try {
     auto map = getenv_to_map(env_var_name.c_str());
     if (!map.has_value()) {
       return Logger(default_log_level,
-                    std::make_unique<logger::StderrSink>(
-                        std::move(logger_name), skip_prefix, skip_linebreak));
+                    std::make_unique<StderrSink>(std::move(logger_name),
+                                                 skip_prefix, skip_linebreak));
     }
 
     auto kv = map->find("level");
@@ -175,8 +155,8 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix,
       std::cerr << "Wrong logger environment variable parameter: '"
                 << map->begin()->first << "'. Default logger options are set.";
       return Logger(default_log_level,
-                    std::make_unique<logger::StderrSink>(
-                        std::move(logger_name), skip_prefix, skip_linebreak));
+                    std::make_unique<StderrSink>(std::move(logger_name),
+                                                 skip_prefix, skip_linebreak));
     }
 
     sink = values.size() == 2 ? sink_from_str(logger_name, values[0], values[1],
@@ -188,8 +168,8 @@ inline Logger create_logger(std::string logger_name, bool skip_prefix,
               << env_var_name << "' environment variable:\n"
               << e.what() << std::endl;
     return Logger(default_log_level,
-                  std::make_unique<logger::StderrSink>(
-                      std::move(logger_name), skip_prefix, skip_linebreak));
+                  std::make_unique<StderrSink>(std::move(logger_name),
+                                               skip_prefix, skip_linebreak));
   }
   sink->setFlushLevel(flush_level);
 

--- a/source/common/logger/ur_logger_details.hpp
+++ b/source/common/logger/ur_logger_details.hpp
@@ -35,52 +35,6 @@ public:
     }
   }
 
-  template <typename... Args> void debug(Args &&...args) {
-    log(Level::DEBUG, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args> void info(Args &&...args) {
-    log(Level::INFO, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args> void warning(Args &&...args) {
-    log(Level::WARN, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args> void warn(Args &&...args) {
-    warning(std::forward<Args>(args)...);
-  }
-
-  template <typename... Args> void error(Args &&...args) {
-    log(Level::ERR, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args> void always(Args &&...args) {
-    if (sink) {
-      sink->log(Level::QUIET, std::forward<Args>(args)...);
-    }
-  }
-
-  template <typename... Args>
-  void debug(const LegacyMessage &p, Args &&...args) {
-    log(p, Level::DEBUG, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args>
-  void info(const LegacyMessage &p, Args &&...args) {
-    log(p, Level::INFO, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args>
-  void warning(const LegacyMessage &p, Args &&...args) {
-    log(p, Level::WARN, std::forward<Args>(args)...);
-  }
-
-  template <typename... Args>
-  void error(const LegacyMessage &p, Args &&...args) {
-    log(p, Level::ERR, std::forward<Args>(args)...);
-  }
-
   template <typename... Args>
   void log(Level level, const char *filename, const char *lineno,
            const char *format, Args &&...args) {
@@ -136,6 +90,6 @@ private:
   }
 
 #define URLOG_ALWAYS_(logger_instance, ...)                                    \
-  { (logger_instance).always(SHORT_FILE, UR_STR(__LINE__), __VA_ARGS__); }
+  URLOG_(logger_instance, QUIET, __VA_ARGS__)
 
 #endif /* UR_LOGGER_DETAILS_HPP */

--- a/source/common/logger/ur_logger_details.hpp
+++ b/source/common/logger/ur_logger_details.hpp
@@ -19,111 +19,123 @@ struct LegacyMessage {
 
 class Logger {
 public:
-  Logger(std::unique_ptr<logger::Sink> sink) : sink(std::move(sink)) {
-    this->level = logger::Level::QUIET;
-  }
+  Logger(std::unique_ptr<Sink> sink)
+      : level(Level::QUIET), sink(std::move(sink)) {}
 
-  Logger(logger::Level level, std::unique_ptr<logger::Sink> sink)
+  Logger(Level level, std::unique_ptr<Sink> sink)
       : level(level), sink(std::move(sink)) {}
 
-  Logger &operator=(Logger &&) = default;
-  ~Logger() = default;
+  void setLevel(Level level) { this->level = level; }
 
-  void setLevel(logger::Level level) { this->level = level; }
+  Level getLevel() { return this->level; }
 
-  logger::Level getLevel() { return this->level; }
-
-  void setFlushLevel(logger::Level level) {
+  void setFlushLevel(Level level) {
     if (sink) {
       this->sink->setFlushLevel(level);
     }
   }
 
-  template <typename... Args> void debug(const char *format, Args &&...args) {
-    log(logger::Level::DEBUG, format, std::forward<Args>(args)...);
+  template <typename... Args> void debug(Args &&...args) {
+    log(Level::DEBUG, std::forward<Args>(args)...);
   }
 
-  template <typename... Args> void info(const char *format, Args &&...args) {
-    log(logger::Level::INFO, format, std::forward<Args>(args)...);
+  template <typename... Args> void info(Args &&...args) {
+    log(Level::INFO, std::forward<Args>(args)...);
   }
 
-  template <typename... Args> void warning(const char *format, Args &&...args) {
-    log(logger::Level::WARN, format, std::forward<Args>(args)...);
+  template <typename... Args> void warning(Args &&...args) {
+    log(Level::WARN, std::forward<Args>(args)...);
   }
 
-  template <typename... Args> void warn(const char *format, Args &&...args) {
-    warning(format, std::forward<Args>(args)...);
+  template <typename... Args> void warn(Args &&...args) {
+    warning(std::forward<Args>(args)...);
   }
 
-  template <typename... Args> void error(const char *format, Args &&...args) {
-    log(logger::Level::ERR, format, std::forward<Args>(args)...);
+  template <typename... Args> void error(Args &&...args) {
+    log(Level::ERR, std::forward<Args>(args)...);
   }
 
-  template <typename... Args> void always(const char *format, Args &&...args) {
+  template <typename... Args> void always(Args &&...args) {
     if (sink) {
-      sink->log(logger::Level::QUIET, format, std::forward<Args>(args)...);
+      sink->log(Level::QUIET, std::forward<Args>(args)...);
     }
   }
 
   template <typename... Args>
-  void debug(const logger::LegacyMessage &p, const char *format,
-             Args &&...args) {
-    log(p, logger::Level::DEBUG, format, std::forward<Args>(args)...);
+  void debug(const LegacyMessage &p, Args &&...args) {
+    log(p, Level::DEBUG, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void info(const logger::LegacyMessage &p, const char *format,
-            Args &&...args) {
-    log(p, logger::Level::INFO, format, std::forward<Args>(args)...);
+  void info(const LegacyMessage &p, Args &&...args) {
+    log(p, Level::INFO, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void warning(const logger::LegacyMessage &p, const char *format,
-               Args &&...args) {
-    log(p, logger::Level::WARN, format, std::forward<Args>(args)...);
+  void warning(const LegacyMessage &p, Args &&...args) {
+    log(p, Level::WARN, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void error(const logger::LegacyMessage &p, const char *format,
-             Args &&...args) {
-    log(p, logger::Level::ERR, format, std::forward<Args>(args)...);
+  void error(const LegacyMessage &p, Args &&...args) {
+    log(p, Level::ERR, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void log(logger::Level level, const char *format, Args &&...args) {
-    log(logger::LegacyMessage(format), level, format,
+  void log(Level level, const char *filename, const char *lineno,
+           const char *format, Args &&...args) {
+    log(LegacyMessage(format), level, filename, lineno, format,
         std::forward<Args>(args)...);
   }
 
   template <typename... Args>
-  void log(const logger::LegacyMessage &p, logger::Level level,
-           const char *format, Args &&...args) {
+  void log(const LegacyMessage &p, Level level, const char *filename,
+           const char *lineno, const char *format, Args &&...args) {
     if (!sink) {
       return;
     }
 
     if (isLegacySink) {
-      sink->log(level, p.message, std::forward<Args>(args)...);
+      sink->log(level, filename, lineno, p.message,
+                std::forward<Args>(args)...);
       return;
     }
     if (level < this->level) {
       return;
     }
 
-    sink->log(level, format, std::forward<Args>(args)...);
+    sink->log(level, filename, lineno, format, std::forward<Args>(args)...);
   }
 
-  void setLegacySink(std::unique_ptr<logger::Sink> legacySink) {
+  void setLegacySink(std::unique_ptr<Sink> legacySink) {
     this->isLegacySink = true;
     this->sink = std::move(legacySink);
   }
 
 private:
-  logger::Level level;
-  std::unique_ptr<logger::Sink> sink;
+  Level level;
+  std::unique_ptr<Sink> sink;
   bool isLegacySink = false;
 };
 
 } // namespace logger
+
+#ifdef SRC_PATH_SIZE
+#define SHORT_FILE ((__FILE__) + (SRC_PATH_SIZE))
+#else
+#define SHORT_FILE __FILE__
+#endif
+
+#define UR_STRIMPL(x) #x
+#define UR_STR(x) UR_STRIMPL(x)
+
+#define URLOG_(logger_instance, level, ...)                                    \
+  {                                                                            \
+    (logger_instance)                                                          \
+        .log(logger::Level::level, SHORT_FILE, UR_STR(__LINE__), __VA_ARGS__); \
+  }
+
+#define URLOG_ALWAYS_(logger_instance, ...)                                    \
+  { (logger_instance).always(SHORT_FILE, UR_STR(__LINE__), __VA_ARGS__); }
 
 #endif /* UR_LOGGER_DETAILS_HPP */

--- a/source/common/umf_helpers.hpp
+++ b/source/common/umf_helpers.hpp
@@ -285,7 +285,7 @@ inline ur_result_t umf2urResult(umf_result_t umfResult) {
     umfMemoryProviderGetLastNativeError(hProvider, &Msg, &Err);
 
     if (Msg) {
-      logger::error("UMF failed with: {}", Msg);
+      URLOG(ERR, "UMF failed with: {}", Msg);
     }
 
     return getProviderNativeError(umfMemoryProviderGetName(hProvider), Err);

--- a/source/common/ur_pool_manager.hpp
+++ b/source/common/ur_pool_manager.hpp
@@ -272,7 +272,7 @@ public:
   ur_result_t addPool(const D &desc,
                       umf::pool_unique_handle_t &&hPool) noexcept {
     if (!descToPoolMap.try_emplace(desc, std::move(hPool)).second) {
-      logger::error("Pool for pool descriptor: {}, already exists", desc);
+      URLOG(ERR, "Pool for pool descriptor: {}, already exists", desc);
       return UR_RESULT_ERROR_INVALID_ARGUMENT;
     }
 
@@ -282,8 +282,7 @@ public:
   std::optional<umf_memory_pool_handle_t> getPool(const D &desc) noexcept {
     auto it = descToPoolMap.find(desc);
     if (it == descToPoolMap.end()) {
-      logger::error("Pool descriptor doesn't match any existing pool: {}",
-                    desc);
+      URLOG(ERR, "Pool descriptor doesn't match any existing pool: {}", desc);
       return std::nullopt;
     }
 

--- a/source/common/ur_util.cpp
+++ b/source/common/ur_util.cpp
@@ -45,14 +45,14 @@ int ur_duplicate_fd(int pid, int fd_in) {
   errno = 0;
   int pid_fd = syscall(__NR_pidfd_open, pid, 0);
   if (pid_fd == -1) {
-    logger::error("__NR_pidfd_open");
+    URLOG(ERR, "__NR_pidfd_open");
     return -1;
   }
 
   int fd_dup = syscall(__NR_pidfd_getfd, pid_fd, fd_in, 0);
   close(pid_fd);
   if (fd_dup == -1) {
-    logger::error("__NR_pidfd_getfd");
+    URLOG(ERR, "__NR_pidfd_getfd");
     return -1;
   }
 
@@ -63,7 +63,7 @@ int ur_duplicate_fd(int pid, int fd_in) {
   (void)pid;       // unused
   (void)fd_in;     // unused
   errno = ENOTSUP; // unsupported
-  logger::error("__NR_pidfd_open or __NR_pidfd_getfd not available");
+  URLOG(ERR, "__NR_pidfd_open or __NR_pidfd_getfd not available");
   return -1;
 #endif /* defined(__NR_pidfd_open) && defined(__NR_pidfd_getfd) */
 }

--- a/source/common/windows/ur_lib_loader.cpp
+++ b/source/common/windows/ur_lib_loader.cpp
@@ -17,11 +17,10 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
   if (handle) {
     BOOL res = FreeLibrary(handle);
     if (!res) {
-      logger::error(
-          "Failed to unload the library with the handle at address 0x{}",
-          handle);
+      URLOG(ERR, "Failed to unload the library with the handle at address 0x{}",
+            handle);
     } else {
-      logger::info("unloaded adapter 0x{}", handle);
+      URLOG(INFO, "unloaded adapter 0x{}", handle);
     }
   }
 }
@@ -29,11 +28,11 @@ void LibLoader::freeAdapterLibrary(HMODULE handle) {
 std::unique_ptr<HMODULE, LibLoader::lib_dtor>
 LibLoader::loadAdapterLibrary(const char *name) {
   if (HMODULE handle = LoadLibraryExA(name, nullptr, 0)) {
-    logger::info("loaded adapter 0x{}: {}", handle, name);
+    URLOG(INFO, "loaded adapter 0x{}: {}", handle, name);
     return std::unique_ptr<HMODULE, LibLoader::lib_dtor>{handle};
   } else {
-    logger::debug("loading adapter failed with error {}: {}", GetLastError(),
-                  name);
+    URLOG(DEBUG, "loading adapter failed with error {}: {}", GetLastError(),
+          name);
   }
   return nullptr;
 }

--- a/source/loader/layers/sanitizer/asan/asan_allocator.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_allocator.cpp
@@ -18,10 +18,10 @@ namespace ur_sanitizer_layer {
 namespace asan {
 
 void AllocInfo::print() {
-  getContext()->logger.info(
-      "AllocInfo(Alloc=[{}-{}),  User=[{}-{}), AllocSize={}, Type={})",
-      (void *)AllocBegin, (void *)(AllocBegin + AllocSize), (void *)UserBegin,
-      (void *)(UserEnd), AllocSize, ToString(Type));
+  URLOG_CTX(INFO, SHORT_FILE, UR_STR(__LINE__),
+            "AllocInfo(Alloc=[{}-{}),  User=[{}-{}), AllocSize={}, Type={})",
+            (void *)AllocBegin, (void *)(AllocBegin + AllocSize),
+            (void *)UserBegin, (void *)(UserEnd), AllocSize, ToString(Type));
 }
 
 } // namespace asan

--- a/source/loader/layers/sanitizer/asan/asan_buffer.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_buffer.cpp
@@ -97,8 +97,8 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
                                                 Size, AllocType::MEM_BUFFER,
                                                 ur_cast<void **>(&Allocation));
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error(
-          "Failed to allocate {} bytes memory for buffer {}", Size, this);
+      URLOG_CTX(ERR, "Failed to allocate {} bytes memory for buffer {}", Size,
+                this);
       return URes;
     }
 
@@ -107,9 +107,10 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
       URes = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy(
           Queue, true, Allocation, HostPtr, Size, 0, nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to copy {} bytes data from host "
-                                   "pointer {} to buffer {}",
-                                   Size, HostPtr, this);
+        URLOG_CTX(ERR,
+                  "Failed to copy {} bytes data from host "
+                  "pointer {} to buffer {}",
+                  Size, HostPtr, this);
         return URes;
       }
     }
@@ -134,9 +135,10 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
           Context, nullptr, &USMDesc, Pool, Size, AllocType::HOST_USM,
           ur_cast<void **>(&HostAllocation));
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to allocate {} bytes host "
-                                   "USM for buffer {} migration",
-                                   Size, this);
+        URLOG_CTX(ERR,
+                  "Failed to allocate {} bytes host "
+                  "USM for buffer {} migration",
+                  Size, this);
         return URes;
       }
     }
@@ -148,7 +150,7 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
           Queue, true, HostAllocation, LastSyncedDevice.MemHandle, Size, 0,
           nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to migrate memory buffer data");
+        URLOG_CTX(ERR, "Failed to migrate memory buffer data");
         return URes;
       }
     }
@@ -159,7 +161,7 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
       URes = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy(
           Queue, true, Allocation, HostAllocation, Size, 0, nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to migrate memory buffer data");
+        URLOG_CTX(ERR, "Failed to migrate memory buffer data");
         return URes;
       }
     }
@@ -174,7 +176,7 @@ ur_result_t MemBuffer::free() {
   for (const auto &[_, Ptr] : Allocations) {
     ur_result_t URes = getAsanInterceptor()->releaseMemory(Context, Ptr);
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Failed to free buffer handle {}", Ptr);
+      URLOG_CTX(ERR, "Failed to free buffer handle {}", Ptr);
       return URes;
     }
   }

--- a/source/loader/layers/sanitizer/asan/asan_ddi.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_ddi.cpp
@@ -41,18 +41,18 @@ ur_result_t setupContext(ur_context_handle_t Context, uint32_t numDevices,
       UR_CALL(getAsanInterceptor()->insertDevice(hDevice, DI));
       DI->Type = GetDeviceType(Context, hDevice);
       if (DI->Type == DeviceType::UNKNOWN) {
-        getContext()->logger.error("Unsupport device");
+        URLOG_CTX(ERR, "Unsupport device");
         return UR_RESULT_ERROR_INVALID_DEVICE;
       }
       if (DI->Type != DeviceType) {
-        getContext()->logger.error("Different device type in the same context");
+        URLOG_CTX(ERR, "Different device type in the same context");
         return UR_RESULT_ERROR_INVALID_DEVICE;
       }
-      getContext()->logger.info(
-          "DeviceInfo {} (Type={}, IsSupportSharedSystemUSM={})",
-          (void *)DI->Handle, ToString(DI->Type), DI->IsSupportSharedSystemUSM);
-      getContext()->logger.info("Add {} into context {}", (void *)DI->Handle,
-                                (void *)Context);
+      URLOG_CTX(INFO, "DeviceInfo {} (Type={}, IsSupportSharedSystemUSM={})",
+                (void *)DI->Handle, ToString(DI->Type),
+                DI->IsSupportSharedSystemUSM);
+      URLOG_CTX(INFO, "Add {} into context {}", (void *)DI->Handle,
+                (void *)Context);
       DI->Shadow = ShadowMemory;
       CI->DeviceList.emplace_back(hDevice);
       CI->AllocInfosMap[hDevice];
@@ -112,7 +112,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urUSMHostAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMHostAlloc");
 
   return getAsanInterceptor()->allocateMemory(hContext, nullptr, pUSMDesc, pool,
                                               size, AllocType::HOST_USM, ppMem);
@@ -139,7 +139,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urUSMDeviceAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMDeviceAlloc");
 
   return getAsanInterceptor()->allocateMemory(
       hContext, hDevice, pUSMDesc, pool, size, AllocType::DEVICE_USM, ppMem);
@@ -166,7 +166,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urUSMSharedAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMSharedAlloc");
 
   return getAsanInterceptor()->allocateMemory(
       hContext, hDevice, pUSMDesc, pool, size, AllocType::SHARED_USM, ppMem);
@@ -185,7 +185,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urUSMFree");
+  URLOG_CTX(DEBUG, "==== urUSMFree");
 
   return getAsanInterceptor()->releaseMemory(hContext, pMem);
 }
@@ -210,7 +210,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramCreateWithIL");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithIL");
 
   UR_CALL(
       pfnProgramCreateWithIL(hContext, pIL, length, pProperties, phProgram));
@@ -246,7 +246,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramCreateWithBinary");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithBinary");
 
   UR_CALL(pfnProgramCreateWithBinary(hContext, numDevices, phDevices, pLengths,
                                      ppBinaries, pProperties, phProgram));
@@ -273,7 +273,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramCreateWithNativeHandle");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithNativeHandle");
 
   UR_CALL(pfnProgramCreateWithNativeHandle(hNativeProgram, hContext,
                                            pProperties, phProgram));
@@ -294,7 +294,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramRetain");
+  URLOG_CTX(DEBUG, "==== urProgramRetain");
 
   UR_CALL(pfnRetain(hProgram));
 
@@ -321,7 +321,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramBuild");
+  URLOG_CTX(DEBUG, "==== urProgramBuild");
 
   UR_CALL(pfnProgramBuild(hContext, hProgram, pOptions));
 
@@ -347,7 +347,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramBuildExp");
+  URLOG_CTX(DEBUG, "==== urProgramBuildExp");
 
   UR_CALL(pfnBuildExp(hProgram, numDevices, phDevices, pOptions));
   UR_CALL(getAsanInterceptor()->registerProgram(hProgram));
@@ -374,7 +374,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramLink");
+  URLOG_CTX(DEBUG, "==== urProgramLink");
 
   UR_CALL(pfnProgramLink(hContext, count, phPrograms, pOptions, phProgram));
 
@@ -407,7 +407,7 @@ ur_result_t UR_APICALL urProgramLinkExp(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramLinkExp");
+  URLOG_CTX(DEBUG, "==== urProgramLinkExp");
 
   UR_CALL(pfnProgramLinkExp(hContext, numDevices, phDevices, count, phPrograms,
                             pOptions, phProgram));
@@ -429,7 +429,7 @@ ur_result_t UR_APICALL urProgramRelease(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urProgramRelease");
+  URLOG_CTX(DEBUG, "==== urProgramRelease");
 
   UR_CALL(pfnProgramRelease(hProgram));
 
@@ -487,7 +487,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueKernelLaunch");
+  URLOG_CTX(DEBUG, "==== urEnqueueKernelLaunch");
 
   LaunchInfo LaunchInfo(GetContext(hQueue), GetDevice(hQueue), pGlobalWorkSize,
                         pLocalWorkSize, pGlobalWorkOffset, workDim);
@@ -530,7 +530,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urContextCreate");
+  URLOG_CTX(DEBUG, "==== urContextCreate");
 
   ur_result_t result = pfnCreate(numDevices, phDevices, pProperties, phContext);
 
@@ -562,7 +562,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urContextCreateWithNativeHandle");
+  URLOG_CTX(DEBUG, "==== urContextCreateWithNativeHandle");
 
   ur_result_t result = pfnCreateWithNativeHandle(
       hNativeContext, hAdapter, numDevices, phDevices, pProperties, phContext);
@@ -585,7 +585,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urContextRetain");
+  URLOG_CTX(DEBUG, "==== urContextRetain");
 
   UR_CALL(pfnRetain(hContext));
 
@@ -607,7 +607,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urContextRelease");
+  URLOG_CTX(DEBUG, "==== urContextRelease");
 
   UR_CALL(pfnRelease(hContext));
 
@@ -643,7 +643,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;
   }
 
-  getContext()->logger.debug("==== urMemBufferCreate");
+  URLOG_CTX(DEBUG, "==== urMemBufferCreate");
 
   void *Host = nullptr;
   if (pProperties) {
@@ -697,7 +697,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urMemGetInfo");
+  URLOG_CTX(DEBUG, "==== urMemGetInfo");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hMemory)) {
     UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -730,7 +730,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urMemRetain");
+  URLOG_CTX(DEBUG, "==== urMemRetain");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hMem)) {
     MemBuffer->RefCount++;
@@ -752,7 +752,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urMemRelease");
+  URLOG_CTX(DEBUG, "==== urMemRelease");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hMem)) {
     if (--MemBuffer->RefCount != 0) {
@@ -787,7 +787,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urMemBufferPartition");
+  URLOG_CTX(DEBUG, "==== urMemBufferPartition");
 
   if (auto ParentBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     if (ParentBuffer->Size < (pRegion->origin + pRegion->size)) {
@@ -818,7 +818,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urMemGetNativeHandle");
+  URLOG_CTX(DEBUG, "==== urMemGetNativeHandle");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hMem)) {
     char *Handle = nullptr;
@@ -862,7 +862,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferRead");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferRead");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     ur_device_handle_t Device = GetDevice(hQueue);
@@ -910,7 +910,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferWrite");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferWrite");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     ur_device_handle_t Device = GetDevice(hQueue);
@@ -972,7 +972,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferReadRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferReadRect");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     char *SrcHandle = nullptr;
@@ -1037,7 +1037,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferWriteRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferWriteRect");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     char *DstHandle = nullptr;
@@ -1089,7 +1089,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferCopy");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferCopy");
 
   auto SrcBuffer = getAsanInterceptor()->getMemBuffer(hBufferSrc);
   auto DstBuffer = getAsanInterceptor()->getMemBuffer(hBufferDst);
@@ -1157,7 +1157,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferCopyRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferCopyRect");
 
   auto SrcBuffer = getAsanInterceptor()->getMemBuffer(hBufferSrc);
   auto DstBuffer = getAsanInterceptor()->getMemBuffer(hBufferDst);
@@ -1219,7 +1219,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferFill");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferFill");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
     char *Handle = nullptr;
@@ -1271,7 +1271,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemBufferMap");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferMap");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hBuffer)) {
 
@@ -1358,7 +1358,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urEnqueueMemUnmap");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemUnmap");
 
   if (auto MemBuffer = getAsanInterceptor()->getMemBuffer(hMem)) {
     MemBuffer::Mapping Mapping{};
@@ -1403,7 +1403,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urKernelRetain");
+  URLOG_CTX(DEBUG, "==== urKernelRetain");
 
   UR_CALL(pfnRetain(hKernel));
 
@@ -1424,7 +1424,7 @@ __urdlllocal ur_result_t urKernelRelease(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urKernelRelease");
+  URLOG_CTX(DEBUG, "==== urKernelRelease");
 
   auto &KernelInfo = getAsanInterceptor()->getOrCreateKernelInfo(hKernel);
   if (--KernelInfo.RefCount == 0) {
@@ -1454,7 +1454,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urKernelSetArgValue");
+  URLOG_CTX(DEBUG, "==== urKernelSetArgValue");
 
   std::shared_ptr<MemBuffer> MemBuffer;
   if (argSize == sizeof(ur_mem_handle_t) &&
@@ -1487,7 +1487,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug("==== urKernelSetArgMemObj");
+  URLOG_CTX(DEBUG, "==== urKernelSetArgMemObj");
 
   std::shared_ptr<MemBuffer> MemBuffer;
   if ((MemBuffer = getAsanInterceptor()->getMemBuffer(hArgValue))) {
@@ -1518,8 +1518,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug(
-      "==== urKernelSetArgLocal (argIndex={}, argSize={})", argIndex, argSize);
+  URLOG_CTX(DEBUG, "==== urKernelSetArgLocal (argIndex={}, argSize={})",
+            argIndex, argSize);
 
   {
     auto &KI = getAsanInterceptor()->getOrCreateKernelInfo(hKernel);
@@ -1554,9 +1554,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 
-  getContext()->logger.debug(
-      "==== urKernelSetArgPointer (argIndex={}, pArgValue={})", argIndex,
-      pArgValue);
+  URLOG_CTX(DEBUG, "==== urKernelSetArgPointer (argIndex={}, pArgValue={})",
+            argIndex, pArgValue);
 
   std::shared_ptr<KernelInfo> KI;
   if (getAsanInterceptor()->getOptions().DetectKernelArguments) {
@@ -1939,7 +1938,7 @@ template <class A, class B> struct NotSupportedApi;
 template <class MsgType, class R, class... A>
 struct NotSupportedApi<MsgType, R (*)(A...)> {
   R static ReportError(A...) {
-    getContext()->logger.error(MsgType::value);
+    URLOG_CTX(ERR, MsgType::value);
     return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }
 };
@@ -2066,7 +2065,7 @@ __urdlllocal ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
 ur_result_t initAsanDDITable(ur_dditable_t *dditable) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
-  getContext()->logger.always("==== DeviceSanitizer: ASAN");
+  URLOG_CTX_ALWAYS("==== DeviceSanitizer: ASAN");
 
   if (UR_RESULT_SUCCESS == result) {
     result = ur_sanitizer_layer::asan::urGetGlobalProcAddrTable(
@@ -2129,7 +2128,7 @@ ur_result_t initAsanDDITable(ur_dditable_t *dditable) {
   }
 
   if (result != UR_RESULT_SUCCESS) {
-    getContext()->logger.error("Initialize ASAN DDI table failed: {}", result);
+    URLOG_CTX(ERR, "Initialize ASAN DDI table failed: {}", result);
   }
 
   return result;

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -118,7 +118,7 @@ ur_result_t AsanInterceptor::allocateMemory(ur_context_handle_t Context,
     UR_CALL(getContext()->urDdiTable.USM.pfnDeviceAlloc(
         Context, Device, Properties, Pool, NeededSize, &Allocated));
   } else {
-    getContext()->logger.error("Unsupport memory type");
+    URLOG_CTX(ERR, "Unsupport memory type");
     return UR_RESULT_ERROR_INVALID_ARGUMENT;
   }
 
@@ -214,7 +214,7 @@ ur_result_t AsanInterceptor::releaseMemory(ur_context_handle_t Context,
 
   // If quarantine is disabled, USM is freed immediately
   if (!m_Quarantine) {
-    getContext()->logger.debug("Free: {}", (void *)AllocInfo->AllocBegin);
+    URLOG_CTX(DEBUG, "Free: {}", (void *)AllocInfo->AllocBegin);
 
     ContextInfo->Stats.UpdateUSMRealFreed(AllocInfo->AllocSize,
                                           AllocInfo->getRedzoneSize());
@@ -232,8 +232,8 @@ ur_result_t AsanInterceptor::releaseMemory(ur_context_handle_t Context,
     std::scoped_lock<ur_shared_mutex> Guard(m_AllocationMapMutex);
     for (auto &It : ReleaseList) {
       auto ToFreeAllocInfo = It->second;
-      getContext()->logger.info("Quarantine Free: {}",
-                                (void *)ToFreeAllocInfo->AllocBegin);
+      URLOG_CTX(INFO, "Quarantine Free: {}",
+                (void *)ToFreeAllocInfo->AllocBegin);
 
       ContextInfo->Stats.UpdateUSMRealFreed(ToFreeAllocInfo->AllocSize,
                                             ToFreeAllocInfo->getRedzoneSize());
@@ -260,7 +260,7 @@ ur_result_t AsanInterceptor::preLaunchKernel(ur_kernel_handle_t Kernel,
 
   ManagedQueue InternalQueue(Context, Device);
   if (!InternalQueue) {
-    getContext()->logger.error("Failed to create internal queue");
+    URLOG_CTX(ERR, "Failed to create internal queue");
     return UR_RESULT_ERROR_INVALID_QUEUE;
   }
 
@@ -316,7 +316,7 @@ AsanInterceptor::getOrCreateShadowMemory(ur_device_handle_t Device,
     auto Res = getContext()->urDdiTable.Context.pfnCreate(1, &Device, nullptr,
                                                           &InternalContext);
     if (Res != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Failed to create shadow context");
+      URLOG_CTX(ERR, "Failed to create shadow context");
       return nullptr;
     }
     std::shared_ptr<ContextInfo> CI;
@@ -429,13 +429,13 @@ AsanInterceptor::updateShadowMemory(std::shared_ptr<ContextInfo> &ContextInfo,
 ur_result_t AsanInterceptor::registerProgram(ur_program_handle_t Program) {
   ur_result_t Result = UR_RESULT_SUCCESS;
 
-  getContext()->logger.info("registerSpirKernels");
+  URLOG_CTX(INFO, "registerSpirKernels");
   Result = registerSpirKernels(Program);
   if (Result != UR_RESULT_SUCCESS) {
     return Result;
   }
 
-  getContext()->logger.info("registerDeviceGlobals");
+  URLOG_CTX(INFO, "registerDeviceGlobals");
   Result = registerDeviceGlobals(Program);
   if (Result != UR_RESULT_SUCCESS) {
     return Result;
@@ -485,8 +485,8 @@ ur_result_t AsanInterceptor::registerSpirKernels(ur_program_handle_t Program) {
         Queue, true, &SKInfo[0], MetadataPtr,
         sizeof(SpirKernelInfo) * NumOfSpirKernel, 0, nullptr, nullptr);
     if (Result != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Can't read the value of <{}>: {}",
-                                 kSPIR_AsanSpirKernelMetadata, Result);
+      URLOG_CTX(ERR, "Can't read the value of <{}>: {}",
+                kSPIR_AsanSpirKernelMetadata, Result);
       return Result;
     }
 
@@ -501,20 +501,20 @@ ur_result_t AsanInterceptor::registerSpirKernels(ur_program_handle_t Program) {
           Queue, true, KernelNameV.data(), (void *)SKI.KernelName,
           sizeof(char) * SKI.Size, 0, nullptr, nullptr);
       if (Result != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Can't read kernel name: {}", Result);
+        URLOG_CTX(ERR, "Can't read kernel name: {}", Result);
         return Result;
       }
 
       std::string KernelName =
           std::string(KernelNameV.begin(), KernelNameV.end());
 
-      getContext()->logger.info("SpirKernel(name='{}', isInstrumented={})",
-                                KernelName, true);
+      URLOG_CTX(INFO, "SpirKernel(name='{}', isInstrumented={})", KernelName,
+                true);
 
       PI->InstrumentedKernels.insert(std::move(KernelName));
     }
-    getContext()->logger.info("Number of sanitized kernel: {}",
-                              PI->InstrumentedKernels.size());
+    URLOG_CTX(INFO, "Number of sanitized kernel: {}",
+              PI->InstrumentedKernels.size());
   }
 
   return UR_RESULT_SUCCESS;
@@ -538,7 +538,7 @@ AsanInterceptor::registerDeviceGlobals(ur_program_handle_t Program) {
         Device, Program, kSPIR_AsanDeviceGlobalMetadata, &MetadataSize,
         &MetadataPtr);
     if (Result != UR_RESULT_SUCCESS) {
-      getContext()->logger.info("No device globals");
+      URLOG_CTX(INFO, "No device globals");
       continue;
     }
 
@@ -550,8 +550,8 @@ AsanInterceptor::registerDeviceGlobals(ur_program_handle_t Program) {
         Queue, true, &GVInfos[0], MetadataPtr,
         sizeof(DeviceGlobalInfo) * NumOfDeviceGlobal, 0, nullptr, nullptr);
     if (Result != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Device Global[{}] Read Failed: {}",
-                                 kSPIR_AsanDeviceGlobalMetadata, Result);
+      URLOG_CTX(ERR, "Device Global[{}] Read Failed: {}",
+                kSPIR_AsanDeviceGlobalMetadata, Result);
       return Result;
     }
 
@@ -717,11 +717,11 @@ ur_result_t AsanInterceptor::prepareLaunch(
   auto PrivateMemoryUsage =
       GetKernelPrivateMemorySize(Kernel, DeviceInfo->Handle);
 
-  getContext()->logger.info(
-      "KernelInfo {} (Name={}, ArgNums={}, IsInstrumented={}, "
-      "LocalMemory={}, PrivateMemory={})",
-      (void *)Kernel, GetKernelName(Kernel), ArgNums, KernelInfo.IsInstrumented,
-      LocalMemoryUsage, PrivateMemoryUsage);
+  URLOG_CTX(INFO,
+            "KernelInfo {} (Name={}, ArgNums={}, IsInstrumented={}, "
+            "LocalMemory={}, PrivateMemory={})",
+            (void *)Kernel, GetKernelName(Kernel), ArgNums,
+            KernelInfo.IsInstrumented, LocalMemoryUsage, PrivateMemoryUsage);
 
   // Validate pointer arguments
   if (getOptions().DetectKernelArguments) {
@@ -748,9 +748,9 @@ ur_result_t AsanInterceptor::prepareLaunch(
     ur_result_t URes = getContext()->urDdiTable.Kernel.pfnSetArgPointer(
         Kernel, ArgIndex, nullptr, ArgPointer);
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error(
-          "Failed to set buffer {} as the {} arg to kernel {}: {}",
-          ur_cast<ur_mem_handle_t>(MemBuffer.get()), ArgIndex, Kernel, URes);
+      URLOG_CTX(ERR, "Failed to set buffer {} as the {} arg to kernel {}: {}",
+                ur_cast<ur_mem_handle_t>(MemBuffer.get()), ArgIndex, Kernel,
+                URes);
     }
   }
 
@@ -768,7 +768,7 @@ ur_result_t AsanInterceptor::prepareLaunch(
     ur_result_t URes = getContext()->urDdiTable.Kernel.pfnSetArgPointer(
         Kernel, ArgNums - 1, nullptr, LaunchInfo.Data.getDevicePtr());
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Failed to set launch info: {}", URes);
+      URLOG_CTX(ERR, "Failed to set launch info: {}", URes);
       return URes;
     }
   }
@@ -808,18 +808,17 @@ ur_result_t AsanInterceptor::prepareLaunch(
     if (DeviceInfo->Shadow->AllocLocalShadow(
             Queue, NumWG, LaunchInfo.Data.Host.LocalShadowOffset,
             LaunchInfo.Data.Host.LocalShadowOffsetEnd) != UR_RESULT_SUCCESS) {
-      getContext()->logger.warning(
-          "Failed to allocate shadow memory for local "
-          "memory, maybe the number of workgroup ({}) is too "
-          "large",
-          NumWG);
-      getContext()->logger.warning("Skip checking local memory of kernel <{}>",
-                                   GetKernelName(Kernel));
+      URLOG_CTX(WARN,
+                "Failed to allocate shadow memory for local "
+                "memory, maybe the number of workgroup ({}) is too "
+                "large",
+                NumWG);
+      URLOG_CTX(WARN, "Skip checking local memory of kernel <{}>",
+                GetKernelName(Kernel));
     } else {
-      getContext()->logger.info(
-          "ShadowMemory(Local, WorkGroup{}, {} - {})", NumWG,
-          (void *)LaunchInfo.Data.Host.LocalShadowOffset,
-          (void *)LaunchInfo.Data.Host.LocalShadowOffsetEnd);
+      URLOG_CTX(INFO, "ShadowMemory(Local, WorkGroup{}, {} - {})", NumWG,
+                (void *)LaunchInfo.Data.Host.LocalShadowOffset,
+                (void *)LaunchInfo.Data.Host.LocalShadowOffsetEnd);
     }
   }
 
@@ -828,18 +827,17 @@ ur_result_t AsanInterceptor::prepareLaunch(
     if (DeviceInfo->Shadow->AllocPrivateShadow(
             Queue, NumWG, LaunchInfo.Data.Host.PrivateShadowOffset,
             LaunchInfo.Data.Host.PrivateShadowOffsetEnd) != UR_RESULT_SUCCESS) {
-      getContext()->logger.warning(
-          "Failed to allocate shadow memory for private "
-          "memory, maybe the number of workgroup ({}) is too "
-          "large",
-          NumWG);
-      getContext()->logger.warning(
-          "Skip checking private memory of kernel <{}>", GetKernelName(Kernel));
+      URLOG_CTX(WARN,
+                "Failed to allocate shadow memory for private "
+                "memory, maybe the number of workgroup ({}) is too "
+                "large",
+                NumWG);
+      URLOG_CTX(WARN, "Skip checking private memory of kernel <{}>",
+                GetKernelName(Kernel));
     } else {
-      getContext()->logger.info(
-          "ShadowMemory(Private, WorkGroup{}, {} - {})", NumWG,
-          (void *)LaunchInfo.Data.Host.PrivateShadowOffset,
-          (void *)LaunchInfo.Data.Host.PrivateShadowOffsetEnd);
+      URLOG_CTX(INFO, "ShadowMemory(Private, WorkGroup{}, {} - {})", NumWG,
+                (void *)LaunchInfo.Data.Host.PrivateShadowOffset,
+                (void *)LaunchInfo.Data.Host.PrivateShadowOffsetEnd);
     }
   }
 
@@ -848,9 +846,8 @@ ur_result_t AsanInterceptor::prepareLaunch(
     std::vector<LocalArgsInfo> LocalArgsInfo;
     for (auto [ArgIndex, ArgInfo] : KernelInfo.LocalArgs) {
       LocalArgsInfo.push_back(ArgInfo);
-      getContext()->logger.debug(
-          "local_args (argIndex={}, size={}, sizeWithRZ={})", ArgIndex,
-          ArgInfo.Size, ArgInfo.SizeWithRedZone);
+      URLOG_CTX(DEBUG, "local_args (argIndex={}, size={}, sizeWithRZ={})",
+                ArgIndex, ArgInfo.Size, ArgInfo.SizeWithRedZone);
     }
     UR_CALL(LaunchInfo.Data.importLocalArgsInfo(Queue, LocalArgsInfo));
   }
@@ -858,7 +855,8 @@ ur_result_t AsanInterceptor::prepareLaunch(
   // sync asan runtime data to device side
   UR_CALL(LaunchInfo.Data.syncToDevice(Queue));
 
-  getContext()->logger.info(
+  URLOG_CTX(
+      INFO,
       "LaunchInfo {} (device={}, debug={}, numLocalArgs={}, localArgs={})",
       (void *)LaunchInfo.Data.getDevicePtr(),
       ToString(LaunchInfo.Data.Host.DeviceTy), LaunchInfo.Data.Host.Debug,
@@ -936,10 +934,10 @@ ur_usm_pool_handle_t ContextInfo::getUSMPool() {
         getContext()->urDdiTable.USM.pfnPoolCreate(Handle, &Desc, &USMPool);
     if (URes != UR_RESULT_SUCCESS &&
         URes != UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
-      getContext()->logger.warning(
-          "Failed to create USM pool, the memory overhead "
-          "may increase: {}",
-          URes);
+      URLOG_CTX(WARN,
+                "Failed to create USM pool, the memory overhead "
+                "may increase: {}",
+                URes);
     }
   });
   return USMPool;

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -185,8 +185,8 @@ struct AsanRuntimeDataWrapper {
           Context, Device, nullptr, nullptr, sizeof(AsanRuntimeData),
           (void **)&DevicePtr);
       if (Result != UR_RESULT_SUCCESS) {
-        getContext()->logger.error(
-            "Failed to alloc device usm for asan runtime data: {}", Result);
+        URLOG_CTX(ERR, "Failed to alloc device usm for asan runtime data: {}",
+                  Result);
       }
     }
     return DevicePtr;

--- a/source/loader/layers/sanitizer/asan/asan_options.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_options.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <sanitizer_common/sanitizer_common.hpp>
 #include <stdexcept>
 
 namespace ur_sanitizer_layer {
@@ -31,7 +32,7 @@ AsanOptions::AsanOptions() {
     std::stringstream SS;
     SS << "<SANITIZER>[ERROR]: ";
     SS << e.what();
-    getContext()->logger.always(SS.str().c_str());
+    URLOG_CTX_ALWAYS(SHORT_FILE, UR_STR(__LINE__), SS.str().c_str());
     die("Sanitizer failed to parse options.\n");
   }
 
@@ -78,7 +79,7 @@ AsanOptions::AsanOptions() {
           SS << " \"" << S << "\"";
         }
         SS << ".";
-        getContext()->logger.error(SS.str().c_str());
+        URLOG_CTX(ERR, SS.str().c_str());
         die("Sanitizer failed to parse options.\n");
       }
     }
@@ -101,9 +102,10 @@ AsanOptions::AsanOptions() {
       }
       MaxQuarantineSizeMB = temp_long;
     } catch (...) {
-      getContext()->logger.error("\"quarantine_size_mb\" should be "
-                                 "an integer in range[0, {}].",
-                                 UINT32_MAX);
+      URLOG_CTX(ERR,
+                "\"quarantine_size_mb\" should be "
+                "an integer in range[0, {}].",
+                UINT32_MAX);
       die("Sanitizer failed to parse options.\n");
     }
   }
@@ -115,12 +117,11 @@ AsanOptions::AsanOptions() {
       MinRZSize = std::stoul(Value);
       if (MinRZSize < 16) {
         MinRZSize = 16;
-        getContext()->logger.warning("Trying to set redzone size to a "
-                                     "value less than 16 is ignored.");
+        URLOG_CTX(WARN, "Trying to set redzone size to a "
+                        "value less than 16 is ignored.");
       }
     } catch (...) {
-      getContext()->logger.error(
-          "\"redzone\" should be an integer in range[0, 16].");
+      URLOG_CTX(ERR, "\"redzone\" should be an integer in range[0, 16].");
       die("Sanitizer failed to parse options.\n");
     }
   }
@@ -132,12 +133,11 @@ AsanOptions::AsanOptions() {
       MaxRZSize = std::stoul(Value);
       if (MaxRZSize > 2048) {
         MaxRZSize = 2048;
-        getContext()->logger.warning("Trying to set max redzone size to a "
-                                     "value greater than 2048 is ignored.");
+        URLOG_CTX(WARN, "Trying to set max redzone size to a "
+                        "value greater than 2048 is ignored.");
       }
     } catch (...) {
-      getContext()->logger.error(
-          "\"max_redzone\" should be an integer in range[0, 2048].");
+      URLOG_CTX(ERR, "\"max_redzone\" should be an integer in range[0, 2048].");
       die("Sanitizer failed to parse options.\n");
     }
   }

--- a/source/loader/layers/sanitizer/asan/asan_report.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_report.cpp
@@ -26,13 +26,13 @@ namespace asan {
 namespace {
 
 void PrintAllocateInfo(uptr Addr, const AllocInfo *AI) {
-  getContext()->logger.always("{} is located inside of {} region [{}, {})",
-                              (void *)Addr, ToString(AI->Type),
-                              (void *)AI->UserBegin, (void *)AI->UserEnd);
-  getContext()->logger.always("allocated here:");
+  URLOG_CTX_ALWAYS("{} is located inside of {} region [{}, {})", (void *)Addr,
+                   ToString(AI->Type), (void *)AI->UserBegin,
+                   (void *)AI->UserEnd);
+  URLOG_CTX_ALWAYS("allocated here:");
   AI->AllocStack.print();
   if (AI->IsReleased) {
-    getContext()->logger.always("freed here:");
+    URLOG_CTX_ALWAYS("freed here:");
     AI->ReleaseStack.print();
   }
 }
@@ -41,13 +41,12 @@ void PrintAllocateInfo(uptr Addr, const AllocInfo *AI) {
 
 void ReportBadFree(uptr Addr, const StackTrace &stack,
                    const std::shared_ptr<AllocInfo> &AI) {
-  getContext()->logger.always(
-      "\n====ERROR: DeviceSanitizer: bad-free on address {}", (void *)Addr);
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: bad-free on address {}",
+                   (void *)Addr);
   stack.print();
 
   if (!AI) {
-    getContext()->logger.always("{} may be allocated on Host Memory",
-                                (void *)Addr);
+    URLOG_CTX_ALWAYS("{} may be allocated on Host Memory", (void *)Addr);
   } else {
     assert(!AI->IsReleased && "Chunk must be not released");
     PrintAllocateInfo(Addr, AI.get());
@@ -56,8 +55,8 @@ void ReportBadFree(uptr Addr, const StackTrace &stack,
 
 void ReportBadContext(uptr Addr, const StackTrace &stack,
                       const std::shared_ptr<AllocInfo> &AI) {
-  getContext()->logger.always(
-      "\n====ERROR: DeviceSanitizer: bad-context on address {}", (void *)Addr);
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: bad-context on address {}",
+                   (void *)Addr);
   stack.print();
 
   PrintAllocateInfo(Addr, AI.get());
@@ -65,32 +64,30 @@ void ReportBadContext(uptr Addr, const StackTrace &stack,
 
 void ReportDoubleFree(uptr Addr, const StackTrace &Stack,
                       const std::shared_ptr<AllocInfo> &AI) {
-  getContext()->logger.always(
-      "\n====ERROR: DeviceSanitizer: double-free on address {}", (void *)Addr);
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: double-free on address {}",
+                   (void *)Addr);
   Stack.print();
 
-  getContext()->logger.always("{} is located inside of {} region [{}, {})",
-                              (void *)Addr, ToString(AI->Type),
-                              (void *)AI->UserBegin, (void *)AI->UserEnd);
-  getContext()->logger.always("freed here:");
+  URLOG_CTX_ALWAYS("{} is located inside of {} region [{}, {})", (void *)Addr,
+                   ToString(AI->Type), (void *)AI->UserBegin,
+                   (void *)AI->UserEnd);
+  URLOG_CTX_ALWAYS("freed here:");
   AI->ReleaseStack.print();
-  getContext()->logger.always("previously allocated here:");
+  URLOG_CTX_ALWAYS("previously allocated here:");
   AI->AllocStack.print();
 }
 
 void ReportMemoryLeak(const std::shared_ptr<AllocInfo> &AI) {
-  getContext()->logger.always(
-      "\n====ERROR: DeviceSanitizer: detected memory leaks of {}",
-      ToString(AI->Type));
-  getContext()->logger.always("Direct leak of {} byte(s) at {} allocated from:",
-                              AI->UserEnd - AI->UserBegin,
-                              (void *)AI->UserBegin);
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: detected memory leaks of {}",
+                   ToString(AI->Type));
+  URLOG_CTX_ALWAYS("Direct leak of {} byte(s) at {} allocated from:",
+                   AI->UserEnd - AI->UserBegin, (void *)AI->UserBegin);
   AI->AllocStack.print();
 }
 
 void ReportFatalError(const AsanErrorReport &Report) {
-  getContext()->logger.always("\n====ERROR: DeviceSanitizer: {}",
-                              ToString(Report.ErrorTy));
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: {}",
+                   ToString(Report.ErrorTy));
 }
 
 void ReportGenericError(const AsanErrorReport &Report,
@@ -102,16 +99,15 @@ void ReportGenericError(const AsanErrorReport &Report,
   // Try to demangle the kernel name
   KernelName = DemangleName(KernelName);
 
-  getContext()->logger.always(
-      "\n====ERROR: DeviceSanitizer: {} on {} ({})", ToString(Report.ErrorTy),
-      ToString(Report.MemoryTy), (void *)Report.Address);
-  getContext()->logger.always(
-      "{} of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
-      "{}, {})",
-      Report.IsWrite ? "WRITE" : "READ", Report.AccessSize, KernelName.c_str(),
-      Report.LID0, Report.LID1, Report.LID2, Report.GID0, Report.GID1,
-      Report.GID2);
-  getContext()->logger.always("  #0 {} {}:{}", Func, File, Report.Line);
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: {} on {} ({})",
+                   ToString(Report.ErrorTy), ToString(Report.MemoryTy),
+                   (void *)Report.Address);
+  URLOG_CTX_ALWAYS("{} of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
+                   "{}, {})",
+                   Report.IsWrite ? "WRITE" : "READ", Report.AccessSize,
+                   KernelName.c_str(), Report.LID0, Report.LID1, Report.LID2,
+                   Report.GID0, Report.GID1, Report.GID2);
+  URLOG_CTX_ALWAYS("  #0 {} {}:{}", Func, File, Report.Line);
 }
 
 void ReportUseAfterFree(const AsanErrorReport &Report,
@@ -124,30 +120,28 @@ void ReportUseAfterFree(const AsanErrorReport &Report,
   // Try to demangle the kernel name
   KernelName = DemangleName(KernelName);
 
-  getContext()->logger.always("\n====ERROR: DeviceSanitizer: {} on address {}",
-                              ToString(Report.ErrorTy), (void *)Report.Address);
-  getContext()->logger.always(
-      "{} of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
-      "{}, {})",
-      Report.IsWrite ? "WRITE" : "READ", Report.AccessSize, KernelName.c_str(),
-      Report.LID0, Report.LID1, Report.LID2, Report.GID0, Report.GID1,
-      Report.GID2);
-  getContext()->logger.always("  #0 {} {}:{}", Func, File, Report.Line);
-  getContext()->logger.always("");
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: {} on address {}",
+                   ToString(Report.ErrorTy), (void *)Report.Address);
+  URLOG_CTX_ALWAYS("{} of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
+                   "{}, {})",
+                   Report.IsWrite ? "WRITE" : "READ", Report.AccessSize,
+                   KernelName.c_str(), Report.LID0, Report.LID1, Report.LID2,
+                   Report.GID0, Report.GID1, Report.GID2);
+  URLOG_CTX_ALWAYS("  #0 {} {}:{}", Func, File, Report.Line);
+  URLOG_CTX_ALWAYS("");
 
   if (getAsanInterceptor()->getOptions().MaxQuarantineSizeMB > 0) {
     auto AllocInfoItOp =
         getAsanInterceptor()->findAllocInfoByAddress(Report.Address);
 
     if (!AllocInfoItOp) {
-      getContext()->logger.always("Failed to find which chunck {} is allocated",
-                                  (void *)Report.Address);
+      URLOG_CTX_ALWAYS("Failed to find which chunck {} is allocated",
+                       (void *)Report.Address);
     } else {
       auto &AllocInfo = (*AllocInfoItOp)->second;
       if (AllocInfo->Context != Context) {
-        getContext()->logger.always(
-            "Failed to find which chunck {} is allocated",
-            (void *)Report.Address);
+        URLOG_CTX_ALWAYS("Failed to find which chunck {} is allocated",
+                         (void *)Report.Address);
       }
       assert(AllocInfo->IsReleased &&
              "It must be released since it's use-after-free");
@@ -155,7 +149,7 @@ void ReportUseAfterFree(const AsanErrorReport &Report,
       PrintAllocateInfo(Report.Address, AllocInfo.get());
     }
   } else {
-    getContext()->logger.always(
+    URLOG_CTX_ALWAYS(
         "Please enable quarantine to get more information like memory "
         "chunck's kind and where the chunck was allocated and released.");
   }
@@ -164,40 +158,37 @@ void ReportUseAfterFree(const AsanErrorReport &Report,
 void ReportInvalidKernelArgument(ur_kernel_handle_t Kernel, uint32_t ArgIndex,
                                  uptr Addr, const ValidateUSMResult &VR,
                                  StackTrace Stack) {
-  getContext()->logger.always("\n====ERROR: DeviceSanitizer: "
-                              "invalid-argument on kernel <{}>",
-                              DemangleName(GetKernelName(Kernel)));
+  URLOG_CTX_ALWAYS("\n====ERROR: DeviceSanitizer: "
+                   "invalid-argument on kernel <{}>",
+                   DemangleName(GetKernelName(Kernel)));
   Stack.print();
   auto &AI = VR.AI;
   ArgIndex = ArgIndex + 1;
   switch (VR.Type) {
   case ValidateUSMResult::MAYBE_HOST_POINTER:
-    getContext()->logger.always("The {}th argument {} is not a USM pointer",
-                                ArgIndex, (void *)Addr);
+    URLOG_CTX_ALWAYS("The {}th argument {} is not a USM pointer", ArgIndex,
+                     (void *)Addr);
     break;
   case ValidateUSMResult::RELEASED_POINTER:
-    getContext()->logger.always(
-        "The {}th argument {} is a released USM pointer", ArgIndex + 1,
-        (void *)Addr);
+    URLOG_CTX_ALWAYS("The {}th argument {} is a released USM pointer",
+                     ArgIndex + 1, (void *)Addr);
     PrintAllocateInfo(Addr, AI.get());
     break;
   case ValidateUSMResult::BAD_CONTEXT:
-    getContext()->logger.always(
-        "The {}th argument {} is allocated in other context", ArgIndex + 1,
-        (void *)Addr);
+    URLOG_CTX_ALWAYS("The {}th argument {} is allocated in other context",
+                     ArgIndex + 1, (void *)Addr);
     PrintAllocateInfo(Addr, AI.get());
     break;
   case ValidateUSMResult::BAD_DEVICE:
-    getContext()->logger.always(
-        "The {}th argument {} is allocated in other device", ArgIndex + 1,
-        (void *)Addr);
+    URLOG_CTX_ALWAYS("The {}th argument {} is allocated in other device",
+                     ArgIndex + 1, (void *)Addr);
     PrintAllocateInfo(Addr, AI.get());
     break;
   case ValidateUSMResult::OUT_OF_BOUNDS:
-    getContext()->logger.always(
+    URLOG_CTX_ALWAYS(
         "The {}th argument {} is located outside of its region [{}, {})",
         ArgIndex + 1, (void *)Addr, (void *)AI->UserBegin, (void *)AI->UserEnd);
-    getContext()->logger.always("allocated here:");
+    URLOG_CTX_ALWAYS("allocated here:");
     AI->AllocStack.print();
     break;
   default:

--- a/source/loader/layers/sanitizer/asan/asan_statistics.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_statistics.cpp
@@ -46,23 +46,22 @@ private:
 };
 
 void AsanStats::Print(ur_context_handle_t Context) {
-  getContext()->logger.always("Stats: Context {}", (void *)Context);
-  getContext()->logger.always("Stats:   peak memory overhead: {}%",
-                              Overhead * 100);
+  URLOG_CTX_ALWAYS("Stats: Context {}", (void *)Context);
+  URLOG_CTX_ALWAYS("Stats:   peak memory overhead: {}%", Overhead * 100);
 }
 
 void AsanStats::UpdateUSMMalloced(uptr MallocedSize, uptr RedzoneSize) {
   UsmMalloced += MallocedSize;
   UsmMallocedRedzones += RedzoneSize;
-  getContext()->logger.debug(
-      "Stats: UpdateUSMMalloced(UsmMalloced={}, UsmMallocedRedzones={})",
-      UsmMalloced, UsmMallocedRedzones);
+  URLOG_CTX(DEBUG,
+            "Stats: UpdateUSMMalloced(UsmMalloced={}, UsmMallocedRedzones={})",
+            UsmMalloced, UsmMallocedRedzones);
   UpdateOverhead();
 }
 
 void AsanStats::UpdateUSMFreed(uptr FreedSize) {
   UsmFreed += FreedSize;
-  getContext()->logger.debug("Stats: UpdateUSMFreed(UsmFreed={})", UsmFreed);
+  URLOG_CTX(DEBUG, "Stats: UpdateUSMFreed(UsmFreed={})", UsmFreed);
 }
 
 void AsanStats::UpdateUSMRealFreed(uptr FreedSize, uptr RedzoneSize) {
@@ -71,23 +70,23 @@ void AsanStats::UpdateUSMRealFreed(uptr FreedSize, uptr RedzoneSize) {
   if (getAsanInterceptor()->getOptions().MaxQuarantineSizeMB) {
     UsmFreed -= FreedSize;
   }
-  getContext()->logger.debug(
-      "Stats: UpdateUSMRealFreed(UsmMalloced={}, UsmMallocedRedzones={})",
-      UsmMalloced, UsmMallocedRedzones);
+  URLOG_CTX(DEBUG,
+            "Stats: UpdateUSMRealFreed(UsmMalloced={}, UsmMallocedRedzones={})",
+            UsmMalloced, UsmMallocedRedzones);
   UpdateOverhead();
 }
 
 void AsanStats::UpdateShadowMalloced(uptr ShadowSize) {
   ShadowMalloced += ShadowSize;
-  getContext()->logger.debug("Stats: UpdateShadowMalloced(ShadowMalloced={})",
-                             ShadowMalloced);
+  URLOG_CTX(DEBUG, "Stats: UpdateShadowMalloced(ShadowMalloced={})",
+            ShadowMalloced);
   UpdateOverhead();
 }
 
 void AsanStats::UpdateShadowFreed(uptr ShadowSize) {
   ShadowMalloced -= ShadowSize;
-  getContext()->logger.debug("Stats: UpdateShadowFreed(ShadowMalloced={})",
-                             ShadowMalloced);
+  URLOG_CTX(DEBUG, "Stats: UpdateShadowFreed(ShadowMalloced={})",
+            ShadowMalloced);
   UpdateOverhead();
 }
 

--- a/source/loader/layers/sanitizer/msan/msan_allocator.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_allocator.cpp
@@ -18,9 +18,8 @@ namespace ur_sanitizer_layer {
 namespace msan {
 
 void MsanAllocInfo::print() {
-  getContext()->logger.info("AllocInfo(Alloc=[{}-{}), AllocSize={})",
-                            (void *)AllocBegin,
-                            (void *)(AllocBegin + AllocSize), AllocSize);
+  URLOG_CTX(INFO, "AllocInfo(Alloc=[{}-{}), AllocSize={})", (void *)AllocBegin,
+            (void *)(AllocBegin + AllocSize), AllocSize);
 }
 
 } // namespace msan

--- a/source/loader/layers/sanitizer/msan/msan_buffer.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_buffer.cpp
@@ -137,8 +137,8 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
                                                 Size, AllocType::DEVICE_USM,
                                                 ur_cast<void **>(&Allocation));
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error(
-          "Failed to allocate {} bytes memory for buffer {}", Size, this);
+      URLOG_CTX(ERR, "Failed to allocate {} bytes memory for buffer {}", Size,
+                this);
       return URes;
     }
 
@@ -147,9 +147,10 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
       URes = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy(
           Queue, true, Allocation, HostPtr, Size, 0, nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to copy {} bytes data from host "
-                                   "pointer {} to buffer {}",
-                                   Size, HostPtr, this);
+        URLOG_CTX(ERR,
+                  "Failed to copy {} bytes data from host "
+                  "pointer {} to buffer {}",
+                  Size, HostPtr, this);
         return URes;
       }
 
@@ -179,9 +180,10 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
       URes = getContext()->urDdiTable.USM.pfnHostAlloc(
           Context, &USMDesc, Pool, Size, ur_cast<void **>(&HostAllocation));
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to allocate {} bytes host "
-                                   "USM for buffer {} migration",
-                                   Size, this);
+        URLOG_CTX(ERR,
+                  "Failed to allocate {} bytes host "
+                  "USM for buffer {} migration",
+                  Size, this);
         return URes;
       }
     }
@@ -193,7 +195,7 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
           Queue, true, HostAllocation, LastSyncedDevice.MemHandle, Size, 0,
           nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to migrate memory buffer data");
+        URLOG_CTX(ERR, "Failed to migrate memory buffer data");
         return URes;
       }
     }
@@ -204,7 +206,7 @@ ur_result_t MemBuffer::getHandle(ur_device_handle_t Device, char *&Handle) {
       URes = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy(
           Queue, true, Allocation, HostAllocation, Size, 0, nullptr, nullptr);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("Failed to migrate memory buffer data");
+        URLOG_CTX(ERR, "Failed to migrate memory buffer data");
         return URes;
       }
     }
@@ -219,7 +221,7 @@ ur_result_t MemBuffer::free() {
   for (const auto &[_, Ptr] : Allocations) {
     ur_result_t URes = getContext()->urDdiTable.USM.pfnFree(Context, Ptr);
     if (URes != UR_RESULT_SUCCESS) {
-      getContext()->logger.error("Failed to free buffer handle {}", Ptr);
+      URLOG_CTX(ERR, "Failed to free buffer handle {}", Ptr);
       return URes;
     }
   }

--- a/source/loader/layers/sanitizer/msan/msan_ddi.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_ddi.cpp
@@ -33,14 +33,14 @@ ur_result_t setupContext(ur_context_handle_t Context, uint32_t numDevices,
     UR_CALL(getMsanInterceptor()->insertDevice(hDevice, DI));
     DI->Type = GetDeviceType(Context, hDevice);
     if (DI->Type == DeviceType::UNKNOWN) {
-      getContext()->logger.error("Unsupport device");
+      URLOG_CTX(ERR, "Unsupport device");
       return UR_RESULT_ERROR_INVALID_DEVICE;
     }
-    getContext()->logger.info(
-        "DeviceInfo {} (Type={}, IsSupportSharedSystemUSM={})",
-        (void *)DI->Handle, ToString(DI->Type), DI->IsSupportSharedSystemUSM);
-    getContext()->logger.info("Add {} into context {}", (void *)DI->Handle,
-                              (void *)Context);
+    URLOG_CTX(INFO, "DeviceInfo {} (Type={}, IsSupportSharedSystemUSM={})",
+              (void *)DI->Handle, ToString(DI->Type),
+              DI->IsSupportSharedSystemUSM);
+    URLOG_CTX(INFO, "Add {} into context {}", (void *)DI->Handle,
+              (void *)Context);
     if (!DI->Shadow) {
       UR_CALL(DI->allocShadowMemory(Context));
     }
@@ -98,7 +98,7 @@ ur_result_t urUSMDeviceAlloc(
     size_t size,
     /// [out] pointer to USM device memory object
     void **ppMem) {
-  getContext()->logger.debug("==== urUSMDeviceAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMDeviceAlloc");
 
   return getMsanInterceptor()->allocateMemory(
       hContext, hDevice, pUSMDesc, pool, size, AllocType::DEVICE_USM, ppMem);
@@ -116,7 +116,7 @@ ur_result_t UR_APICALL urUSMHostAlloc(
         size, ///< [in] size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM host memory object
 ) {
-  getContext()->logger.debug("==== urUSMHostAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMHostAlloc");
 
   return getMsanInterceptor()->allocateMemory(hContext, nullptr, pUSMDesc, pool,
                                               size, AllocType::HOST_USM, ppMem);
@@ -135,7 +135,7 @@ ur_result_t UR_APICALL urUSMSharedAlloc(
         size, ///< [in] size in bytes of the USM memory object to be allocated
     void **ppMem ///< [out] pointer to USM shared memory object
 ) {
-  getContext()->logger.debug("==== urUSMSharedAlloc");
+  URLOG_CTX(DEBUG, "==== urUSMSharedAlloc");
 
   return getMsanInterceptor()->allocateMemory(
       hContext, hDevice, pUSMDesc, pool, size, AllocType::SHARED_USM, ppMem);
@@ -148,7 +148,7 @@ ur_result_t UR_APICALL urUSMFree(
     ur_context_handle_t hContext,
     /// [in] pointer to USM memory object
     void *pMem) {
-  getContext()->logger.debug("==== urUSMFree");
+  URLOG_CTX(DEBUG, "==== urUSMFree");
 
   return getMsanInterceptor()->releaseMemory(hContext, pMem);
 }
@@ -169,7 +169,7 @@ ur_result_t urProgramCreateWithIL(
   auto pfnProgramCreateWithIL =
       getContext()->urDdiTable.Program.pfnCreateWithIL;
 
-  getContext()->logger.debug("==== urProgramCreateWithIL");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithIL");
 
   UR_CALL(
       pfnProgramCreateWithIL(hContext, pIL, length, pProperties, phProgram));
@@ -201,7 +201,7 @@ ur_result_t urProgramCreateWithBinary(
   auto pfnProgramCreateWithBinary =
       getContext()->urDdiTable.Program.pfnCreateWithBinary;
 
-  getContext()->logger.debug("==== urProgramCreateWithBinary");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithBinary");
 
   UR_CALL(pfnProgramCreateWithBinary(hContext, numDevices, phDevices, pLengths,
                                      ppBinaries, pProperties, phProgram));
@@ -224,7 +224,7 @@ ur_result_t urProgramCreateWithNativeHandle(
   auto pfnProgramCreateWithNativeHandle =
       getContext()->urDdiTable.Program.pfnCreateWithNativeHandle;
 
-  getContext()->logger.debug("==== urProgramCreateWithNativeHandle");
+  URLOG_CTX(DEBUG, "==== urProgramCreateWithNativeHandle");
 
   UR_CALL(pfnProgramCreateWithNativeHandle(hNativeProgram, hContext,
                                            pProperties, phProgram));
@@ -241,7 +241,7 @@ urProgramRetain(ur_program_handle_t
                     hProgram) {
   auto pfnRetain = getContext()->urDdiTable.Program.pfnRetain;
 
-  getContext()->logger.debug("==== urProgramRetain");
+  URLOG_CTX(DEBUG, "==== urProgramRetain");
 
   UR_CALL(pfnRetain(hProgram));
 
@@ -263,7 +263,7 @@ ur_result_t urProgramBuild(
     const char *pOptions) {
   auto pfnProgramBuild = getContext()->urDdiTable.Program.pfnBuild;
 
-  getContext()->logger.debug("==== urProgramBuild");
+  URLOG_CTX(DEBUG, "==== urProgramBuild");
 
   UR_CALL(pfnProgramBuild(hContext, hProgram, pOptions));
 
@@ -285,7 +285,7 @@ ur_result_t urProgramBuildExp(
     const char *pOptions) {
   auto pfnBuildExp = getContext()->urDdiTable.ProgramExp.pfnBuildExp;
 
-  getContext()->logger.debug("==== urProgramBuildExp");
+  URLOG_CTX(DEBUG, "==== urProgramBuildExp");
 
   UR_CALL(pfnBuildExp(hProgram, numDevices, phDevices, pOptions));
   UR_CALL(getMsanInterceptor()->registerProgram(hProgram));
@@ -308,7 +308,7 @@ ur_result_t urProgramLink(
     ur_program_handle_t *phProgram) {
   auto pfnProgramLink = getContext()->urDdiTable.Program.pfnLink;
 
-  getContext()->logger.debug("==== urProgramLink");
+  URLOG_CTX(DEBUG, "==== urProgramLink");
 
   UR_CALL(pfnProgramLink(hContext, count, phPrograms, pOptions, phProgram));
 
@@ -337,7 +337,7 @@ ur_result_t urProgramLinkExp(
     ur_program_handle_t *phProgram) {
   auto pfnProgramLinkExp = getContext()->urDdiTable.ProgramExp.pfnLinkExp;
 
-  getContext()->logger.debug("==== urProgramLinkExp");
+  URLOG_CTX(DEBUG, "==== urProgramLinkExp");
 
   UR_CALL(pfnProgramLinkExp(hContext, numDevices, phDevices, count, phPrograms,
                             pOptions, phProgram));
@@ -355,7 +355,7 @@ ur_result_t urProgramRelease(
     ur_program_handle_t hProgram) {
   auto pfnProgramRelease = getContext()->urDdiTable.Program.pfnRelease;
 
-  getContext()->logger.debug("==== urProgramRelease");
+  URLOG_CTX(DEBUG, "==== urProgramRelease");
 
   UR_CALL(pfnProgramRelease(hProgram));
 
@@ -403,7 +403,7 @@ ur_result_t urEnqueueKernelLaunch(
     ur_event_handle_t *phEvent) {
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
-  getContext()->logger.debug("==== urEnqueueKernelLaunch");
+  URLOG_CTX(DEBUG, "==== urEnqueueKernelLaunch");
 
   USMLaunchInfo LaunchInfo(GetContext(hQueue), GetDevice(hQueue),
                            pGlobalWorkSize, pLocalWorkSize, pGlobalWorkOffset,
@@ -443,7 +443,7 @@ ur_result_t urContextCreate(
     ur_context_handle_t *phContext) {
   auto pfnCreate = getContext()->urDdiTable.Context.pfnCreate;
 
-  getContext()->logger.debug("==== urContextCreate");
+  URLOG_CTX(DEBUG, "==== urContextCreate");
 
   ur_result_t result = pfnCreate(numDevices, phDevices, pProperties, phContext);
 
@@ -471,7 +471,7 @@ ur_result_t urContextCreateWithNativeHandle(
   auto pfnCreateWithNativeHandle =
       getContext()->urDdiTable.Context.pfnCreateWithNativeHandle;
 
-  getContext()->logger.debug("==== urContextCreateWithNativeHandle");
+  URLOG_CTX(DEBUG, "==== urContextCreateWithNativeHandle");
 
   ur_result_t result = pfnCreateWithNativeHandle(
       hNativeContext, hAdapter, numDevices, phDevices, pProperties, phContext);
@@ -491,7 +491,7 @@ ur_result_t urContextRetain(
     ur_context_handle_t hContext) {
   auto pfnRetain = getContext()->urDdiTable.Context.pfnRetain;
 
-  getContext()->logger.debug("==== urContextRetain");
+  URLOG_CTX(DEBUG, "==== urContextRetain");
 
   UR_CALL(pfnRetain(hContext));
 
@@ -509,7 +509,7 @@ ur_result_t urContextRelease(
     ur_context_handle_t hContext) {
   auto pfnRelease = getContext()->urDdiTable.Context.pfnRelease;
 
-  getContext()->logger.debug("==== urContextRelease");
+  URLOG_CTX(DEBUG, "==== urContextRelease");
 
   UR_CALL(pfnRelease(hContext));
 
@@ -539,7 +539,7 @@ ur_result_t urMemBufferCreate(
     return UR_RESULT_ERROR_INVALID_NULL_POINTER;
   }
 
-  getContext()->logger.debug("==== urMemBufferCreate");
+  URLOG_CTX(DEBUG, "==== urMemBufferCreate");
 
   void *Host = nullptr;
   if (pProperties) {
@@ -595,7 +595,7 @@ ur_result_t urMemGetInfo(
     size_t *pPropSizeRet) {
   auto pfnGetInfo = getContext()->urDdiTable.Mem.pfnGetInfo;
 
-  getContext()->logger.debug("==== urMemGetInfo");
+  URLOG_CTX(DEBUG, "==== urMemGetInfo");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hMemory)) {
     UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
@@ -624,7 +624,7 @@ ur_result_t urMemRetain(
     ur_mem_handle_t hMem) {
   auto pfnRetain = getContext()->urDdiTable.Mem.pfnRetain;
 
-  getContext()->logger.debug("==== urMemRetain");
+  URLOG_CTX(DEBUG, "==== urMemRetain");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hMem)) {
     MemBuffer->RefCount++;
@@ -642,7 +642,7 @@ ur_result_t urMemRelease(
     ur_mem_handle_t hMem) {
   auto pfnRelease = getContext()->urDdiTable.Mem.pfnRelease;
 
-  getContext()->logger.debug("==== urMemRelease");
+  URLOG_CTX(DEBUG, "==== urMemRelease");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hMem)) {
     if (--MemBuffer->RefCount != 0) {
@@ -673,7 +673,7 @@ ur_result_t urMemBufferPartition(
     ur_mem_handle_t *phMem) {
   auto pfnBufferPartition = getContext()->urDdiTable.Mem.pfnBufferPartition;
 
-  getContext()->logger.debug("==== urMemBufferPartition");
+  URLOG_CTX(DEBUG, "==== urMemBufferPartition");
 
   if (auto ParentBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     if (ParentBuffer->Size < (pRegion->origin + pRegion->size)) {
@@ -700,7 +700,7 @@ ur_result_t urMemGetNativeHandle(
     ur_native_handle_t *phNativeMem) {
   auto pfnGetNativeHandle = getContext()->urDdiTable.Mem.pfnGetNativeHandle;
 
-  getContext()->logger.debug("==== urMemGetNativeHandle");
+  URLOG_CTX(DEBUG, "==== urMemGetNativeHandle");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hMem)) {
     char *Handle = nullptr;
@@ -740,7 +740,7 @@ ur_result_t urEnqueueMemBufferRead(
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferRead = getContext()->urDdiTable.Enqueue.pfnMemBufferRead;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferRead");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferRead");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     ur_device_handle_t Device = GetDevice(hQueue);
@@ -784,7 +784,7 @@ ur_result_t urEnqueueMemBufferWrite(
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferWrite = getContext()->urDdiTable.Enqueue.pfnMemBufferWrite;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferWrite");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferWrite");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     ur_device_handle_t Device = GetDevice(hQueue);
@@ -861,7 +861,7 @@ ur_result_t urEnqueueMemBufferReadRect(
   auto pfnMemBufferReadRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferReadRect;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferReadRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferReadRect");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     char *SrcHandle = nullptr;
@@ -922,7 +922,7 @@ ur_result_t urEnqueueMemBufferWriteRect(
   auto pfnMemBufferWriteRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferWriteRect;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferWriteRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferWriteRect");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     char *DstHandle = nullptr;
@@ -970,7 +970,7 @@ ur_result_t urEnqueueMemBufferCopy(
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferCopy = getContext()->urDdiTable.Enqueue.pfnMemBufferCopy;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferCopy");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferCopy");
 
   auto SrcBuffer = getMsanInterceptor()->getMemBuffer(hBufferSrc);
   auto DstBuffer = getMsanInterceptor()->getMemBuffer(hBufferDst);
@@ -1055,7 +1055,7 @@ ur_result_t urEnqueueMemBufferCopyRect(
   auto pfnMemBufferCopyRect =
       getContext()->urDdiTable.Enqueue.pfnMemBufferCopyRect;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferCopyRect");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferCopyRect");
 
   auto SrcBuffer = getMsanInterceptor()->getMemBuffer(hBufferSrc);
   auto DstBuffer = getMsanInterceptor()->getMemBuffer(hBufferDst);
@@ -1112,7 +1112,7 @@ ur_result_t urEnqueueMemBufferFill(
     ur_event_handle_t *phEvent) {
   auto pfnMemBufferFill = getContext()->urDdiTable.Enqueue.pfnMemBufferFill;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferFill");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferFill");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
     char *Handle = nullptr;
@@ -1179,7 +1179,7 @@ ur_result_t urEnqueueMemBufferMap(
     void **ppRetMap) {
   auto pfnMemBufferMap = getContext()->urDdiTable.Enqueue.pfnMemBufferMap;
 
-  getContext()->logger.debug("==== urEnqueueMemBufferMap");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemBufferMap");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hBuffer)) {
 
@@ -1261,7 +1261,7 @@ ur_result_t urEnqueueMemUnmap(
     ur_event_handle_t *phEvent) {
   auto pfnMemUnmap = getContext()->urDdiTable.Enqueue.pfnMemUnmap;
 
-  getContext()->logger.debug("==== urEnqueueMemUnmap");
+  URLOG_CTX(DEBUG, "==== urEnqueueMemUnmap");
 
   if (auto MemBuffer = getMsanInterceptor()->getMemBuffer(hMem)) {
     MemBuffer::Mapping Mapping{};
@@ -1302,7 +1302,7 @@ ur_result_t urKernelRetain(
     ur_kernel_handle_t hKernel) {
   auto pfnRetain = getContext()->urDdiTable.Kernel.pfnRetain;
 
-  getContext()->logger.debug("==== urKernelRetain");
+  URLOG_CTX(DEBUG, "==== urKernelRetain");
 
   UR_CALL(pfnRetain(hKernel));
 
@@ -1319,7 +1319,7 @@ ur_result_t urKernelRelease(
     ur_kernel_handle_t hKernel) {
   auto pfnRelease = getContext()->urDdiTable.Kernel.pfnRelease;
 
-  getContext()->logger.debug("==== urKernelRelease");
+  URLOG_CTX(DEBUG, "==== urKernelRelease");
 
   auto &KernelInfo = getMsanInterceptor()->getOrCreateKernelInfo(hKernel);
   if (--KernelInfo.RefCount == 0) {
@@ -1345,7 +1345,7 @@ ur_result_t urKernelSetArgValue(
     const void *pArgValue) {
   auto pfnSetArgValue = getContext()->urDdiTable.Kernel.pfnSetArgValue;
 
-  getContext()->logger.debug("==== urKernelSetArgValue");
+  URLOG_CTX(DEBUG, "==== urKernelSetArgValue");
 
   std::shared_ptr<MemBuffer> MemBuffer;
   if (argSize == sizeof(ur_mem_handle_t) &&
@@ -1374,7 +1374,7 @@ ur_result_t urKernelSetArgMemObj(
     ur_mem_handle_t hArgValue) {
   auto pfnSetArgMemObj = getContext()->urDdiTable.Kernel.pfnSetArgMemObj;
 
-  getContext()->logger.debug("==== urKernelSetArgMemObj");
+  URLOG_CTX(DEBUG, "==== urKernelSetArgMemObj");
 
   std::shared_ptr<MemBuffer> MemBuffer;
   std::shared_ptr<KernelInfo> KernelInfo;
@@ -1415,7 +1415,7 @@ ur_result_t UR_APICALL urEnqueueUSMFill(
     /// must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill = getContext()->urDdiTable.Enqueue.pfnUSMFill;
-  getContext()->logger.debug("==== urEnqueueUSMFill");
+  URLOG_CTX(DEBUG, "==== urEnqueueUSMFill");
 
   std::vector<ur_event_handle_t> Events;
   ur_event_handle_t Event{};
@@ -1471,7 +1471,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     /// must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy;
-  getContext()->logger.debug("==== pfnUSMMemcpy");
+  URLOG_CTX(DEBUG, "==== pfnUSMMemcpy");
 
   std::vector<ur_event_handle_t> Events;
   ur_event_handle_t Event{};
@@ -1548,7 +1548,7 @@ ur_result_t UR_APICALL urEnqueueUSMFill2D(
     /// phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMFill2D = getContext()->urDdiTable.Enqueue.pfnUSMFill2D;
-  getContext()->logger.debug("==== urEnqueueUSMFill2D");
+  URLOG_CTX(DEBUG, "==== urEnqueueUSMFill2D");
 
   std::vector<ur_event_handle_t> Events;
   ur_event_handle_t Event{};
@@ -1612,7 +1612,7 @@ ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     /// phEvent must not refer to an element of the phEventWaitList array.
     ur_event_handle_t *phEvent) {
   auto pfnUSMMemcpy2D = getContext()->urDdiTable.Enqueue.pfnUSMMemcpy2D;
-  getContext()->logger.debug("==== pfnUSMMemcpy2D");
+  URLOG_CTX(DEBUG, "==== pfnUSMMemcpy2D");
 
   std::vector<ur_event_handle_t> Events;
   ur_event_handle_t Event{};
@@ -1851,7 +1851,7 @@ ur_result_t urCheckVersion(ur_api_version_t version) {
 ur_result_t initMsanDDITable(ur_dditable_t *dditable) {
   ur_result_t result = UR_RESULT_SUCCESS;
 
-  getContext()->logger.always("==== DeviceSanitizer: MSAN");
+  URLOG_CTX_ALWAYS("==== DeviceSanitizer: MSAN");
 
   if (UR_RESULT_SUCCESS == result) {
     result = ur_sanitizer_layer::msan::urCheckVersion(UR_API_VERSION_CURRENT);
@@ -1901,7 +1901,7 @@ ur_result_t initMsanDDITable(ur_dditable_t *dditable) {
   }
 
   if (result != UR_RESULT_SUCCESS) {
-    getContext()->logger.error("Initialize MSAN DDI table failed: {}", result);
+    URLOG_CTX(ERR, "Initialize MSAN DDI table failed: {}", result);
   }
 
   return result;

--- a/source/loader/layers/sanitizer/msan/msan_options.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_options.cpp
@@ -31,7 +31,7 @@ MsanOptions::MsanOptions() {
     std::stringstream SS;
     SS << "<SANITIZER>[ERROR]: ";
     SS << e.what();
-    getContext()->logger.always(SS.str().c_str());
+    URLOG_CTX_ALWAYS(SHORT_FILE, UR_STR(__LINE__), SS.str().c_str());
     die("Sanitizer failed to parse options.\n");
   }
 
@@ -78,7 +78,7 @@ MsanOptions::MsanOptions() {
           SS << " \"" << S << "\"";
         }
         SS << ".";
-        getContext()->logger.error(SS.str().c_str());
+        URLOG_CTX(ERR, SS.str().c_str());
         die("Sanitizer failed to parse options.\n");
       }
     }

--- a/source/loader/layers/sanitizer/msan/msan_report.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_report.cpp
@@ -30,14 +30,15 @@ void ReportUsesUninitializedValue(const MsanErrorReport &Report,
   // Try to demangle the kernel name
   KernelName = DemangleName(KernelName);
 
-  getContext()->logger.always(
-      "====WARNING: DeviceSanitizer: use-of-uninitialized-value");
-  getContext()->logger.always(
-      "use of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
-      "{}, {})",
-      Report.AccessSize, KernelName.c_str(), Report.LID0, Report.LID1,
-      Report.LID2, Report.GID0, Report.GID1, Report.GID2);
-  getContext()->logger.always("  #0 {} {}:{}", Func, File, Report.Line);
+  URLOG_CTX_ALWAYS(SHORT_FILE, UR_STR(__LINE__),
+                   "====WARNING: DeviceSanitizer: use-of-uninitialized-value");
+  URLOG_CTX_ALWAYS(SHORT_FILE, UR_STR(__LINE__),
+                   "use of size {} at kernel <{}> LID({}, {}, {}) GID({}, "
+                   "{}, {})",
+                   Report.AccessSize, KernelName.c_str(), Report.LID0,
+                   Report.LID1, Report.LID2, Report.GID0, Report.GID1,
+                   Report.GID2);
+  URLOG_CTX_ALWAYS("  #0 {} {}:{}", Func, File, Report.Line);
 }
 
 } // namespace msan

--- a/source/loader/layers/sanitizer/msan/msan_shadow.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_shadow.cpp
@@ -45,7 +45,7 @@ GetMsanShadowMemory(ur_context_handle_t Context, ur_device_handle_t Device,
         std::make_shared<MsanShadowMemoryDG2>(Context, Device);
     return ShadowDG2;
   } else {
-    getContext()->logger.error("Unsupport device type");
+    URLOG_CTX(ERR, "Unsupport device type");
     return nullptr;
   }
 }
@@ -118,9 +118,9 @@ ur_result_t MsanShadowMemoryCPU::EnqueuePoisonShadow(
     const uptr ShadowBegin = MemToShadow(Ptr);
     const uptr ShadowEnd = MemToShadow(Ptr + Size - 1);
     assert(ShadowBegin <= ShadowEnd);
-    getContext()->logger.debug(
-        "EnqueuePoisonShadow(addr={}, count={}, value={})", (void *)ShadowBegin,
-        ShadowEnd - ShadowBegin + 1, (void *)(size_t)Value);
+    URLOG_CTX(DEBUG, "EnqueuePoisonShadow(addr={}, count={}, value={})",
+              (void *)ShadowBegin, ShadowEnd - ShadowBegin + 1,
+              (void *)(size_t)Value);
     memset((void *)ShadowBegin, Value, ShadowEnd - ShadowBegin + 1);
   }
 
@@ -146,9 +146,8 @@ ur_result_t MsanShadowMemoryGPU::Setup() {
     auto Result = getContext()->urDdiTable.VirtualMem.pfnReserve(
         Context, StartAddress, ShadowSize, (void **)&ShadowBegin);
     if (Result != UR_RESULT_SUCCESS) {
-      getContext()->logger.error(
-          "Shadow memory reserved failed with size {}: {}", (void *)ShadowSize,
-          Result);
+      URLOG_CTX(ERR, "Shadow memory reserved failed with size {}: {}",
+                (void *)ShadowSize, Result);
       return Result;
     }
     ShadowEnd = ShadowBegin + ShadowSize;
@@ -192,7 +191,7 @@ ur_result_t MsanShadowMemoryGPU::EnqueueMapShadow(
       auto URes = getContext()->urDdiTable.PhysicalMem.pfnCreate(
           Context, Device, PageSize, nullptr, &PhysicalMem);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("urPhysicalMemCreate(): {}", URes);
+        URLOG_CTX(ERR, "urPhysicalMemCreate(): {}", URes);
         return URes;
       }
 
@@ -200,20 +199,20 @@ ur_result_t MsanShadowMemoryGPU::EnqueueMapShadow(
           Context, (void *)MappedPtr, PageSize, PhysicalMem, 0,
           UR_VIRTUAL_MEM_ACCESS_FLAG_READ_WRITE);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("urVirtualMemMap({}, {}): {}",
-                                   (void *)MappedPtr, PageSize, URes);
+        URLOG_CTX(ERR, "urVirtualMemMap({}, {}): {}", (void *)MappedPtr,
+                  PageSize, URes);
         return URes;
       }
 
-      getContext()->logger.debug("urVirtualMemMap: {} ~ {}", (void *)MappedPtr,
-                                 (void *)(MappedPtr + PageSize - 1));
+      URLOG_CTX(DEBUG, "urVirtualMemMap: {} ~ {}", (void *)MappedPtr,
+                (void *)(MappedPtr + PageSize - 1));
 
       // Initialize to zero
       URes = EnqueueUSMBlockingSet(Queue, (void *)MappedPtr, 0, PageSize,
                                    EventWaitList.size(), EventWaitList.data(),
                                    OutEvent);
       if (URes != UR_RESULT_SUCCESS) {
-        getContext()->logger.error("EnqueueUSMSet(): {}", URes);
+        URLOG_CTX(ERR, "EnqueueUSMSet(): {}", URes);
         return URes;
       }
 
@@ -257,10 +256,9 @@ ur_result_t MsanShadowMemoryGPU::EnqueuePoisonShadow(
                                       ShadowEnd - ShadowBegin + 1,
                                       Events.size(), Events.data(), OutEvent);
 
-  getContext()->logger.debug(
-      "EnqueuePoisonShadow(addr={}, count={}, value={}): {}",
-      (void *)ShadowBegin, ShadowEnd - ShadowBegin + 1, (void *)(size_t)Value,
-      Result);
+  URLOG_CTX(DEBUG, "EnqueuePoisonShadow(addr={}, count={}, value={}): {}",
+            (void *)ShadowBegin, ShadowEnd - ShadowBegin + 1,
+            (void *)(size_t)Value, Result);
 
   return Result;
 }
@@ -285,9 +283,8 @@ MsanShadowMemoryGPU::ReleaseShadow(std::shared_ptr<MsanAllocInfo> AI) {
           Context, (void *)MappedPtr, PageSize));
       UR_CALL(getContext()->urDdiTable.PhysicalMem.pfnRelease(
           VirtualMemMaps[MappedPtr].first));
-      getContext()->logger.debug("urVirtualMemUnmap: {} ~ {}",
-                                 (void *)MappedPtr,
-                                 (void *)(MappedPtr + PageSize - 1));
+      URLOG_CTX(DEBUG, "urVirtualMemUnmap: {} ~ {}", (void *)MappedPtr,
+                (void *)(MappedPtr + PageSize - 1));
     }
   }
 

--- a/source/loader/layers/sanitizer/sanitizer_common/linux/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/linux/sanitizer_utils.cpp
@@ -67,12 +67,12 @@ bool DontCoredumpRange(uptr Addr, uptr Size) {
 void *GetMemFunctionPointer(const char *FuncName) {
   void *handle = dlopen(LIBC_SO, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
-    getContext()->logger.error("Failed to dlopen {}", LIBC_SO);
+    URLOG_CTX(ERR, "Failed to dlopen {}", LIBC_SO);
     return nullptr;
   }
   auto ptr = dlsym(handle, FuncName);
   if (!ptr) {
-    getContext()->logger.error("Failed to get '{}' from {}", FuncName, LIBC_SO);
+    URLOG_CTX(ERR, "Failed to get '{}' from {}", FuncName, LIBC_SO);
   }
   return ptr;
 }

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_common.hpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_common.hpp
@@ -120,10 +120,10 @@ inline uint64_t GetSizeAndRedzoneSizeForLocal(uint64_t Size,
 #define UR_CALL(Call)                                                          \
   {                                                                            \
     if (PrintTrace)                                                            \
-      getContext()->logger.debug("UR ---> {}", #Call);                         \
+      URLOG_CTX(DEBUG, "UR ---> {}", #Call);                                   \
     ur_result_t Result = (Call);                                               \
     if (PrintTrace)                                                            \
-      getContext()->logger.debug("UR <--- {}({})", #Call, Result);             \
+      URLOG_CTX(DEBUG, "UR <--- {}({})", #Call, Result);                       \
     if (Result != UR_RESULT_SUCCESS)                                           \
       return Result;                                                           \
   }

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_stacktrace.cpp
@@ -82,7 +82,8 @@ SourceInfo ParseSymbolizerOutput(const std::string &Output) {
 
 void StackTrace::print() const {
   if (!stack.size()) {
-    getContext()->logger.always("  failed to acquire backtrace");
+    URLOG_CTX_ALWAYS(SHORT_FILE, UR_STR(__LINE__),
+                     "  failed to acquire backtrace");
   }
 
   unsigned index = 0;
@@ -113,21 +114,19 @@ void StackTrace::print() const {
         std::string Result((char *)ResultVector.data());
         SourceInfo SrcInfo = ParseSymbolizerOutput(Result);
         if (SrcInfo.file != "??") {
-          getContext()->logger.always(" #{} in {} {}:{}:{}", index,
-                                      SrcInfo.function, SrcInfo.file,
-                                      SrcInfo.line, SrcInfo.column);
+          URLOG_CTX_ALWAYS(" #{} in {} {}:{}:{}", index, SrcInfo.function,
+                           SrcInfo.file, SrcInfo.line, SrcInfo.column);
         } else {
-          getContext()->logger.always(" #{} in {} ({}+{})", index,
-                                      SrcInfo.function, ModuleName,
-                                      (void *)Offset);
+          URLOG_CTX_ALWAYS(" #{} in {} ({}+{})", index, SrcInfo.function,
+                           ModuleName, (void *)Offset);
         }
       }
     } else {
-      getContext()->logger.always("  #{} {}", index, BI);
+      URLOG_CTX_ALWAYS("  #{} {}", index, BI);
     }
     ++index;
   }
-  getContext()->logger.always("");
+  URLOG_CTX_ALWAYS("");
 
   free(BacktraceSymbols);
 }

--- a/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
+++ b/source/loader/layers/sanitizer/sanitizer_common/sanitizer_utils.cpp
@@ -22,16 +22,16 @@ ManagedQueue::ManagedQueue(ur_context_handle_t Context,
   [[maybe_unused]] auto Result = getContext()->urDdiTable.Queue.pfnCreate(
       Context, Device, nullptr, &Handle);
   assert(Result == UR_RESULT_SUCCESS && "Failed to create ManagedQueue");
-  getContext()->logger.debug(">>> ManagedQueue {}", (void *)Handle);
+  URLOG_CTX(DEBUG, ">>> ManagedQueue {}", (void *)Handle);
 }
 
 ManagedQueue::~ManagedQueue() {
-  getContext()->logger.debug("<<< ~ManagedQueue {}", (void *)Handle);
+  URLOG_CTX(DEBUG, "<<< ~ManagedQueue {}", (void *)Handle);
 
   [[maybe_unused]] ur_result_t Result;
   Result = getContext()->urDdiTable.Queue.pfnFinish(Handle);
   if (Result != UR_RESULT_SUCCESS) {
-    getContext()->logger.error("Failed to finish ManagedQueue: {}", Result);
+    URLOG_CTX(ERR, "Failed to finish ManagedQueue: {}", Result);
   }
   assert(Result == UR_RESULT_SUCCESS && "Failed to finish ManagedQueue");
   Result = getContext()->urDdiTable.Queue.pfnRelease(Handle);
@@ -149,7 +149,7 @@ DeviceType GetDeviceType(ur_context_handle_t Context,
     [[maybe_unused]] ur_result_t Result =
         getContext()->urDdiTable.USM.pfnDeviceAlloc(Context, Device, nullptr,
                                                     nullptr, 4, (void **)&Ptr);
-    getContext()->logger.debug("GetDeviceType: {}", (void *)Ptr);
+    URLOG_CTX(DEBUG, "GetDeviceType: {}", (void *)Ptr);
     assert(Result == UR_RESULT_SUCCESS &&
            "getDeviceType() failed at allocating device USM");
     // FIXME: There's no API querying the address bits of device, so we guess it

--- a/source/loader/layers/sanitizer/ur_sanddi.cpp
+++ b/source/loader/layers/sanitizer/ur_sanddi.cpp
@@ -24,9 +24,9 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
   bool msanEnabled = enabledLayerNames.count("UR_LAYER_MSAN");
 
   if (asanEnabled && msanEnabled) {
-    getContext()->logger.warning(
-        "Enabling ASAN and MSAN at the same time is not "
-        "supported.");
+    URLOG_CTX(WARN, SHORT_FILE, UR_STR(__LINE__),
+              "Enabling ASAN and MSAN at the same time is not "
+              "supported.");
     return UR_RESULT_SUCCESS;
   } else if (asanEnabled) {
     enabledType = SanitizerType::AddressSanitizer;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -41,7 +41,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
                                                  "urAdapterGet", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urAdapterGet\n");
+  URLOG_(logger, INFO, "   ---> urAdapterGet\n");
 
   ur_result_t result = pfnAdapterGet(NumEntries, phAdapters, pNumAdapters);
 
@@ -51,7 +51,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET, &params);
-    logger.info("   <--- urAdapterGet({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urAdapterGet({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -72,7 +73,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
                                                  "urAdapterRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urAdapterRelease\n");
+  URLOG_(logger, INFO, "   ---> urAdapterRelease\n");
 
   ur_result_t result = pfnAdapterRelease(hAdapter);
 
@@ -83,8 +84,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RELEASE,
                                     &params);
-    logger.info("   <--- urAdapterRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urAdapterRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -105,7 +106,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
                                                  "urAdapterRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urAdapterRetain\n");
+  URLOG_(logger, INFO, "   ---> urAdapterRetain\n");
 
   ur_result_t result = pfnAdapterRetain(hAdapter);
 
@@ -116,7 +117,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RETAIN,
                                     &params);
-    logger.info("   <--- urAdapterRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urAdapterRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -144,7 +146,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
       UR_FUNCTION_ADAPTER_GET_LAST_ERROR, "urAdapterGetLastError", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urAdapterGetLastError\n");
+  URLOG_(logger, INFO, "   ---> urAdapterGetLastError\n");
 
   ur_result_t result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
 
@@ -155,8 +157,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ADAPTER_GET_LAST_ERROR, &params);
-    logger.info("   <--- urAdapterGetLastError({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urAdapterGetLastError({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -191,7 +193,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
                                                  "urAdapterGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urAdapterGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urAdapterGetInfo\n");
 
   ur_result_t result =
       pfnAdapterGetInfo(hAdapter, propName, propSize, pPropValue, pPropSizeRet);
@@ -203,8 +205,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET_INFO,
                                     &params);
-    logger.info("   <--- urAdapterGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urAdapterGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -239,7 +241,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
                                                  "urPlatformGet", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformGet\n");
+  URLOG_(logger, INFO, "   ---> urPlatformGet\n");
 
   ur_result_t result =
       pfnGet(phAdapters, NumAdapters, NumEntries, phPlatforms, pNumPlatforms);
@@ -251,7 +253,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET,
                                     &params);
-    logger.info("   <--- urPlatformGet({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urPlatformGet({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -286,7 +289,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
                                                  "urPlatformGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urPlatformGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hPlatform, propName, propSize, pPropValue, pPropSizeRet);
@@ -298,8 +301,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET_INFO,
                                     &params);
-    logger.info("   <--- urPlatformGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPlatformGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -322,7 +325,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
       UR_FUNCTION_PLATFORM_GET_API_VERSION, "urPlatformGetApiVersion", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformGetApiVersion\n");
+  URLOG_(logger, INFO, "   ---> urPlatformGetApiVersion\n");
 
   ur_result_t result = pfnGetApiVersion(hPlatform, pVersion);
 
@@ -334,8 +337,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_API_VERSION, &params);
-    logger.info("   <--- urPlatformGetApiVersion({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPlatformGetApiVersion({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -361,7 +364,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
                                  "urPlatformGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urPlatformGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hPlatform, phNativePlatform);
 
@@ -373,8 +376,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urPlatformGetNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urPlatformGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -404,7 +407,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
                                  "urPlatformCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urPlatformCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter,
                                                  pProperties, phPlatform);
@@ -417,8 +420,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urPlatformCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urPlatformCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -447,7 +450,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
                                  "urPlatformGetBackendOption", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPlatformGetBackendOption\n");
+  URLOG_(logger, INFO, "   ---> urPlatformGetBackendOption\n");
 
   ur_result_t result =
       pfnGetBackendOption(hPlatform, pFrontendOption, ppPlatformOption);
@@ -460,8 +463,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION, &params);
-    logger.info("   <--- urPlatformGetBackendOption({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urPlatformGetBackendOption({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -497,7 +500,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
                                                  "urDeviceGet", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceGet\n");
+  URLOG_(logger, INFO, "   ---> urDeviceGet\n");
 
   ur_result_t result =
       pfnGet(hPlatform, DeviceType, NumEntries, phDevices, pNumDevices);
@@ -508,7 +511,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET, &params);
-    logger.info("   <--- urDeviceGet({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceGet({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -544,7 +548,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
                                                  "urDeviceGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urDeviceGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hDevice, propName, propSize, pPropValue, pPropSizeRet);
@@ -556,7 +560,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET_INFO,
                                     &params);
-    logger.info("   <--- urDeviceGetInfo({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -577,7 +582,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
                                                  "urDeviceRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceRetain\n");
+  URLOG_(logger, INFO, "   ---> urDeviceRetain\n");
 
   ur_result_t result = pfnRetain(hDevice);
 
@@ -588,7 +593,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RETAIN,
                                     &params);
-    logger.info("   <--- urDeviceRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -609,7 +615,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
                                                  "urDeviceRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceRelease\n");
+  URLOG_(logger, INFO, "   ---> urDeviceRelease\n");
 
   ur_result_t result = pfnRelease(hDevice);
 
@@ -620,7 +626,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RELEASE,
                                     &params);
-    logger.info("   <--- urDeviceRelease({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -653,7 +660,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
                                                  "urDevicePartition", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDevicePartition\n");
+  URLOG_(logger, INFO, "   ---> urDevicePartition\n");
 
   ur_result_t result = pfnPartition(hDevice, pProperties, NumDevices,
                                     phSubDevices, pNumDevicesRet);
@@ -665,8 +672,8 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_PARTITION,
                                     &params);
-    logger.info("   <--- urDevicePartition({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urDevicePartition({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -698,7 +705,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
       UR_FUNCTION_DEVICE_SELECT_BINARY, "urDeviceSelectBinary", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceSelectBinary\n");
+  URLOG_(logger, INFO, "   ---> urDeviceSelectBinary\n");
 
   ur_result_t result =
       pfnSelectBinary(hDevice, pBinaries, NumBinaries, pSelectedBinary);
@@ -710,8 +717,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_SELECT_BINARY,
                                     &params);
-    logger.info("   <--- urDeviceSelectBinary({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urDeviceSelectBinary({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -734,7 +741,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
       UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, "urDeviceGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urDeviceGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hDevice, phNativeDevice);
 
@@ -746,8 +753,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urDeviceGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urDeviceGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -777,7 +784,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
                                  "urDeviceCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urDeviceCreateWithNativeHandle\n");
 
   ur_result_t result =
       pfnCreateWithNativeHandle(hNativeDevice, hAdapter, pProperties, phDevice);
@@ -790,8 +797,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urDeviceCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -821,7 +828,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
                                  "urDeviceGetGlobalTimestamps", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urDeviceGetGlobalTimestamps\n");
+  URLOG_(logger, INFO, "   ---> urDeviceGetGlobalTimestamps\n");
 
   ur_result_t result =
       pfnGetGlobalTimestamps(hDevice, pDeviceTimestamp, pHostTimestamp);
@@ -834,8 +841,8 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, &params);
-    logger.info("   <--- urDeviceGetGlobalTimestamps({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urDeviceGetGlobalTimestamps({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -863,7 +870,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
                                                  "urContextCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextCreate\n");
+  URLOG_(logger, INFO, "   ---> urContextCreate\n");
 
   ur_result_t result =
       pfnCreate(DeviceCount, phDevices, pProperties, phContext);
@@ -875,7 +882,8 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_CREATE,
                                     &params);
-    logger.info("   <--- urContextCreate({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urContextCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -896,7 +904,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
                                                  "urContextRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextRetain\n");
+  URLOG_(logger, INFO, "   ---> urContextRetain\n");
 
   ur_result_t result = pfnRetain(hContext);
 
@@ -907,7 +915,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RETAIN,
                                     &params);
-    logger.info("   <--- urContextRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urContextRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -928,7 +937,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
                                                  "urContextRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextRelease\n");
+  URLOG_(logger, INFO, "   ---> urContextRelease\n");
 
   ur_result_t result = pfnRelease(hContext);
 
@@ -939,8 +948,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RELEASE,
                                     &params);
-    logger.info("   <--- urContextRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urContextRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -976,7 +985,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
                                                  "urContextGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urContextGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hContext, propName, propSize, pPropValue, pPropSizeRet);
@@ -988,8 +997,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_GET_INFO,
                                     &params);
-    logger.info("   <--- urContextGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urContextGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1013,7 +1022,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
                                  "urContextGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urContextGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hContext, phNativeContext);
 
@@ -1025,8 +1034,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urContextGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urContextGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1062,7 +1071,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
                                  "urContextCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urContextCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(
       hNativeContext, hAdapter, numDevices, phDevices, pProperties, phContext);
@@ -1075,8 +1084,8 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urContextCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urContextCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1104,7 +1113,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
                                  "urContextSetExtendedDeleter", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urContextSetExtendedDeleter\n");
+  URLOG_(logger, INFO, "   ---> urContextSetExtendedDeleter\n");
 
   ur_result_t result = pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
 
@@ -1116,8 +1125,8 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, &params);
-    logger.info("   <--- urContextSetExtendedDeleter({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urContextSetExtendedDeleter({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1149,7 +1158,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
                                                  "urMemImageCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemImageCreate\n");
+  URLOG_(logger, INFO, "   ---> urMemImageCreate\n");
 
   ur_result_t result =
       pfnImageCreate(hContext, flags, pImageFormat, pImageDesc, pHost, phMem);
@@ -1161,8 +1170,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_CREATE,
                                     &params);
-    logger.info("   <--- urMemImageCreate({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urMemImageCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1192,7 +1201,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
                                                  "urMemBufferCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemBufferCreate\n");
+  URLOG_(logger, INFO, "   ---> urMemBufferCreate\n");
 
   ur_result_t result =
       pfnBufferCreate(hContext, flags, size, pProperties, phBuffer);
@@ -1204,8 +1213,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_CREATE,
                                     &params);
-    logger.info("   <--- urMemBufferCreate({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urMemBufferCreate({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1226,7 +1235,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
                                                  "urMemRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemRetain\n");
+  URLOG_(logger, INFO, "   ---> urMemRetain\n");
 
   ur_result_t result = pfnRetain(hMem);
 
@@ -1236,7 +1245,8 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RETAIN, &params);
-    logger.info("   <--- urMemRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urMemRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1257,7 +1267,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
                                                  "urMemRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemRelease\n");
+  URLOG_(logger, INFO, "   ---> urMemRelease\n");
 
   ur_result_t result = pfnRelease(hMem);
 
@@ -1267,7 +1277,8 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RELEASE, &params);
-    logger.info("   <--- urMemRelease({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urMemRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1297,7 +1308,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
       UR_FUNCTION_MEM_BUFFER_PARTITION, "urMemBufferPartition", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemBufferPartition\n");
+  URLOG_(logger, INFO, "   ---> urMemBufferPartition\n");
 
   ur_result_t result =
       pfnBufferPartition(hBuffer, flags, bufferCreateType, pRegion, phMem);
@@ -1309,8 +1320,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_PARTITION,
                                     &params);
-    logger.info("   <--- urMemBufferPartition({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urMemBufferPartition({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1336,7 +1347,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
       UR_FUNCTION_MEM_GET_NATIVE_HANDLE, "urMemGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urMemGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hMem, hDevice, phNativeMem);
 
@@ -1347,8 +1358,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                                     &params);
-    logger.info("   <--- urMemGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urMemGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1378,7 +1389,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
       "urMemBufferCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemBufferCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urMemBufferCreateWithNativeHandle\n");
 
   ur_result_t result =
       pfnBufferCreateWithNativeHandle(hNativeMem, hContext, pProperties, phMem);
@@ -1391,8 +1402,9 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urMemBufferCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urMemBufferCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1426,7 +1438,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
       "urMemImageCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemImageCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urMemImageCreateWithNativeHandle\n");
 
   ur_result_t result = pfnImageCreateWithNativeHandle(
       hNativeMem, hContext, pImageFormat, pImageDesc, pProperties, phMem);
@@ -1439,8 +1451,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urMemImageCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urMemImageCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1475,7 +1487,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
                                                  "urMemGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urMemGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
@@ -1487,7 +1499,8 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_INFO,
                                     &params);
-    logger.info("   <--- urMemGetInfo({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urMemGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1522,7 +1535,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
                                                  "urMemImageGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urMemImageGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urMemImageGetInfo\n");
 
   ur_result_t result =
       pfnImageGetInfo(hMemory, propName, propSize, pPropValue, pPropSizeRet);
@@ -1534,8 +1547,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_GET_INFO,
                                     &params);
-    logger.info("   <--- urMemImageGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urMemImageGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1560,7 +1573,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
                                                  "urSamplerCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerCreate\n");
+  URLOG_(logger, INFO, "   ---> urSamplerCreate\n");
 
   ur_result_t result = pfnCreate(hContext, pDesc, phSampler);
 
@@ -1571,7 +1584,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_CREATE,
                                     &params);
-    logger.info("   <--- urSamplerCreate({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urSamplerCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1592,7 +1606,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
                                                  "urSamplerRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerRetain\n");
+  URLOG_(logger, INFO, "   ---> urSamplerRetain\n");
 
   ur_result_t result = pfnRetain(hSampler);
 
@@ -1603,7 +1617,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RETAIN,
                                     &params);
-    logger.info("   <--- urSamplerRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urSamplerRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1624,7 +1639,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
                                                  "urSamplerRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerRelease\n");
+  URLOG_(logger, INFO, "   ---> urSamplerRelease\n");
 
   ur_result_t result = pfnRelease(hSampler);
 
@@ -1635,8 +1650,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RELEASE,
                                     &params);
-    logger.info("   <--- urSamplerRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urSamplerRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1667,7 +1682,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
                                                  "urSamplerGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urSamplerGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hSampler, propName, propSize, pPropValue, pPropSizeRet);
@@ -1679,8 +1694,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_GET_INFO,
                                     &params);
-    logger.info("   <--- urSamplerGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urSamplerGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1704,7 +1719,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
                                  "urSamplerGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urSamplerGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hSampler, phNativeSampler);
 
@@ -1716,8 +1731,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urSamplerGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urSamplerGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1747,7 +1762,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
                                  "urSamplerCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urSamplerCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urSamplerCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeSampler, hContext,
                                                  pProperties, phSampler);
@@ -1760,8 +1775,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urSamplerCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urSamplerCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1791,7 +1806,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
                                                  "urUSMHostAlloc", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMHostAlloc\n");
+  URLOG_(logger, INFO, "   ---> urUSMHostAlloc\n");
 
   ur_result_t result = pfnHostAlloc(hContext, pUSMDesc, pool, size, ppMem);
 
@@ -1802,7 +1817,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_HOST_ALLOC,
                                     &params);
-    logger.info("   <--- urUSMHostAlloc({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMHostAlloc({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1834,7 +1850,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
                                                  "urUSMDeviceAlloc", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMDeviceAlloc\n");
+  URLOG_(logger, INFO, "   ---> urUSMDeviceAlloc\n");
 
   ur_result_t result =
       pfnDeviceAlloc(hContext, hDevice, pUSMDesc, pool, size, ppMem);
@@ -1846,8 +1862,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_DEVICE_ALLOC,
                                     &params);
-    logger.info("   <--- urUSMDeviceAlloc({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMDeviceAlloc({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1879,7 +1895,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
                                                  "urUSMSharedAlloc", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMSharedAlloc\n");
+  URLOG_(logger, INFO, "   ---> urUSMSharedAlloc\n");
 
   ur_result_t result =
       pfnSharedAlloc(hContext, hDevice, pUSMDesc, pool, size, ppMem);
@@ -1891,8 +1907,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_SHARED_ALLOC,
                                     &params);
-    logger.info("   <--- urUSMSharedAlloc({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMSharedAlloc({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1915,7 +1931,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
       getContext()->notify_begin(UR_FUNCTION_USM_FREE, "urUSMFree", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMFree\n");
+  URLOG_(logger, INFO, "   ---> urUSMFree\n");
 
   ur_result_t result = pfnFree(hContext, pMem);
 
@@ -1925,7 +1941,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_FREE, &params);
-    logger.info("   <--- urUSMFree({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMFree({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -1958,7 +1975,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
       UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, "urUSMGetMemAllocInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMGetMemAllocInfo\n");
+  URLOG_(logger, INFO, "   ---> urUSMGetMemAllocInfo\n");
 
   ur_result_t result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize,
                                           pPropValue, pPropSizeRet);
@@ -1970,8 +1987,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, &params);
-    logger.info("   <--- urUSMGetMemAllocInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMGetMemAllocInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1997,7 +2014,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
                                                  "urUSMPoolCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMPoolCreate\n");
+  URLOG_(logger, INFO, "   ---> urUSMPoolCreate\n");
 
   ur_result_t result = pfnPoolCreate(hContext, pPoolDesc, ppPool);
 
@@ -2008,7 +2025,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_CREATE,
                                     &params);
-    logger.info("   <--- urUSMPoolCreate({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMPoolCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2029,7 +2047,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
                                                  "urUSMPoolRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMPoolRetain\n");
+  URLOG_(logger, INFO, "   ---> urUSMPoolRetain\n");
 
   ur_result_t result = pfnPoolRetain(pPool);
 
@@ -2040,7 +2058,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RETAIN,
                                     &params);
-    logger.info("   <--- urUSMPoolRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMPoolRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2061,7 +2080,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
                                                  "urUSMPoolRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMPoolRelease\n");
+  URLOG_(logger, INFO, "   ---> urUSMPoolRelease\n");
 
   ur_result_t result = pfnPoolRelease(pPool);
 
@@ -2072,8 +2091,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RELEASE,
                                     &params);
-    logger.info("   <--- urUSMPoolRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMPoolRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2104,7 +2123,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
                                                  "urUSMPoolGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMPoolGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urUSMPoolGetInfo\n");
 
   ur_result_t result =
       pfnPoolGetInfo(hPool, propName, propSize, pPropValue, pPropSizeRet);
@@ -2116,8 +2135,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_GET_INFO,
                                     &params);
-    logger.info("   <--- urUSMPoolGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMPoolGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2157,7 +2176,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
                                  "urVirtualMemGranularityGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemGranularityGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemGranularityGetInfo\n");
 
   ur_result_t result = pfnGranularityGetInfo(
       hContext, hDevice, propName, propSize, pPropValue, pPropSizeRet);
@@ -2170,8 +2189,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO, &params);
-    logger.info("   <--- urVirtualMemGranularityGetInfo({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urVirtualMemGranularityGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2202,7 +2221,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
       UR_FUNCTION_VIRTUAL_MEM_RESERVE, "urVirtualMemReserve", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemReserve\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemReserve\n");
 
   ur_result_t result = pfnReserve(hContext, pStart, size, ppStart);
 
@@ -2213,8 +2232,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                                     &params);
-    logger.info("   <--- urVirtualMemReserve({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urVirtualMemReserve({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2239,7 +2258,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
                                                  "urVirtualMemFree", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemFree\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemFree\n");
 
   ur_result_t result = pfnFree(hContext, pStart, size);
 
@@ -2250,8 +2269,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_FREE,
                                     &params);
-    logger.info("   <--- urVirtualMemFree({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urVirtualMemFree({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2283,7 +2302,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
                                                  "urVirtualMemMap", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemMap\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemMap\n");
 
   ur_result_t result =
       pfnMap(hContext, pStart, size, hPhysicalMem, offset, flags);
@@ -2295,7 +2314,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_MAP,
                                     &params);
-    logger.info("   <--- urVirtualMemMap({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urVirtualMemMap({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2320,7 +2340,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
                                                  "urVirtualMemUnmap", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemUnmap\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemUnmap\n");
 
   ur_result_t result = pfnUnmap(hContext, pStart, size);
 
@@ -2331,8 +2351,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_UNMAP,
                                     &params);
-    logger.info("   <--- urVirtualMemUnmap({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urVirtualMemUnmap({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2360,7 +2380,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
       UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS, "urVirtualMemSetAccess", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemSetAccess\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemSetAccess\n");
 
   ur_result_t result = pfnSetAccess(hContext, pStart, size, flags);
 
@@ -2371,8 +2391,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS, &params);
-    logger.info("   <--- urVirtualMemSetAccess({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urVirtualMemSetAccess({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2411,7 +2431,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
       UR_FUNCTION_VIRTUAL_MEM_GET_INFO, "urVirtualMemGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urVirtualMemGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urVirtualMemGetInfo\n");
 
   ur_result_t result = pfnGetInfo(hContext, pStart, size, propName, propSize,
                                   pPropValue, pPropSizeRet);
@@ -2423,8 +2443,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                                     &params);
-    logger.info("   <--- urVirtualMemGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urVirtualMemGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2455,7 +2475,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
       UR_FUNCTION_PHYSICAL_MEM_CREATE, "urPhysicalMemCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPhysicalMemCreate\n");
+  URLOG_(logger, INFO, "   ---> urPhysicalMemCreate\n");
 
   ur_result_t result =
       pfnCreate(hContext, hDevice, size, pProperties, phPhysicalMem);
@@ -2467,8 +2487,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_CREATE,
                                     &params);
-    logger.info("   <--- urPhysicalMemCreate({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPhysicalMemCreate({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2489,7 +2509,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
       UR_FUNCTION_PHYSICAL_MEM_RETAIN, "urPhysicalMemRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPhysicalMemRetain\n");
+  URLOG_(logger, INFO, "   ---> urPhysicalMemRetain\n");
 
   ur_result_t result = pfnRetain(hPhysicalMem);
 
@@ -2500,8 +2520,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                                     &params);
-    logger.info("   <--- urPhysicalMemRetain({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPhysicalMemRetain({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2522,7 +2542,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
       UR_FUNCTION_PHYSICAL_MEM_RELEASE, "urPhysicalMemRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPhysicalMemRelease\n");
+  URLOG_(logger, INFO, "   ---> urPhysicalMemRelease\n");
 
   ur_result_t result = pfnRelease(hPhysicalMem);
 
@@ -2533,8 +2553,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                                     &params);
-    logger.info("   <--- urPhysicalMemRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPhysicalMemRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2568,7 +2588,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
       UR_FUNCTION_PHYSICAL_MEM_GET_INFO, "urPhysicalMemGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urPhysicalMemGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urPhysicalMemGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hPhysicalMem, propName, propSize, pPropValue, pPropSizeRet);
@@ -2580,8 +2600,8 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                                     &params);
-    logger.info("   <--- urPhysicalMemGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urPhysicalMemGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2611,7 +2631,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
       UR_FUNCTION_PROGRAM_CREATE_WITH_IL, "urProgramCreateWithIL", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramCreateWithIL\n");
+  URLOG_(logger, INFO, "   ---> urProgramCreateWithIL\n");
 
   ur_result_t result =
       pfnCreateWithIL(hContext, pIL, length, pProperties, phProgram);
@@ -2623,8 +2643,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_IL, &params);
-    logger.info("   <--- urProgramCreateWithIL({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramCreateWithIL({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2664,7 +2684,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
                                  "urProgramCreateWithBinary", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramCreateWithBinary\n");
+  URLOG_(logger, INFO, "   ---> urProgramCreateWithBinary\n");
 
   ur_result_t result =
       pfnCreateWithBinary(hContext, numDevices, phDevices, pLengths, ppBinaries,
@@ -2678,8 +2698,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, &params);
-    logger.info("   <--- urProgramCreateWithBinary({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramCreateWithBinary({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2704,7 +2724,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
                                                  "urProgramBuild", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramBuild\n");
+  URLOG_(logger, INFO, "   ---> urProgramBuild\n");
 
   ur_result_t result = pfnBuild(hContext, hProgram, pOptions);
 
@@ -2715,7 +2735,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD,
                                     &params);
-    logger.info("   <--- urProgramBuild({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramBuild({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2740,7 +2761,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
                                                  "urProgramCompile", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramCompile\n");
+  URLOG_(logger, INFO, "   ---> urProgramCompile\n");
 
   ur_result_t result = pfnCompile(hContext, hProgram, pOptions);
 
@@ -2751,8 +2772,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE,
                                     &params);
-    logger.info("   <--- urProgramCompile({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramCompile({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2785,7 +2806,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
                                                  "urProgramLink", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramLink\n");
+  URLOG_(logger, INFO, "   ---> urProgramLink\n");
 
   ur_result_t result =
       pfnLink(hContext, count, phPrograms, pOptions, phProgram);
@@ -2797,7 +2818,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK,
                                     &params);
-    logger.info("   <--- urProgramLink({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramLink({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2818,7 +2840,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
                                                  "urProgramRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramRetain\n");
+  URLOG_(logger, INFO, "   ---> urProgramRetain\n");
 
   ur_result_t result = pfnRetain(hProgram);
 
@@ -2829,7 +2851,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RETAIN,
                                     &params);
-    logger.info("   <--- urProgramRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2850,7 +2873,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
                                                  "urProgramRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramRelease\n");
+  URLOG_(logger, INFO, "   ---> urProgramRelease\n");
 
   ur_result_t result = pfnRelease(hProgram);
 
@@ -2861,8 +2884,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RELEASE,
                                     &params);
-    logger.info("   <--- urProgramRelease({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -2894,7 +2917,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
                                  "urProgramGetFunctionPointer", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramGetFunctionPointer\n");
+  URLOG_(logger, INFO, "   ---> urProgramGetFunctionPointer\n");
 
   ur_result_t result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
                                              ppFunctionPointer);
@@ -2907,8 +2930,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, &params);
-    logger.info("   <--- urProgramGetFunctionPointer({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramGetFunctionPointer({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2943,7 +2966,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
       "urProgramGetGlobalVariablePointer", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramGetGlobalVariablePointer\n");
+  URLOG_(logger, INFO, "   ---> urProgramGetGlobalVariablePointer\n");
 
   ur_result_t result = pfnGetGlobalVariablePointer(
       hDevice, hProgram, pGlobalVariableName, pGlobalVariableSizeRet,
@@ -2957,8 +2980,9 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER, &params);
-    logger.info("   <--- urProgramGetGlobalVariablePointer({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urProgramGetGlobalVariablePointer({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2994,7 +3018,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
                                                  "urProgramGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urProgramGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hProgram, propName, propSize, pPropValue, pPropSizeRet);
@@ -3006,8 +3030,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_GET_INFO,
                                     &params);
-    logger.info("   <--- urProgramGetInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3044,7 +3068,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
       UR_FUNCTION_PROGRAM_GET_BUILD_INFO, "urProgramGetBuildInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramGetBuildInfo\n");
+  URLOG_(logger, INFO, "   ---> urProgramGetBuildInfo\n");
 
   ur_result_t result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
                                        pPropValue, pPropSizeRet);
@@ -3056,8 +3080,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_BUILD_INFO, &params);
-    logger.info("   <--- urProgramGetBuildInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramGetBuildInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3086,7 +3110,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
       "urProgramSetSpecializationConstants", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramSetSpecializationConstants\n");
+  URLOG_(logger, INFO, "   ---> urProgramSetSpecializationConstants\n");
 
   ur_result_t result =
       pfnSetSpecializationConstants(hProgram, count, pSpecConstants);
@@ -3099,8 +3123,9 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, &params);
-    logger.info("   <--- urProgramSetSpecializationConstants({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urProgramSetSpecializationConstants({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3124,7 +3149,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
                                  "urProgramGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urProgramGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hProgram, phNativeProgram);
 
@@ -3136,8 +3161,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urProgramGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3167,7 +3192,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
                                  "urProgramCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urProgramCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeProgram, hContext,
                                                  pProperties, phProgram);
@@ -3180,8 +3205,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urProgramCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urProgramCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3206,7 +3231,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
                                                  "urKernelCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelCreate\n");
+  URLOG_(logger, INFO, "   ---> urKernelCreate\n");
 
   ur_result_t result = pfnCreate(hProgram, pKernelName, phKernel);
 
@@ -3217,7 +3242,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_CREATE,
                                     &params);
-    logger.info("   <--- urKernelCreate({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urKernelCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3249,7 +3275,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
       UR_FUNCTION_KERNEL_SET_ARG_VALUE, "urKernelSetArgValue", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetArgValue\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetArgValue\n");
 
   ur_result_t result =
       pfnSetArgValue(hKernel, argIndex, argSize, pProperties, pArgValue);
@@ -3261,8 +3287,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                                     &params);
-    logger.info("   <--- urKernelSetArgValue({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetArgValue({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3290,7 +3316,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
       UR_FUNCTION_KERNEL_SET_ARG_LOCAL, "urKernelSetArgLocal", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetArgLocal\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetArgLocal\n");
 
   ur_result_t result = pfnSetArgLocal(hKernel, argIndex, argSize, pProperties);
 
@@ -3301,8 +3327,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                                     &params);
-    logger.info("   <--- urKernelSetArgLocal({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetArgLocal({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3338,7 +3364,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
                                                  "urKernelGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urKernelGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hKernel, propName, propSize, pPropValue, pPropSizeRet);
@@ -3350,7 +3376,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_INFO,
                                     &params);
-    logger.info("   <--- urKernelGetInfo({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urKernelGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3384,7 +3411,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
       UR_FUNCTION_KERNEL_GET_GROUP_INFO, "urKernelGetGroupInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelGetGroupInfo\n");
+  URLOG_(logger, INFO, "   ---> urKernelGetGroupInfo\n");
 
   ur_result_t result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
                                        pPropValue, pPropSizeRet);
@@ -3396,8 +3423,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                                     &params);
-    logger.info("   <--- urKernelGetGroupInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelGetGroupInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3432,7 +3459,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
                                  "urKernelGetSubGroupInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelGetSubGroupInfo\n");
+  URLOG_(logger, INFO, "   ---> urKernelGetSubGroupInfo\n");
 
   ur_result_t result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
                                           pPropValue, pPropSizeRet);
@@ -3445,8 +3472,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, &params);
-    logger.info("   <--- urKernelGetSubGroupInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelGetSubGroupInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3467,7 +3494,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
                                                  "urKernelRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelRetain\n");
+  URLOG_(logger, INFO, "   ---> urKernelRetain\n");
 
   ur_result_t result = pfnRetain(hKernel);
 
@@ -3478,7 +3505,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RETAIN,
                                     &params);
-    logger.info("   <--- urKernelRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urKernelRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3499,7 +3527,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
                                                  "urKernelRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelRelease\n");
+  URLOG_(logger, INFO, "   ---> urKernelRelease\n");
 
   ur_result_t result = pfnRelease(hKernel);
 
@@ -3510,7 +3538,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RELEASE,
                                     &params);
-    logger.info("   <--- urKernelRelease({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urKernelRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3539,7 +3568,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
       UR_FUNCTION_KERNEL_SET_ARG_POINTER, "urKernelSetArgPointer", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetArgPointer\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetArgPointer\n");
 
   ur_result_t result =
       pfnSetArgPointer(hKernel, argIndex, pProperties, pArgValue);
@@ -3551,8 +3580,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_POINTER, &params);
-    logger.info("   <--- urKernelSetArgPointer({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetArgPointer({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3583,7 +3612,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
       UR_FUNCTION_KERNEL_SET_EXEC_INFO, "urKernelSetExecInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetExecInfo\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetExecInfo\n");
 
   ur_result_t result =
       pfnSetExecInfo(hKernel, propName, propSize, pProperties, pPropValue);
@@ -3595,8 +3624,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                                     &params);
-    logger.info("   <--- urKernelSetExecInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetExecInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3624,7 +3653,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
       UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, "urKernelSetArgSampler", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetArgSampler\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetArgSampler\n");
 
   ur_result_t result =
       pfnSetArgSampler(hKernel, argIndex, pProperties, hArgValue);
@@ -3636,8 +3665,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, &params);
-    logger.info("   <--- urKernelSetArgSampler({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetArgSampler({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3665,7 +3694,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
       UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, "urKernelSetArgMemObj", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetArgMemObj\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetArgMemObj\n");
 
   ur_result_t result =
       pfnSetArgMemObj(hKernel, argIndex, pProperties, hArgValue);
@@ -3677,8 +3706,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, &params);
-    logger.info("   <--- urKernelSetArgMemObj({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelSetArgMemObj({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3706,7 +3735,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
       "urKernelSetSpecializationConstants", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSetSpecializationConstants\n");
+  URLOG_(logger, INFO, "   ---> urKernelSetSpecializationConstants\n");
 
   ur_result_t result =
       pfnSetSpecializationConstants(hKernel, count, pSpecConstants);
@@ -3719,8 +3748,9 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, &params);
-    logger.info("   <--- urKernelSetSpecializationConstants({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urKernelSetSpecializationConstants({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3743,7 +3773,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
       UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, "urKernelGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urKernelGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hKernel, phNativeKernel);
 
@@ -3755,8 +3785,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urKernelGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urKernelGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3788,7 +3818,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
                                  "urKernelCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urKernelCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(
       hNativeKernel, hContext, hProgram, pProperties, phKernel);
@@ -3801,8 +3831,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urKernelCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urKernelCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3842,7 +3872,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
       "urKernelGetSuggestedLocalWorkSize", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelGetSuggestedLocalWorkSize\n");
+  URLOG_(logger, INFO, "   ---> urKernelGetSuggestedLocalWorkSize\n");
 
   ur_result_t result = pfnGetSuggestedLocalWorkSize(
       hKernel, hQueue, numWorkDim, pGlobalWorkOffset, pGlobalWorkSize,
@@ -3856,8 +3886,9 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE, &params);
-    logger.info("   <--- urKernelGetSuggestedLocalWorkSize({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urKernelGetSuggestedLocalWorkSize({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3888,7 +3919,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
                                                  "urQueueGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urQueueGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hQueue, propName, propSize, pPropValue, pPropSizeRet);
@@ -3900,7 +3931,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_GET_INFO,
                                     &params);
-    logger.info("   <--- urQueueGetInfo({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3928,7 +3960,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
                                                  "urQueueCreate", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueCreate\n");
+  URLOG_(logger, INFO, "   ---> urQueueCreate\n");
 
   ur_result_t result = pfnCreate(hContext, hDevice, pProperties, phQueue);
 
@@ -3939,7 +3971,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_CREATE,
                                     &params);
-    logger.info("   <--- urQueueCreate({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueCreate({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3960,7 +3993,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
                                                  "urQueueRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueRetain\n");
+  URLOG_(logger, INFO, "   ---> urQueueRetain\n");
 
   ur_result_t result = pfnRetain(hQueue);
 
@@ -3971,7 +4004,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RETAIN,
                                     &params);
-    logger.info("   <--- urQueueRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -3992,7 +4026,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
                                                  "urQueueRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueRelease\n");
+  URLOG_(logger, INFO, "   ---> urQueueRelease\n");
 
   ur_result_t result = pfnRelease(hQueue);
 
@@ -4003,7 +4037,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RELEASE,
                                     &params);
-    logger.info("   <--- urQueueRelease({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4029,7 +4064,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
       UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, "urQueueGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urQueueGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
 
@@ -4041,8 +4076,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urQueueGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urQueueGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4074,7 +4109,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                                  "urQueueCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urQueueCreateWithNativeHandle\n");
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeQueue, hContext,
                                                  hDevice, pProperties, phQueue);
@@ -4087,8 +4122,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urQueueCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4109,7 +4144,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
                                                  "urQueueFinish", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueFinish\n");
+  URLOG_(logger, INFO, "   ---> urQueueFinish\n");
 
   ur_result_t result = pfnFinish(hQueue);
 
@@ -4120,7 +4155,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FINISH,
                                     &params);
-    logger.info("   <--- urQueueFinish({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueFinish({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4141,7 +4177,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
                                                  "urQueueFlush", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urQueueFlush\n");
+  URLOG_(logger, INFO, "   ---> urQueueFlush\n");
 
   ur_result_t result = pfnFlush(hQueue);
 
@@ -4151,7 +4187,8 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FLUSH, &params);
-    logger.info("   <--- urQueueFlush({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urQueueFlush({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4182,7 +4219,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
                                                  "urEventGetInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventGetInfo\n");
+  URLOG_(logger, INFO, "   ---> urEventGetInfo\n");
 
   ur_result_t result =
       pfnGetInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
@@ -4194,7 +4231,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_GET_INFO,
                                     &params);
-    logger.info("   <--- urEventGetInfo({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEventGetInfo({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4226,7 +4264,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
       UR_FUNCTION_EVENT_GET_PROFILING_INFO, "urEventGetProfilingInfo", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventGetProfilingInfo\n");
+  URLOG_(logger, INFO, "   ---> urEventGetProfilingInfo\n");
 
   ur_result_t result =
       pfnGetProfilingInfo(hEvent, propName, propSize, pPropValue, pPropSizeRet);
@@ -4239,8 +4277,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_PROFILING_INFO, &params);
-    logger.info("   <--- urEventGetProfilingInfo({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEventGetProfilingInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4264,7 +4302,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
                                                  "urEventWait", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventWait\n");
+  URLOG_(logger, INFO, "   ---> urEventWait\n");
 
   ur_result_t result = pfnWait(numEvents, phEventWaitList);
 
@@ -4274,7 +4312,8 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_WAIT, &params);
-    logger.info("   <--- urEventWait({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEventWait({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4295,7 +4334,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
                                                  "urEventRetain", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventRetain\n");
+  URLOG_(logger, INFO, "   ---> urEventRetain\n");
 
   ur_result_t result = pfnRetain(hEvent);
 
@@ -4306,7 +4345,8 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RETAIN,
                                     &params);
-    logger.info("   <--- urEventRetain({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEventRetain({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4327,7 +4367,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
                                                  "urEventRelease", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventRelease\n");
+  URLOG_(logger, INFO, "   ---> urEventRelease\n");
 
   ur_result_t result = pfnRelease(hEvent);
 
@@ -4338,7 +4378,8 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RELEASE,
                                     &params);
-    logger.info("   <--- urEventRelease({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEventRelease({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -4361,7 +4402,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
       UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, "urEventGetNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventGetNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urEventGetNativeHandle\n");
 
   ur_result_t result = pfnGetNativeHandle(hEvent, phNativeEvent);
 
@@ -4373,8 +4414,8 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, &params);
-    logger.info("   <--- urEventGetNativeHandle({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEventGetNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4404,7 +4445,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
                                  "urEventCreateWithNativeHandle", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventCreateWithNativeHandle\n");
+  URLOG_(logger, INFO, "   ---> urEventCreateWithNativeHandle\n");
 
   ur_result_t result =
       pfnCreateWithNativeHandle(hNativeEvent, hContext, pProperties, phEvent);
@@ -4417,8 +4458,8 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, &params);
-    logger.info("   <--- urEventCreateWithNativeHandle({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEventCreateWithNativeHandle({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4446,7 +4487,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
                                                  "urEventSetCallback", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEventSetCallback\n");
+  URLOG_(logger, INFO, "   ---> urEventSetCallback\n");
 
   ur_result_t result = pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
 
@@ -4457,8 +4498,8 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_SET_CALLBACK,
                                     &params);
-    logger.info("   <--- urEventSetCallback({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEventSetCallback({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4515,7 +4556,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
       UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH, "urEnqueueKernelLaunch", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueKernelLaunch\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueKernelLaunch\n");
 
   ur_result_t result = pfnKernelLaunch(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
@@ -4528,8 +4569,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                                     &params);
-    logger.info("   <--- urEnqueueKernelLaunch({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueKernelLaunch({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4563,7 +4604,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
       UR_FUNCTION_ENQUEUE_EVENTS_WAIT, "urEnqueueEventsWait", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueEventsWait\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueEventsWait\n");
 
   ur_result_t result =
       pfnEventsWait(hQueue, numEventsInWaitList, phEventWaitList, phEvent);
@@ -4575,8 +4616,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                                     &params);
-    logger.info("   <--- urEnqueueEventsWait({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueEventsWait({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4612,7 +4653,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
                                  "urEnqueueEventsWaitWithBarrier", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueEventsWaitWithBarrier\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueEventsWaitWithBarrier\n");
 
   ur_result_t result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
                                                 phEventWaitList, phEvent);
@@ -4625,8 +4666,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, &params);
-    logger.info("   <--- urEnqueueEventsWaitWithBarrier({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueEventsWaitWithBarrier({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4671,7 +4712,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
       UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, "urEnqueueMemBufferRead", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferRead\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferRead\n");
 
   ur_result_t result =
       pfnMemBufferRead(hQueue, hBuffer, blockingRead, offset, size, pDst,
@@ -4685,8 +4726,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, &params);
-    logger.info("   <--- urEnqueueMemBufferRead({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferRead({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4731,7 +4772,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
       UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, "urEnqueueMemBufferWrite", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferWrite\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferWrite\n");
 
   ur_result_t result =
       pfnMemBufferWrite(hQueue, hBuffer, blockingWrite, offset, size, pSrc,
@@ -4745,8 +4786,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, &params);
-    logger.info("   <--- urEnqueueMemBufferWrite({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferWrite({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4806,7 +4847,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
                                  "urEnqueueMemBufferReadRect", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferReadRect\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferReadRect\n");
 
   ur_result_t result = pfnMemBufferReadRect(
       hQueue, hBuffer, blockingRead, bufferOrigin, hostOrigin, region,
@@ -4821,8 +4862,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, &params);
-    logger.info("   <--- urEnqueueMemBufferReadRect({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferReadRect({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4883,7 +4924,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
                                  "urEnqueueMemBufferWriteRect", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferWriteRect\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferWriteRect\n");
 
   ur_result_t result = pfnMemBufferWriteRect(
       hQueue, hBuffer, blockingWrite, bufferOrigin, hostOrigin, region,
@@ -4898,8 +4939,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, &params);
-    logger.info("   <--- urEnqueueMemBufferWriteRect({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferWriteRect({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -4943,7 +4984,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
       UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, "urEnqueueMemBufferCopy", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferCopy\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferCopy\n");
 
   ur_result_t result =
       pfnMemBufferCopy(hQueue, hBufferSrc, hBufferDst, srcOffset, dstOffset,
@@ -4957,8 +4998,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, &params);
-    logger.info("   <--- urEnqueueMemBufferCopy({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferCopy({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5014,7 +5055,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
                                  "urEnqueueMemBufferCopyRect", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferCopyRect\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferCopyRect\n");
 
   ur_result_t result = pfnMemBufferCopyRect(
       hQueue, hBufferSrc, hBufferDst, srcOrigin, dstOrigin, region, srcRowPitch,
@@ -5029,8 +5070,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, &params);
-    logger.info("   <--- urEnqueueMemBufferCopyRect({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferCopyRect({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5080,7 +5121,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
       UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, "urEnqueueMemBufferFill", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferFill\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferFill\n");
 
   ur_result_t result =
       pfnMemBufferFill(hQueue, hBuffer, pPattern, patternSize, offset, size,
@@ -5094,8 +5135,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, &params);
-    logger.info("   <--- urEnqueueMemBufferFill({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferFill({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5146,7 +5187,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
       UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, "urEnqueueMemImageRead", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemImageRead\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemImageRead\n");
 
   ur_result_t result = pfnMemImageRead(
       hQueue, hImage, blockingRead, origin, region, rowPitch, slicePitch, pDst,
@@ -5159,8 +5200,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, &params);
-    logger.info("   <--- urEnqueueMemImageRead({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemImageRead({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5211,7 +5252,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
       UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, "urEnqueueMemImageWrite", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemImageWrite\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemImageWrite\n");
 
   ur_result_t result = pfnMemImageWrite(
       hQueue, hImage, blockingWrite, origin, region, rowPitch, slicePitch, pSrc,
@@ -5225,8 +5266,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, &params);
-    logger.info("   <--- urEnqueueMemImageWrite({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemImageWrite({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5273,7 +5314,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
       UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, "urEnqueueMemImageCopy", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemImageCopy\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemImageCopy\n");
 
   ur_result_t result =
       pfnMemImageCopy(hQueue, hImageSrc, hImageDst, srcOrigin, dstOrigin,
@@ -5286,8 +5327,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, &params);
-    logger.info("   <--- urEnqueueMemImageCopy({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemImageCopy({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5335,7 +5376,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
       UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, "urEnqueueMemBufferMap", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemBufferMap\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemBufferMap\n");
 
   ur_result_t result =
       pfnMemBufferMap(hQueue, hBuffer, blockingMap, mapFlags, offset, size,
@@ -5348,8 +5389,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, &params);
-    logger.info("   <--- urEnqueueMemBufferMap({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemBufferMap({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5387,7 +5428,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
                                                  "urEnqueueMemUnmap", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueMemUnmap\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueMemUnmap\n");
 
   ur_result_t result = pfnMemUnmap(
       hQueue, hMem, pMappedPtr, numEventsInWaitList, phEventWaitList, phEvent);
@@ -5399,8 +5440,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_MEM_UNMAP,
                                     &params);
-    logger.info("   <--- urEnqueueMemUnmap({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueMemUnmap({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5444,7 +5485,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
                                                  "urEnqueueUSMFill", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMFill\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMFill\n");
 
   ur_result_t result =
       pfnUSMFill(hQueue, pMem, patternSize, pPattern, size, numEventsInWaitList,
@@ -5457,8 +5498,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL,
                                     &params);
-    logger.info("   <--- urEnqueueUSMFill({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMFill({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -5500,7 +5541,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
                                                  "urEnqueueUSMMemcpy", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMMemcpy\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMMemcpy\n");
 
   ur_result_t result =
       pfnUSMMemcpy(hQueue, blocking, pDst, pSrc, size, numEventsInWaitList,
@@ -5513,8 +5554,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY,
                                     &params);
-    logger.info("   <--- urEnqueueUSMMemcpy({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMMemcpy({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5554,7 +5595,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
       UR_FUNCTION_ENQUEUE_USM_PREFETCH, "urEnqueueUSMPrefetch", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMPrefetch\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMPrefetch\n");
 
   ur_result_t result = pfnUSMPrefetch(
       hQueue, pMem, size, flags, numEventsInWaitList, phEventWaitList, phEvent);
@@ -5566,8 +5607,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                                     &params);
-    logger.info("   <--- urEnqueueUSMPrefetch({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMPrefetch({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5598,7 +5639,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
                                                  "urEnqueueUSMAdvise", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMAdvise\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMAdvise\n");
 
   ur_result_t result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
 
@@ -5609,8 +5650,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_ADVISE,
                                     &params);
-    logger.info("   <--- urEnqueueUSMAdvise({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMAdvise({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5659,7 +5700,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
       UR_FUNCTION_ENQUEUE_USM_FILL_2D, "urEnqueueUSMFill2D", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMFill2D\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMFill2D\n");
 
   ur_result_t result =
       pfnUSMFill2D(hQueue, pMem, pitch, patternSize, pPattern, width, height,
@@ -5672,8 +5713,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                                     &params);
-    logger.info("   <--- urEnqueueUSMFill2D({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMFill2D({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5724,7 +5765,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
       UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D, "urEnqueueUSMMemcpy2D", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueUSMMemcpy2D\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueUSMMemcpy2D\n");
 
   ur_result_t result =
       pfnUSMMemcpy2D(hQueue, blocking, pDst, dstPitch, pSrc, srcPitch, width,
@@ -5737,8 +5778,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                                     &params);
-    logger.info("   <--- urEnqueueUSMMemcpy2D({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueUSMMemcpy2D({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5787,7 +5828,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
       "urEnqueueDeviceGlobalVariableWrite", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueDeviceGlobalVariableWrite\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueDeviceGlobalVariableWrite\n");
 
   ur_result_t result = pfnDeviceGlobalVariableWrite(
       hQueue, hProgram, name, blockingWrite, count, offset, pSrc,
@@ -5801,8 +5842,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, &params);
-    logger.info("   <--- urEnqueueDeviceGlobalVariableWrite({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urEnqueueDeviceGlobalVariableWrite({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5851,7 +5893,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
       "urEnqueueDeviceGlobalVariableRead", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueDeviceGlobalVariableRead\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueDeviceGlobalVariableRead\n");
 
   ur_result_t result = pfnDeviceGlobalVariableRead(
       hQueue, hProgram, name, blockingRead, count, offset, pDst,
@@ -5865,8 +5907,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, &params);
-    logger.info("   <--- urEnqueueDeviceGlobalVariableRead({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urEnqueueDeviceGlobalVariableRead({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5915,7 +5958,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
       UR_FUNCTION_ENQUEUE_READ_HOST_PIPE, "urEnqueueReadHostPipe", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueReadHostPipe\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueReadHostPipe\n");
 
   ur_result_t result =
       pfnReadHostPipe(hQueue, hProgram, pipe_symbol, blocking, pDst, size,
@@ -5928,8 +5971,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_READ_HOST_PIPE, &params);
-    logger.info("   <--- urEnqueueReadHostPipe({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueReadHostPipe({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5979,7 +6022,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
       UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE, "urEnqueueWriteHostPipe", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueWriteHostPipe\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueWriteHostPipe\n");
 
   ur_result_t result =
       pfnWriteHostPipe(hQueue, hProgram, pipe_symbol, blocking, pSrc, size,
@@ -5993,8 +6036,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE, &params);
-    logger.info("   <--- urEnqueueWriteHostPipe({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urEnqueueWriteHostPipe({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6033,7 +6076,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
       UR_FUNCTION_USM_PITCHED_ALLOC_EXP, "urUSMPitchedAllocExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMPitchedAllocExp\n");
+  URLOG_(logger, INFO, "   ---> urUSMPitchedAllocExp\n");
 
   ur_result_t result =
       pfnPitchedAllocExp(hContext, hDevice, pUSMDesc, pool, widthInBytes,
@@ -6046,8 +6089,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                                     &params);
-    logger.info("   <--- urUSMPitchedAllocExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urUSMPitchedAllocExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6077,7 +6120,8 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
       "urBindlessImagesUnsampledImageHandleDestroyExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesUnsampledImageHandleDestroyExp\n");
+  URLOG_(logger, INFO,
+         "   ---> urBindlessImagesUnsampledImageHandleDestroyExp\n");
 
   ur_result_t result =
       pfnUnsampledImageHandleDestroyExp(hContext, hDevice, hImage);
@@ -6093,7 +6137,9 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
         args_str,
         UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP,
         &params);
-    logger.info(
+    URLOG_(
+        logger,
+        INFO
         "   <--- urBindlessImagesUnsampledImageHandleDestroyExp({}) -> {};\n",
         args_str.str(), result);
   }
@@ -6125,7 +6171,8 @@ urBindlessImagesSampledImageHandleDestroyExp(
       "urBindlessImagesSampledImageHandleDestroyExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesSampledImageHandleDestroyExp\n");
+  URLOG_(logger, INFO,
+         "   ---> urBindlessImagesSampledImageHandleDestroyExp\n");
 
   ur_result_t result =
       pfnSampledImageHandleDestroyExp(hContext, hDevice, hImage);
@@ -6140,9 +6187,10 @@ urBindlessImagesSampledImageHandleDestroyExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
         &params);
-    logger.info(
-        "   <--- urBindlessImagesSampledImageHandleDestroyExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urBindlessImagesSampledImageHandleDestroyExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6174,7 +6222,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
                                  "urBindlessImagesImageAllocateExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImageAllocateExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImageAllocateExp\n");
 
   ur_result_t result = pfnImageAllocateExp(hContext, hDevice, pImageFormat,
                                            pImageDesc, phImageMem);
@@ -6187,8 +6235,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP, &params);
-    logger.info("   <--- urBindlessImagesImageAllocateExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urBindlessImagesImageAllocateExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6216,7 +6264,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
                                  "urBindlessImagesImageFreeExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImageFreeExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImageFreeExp\n");
 
   ur_result_t result = pfnImageFreeExp(hContext, hDevice, hImageMem);
 
@@ -6228,8 +6276,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP, &params);
-    logger.info("   <--- urBindlessImagesImageFreeExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urBindlessImagesImageFreeExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6263,7 +6311,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
       "urBindlessImagesUnsampledImageCreateExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesUnsampledImageCreateExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesUnsampledImageCreateExp\n");
 
   ur_result_t result = pfnUnsampledImageCreateExp(
       hContext, hDevice, hImageMem, pImageFormat, pImageDesc, phImage);
@@ -6277,8 +6325,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
         &params);
-    logger.info("   <--- urBindlessImagesUnsampledImageCreateExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesUnsampledImageCreateExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6315,7 +6364,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
       "urBindlessImagesSampledImageCreateExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesSampledImageCreateExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesSampledImageCreateExp\n");
 
   ur_result_t result =
       pfnSampledImageCreateExp(hContext, hDevice, hImageMem, pImageFormat,
@@ -6330,8 +6379,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
         &params);
-    logger.info("   <--- urBindlessImagesSampledImageCreateExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesSampledImageCreateExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6394,7 +6444,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
                                  "urBindlessImagesImageCopyExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImageCopyExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImageCopyExp\n");
 
   ur_result_t result = pfnImageCopyExp(
       hQueue, pSrc, pDst, pSrcImageDesc, pDstImageDesc, pSrcImageFormat,
@@ -6409,8 +6459,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP, &params);
-    logger.info("   <--- urBindlessImagesImageCopyExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urBindlessImagesImageCopyExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6442,7 +6492,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
                                  "urBindlessImagesImageGetInfoExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImageGetInfoExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImageGetInfoExp\n");
 
   ur_result_t result = pfnImageGetInfoExp(hContext, hImageMem, propName,
                                           pPropValue, pPropSizeRet);
@@ -6455,8 +6505,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP, &params);
-    logger.info("   <--- urBindlessImagesImageGetInfoExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urBindlessImagesImageGetInfoExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6488,7 +6538,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
       "urBindlessImagesMipmapGetLevelExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesMipmapGetLevelExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesMipmapGetLevelExp\n");
 
   ur_result_t result = pfnMipmapGetLevelExp(hContext, hDevice, hImageMem,
                                             mipmapLevel, phImageMem);
@@ -6501,8 +6551,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP, &params);
-    logger.info("   <--- urBindlessImagesMipmapGetLevelExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesMipmapGetLevelExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6530,7 +6581,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
                                  "urBindlessImagesMipmapFreeExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesMipmapFreeExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesMipmapFreeExp\n");
 
   ur_result_t result = pfnMipmapFreeExp(hContext, hDevice, hMem);
 
@@ -6542,8 +6593,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP, &params);
-    logger.info("   <--- urBindlessImagesMipmapFreeExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urBindlessImagesMipmapFreeExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6578,7 +6629,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
       "urBindlessImagesImportExternalMemoryExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImportExternalMemoryExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImportExternalMemoryExp\n");
 
   ur_result_t result = pfnImportExternalMemoryExp(
       hContext, hDevice, size, memHandleType, pExternalMemDesc, phExternalMem);
@@ -6592,8 +6643,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
         &params);
-    logger.info("   <--- urBindlessImagesImportExternalMemoryExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesImportExternalMemoryExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6628,7 +6680,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
       "urBindlessImagesMapExternalArrayExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesMapExternalArrayExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesMapExternalArrayExp\n");
 
   ur_result_t result = pfnMapExternalArrayExp(
       hContext, hDevice, pImageFormat, pImageDesc, hExternalMem, phImageMem);
@@ -6641,8 +6693,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP, &params);
-    logger.info("   <--- urBindlessImagesMapExternalArrayExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesMapExternalArrayExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6676,7 +6729,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
       "urBindlessImagesMapExternalLinearMemoryExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesMapExternalLinearMemoryExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesMapExternalLinearMemoryExp\n");
 
   ur_result_t result = pfnMapExternalLinearMemoryExp(
       hContext, hDevice, offset, size, hExternalMem, ppRetMem);
@@ -6690,9 +6743,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
         &params);
-    logger.info(
-        "   <--- urBindlessImagesMapExternalLinearMemoryExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urBindlessImagesMapExternalLinearMemoryExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6720,7 +6774,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
       "urBindlessImagesReleaseExternalMemoryExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesReleaseExternalMemoryExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesReleaseExternalMemoryExp\n");
 
   ur_result_t result =
       pfnReleaseExternalMemoryExp(hContext, hDevice, hExternalMem);
@@ -6734,8 +6788,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
         &params);
-    logger.info("   <--- urBindlessImagesReleaseExternalMemoryExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesReleaseExternalMemoryExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6768,7 +6823,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
       "urBindlessImagesImportExternalSemaphoreExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesImportExternalSemaphoreExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesImportExternalSemaphoreExp\n");
 
   ur_result_t result = pfnImportExternalSemaphoreExp(
       hContext, hDevice, semHandleType, pExternalSemaphoreDesc,
@@ -6783,9 +6838,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    logger.info(
-        "   <--- urBindlessImagesImportExternalSemaphoreExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urBindlessImagesImportExternalSemaphoreExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6813,7 +6869,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
       "urBindlessImagesReleaseExternalSemaphoreExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesReleaseExternalSemaphoreExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesReleaseExternalSemaphoreExp\n");
 
   ur_result_t result =
       pfnReleaseExternalSemaphoreExp(hContext, hDevice, hExternalSemaphore);
@@ -6828,9 +6884,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    logger.info(
-        "   <--- urBindlessImagesReleaseExternalSemaphoreExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urBindlessImagesReleaseExternalSemaphoreExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6877,7 +6934,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
       "urBindlessImagesWaitExternalSemaphoreExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesWaitExternalSemaphoreExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesWaitExternalSemaphoreExp\n");
 
   ur_result_t result = pfnWaitExternalSemaphoreExp(
       hQueue, hSemaphore, hasWaitValue, waitValue, numEventsInWaitList,
@@ -6892,8 +6949,9 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    logger.info("   <--- urBindlessImagesWaitExternalSemaphoreExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urBindlessImagesWaitExternalSemaphoreExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6940,7 +6998,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
       "urBindlessImagesSignalExternalSemaphoreExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urBindlessImagesSignalExternalSemaphoreExp\n");
+  URLOG_(logger, INFO, "   ---> urBindlessImagesSignalExternalSemaphoreExp\n");
 
   ur_result_t result = pfnSignalExternalSemaphoreExp(
       hQueue, hSemaphore, hasSignalValue, signalValue, numEventsInWaitList,
@@ -6955,9 +7013,10 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    logger.info(
-        "   <--- urBindlessImagesSignalExternalSemaphoreExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urBindlessImagesSignalExternalSemaphoreExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -6986,7 +7045,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
                                  "urCommandBufferCreateExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferCreateExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferCreateExp\n");
 
   ur_result_t result =
       pfnCreateExp(hContext, hDevice, pCommandBufferDesc, phCommandBuffer);
@@ -6999,8 +7058,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP, &params);
-    logger.info("   <--- urCommandBufferCreateExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urCommandBufferCreateExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7022,7 +7081,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
                                  "urCommandBufferRetainExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferRetainExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferRetainExp\n");
 
   ur_result_t result = pfnRetainExp(hCommandBuffer);
 
@@ -7034,8 +7093,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP, &params);
-    logger.info("   <--- urCommandBufferRetainExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urCommandBufferRetainExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7057,7 +7116,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
                                  "urCommandBufferReleaseExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferReleaseExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferReleaseExp\n");
 
   ur_result_t result = pfnReleaseExp(hCommandBuffer);
 
@@ -7069,8 +7128,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP, &params);
-    logger.info("   <--- urCommandBufferReleaseExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urCommandBufferReleaseExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7093,7 +7152,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
                                  "urCommandBufferFinalizeExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferFinalizeExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferFinalizeExp\n");
 
   ur_result_t result = pfnFinalizeExp(hCommandBuffer);
 
@@ -7105,8 +7164,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP, &params);
-    logger.info("   <--- urCommandBufferFinalizeExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urCommandBufferFinalizeExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7185,7 +7244,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
       "urCommandBufferAppendKernelLaunchExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendKernelLaunchExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendKernelLaunchExp\n");
 
   ur_result_t result = pfnAppendKernelLaunchExp(
       hCommandBuffer, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
@@ -7201,8 +7260,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP, &params);
-    logger.info("   <--- urCommandBufferAppendKernelLaunchExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendKernelLaunchExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7261,7 +7321,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
       "urCommandBufferAppendUSMMemcpyExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendUSMMemcpyExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendUSMMemcpyExp\n");
 
   ur_result_t result = pfnAppendUSMMemcpyExp(
       hCommandBuffer, pDst, pSrc, size, numSyncPointsInWaitList,
@@ -7276,8 +7336,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP, &params);
-    logger.info("   <--- urCommandBufferAppendUSMMemcpyExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendUSMMemcpyExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7339,7 +7400,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
                                  "urCommandBufferAppendUSMFillExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendUSMFillExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendUSMFillExp\n");
 
   ur_result_t result = pfnAppendUSMFillExp(
       hCommandBuffer, pMemory, pPattern, patternSize, size,
@@ -7354,8 +7415,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP, &params);
-    logger.info("   <--- urCommandBufferAppendUSMFillExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urCommandBufferAppendUSMFillExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7420,7 +7481,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
       "urCommandBufferAppendMemBufferCopyExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferCopyExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferCopyExp\n");
 
   ur_result_t result = pfnAppendMemBufferCopyExp(
       hCommandBuffer, hSrcMem, hDstMem, srcOffset, dstOffset, size,
@@ -7436,8 +7497,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
         &params);
-    logger.info("   <--- urCommandBufferAppendMemBufferCopyExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendMemBufferCopyExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7499,7 +7561,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
       "urCommandBufferAppendMemBufferWriteExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferWriteExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferWriteExp\n");
 
   ur_result_t result = pfnAppendMemBufferWriteExp(
       hCommandBuffer, hBuffer, offset, size, pSrc, numSyncPointsInWaitList,
@@ -7515,8 +7577,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
         &params);
-    logger.info("   <--- urCommandBufferAppendMemBufferWriteExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendMemBufferWriteExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7578,7 +7641,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
       "urCommandBufferAppendMemBufferReadExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferReadExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferReadExp\n");
 
   ur_result_t result = pfnAppendMemBufferReadExp(
       hCommandBuffer, hBuffer, offset, size, pDst, numSyncPointsInWaitList,
@@ -7594,8 +7657,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
         &params);
-    logger.info("   <--- urCommandBufferAppendMemBufferReadExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendMemBufferReadExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7672,7 +7736,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
       "urCommandBufferAppendMemBufferCopyRectExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferCopyRectExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferCopyRectExp\n");
 
   ur_result_t result = pfnAppendMemBufferCopyRectExp(
       hCommandBuffer, hSrcMem, hDstMem, srcOrigin, dstOrigin, region,
@@ -7689,9 +7753,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
         &params);
-    logger.info(
-        "   <--- urCommandBufferAppendMemBufferCopyRectExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urCommandBufferAppendMemBufferCopyRectExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7771,7 +7836,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
       "urCommandBufferAppendMemBufferWriteRectExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferWriteRectExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferWriteRectExp\n");
 
   ur_result_t result = pfnAppendMemBufferWriteRectExp(
       hCommandBuffer, hBuffer, bufferOffset, hostOffset, region, bufferRowPitch,
@@ -7788,9 +7853,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
         &params);
-    logger.info(
-        "   <--- urCommandBufferAppendMemBufferWriteRectExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urCommandBufferAppendMemBufferWriteRectExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7869,7 +7935,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
       "urCommandBufferAppendMemBufferReadRectExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferReadRectExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferReadRectExp\n");
 
   ur_result_t result = pfnAppendMemBufferReadRectExp(
       hCommandBuffer, hBuffer, bufferOffset, hostOffset, region, bufferRowPitch,
@@ -7886,9 +7952,10 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
         &params);
-    logger.info(
-        "   <--- urCommandBufferAppendMemBufferReadRectExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urCommandBufferAppendMemBufferReadRectExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -7953,7 +8020,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
       "urCommandBufferAppendMemBufferFillExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendMemBufferFillExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendMemBufferFillExp\n");
 
   ur_result_t result = pfnAppendMemBufferFillExp(
       hCommandBuffer, hBuffer, pPattern, patternSize, offset, size,
@@ -7969,8 +8036,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
         &params);
-    logger.info("   <--- urCommandBufferAppendMemBufferFillExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendMemBufferFillExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8029,7 +8097,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
       "urCommandBufferAppendUSMPrefetchExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendUSMPrefetchExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendUSMPrefetchExp\n");
 
   ur_result_t result = pfnAppendUSMPrefetchExp(
       hCommandBuffer, pMemory, size, flags, numSyncPointsInWaitList,
@@ -8044,8 +8112,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP, &params);
-    logger.info("   <--- urCommandBufferAppendUSMPrefetchExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendUSMPrefetchExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8104,7 +8173,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
       "urCommandBufferAppendUSMAdviseExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferAppendUSMAdviseExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferAppendUSMAdviseExp\n");
 
   ur_result_t result = pfnAppendUSMAdviseExp(
       hCommandBuffer, pMemory, size, advice, numSyncPointsInWaitList,
@@ -8119,8 +8188,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP, &params);
-    logger.info("   <--- urCommandBufferAppendUSMAdviseExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferAppendUSMAdviseExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8158,7 +8228,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
                                  "urCommandBufferEnqueueExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferEnqueueExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferEnqueueExp\n");
 
   ur_result_t result = pfnEnqueueExp(
       hCommandBuffer, hQueue, numEventsInWaitList, phEventWaitList, phEvent);
@@ -8171,8 +8241,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP, &params);
-    logger.info("   <--- urCommandBufferEnqueueExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urCommandBufferEnqueueExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8199,7 +8269,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
       "urCommandBufferUpdateKernelLaunchExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferUpdateKernelLaunchExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferUpdateKernelLaunchExp\n");
 
   ur_result_t result = pfnUpdateKernelLaunchExp(hCommand, pUpdateKernelLaunch);
 
@@ -8211,8 +8281,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP, &params);
-    logger.info("   <--- urCommandBufferUpdateKernelLaunchExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferUpdateKernelLaunchExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8238,7 +8309,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
       "urCommandBufferUpdateSignalEventExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferUpdateSignalEventExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferUpdateSignalEventExp\n");
 
   ur_result_t result = pfnUpdateSignalEventExp(hCommand, phSignalEvent);
 
@@ -8250,8 +8321,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP, &params);
-    logger.info("   <--- urCommandBufferUpdateSignalEventExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferUpdateSignalEventExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8281,7 +8353,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
       "urCommandBufferUpdateWaitEventsExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferUpdateWaitEventsExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferUpdateWaitEventsExp\n");
 
   ur_result_t result =
       pfnUpdateWaitEventsExp(hCommand, numEventsInWaitList, phEventWaitList);
@@ -8294,8 +8366,9 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP, &params);
-    logger.info("   <--- urCommandBufferUpdateWaitEventsExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urCommandBufferUpdateWaitEventsExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8327,7 +8400,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
                                  "urCommandBufferGetInfoExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urCommandBufferGetInfoExp\n");
+  URLOG_(logger, INFO, "   ---> urCommandBufferGetInfoExp\n");
 
   ur_result_t result = pfnGetInfoExp(hCommandBuffer, propName, propSize,
                                      pPropValue, pPropSizeRet);
@@ -8340,8 +8413,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP, &params);
-    logger.info("   <--- urCommandBufferGetInfoExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urCommandBufferGetInfoExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8401,7 +8474,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
       "urEnqueueCooperativeKernelLaunchExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueCooperativeKernelLaunchExp\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueCooperativeKernelLaunchExp\n");
 
   ur_result_t result = pfnCooperativeKernelLaunchExp(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
@@ -8415,8 +8488,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP, &params);
-    logger.info("   <--- urEnqueueCooperativeKernelLaunchExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urEnqueueCooperativeKernelLaunchExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8459,7 +8533,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
       "urKernelSuggestMaxCooperativeGroupCountExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urKernelSuggestMaxCooperativeGroupCountExp\n");
+  URLOG_(logger, INFO, "   ---> urKernelSuggestMaxCooperativeGroupCountExp\n");
 
   ur_result_t result = pfnSuggestMaxCooperativeGroupCountExp(
       hKernel, hDevice, workDim, pLocalWorkSize, dynamicSharedMemorySize,
@@ -8474,9 +8548,10 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
         &params);
-    logger.info(
-        "   <--- urKernelSuggestMaxCooperativeGroupCountExp({}) -> {};\n",
-        args_str.str(), result);
+    URLOG_(logger,
+           INFO
+           "   <--- urKernelSuggestMaxCooperativeGroupCountExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8522,7 +8597,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
                                  "urEnqueueTimestampRecordingExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueTimestampRecordingExp\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueTimestampRecordingExp\n");
 
   ur_result_t result = pfnTimestampRecordingExp(
       hQueue, blocking, numEventsInWaitList, phEventWaitList, phEvent);
@@ -8535,8 +8610,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP, &params);
-    logger.info("   <--- urEnqueueTimestampRecordingExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueTimestampRecordingExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8603,7 +8678,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
                                  "urEnqueueKernelLaunchCustomExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueKernelLaunchCustomExp\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueKernelLaunchCustomExp\n");
 
   ur_result_t result = pfnKernelLaunchCustomExp(
       hQueue, hKernel, workDim, pGlobalWorkOffset, pGlobalWorkSize,
@@ -8618,8 +8693,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP, &params);
-    logger.info("   <--- urEnqueueKernelLaunchCustomExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueKernelLaunchCustomExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8647,7 +8722,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
                                                  "urProgramBuildExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramBuildExp\n");
+  URLOG_(logger, INFO, "   ---> urProgramBuildExp\n");
 
   ur_result_t result = pfnBuildExp(hProgram, numDevices, phDevices, pOptions);
 
@@ -8658,8 +8733,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD_EXP,
                                     &params);
-    logger.info("   <--- urProgramBuildExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramBuildExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8687,7 +8762,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
       UR_FUNCTION_PROGRAM_COMPILE_EXP, "urProgramCompileExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramCompileExp\n");
+  URLOG_(logger, INFO, "   ---> urProgramCompileExp\n");
 
   ur_result_t result = pfnCompileExp(hProgram, numDevices, phDevices, pOptions);
 
@@ -8698,8 +8773,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE_EXP,
                                     &params);
-    logger.info("   <--- urProgramCompileExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramCompileExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8737,7 +8812,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
                                                  "urProgramLinkExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urProgramLinkExp\n");
+  URLOG_(logger, INFO, "   ---> urProgramLinkExp\n");
 
   ur_result_t result = pfnLinkExp(hContext, numDevices, phDevices, count,
                                   phPrograms, pOptions, phProgram);
@@ -8749,8 +8824,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK_EXP,
                                     &params);
-    logger.info("   <--- urProgramLinkExp({}) -> {};\n", args_str.str(),
-                result);
+    URLOG_(logger, INFO "   <--- urProgramLinkExp({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -8775,7 +8850,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
                                                  "urUSMImportExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMImportExp\n");
+  URLOG_(logger, INFO, "   ---> urUSMImportExp\n");
 
   ur_result_t result = pfnImportExp(hContext, pMem, size);
 
@@ -8786,7 +8861,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_IMPORT_EXP,
                                     &params);
-    logger.info("   <--- urUSMImportExp({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMImportExp({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -8809,7 +8885,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
                                                  "urUSMReleaseExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUSMReleaseExp\n");
+  URLOG_(logger, INFO, "   ---> urUSMReleaseExp\n");
 
   ur_result_t result = pfnReleaseExp(hContext, pMem);
 
@@ -8820,7 +8896,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_RELEASE_EXP,
                                     &params);
-    logger.info("   <--- urUSMReleaseExp({}) -> {};\n", args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUSMReleaseExp({}) -> {};\n", args_str.str(),
+           result);
   }
 
   return result;
@@ -8846,7 +8923,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
                                  "urUsmP2PEnablePeerAccessExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUsmP2PEnablePeerAccessExp\n");
+  URLOG_(logger, INFO, "   ---> urUsmP2PEnablePeerAccessExp\n");
 
   ur_result_t result = pfnEnablePeerAccessExp(commandDevice, peerDevice);
 
@@ -8858,8 +8935,8 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP, &params);
-    logger.info("   <--- urUsmP2PEnablePeerAccessExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUsmP2PEnablePeerAccessExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8885,7 +8962,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
                                  "urUsmP2PDisablePeerAccessExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUsmP2PDisablePeerAccessExp\n");
+  URLOG_(logger, INFO, "   ---> urUsmP2PDisablePeerAccessExp\n");
 
   ur_result_t result = pfnDisablePeerAccessExp(commandDevice, peerDevice);
 
@@ -8897,8 +8974,8 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP, &params);
-    logger.info("   <--- urUsmP2PDisablePeerAccessExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUsmP2PDisablePeerAccessExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8939,7 +9016,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
                                  "urUsmP2PPeerAccessGetInfoExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urUsmP2PPeerAccessGetInfoExp\n");
+  URLOG_(logger, INFO, "   ---> urUsmP2PPeerAccessGetInfoExp\n");
 
   ur_result_t result = pfnPeerAccessGetInfoExp(
       commandDevice, peerDevice, propName, propSize, pPropValue, pPropSizeRet);
@@ -8952,8 +9029,8 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP, &params);
-    logger.info("   <--- urUsmP2PPeerAccessGetInfoExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urUsmP2PPeerAccessGetInfoExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8991,7 +9068,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
       "urEnqueueEventsWaitWithBarrierExt", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueEventsWaitWithBarrierExt\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueEventsWaitWithBarrierExt\n");
 
   ur_result_t result = pfnEventsWaitWithBarrierExt(
       hQueue, pProperties, numEventsInWaitList, phEventWaitList, phEvent);
@@ -9004,8 +9081,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT, &params);
-    logger.info("   <--- urEnqueueEventsWaitWithBarrierExt({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger,
+           INFO "   <--- urEnqueueEventsWaitWithBarrierExt({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -9062,7 +9140,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
                                  "urEnqueueNativeCommandExp", &params);
 
   auto &logger = getContext()->logger;
-  logger.info("   ---> urEnqueueNativeCommandExp\n");
+  URLOG_(logger, INFO, "   ---> urEnqueueNativeCommandExp\n");
 
   ur_result_t result = pfnNativeCommandExp(
       hQueue, pfnNativeEnqueue, data, numMemsInMemList, phMemList, pProperties,
@@ -9076,8 +9154,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP, &params);
-    logger.info("   <--- urEnqueueNativeCommandExp({}) -> {};\n",
-                args_str.str(), result);
+    URLOG_(logger, INFO "   <--- urEnqueueNativeCommandExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;

--- a/source/loader/layers/tracing/ur_trcddi.cpp
+++ b/source/loader/layers/tracing/ur_trcddi.cpp
@@ -51,7 +51,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGet(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET, &params);
-    URLOG_(logger, INFO "   <--- urAdapterGet({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urAdapterGet({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -84,8 +84,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urAdapterRelease({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urAdapterRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -117,7 +117,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urAdapterRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urAdapterRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -157,7 +157,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ADAPTER_GET_LAST_ERROR, &params);
-    URLOG_(logger, INFO "   <--- urAdapterGetLastError({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urAdapterGetLastError({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -205,8 +205,8 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ADAPTER_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urAdapterGetInfo({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urAdapterGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -253,7 +253,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGet(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPlatformGet({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urPlatformGet({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -301,7 +301,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PLATFORM_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPlatformGetInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPlatformGetInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -337,7 +337,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetApiVersion(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_API_VERSION, &params);
-    URLOG_(logger, INFO "   <--- urPlatformGetApiVersion({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPlatformGetApiVersion({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -376,7 +376,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urPlatformGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPlatformGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -420,7 +420,8 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urPlatformCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urPlatformCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -463,7 +464,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformGetBackendOption(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PLATFORM_GET_BACKEND_OPTION, &params);
-    URLOG_(logger, INFO "   <--- urPlatformGetBackendOption({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPlatformGetBackendOption({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -511,7 +512,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGet(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET, &params);
-    URLOG_(logger, INFO "   <--- urDeviceGet({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urDeviceGet({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -560,7 +561,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urDeviceGetInfo({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urDeviceGetInfo({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -593,7 +594,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urDeviceRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urDeviceRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -626,7 +627,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urDeviceRelease({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urDeviceRelease({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -672,7 +673,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_PARTITION,
                                     &params);
-    URLOG_(logger, INFO "   <--- urDevicePartition({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urDevicePartition({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -717,7 +718,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_DEVICE_SELECT_BINARY,
                                     &params);
-    URLOG_(logger, INFO "   <--- urDeviceSelectBinary({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urDeviceSelectBinary({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -753,7 +754,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urDeviceGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urDeviceGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -797,7 +798,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urDeviceCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urDeviceCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -841,7 +842,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_DEVICE_GET_GLOBAL_TIMESTAMPS, &params);
-    URLOG_(logger, INFO "   <--- urDeviceGetGlobalTimestamps({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urDeviceGetGlobalTimestamps({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -882,7 +883,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urContextCreate({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urContextCreate({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -915,7 +916,7 @@ __urdlllocal ur_result_t UR_APICALL urContextRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urContextRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urContextRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -948,8 +949,8 @@ __urdlllocal ur_result_t UR_APICALL urContextRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urContextRelease({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urContextRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -997,8 +998,8 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_CONTEXT_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urContextGetInfo({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urContextGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1034,7 +1035,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urContextGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urContextGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1084,7 +1085,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urContextCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urContextCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1125,7 +1126,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_CONTEXT_SET_EXTENDED_DELETER, &params);
-    URLOG_(logger, INFO "   <--- urContextSetExtendedDeleter({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urContextSetExtendedDeleter({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1170,8 +1171,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemImageCreate({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urMemImageCreate({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1213,7 +1214,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemBufferCreate({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urMemBufferCreate({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1245,7 +1246,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRetain(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RETAIN, &params);
-    URLOG_(logger, INFO "   <--- urMemRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urMemRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1277,7 +1278,7 @@ __urdlllocal ur_result_t UR_APICALL urMemRelease(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_RELEASE, &params);
-    URLOG_(logger, INFO "   <--- urMemRelease({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urMemRelease({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1320,7 +1321,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_BUFFER_PARTITION,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemBufferPartition({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urMemBufferPartition({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1358,7 +1359,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_NATIVE_HANDLE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urMemGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1402,8 +1403,8 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_BUFFER_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger,
-           INFO "   <--- urMemBufferCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urMemBufferCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1451,7 +1452,8 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_MEM_IMAGE_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urMemImageCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urMemImageCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1499,7 +1501,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemGetInfo({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urMemGetInfo({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1547,7 +1549,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_MEM_IMAGE_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urMemImageGetInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urMemImageGetInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1584,7 +1586,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urSamplerCreate({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urSamplerCreate({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1617,7 +1619,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urSamplerRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urSamplerRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1650,8 +1652,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urSamplerRelease({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urSamplerRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1694,8 +1696,8 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_SAMPLER_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urSamplerGetInfo({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urSamplerGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1731,7 +1733,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urSamplerGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urSamplerGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1775,7 +1777,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_SAMPLER_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urSamplerCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urSamplerCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -1817,7 +1819,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_HOST_ALLOC,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMHostAlloc({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMHostAlloc({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1862,8 +1864,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_DEVICE_ALLOC,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMDeviceAlloc({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urUSMDeviceAlloc({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1907,8 +1909,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_SHARED_ALLOC,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMSharedAlloc({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urUSMSharedAlloc({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -1941,7 +1943,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_FREE, &params);
-    URLOG_(logger, INFO "   <--- urUSMFree({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMFree({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -1987,7 +1989,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_GET_MEM_ALLOC_INFO, &params);
-    URLOG_(logger, INFO "   <--- urUSMGetMemAllocInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urUSMGetMemAllocInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2025,7 +2027,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMPoolCreate({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMPoolCreate({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2058,7 +2060,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMPoolRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMPoolRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2091,8 +2093,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMPoolRelease({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urUSMPoolRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2135,8 +2137,8 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_POOL_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMPoolGetInfo({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urUSMPoolGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2189,7 +2191,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_GRANULARITY_GET_INFO, &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemGranularityGetInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urVirtualMemGranularityGetInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2232,7 +2234,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_RESERVE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemReserve({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urVirtualMemReserve({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2269,8 +2271,8 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_FREE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemFree({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urVirtualMemFree({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2314,7 +2316,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_MAP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemMap({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urVirtualMemMap({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2351,7 +2353,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_UNMAP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemUnmap({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urVirtualMemUnmap({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2391,7 +2393,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_VIRTUAL_MEM_SET_ACCESS, &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemSetAccess({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urVirtualMemSetAccess({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2443,7 +2445,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_VIRTUAL_MEM_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urVirtualMemGetInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urVirtualMemGetInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2487,7 +2489,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPhysicalMemCreate({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPhysicalMemCreate({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2520,7 +2522,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPhysicalMemRetain({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPhysicalMemRetain({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2553,7 +2555,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPhysicalMemRelease({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPhysicalMemRelease({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2600,7 +2602,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PHYSICAL_MEM_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urPhysicalMemGetInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urPhysicalMemGetInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2643,7 +2645,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_IL, &params);
-    URLOG_(logger, INFO "   <--- urProgramCreateWithIL({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramCreateWithIL({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2698,7 +2700,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_BINARY, &params);
-    URLOG_(logger, INFO "   <--- urProgramCreateWithBinary({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramCreateWithBinary({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2735,7 +2737,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramBuild({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urProgramBuild({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2772,8 +2774,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramCompile({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urProgramCompile({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2818,7 +2820,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramLink({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urProgramLink({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2851,7 +2853,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urProgramRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -2884,8 +2886,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramRelease({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urProgramRelease({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -2930,7 +2932,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_FUNCTION_POINTER, &params);
-    URLOG_(logger, INFO "   <--- urProgramGetFunctionPointer({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramGetFunctionPointer({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -2980,8 +2982,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_GLOBAL_VARIABLE_POINTER, &params);
-    URLOG_(logger,
-           INFO "   <--- urProgramGetGlobalVariablePointer({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urProgramGetGlobalVariablePointer({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3030,8 +3032,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramGetInfo({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urProgramGetInfo({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -3080,7 +3082,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_BUILD_INFO, &params);
-    URLOG_(logger, INFO "   <--- urProgramGetBuildInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramGetBuildInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3123,8 +3125,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_SET_SPECIALIZATION_CONSTANTS, &params);
-    URLOG_(logger,
-           INFO "   <--- urProgramSetSpecializationConstants({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urProgramSetSpecializationConstants({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3161,7 +3163,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urProgramGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3205,7 +3207,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_PROGRAM_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urProgramCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3242,7 +3244,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelCreate({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urKernelCreate({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -3287,7 +3289,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_VALUE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelSetArgValue({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetArgValue({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3327,7 +3329,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_ARG_LOCAL,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelSetArgLocal({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetArgLocal({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3376,7 +3378,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelGetInfo({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urKernelGetInfo({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -3423,7 +3425,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_GET_GROUP_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelGetGroupInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelGetGroupInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3472,7 +3474,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUB_GROUP_INFO, &params);
-    URLOG_(logger, INFO "   <--- urKernelGetSubGroupInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelGetSubGroupInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3505,7 +3507,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urKernelRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -3538,7 +3540,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelRelease({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urKernelRelease({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -3580,7 +3582,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_POINTER, &params);
-    URLOG_(logger, INFO "   <--- urKernelSetArgPointer({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetArgPointer({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3624,7 +3626,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_KERNEL_SET_EXEC_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urKernelSetExecInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetExecInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3665,7 +3667,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_SAMPLER, &params);
-    URLOG_(logger, INFO "   <--- urKernelSetArgSampler({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetArgSampler({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3706,7 +3708,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_ARG_MEM_OBJ, &params);
-    URLOG_(logger, INFO "   <--- urKernelSetArgMemObj({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelSetArgMemObj({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3748,8 +3750,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SET_SPECIALIZATION_CONSTANTS, &params);
-    URLOG_(logger,
-           INFO "   <--- urKernelSetSpecializationConstants({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urKernelSetSpecializationConstants({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3785,7 +3787,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urKernelGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3831,7 +3833,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urKernelCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urKernelCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3886,8 +3888,8 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_GET_SUGGESTED_LOCAL_WORK_SIZE, &params);
-    URLOG_(logger,
-           INFO "   <--- urKernelGetSuggestedLocalWorkSize({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urKernelGetSuggestedLocalWorkSize({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -3931,7 +3933,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urQueueGetInfo({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueGetInfo({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -3971,7 +3973,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_CREATE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urQueueCreate({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueCreate({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4004,7 +4006,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urQueueRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4037,7 +4039,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urQueueRelease({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueRelease({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4076,7 +4078,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urQueueGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urQueueGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4122,7 +4124,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_QUEUE_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urQueueCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urQueueCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4155,7 +4157,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FINISH,
                                     &params);
-    URLOG_(logger, INFO "   <--- urQueueFinish({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueFinish({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4187,7 +4189,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_QUEUE_FLUSH, &params);
-    URLOG_(logger, INFO "   <--- urQueueFlush({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urQueueFlush({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4231,7 +4233,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_GET_INFO,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEventGetInfo({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urEventGetInfo({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4277,7 +4279,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_PROFILING_INFO, &params);
-    URLOG_(logger, INFO "   <--- urEventGetProfilingInfo({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEventGetProfilingInfo({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4312,7 +4314,7 @@ __urdlllocal ur_result_t UR_APICALL urEventWait(
   if (logger.getLevel() <= logger::Level::INFO) {
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_WAIT, &params);
-    URLOG_(logger, INFO "   <--- urEventWait({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urEventWait({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4345,7 +4347,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRetain(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RETAIN,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEventRetain({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urEventRetain({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4378,7 +4380,7 @@ __urdlllocal ur_result_t UR_APICALL urEventRelease(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_RELEASE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEventRelease({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urEventRelease({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -4414,7 +4416,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_GET_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urEventGetNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEventGetNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4458,7 +4460,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_EVENT_CREATE_WITH_NATIVE_HANDLE, &params);
-    URLOG_(logger, INFO "   <--- urEventCreateWithNativeHandle({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEventCreateWithNativeHandle({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4498,7 +4500,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_EVENT_SET_CALLBACK,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEventSetCallback({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEventSetCallback({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4569,7 +4571,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueKernelLaunch({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueKernelLaunch({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4616,7 +4618,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueEventsWait({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueEventsWait({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4666,7 +4668,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueEventsWaitWithBarrier({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueEventsWaitWithBarrier({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4726,7 +4728,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferRead({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferRead({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4786,7 +4788,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferWrite({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferWrite({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4862,7 +4864,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_READ_RECT, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferReadRect({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferReadRect({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4939,7 +4941,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_WRITE_RECT, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferWriteRect({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferWriteRect({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -4998,7 +5000,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferCopy({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferCopy({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5070,7 +5072,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_COPY_RECT, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferCopyRect({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferCopyRect({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5135,7 +5137,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_FILL, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferFill({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferFill({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5200,7 +5202,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_READ, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemImageRead({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemImageRead({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5266,7 +5268,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_WRITE, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemImageWrite({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemImageWrite({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5327,7 +5329,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_IMAGE_COPY, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemImageCopy({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemImageCopy({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5389,7 +5391,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_MEM_BUFFER_MAP, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemBufferMap({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemBufferMap({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5440,7 +5442,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_MEM_UNMAP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueMemUnmap({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueMemUnmap({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5498,8 +5500,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMFill({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMFill({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -5554,7 +5556,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMMemcpy({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMMemcpy({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5607,7 +5609,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_PREFETCH,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMPrefetch({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMPrefetch({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5650,7 +5652,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_ADVISE,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMAdvise({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMAdvise({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5713,7 +5715,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_FILL_2D,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMFill2D({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMFill2D({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5778,7 +5780,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_ENQUEUE_USM_MEMCPY_2D,
                                     &params);
-    URLOG_(logger, INFO "   <--- urEnqueueUSMMemcpy2D({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueUSMMemcpy2D({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5842,8 +5844,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_WRITE, &params);
-    URLOG_(logger,
-           INFO "   <--- urEnqueueDeviceGlobalVariableWrite({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urEnqueueDeviceGlobalVariableWrite({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5907,8 +5909,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_DEVICE_GLOBAL_VARIABLE_READ, &params);
-    URLOG_(logger,
-           INFO "   <--- urEnqueueDeviceGlobalVariableRead({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urEnqueueDeviceGlobalVariableRead({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -5971,7 +5973,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_READ_HOST_PIPE, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueReadHostPipe({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueReadHostPipe({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6036,7 +6038,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_WRITE_HOST_PIPE, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueWriteHostPipe({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueWriteHostPipe({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6089,7 +6091,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_PITCHED_ALLOC_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMPitchedAllocExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urUSMPitchedAllocExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6138,8 +6140,7 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
         UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_HANDLE_DESTROY_EXP,
         &params);
     URLOG_(
-        logger,
-        INFO
+        logger, INFO,
         "   <--- urBindlessImagesUnsampledImageHandleDestroyExp({}) -> {};\n",
         args_str.str(), result);
   }
@@ -6187,8 +6188,7 @@ urBindlessImagesSampledImageHandleDestroyExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_HANDLE_DESTROY_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urBindlessImagesSampledImageHandleDestroyExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -6235,7 +6235,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_ALLOCATE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urBindlessImagesImageAllocateExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesImageAllocateExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6276,7 +6277,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_FREE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urBindlessImagesImageFreeExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urBindlessImagesImageFreeExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6325,8 +6326,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_UNSAMPLED_IMAGE_CREATE_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesUnsampledImageCreateExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesUnsampledImageCreateExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6379,8 +6380,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SAMPLED_IMAGE_CREATE_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesSampledImageCreateExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesSampledImageCreateExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6459,7 +6460,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_COPY_EXP, &params);
-    URLOG_(logger, INFO "   <--- urBindlessImagesImageCopyExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urBindlessImagesImageCopyExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6505,7 +6506,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMAGE_GET_INFO_EXP, &params);
-    URLOG_(logger, INFO "   <--- urBindlessImagesImageGetInfoExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urBindlessImagesImageGetInfoExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6551,8 +6552,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_GET_LEVEL_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesMipmapGetLevelExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesMipmapGetLevelExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6593,7 +6594,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MIPMAP_FREE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urBindlessImagesMipmapFreeExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urBindlessImagesMipmapFreeExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6643,8 +6644,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_MEMORY_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesImportExternalMemoryExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesImportExternalMemoryExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6693,8 +6694,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_ARRAY_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesMapExternalArrayExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesMapExternalArrayExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6743,8 +6744,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_MAP_EXTERNAL_LINEAR_MEMORY_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urBindlessImagesMapExternalLinearMemoryExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -6788,8 +6788,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_MEMORY_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesReleaseExternalMemoryExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesReleaseExternalMemoryExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -6838,8 +6838,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_IMPORT_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urBindlessImagesImportExternalSemaphoreExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -6884,8 +6883,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_RELEASE_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urBindlessImagesReleaseExternalSemaphoreExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -6949,8 +6947,8 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_WAIT_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urBindlessImagesWaitExternalSemaphoreExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urBindlessImagesWaitExternalSemaphoreExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7013,8 +7011,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_BINDLESS_IMAGES_SIGNAL_EXTERNAL_SEMAPHORE_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urBindlessImagesSignalExternalSemaphoreExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -7058,7 +7055,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_CREATE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferCreateExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferCreateExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7093,7 +7090,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferRetainExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RETAIN_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferRetainExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferRetainExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7128,7 +7125,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferReleaseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_RELEASE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferReleaseExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferReleaseExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7164,7 +7161,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferFinalizeExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_FINALIZE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferFinalizeExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferFinalizeExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7260,8 +7257,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_KERNEL_LAUNCH_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendKernelLaunchExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendKernelLaunchExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7336,8 +7333,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMMemcpyExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_MEMCPY_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendUSMMemcpyExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendUSMMemcpyExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7415,7 +7412,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMFillExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_FILL_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferAppendUSMFillExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferAppendUSMFillExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7497,8 +7494,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendMemBufferCopyExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendMemBufferCopyExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7577,8 +7574,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendMemBufferWriteExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendMemBufferWriteExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7657,8 +7654,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendMemBufferReadExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendMemBufferReadExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -7753,8 +7750,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_COPY_RECT_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urCommandBufferAppendMemBufferCopyRectExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -7853,8 +7849,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_WRITE_RECT_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urCommandBufferAppendMemBufferWriteRectExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -7952,8 +7947,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_READ_RECT_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urCommandBufferAppendMemBufferReadRectExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -8036,8 +8030,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_MEM_BUFFER_FILL_EXP,
         &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendMemBufferFillExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendMemBufferFillExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8112,8 +8106,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMPrefetchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_PREFETCH_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendUSMPrefetchExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendUSMPrefetchExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8188,8 +8182,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendUSMAdviseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_APPEND_USM_ADVISE_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferAppendUSMAdviseExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferAppendUSMAdviseExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8241,7 +8235,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_ENQUEUE_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferEnqueueExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferEnqueueExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8281,8 +8275,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferUpdateKernelLaunchExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferUpdateKernelLaunchExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8321,8 +8315,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateSignalEventExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_SIGNAL_EVENT_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferUpdateSignalEventExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferUpdateSignalEventExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8366,8 +8360,8 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferUpdateWaitEventsExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_UPDATE_WAIT_EVENTS_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urCommandBufferUpdateWaitEventsExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urCommandBufferUpdateWaitEventsExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8413,7 +8407,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_COMMAND_BUFFER_GET_INFO_EXP, &params);
-    URLOG_(logger, INFO "   <--- urCommandBufferGetInfoExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urCommandBufferGetInfoExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8488,8 +8482,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_COOPERATIVE_KERNEL_LAUNCH_EXP, &params);
-    URLOG_(logger,
-           INFO "   <--- urEnqueueCooperativeKernelLaunchExp({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urEnqueueCooperativeKernelLaunchExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8548,8 +8542,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_KERNEL_SUGGEST_MAX_COOPERATIVE_GROUP_COUNT_EXP,
         &params);
-    URLOG_(logger,
-           INFO
+    URLOG_(logger, INFO,
            "   <--- urKernelSuggestMaxCooperativeGroupCountExp({}) -> {};\n",
            args_str.str(), result);
   }
@@ -8610,7 +8603,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_TIMESTAMP_RECORDING_EXP, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueTimestampRecordingExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueTimestampRecordingExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8693,7 +8686,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_KERNEL_LAUNCH_CUSTOM_EXP, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueKernelLaunchCustomExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueKernelLaunchCustomExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8733,7 +8726,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_BUILD_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramBuildExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramBuildExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8773,7 +8766,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_COMPILE_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramCompileExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urProgramCompileExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8824,8 +8817,8 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_PROGRAM_LINK_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urProgramLinkExp({}) -> {};\n", args_str.str(),
-           result);
+    URLOG_(logger, INFO, "   <--- urProgramLinkExp({}) -> {};\n",
+           args_str.str(), result);
   }
 
   return result;
@@ -8861,7 +8854,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_IMPORT_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMImportExp({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMImportExp({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -8896,7 +8889,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(args_str, UR_FUNCTION_USM_RELEASE_EXP,
                                     &params);
-    URLOG_(logger, INFO "   <--- urUSMReleaseExp({}) -> {};\n", args_str.str(),
+    URLOG_(logger, INFO, "   <--- urUSMReleaseExp({}) -> {};\n", args_str.str(),
            result);
   }
 
@@ -8935,7 +8928,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_ENABLE_PEER_ACCESS_EXP, &params);
-    URLOG_(logger, INFO "   <--- urUsmP2PEnablePeerAccessExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urUsmP2PEnablePeerAccessExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -8974,7 +8967,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_DISABLE_PEER_ACCESS_EXP, &params);
-    URLOG_(logger, INFO "   <--- urUsmP2PDisablePeerAccessExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urUsmP2PDisablePeerAccessExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -9029,7 +9022,7 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_USM_P2P_PEER_ACCESS_GET_INFO_EXP, &params);
-    URLOG_(logger, INFO "   <--- urUsmP2PPeerAccessGetInfoExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urUsmP2PPeerAccessGetInfoExp({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -9081,8 +9074,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_EVENTS_WAIT_WITH_BARRIER_EXT, &params);
-    URLOG_(logger,
-           INFO "   <--- urEnqueueEventsWaitWithBarrierExt({}) -> {};\n",
+    URLOG_(logger, INFO,
+           "   <--- urEnqueueEventsWaitWithBarrierExt({}) -> {};\n",
            args_str.str(), result);
   }
 
@@ -9154,7 +9147,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
     std::ostringstream args_str;
     ur::extras::printFunctionParams(
         args_str, UR_FUNCTION_ENQUEUE_NATIVE_COMMAND_EXP, &params);
-    URLOG_(logger, INFO "   <--- urEnqueueNativeCommandExp({}) -> {};\n",
+    URLOG_(logger, INFO, "   <--- urEnqueueNativeCommandExp({}) -> {};\n",
            args_str.str(), result);
   }
 

--- a/source/loader/layers/validation/ur_leak_check.hpp
+++ b/source/loader/layers/validation/ur_leak_check.hpp
@@ -68,14 +68,14 @@ private:
             ptr, RefRuntimeInfo{1, std::type_index(typeid(handle)),
                                 getCurrentBacktrace()});
       } else {
-        getContext()->logger.error("Handle {} already exists", ptr);
+        getContext();
+        URLOG_CTX(ERR, "Handle {} already exists", ptr);
         return;
       }
       break;
     case REFCOUNT_INCREASE:
       if (it == counts.end()) {
-        getContext()->logger.error("Attempting to retain nonexistent handle {}",
-                                   ptr);
+        URLOG_CTX(ERR, "Attempting to retain nonexistent handle {}", ptr);
         return;
       } else {
         it->second.refCount++;
@@ -91,16 +91,15 @@ private:
       }
 
       if (it->second.refCount < 0) {
-        getContext()->logger.error(
-            "Attempting to release nonexistent handle {}", ptr);
+        URLOG_CTX(ERR, "Attempting to release nonexistent handle {}", ptr);
       } else if (it->second.refCount == 0 && isAdapterHandle) {
         adapterCount--;
       }
       break;
     }
 
-    getContext()->logger.debug("Reference count for handle {} changed to {}",
-                               ptr, it->second.refCount);
+    URLOG_CTX(DEBUG, "Reference count for handle {} changed to {}", ptr,
+              it->second.refCount);
 
     if (it->second.refCount == 0) {
       counts.erase(ptr);
@@ -108,7 +107,7 @@ private:
 
     // No more active adapters, so any references still held are leaked
     if (adapterCount == 0) {
-      logInvalidReferences();
+      logInvalidReferences(SHORT_FILE, UR_STR(__LINE__));
       counts.clear();
     }
   }
@@ -143,24 +142,34 @@ public:
     return (it->second.type == std::type_index(typeid(handle)));
   }
 
-  void logInvalidReferences() {
+  void logInvalidReferences(const char *filename, const char *lineno) {
     for (auto &[ptr, refRuntimeInfo] : counts) {
-      getContext()->logger.error("Retained {} reference(s) to handle {}",
-                                 refRuntimeInfo.refCount, ptr);
-      getContext()->logger.error("Handle {} was recorded for first time here:",
-                                 ptr);
+      getContext()->logger.log(logger::Level::ERR, filename, lineno,
+                               "Retained {} reference(s) to handle {}",
+                               refRuntimeInfo.refCount, ptr);
+      getContext()->logger.log(
+          logger::Level::ERR, filename, lineno,
+          "Handle {} was recorded for first time here:", ptr);
       for (size_t i = 0; i < refRuntimeInfo.backtrace.size(); i++) {
-        getContext()->logger.error("#{} {}", i,
-                                   refRuntimeInfo.backtrace[i].c_str());
+        getContext()->logger.log(logger::Level::ERR, filename, lineno, "#{} {}",
+                                 i, refRuntimeInfo.backtrace[i].c_str());
       }
     }
   }
 
-  void logInvalidReference(void *ptr) {
-    getContext()->logger.error("There are no valid references to handle {}",
-                               ptr);
+  void logInvalidReference(const char *filename, const char *lineno,
+                           void *ptr) {
+    getContext()->logger.log(logger::Level::ERR, filename, lineno,
+                             "There are no valid references to handle {}", ptr);
   }
 };
+
+#define URLOG_CTX_INVALID_REFERENCE(ptr)                                       \
+  getContext()->refCountContext->logInvalidReference(SHORT_FILE,               \
+                                                     UR_STR(__LINE__), ptr);
+#define URLOG_CTX_INVALID_REFERENCES()                                         \
+  getContext()->refCountContext->logInvalidReferences(SHORT_FILE,              \
+                                                      UR_STR(__LINE__));
 
 } // namespace ur_validation_layer
 

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -135,7 +135,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetLastError(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hAdapter)) {
-    getContext()->refCountContext->logInvalidReference(hAdapter);
+    URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
   ur_result_t result = pfnAdapterGetLastError(hAdapter, ppMessage, pError);
@@ -186,7 +186,7 @@ __urdlllocal ur_result_t UR_APICALL urAdapterGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hAdapter)) {
-    getContext()->refCountContext->logInvalidReference(hAdapter);
+    URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
   ur_result_t result =
@@ -364,7 +364,7 @@ __urdlllocal ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hAdapter)) {
-    getContext()->refCountContext->logInvalidReference(hAdapter);
+    URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativePlatform, hAdapter,
@@ -504,7 +504,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -598,7 +598,7 @@ __urdlllocal ur_result_t UR_APICALL urDevicePartition(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnPartition(hDevice, pProperties, NumDevices,
@@ -644,7 +644,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceSelectBinary(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -676,7 +676,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGetNativeHandle(hDevice, phNativeDevice);
@@ -712,7 +712,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hAdapter)) {
-    getContext()->refCountContext->logInvalidReference(hAdapter);
+    URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
   ur_result_t result =
@@ -750,7 +750,7 @@ __urdlllocal ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -891,7 +891,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -923,7 +923,7 @@ __urdlllocal ur_result_t UR_APICALL urContextGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnGetNativeHandle(hContext, phNativeContext);
@@ -964,7 +964,7 @@ __urdlllocal ur_result_t UR_APICALL urContextCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hAdapter)) {
-    getContext()->refCountContext->logInvalidReference(hAdapter);
+    URLOG_CTX_INVALID_REFERENCE(hAdapter);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(
@@ -1003,7 +1003,7 @@ __urdlllocal ur_result_t UR_APICALL urContextSetExtendedDeleter(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnSetExtendedDeleter(hContext, pfnDeleter, pUserData);
@@ -1077,7 +1077,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -1140,7 +1140,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -1244,7 +1244,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferPartition(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result =
@@ -1279,12 +1279,12 @@ __urdlllocal ur_result_t UR_APICALL urMemGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hMem)) {
-    getContext()->refCountContext->logInvalidReference(hMem);
+    URLOG_CTX_INVALID_REFERENCE(hMem);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGetNativeHandle(hMem, hDevice, phNativeMem);
@@ -1320,7 +1320,7 @@ __urdlllocal ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -1371,7 +1371,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnImageCreateWithNativeHandle(
@@ -1427,7 +1427,7 @@ __urdlllocal ur_result_t UR_APICALL urMemGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hMemory)) {
-    getContext()->refCountContext->logInvalidReference(hMemory);
+    URLOG_CTX_INVALID_REFERENCE(hMemory);
   }
 
   ur_result_t result =
@@ -1479,7 +1479,7 @@ __urdlllocal ur_result_t UR_APICALL urMemImageGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hMemory)) {
-    getContext()->refCountContext->logInvalidReference(hMemory);
+    URLOG_CTX_INVALID_REFERENCE(hMemory);
   }
 
   ur_result_t result =
@@ -1522,7 +1522,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnCreate(hContext, pDesc, phSampler);
@@ -1623,7 +1623,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hSampler)) {
-    getContext()->refCountContext->logInvalidReference(hSampler);
+    URLOG_CTX_INVALID_REFERENCE(hSampler);
   }
 
   ur_result_t result =
@@ -1655,7 +1655,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hSampler)) {
-    getContext()->refCountContext->logInvalidReference(hSampler);
+    URLOG_CTX_INVALID_REFERENCE(hSampler);
   }
 
   ur_result_t result = pfnGetNativeHandle(hSampler, phNativeSampler);
@@ -1691,7 +1691,7 @@ __urdlllocal ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeSampler, hContext,
@@ -1743,12 +1743,12 @@ __urdlllocal ur_result_t UR_APICALL urUSMHostAlloc(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(pool)) {
-    getContext()->refCountContext->logInvalidReference(pool);
+    URLOG_CTX_INVALID_REFERENCE(pool);
   }
 
   ur_result_t result = pfnHostAlloc(hContext, pUSMDesc, pool, size, ppMem);
@@ -1800,17 +1800,17 @@ __urdlllocal ur_result_t UR_APICALL urUSMDeviceAlloc(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(pool)) {
-    getContext()->refCountContext->logInvalidReference(pool);
+    URLOG_CTX_INVALID_REFERENCE(pool);
   }
 
   ur_result_t result =
@@ -1863,17 +1863,17 @@ __urdlllocal ur_result_t UR_APICALL urUSMSharedAlloc(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(pool)) {
-    getContext()->refCountContext->logInvalidReference(pool);
+    URLOG_CTX_INVALID_REFERENCE(pool);
   }
 
   ur_result_t result =
@@ -1905,7 +1905,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMFree(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnFree(hContext, pMem);
@@ -1948,7 +1948,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMGetMemAllocInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnGetMemAllocInfo(hContext, pMem, propName, propSize,
@@ -1989,7 +1989,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnPoolCreate(hContext, pPoolDesc, ppPool);
@@ -2090,7 +2090,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMPoolGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hPool)) {
-    getContext()->refCountContext->logInvalidReference(hPool);
+    URLOG_CTX_INVALID_REFERENCE(hPool);
   }
 
   ur_result_t result =
@@ -2146,12 +2146,12 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGranularityGetInfo(
@@ -2190,7 +2190,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemReserve(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnReserve(hContext, pStart, size, ppStart);
@@ -2223,7 +2223,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemFree(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnFree(hContext, pStart, size);
@@ -2268,12 +2268,12 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemMap(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hPhysicalMem)) {
-    getContext()->refCountContext->logInvalidReference(hPhysicalMem);
+    URLOG_CTX_INVALID_REFERENCE(hPhysicalMem);
   }
 
   ur_result_t result =
@@ -2307,7 +2307,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemUnmap(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnUnmap(hContext, pStart, size);
@@ -2345,7 +2345,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemSetAccess(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnSetAccess(hContext, pStart, size, flags);
@@ -2393,7 +2393,7 @@ __urdlllocal ur_result_t UR_APICALL urVirtualMemGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnGetInfo(hContext, pStart, size, propName, propSize,
@@ -2438,12 +2438,12 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -2539,7 +2539,7 @@ __urdlllocal ur_result_t UR_APICALL urPhysicalMemGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hPhysicalMem)) {
-    getContext()->refCountContext->logInvalidReference(hPhysicalMem);
+    URLOG_CTX_INVALID_REFERENCE(hPhysicalMem);
   }
 
   ur_result_t result =
@@ -2591,7 +2591,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithIL(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -2661,7 +2661,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithBinary(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -2700,12 +2700,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuild(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnBuild(hContext, hProgram, pOptions);
@@ -2738,12 +2738,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompile(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnCompile(hContext, hProgram, pOptions);
@@ -2789,7 +2789,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLink(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -2884,12 +2884,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetFunctionPointer(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnGetFunctionPointer(hDevice, hProgram, pFunctionName,
@@ -2936,12 +2936,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetGlobalVariablePointer(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnGetGlobalVariablePointer(
@@ -2995,7 +2995,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result =
@@ -3043,12 +3043,12 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetBuildInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGetBuildInfo(hProgram, hDevice, propName, propSize,
@@ -3087,7 +3087,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramSetSpecializationConstants(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result =
@@ -3119,7 +3119,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnGetNativeHandle(hProgram, phNativeProgram);
@@ -3155,7 +3155,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeProgram, hContext,
@@ -3196,7 +3196,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnCreate(hProgram, pKernelName, phKernel);
@@ -3239,7 +3239,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgValue(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result =
@@ -3272,7 +3272,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgLocal(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnSetArgLocal(hKernel, argIndex, argSize, pProperties);
@@ -3324,7 +3324,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result =
@@ -3369,12 +3369,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetGroupInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGetGroupInfo(hKernel, hDevice, propName, propSize,
@@ -3419,12 +3419,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSubGroupInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnGetSubGroupInfo(hKernel, hDevice, propName, propSize,
@@ -3508,7 +3508,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgPointer(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result =
@@ -3550,7 +3550,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetExecInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result =
@@ -3586,12 +3586,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgSampler(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hArgValue)) {
-    getContext()->refCountContext->logInvalidReference(hArgValue);
+    URLOG_CTX_INVALID_REFERENCE(hArgValue);
   }
 
   ur_result_t result =
@@ -3627,12 +3627,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetArgMemObj(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hArgValue)) {
-    getContext()->refCountContext->logInvalidReference(hArgValue);
+    URLOG_CTX_INVALID_REFERENCE(hArgValue);
   }
 
   ur_result_t result =
@@ -3670,7 +3670,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelSetSpecializationConstants(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result =
@@ -3702,7 +3702,7 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnGetNativeHandle(hKernel, phNativeKernel);
@@ -3740,12 +3740,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(
@@ -3804,12 +3804,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelGetSuggestedLocalWorkSize(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnGetSuggestedLocalWorkSize(
@@ -3858,7 +3858,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -3910,12 +3910,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreate(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnCreate(hContext, hDevice, pProperties, phQueue);
@@ -4002,7 +4002,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnGetNativeHandle(hQueue, pDesc, phNativeQueue);
@@ -4040,12 +4040,12 @@ __urdlllocal ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnCreateWithNativeHandle(hNativeQueue, hContext,
@@ -4076,7 +4076,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFinish(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnFinish(hQueue);
@@ -4102,7 +4102,7 @@ __urdlllocal ur_result_t UR_APICALL urQueueFlush(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnFlush(hQueue);
@@ -4149,7 +4149,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hEvent)) {
-    getContext()->refCountContext->logInvalidReference(hEvent);
+    URLOG_CTX_INVALID_REFERENCE(hEvent);
   }
 
   ur_result_t result =
@@ -4192,7 +4192,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetProfilingInfo(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hEvent)) {
-    getContext()->refCountContext->logInvalidReference(hEvent);
+    URLOG_CTX_INVALID_REFERENCE(hEvent);
   }
 
   ur_result_t result =
@@ -4301,7 +4301,7 @@ __urdlllocal ur_result_t UR_APICALL urEventGetNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hEvent)) {
-    getContext()->refCountContext->logInvalidReference(hEvent);
+    URLOG_CTX_INVALID_REFERENCE(hEvent);
   }
 
   ur_result_t result = pfnGetNativeHandle(hEvent, phNativeEvent);
@@ -4337,7 +4337,7 @@ __urdlllocal ur_result_t UR_APICALL urEventCreateWithNativeHandle(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result =
@@ -4383,7 +4383,7 @@ __urdlllocal ur_result_t UR_APICALL urEventSetCallback(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hEvent)) {
-    getContext()->refCountContext->logInvalidReference(hEvent);
+    URLOG_CTX_INVALID_REFERENCE(hEvent);
   }
 
   ur_result_t result = pfnSetCallback(hEvent, execStatus, pfnNotify, pUserData);
@@ -4460,12 +4460,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnKernelLaunch(
@@ -4519,7 +4519,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWait(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -4573,7 +4573,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnEventsWaitWithBarrier(hQueue, numEventsInWaitList,
@@ -4648,12 +4648,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferRead(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result =
@@ -4729,12 +4729,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWrite(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result =
@@ -4852,12 +4852,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnMemBufferReadRect(
@@ -4977,12 +4977,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnMemBufferWriteRect(
@@ -5066,17 +5066,17 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBufferSrc)) {
-    getContext()->refCountContext->logInvalidReference(hBufferSrc);
+    URLOG_CTX_INVALID_REFERENCE(hBufferSrc);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBufferDst)) {
-    getContext()->refCountContext->logInvalidReference(hBufferDst);
+    URLOG_CTX_INVALID_REFERENCE(hBufferDst);
   }
 
   ur_result_t result =
@@ -5195,17 +5195,17 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBufferSrc)) {
-    getContext()->refCountContext->logInvalidReference(hBufferSrc);
+    URLOG_CTX_INVALID_REFERENCE(hBufferSrc);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBufferDst)) {
-    getContext()->refCountContext->logInvalidReference(hBufferDst);
+    URLOG_CTX_INVALID_REFERENCE(hBufferDst);
   }
 
   ur_result_t result = pfnMemBufferCopyRect(
@@ -5297,12 +5297,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferFill(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result =
@@ -5386,12 +5386,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageRead(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hImage)) {
-    getContext()->refCountContext->logInvalidReference(hImage);
+    URLOG_CTX_INVALID_REFERENCE(hImage);
   }
 
   ur_result_t result = pfnMemImageRead(
@@ -5475,12 +5475,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hImage)) {
-    getContext()->refCountContext->logInvalidReference(hImage);
+    URLOG_CTX_INVALID_REFERENCE(hImage);
   }
 
   ur_result_t result = pfnMemImageWrite(
@@ -5569,17 +5569,17 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hImageSrc)) {
-    getContext()->refCountContext->logInvalidReference(hImageSrc);
+    URLOG_CTX_INVALID_REFERENCE(hImageSrc);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hImageDst)) {
-    getContext()->refCountContext->logInvalidReference(hImageDst);
+    URLOG_CTX_INVALID_REFERENCE(hImageDst);
   }
 
   ur_result_t result =
@@ -5661,12 +5661,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferMap(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result =
@@ -5729,12 +5729,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemUnmap(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hMem)) {
-    getContext()->refCountContext->logInvalidReference(hMem);
+    URLOG_CTX_INVALID_REFERENCE(hMem);
   }
 
   ur_result_t result = pfnMemUnmap(
@@ -5817,7 +5817,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -5901,7 +5901,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -5976,7 +5976,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnUSMPrefetch(
@@ -6028,7 +6028,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMAdvise(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnUSMAdvise(hQueue, pMem, size, advice, phEvent);
@@ -6130,7 +6130,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMFill2D(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -6233,7 +6233,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result =
@@ -6308,12 +6308,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnDeviceGlobalVariableWrite(
@@ -6388,12 +6388,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnDeviceGlobalVariableRead(
@@ -6469,12 +6469,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueReadHostPipe(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result =
@@ -6551,12 +6551,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueWriteHostPipe(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result =
@@ -6619,17 +6619,17 @@ __urdlllocal ur_result_t UR_APICALL urUSMPitchedAllocExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(pool)) {
-    getContext()->refCountContext->logInvalidReference(pool);
+    URLOG_CTX_INVALID_REFERENCE(pool);
   }
 
   ur_result_t result =
@@ -6667,12 +6667,12 @@ urBindlessImagesUnsampledImageHandleDestroyExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -6709,12 +6709,12 @@ urBindlessImagesSampledImageHandleDestroyExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -6765,12 +6765,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnImageAllocateExp(hContext, hDevice, pImageFormat,
@@ -6805,12 +6805,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageFreeExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnImageFreeExp(hContext, hDevice, hImageMem);
@@ -6862,12 +6862,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnUnsampledImageCreateExp(
@@ -6925,17 +6925,17 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hSampler)) {
-    getContext()->refCountContext->logInvalidReference(hSampler);
+    URLOG_CTX_INVALID_REFERENCE(hSampler);
   }
 
   ur_result_t result =
@@ -7031,7 +7031,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnImageCopyExp(
@@ -7075,7 +7075,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImageGetInfoExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnImageGetInfoExp(hContext, hImageMem, propName,
@@ -7117,12 +7117,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapGetLevelExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnMipmapGetLevelExp(hContext, hDevice, hImageMem,
@@ -7157,12 +7157,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMipmapFreeExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnMipmapFreeExp(hContext, hDevice, hMem);
@@ -7211,12 +7211,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalMemoryExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnImportExternalMemoryExp(
@@ -7272,12 +7272,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnMapExternalArrayExp(
@@ -7324,12 +7324,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesMapExternalLinearMemoryExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnMapExternalLinearMemoryExp(
@@ -7367,12 +7367,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalMemoryExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -7420,12 +7420,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesImportExternalSemaphoreExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnImportExternalSemaphoreExp(
@@ -7464,12 +7464,12 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesReleaseExternalSemaphoreExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -7529,7 +7529,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesWaitExternalSemaphoreExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnWaitExternalSemaphoreExp(
@@ -7590,7 +7590,7 @@ __urdlllocal ur_result_t UR_APICALL urBindlessImagesSignalExternalSemaphoreExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnSignalExternalSemaphoreExp(
@@ -7630,12 +7630,12 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferCreateExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result =
@@ -7803,7 +7803,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnAppendKernelLaunchExp(
@@ -8055,12 +8055,12 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hSrcMem)) {
-    getContext()->refCountContext->logInvalidReference(hSrcMem);
+    URLOG_CTX_INVALID_REFERENCE(hSrcMem);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDstMem)) {
-    getContext()->refCountContext->logInvalidReference(hDstMem);
+    URLOG_CTX_INVALID_REFERENCE(hDstMem);
   }
 
   ur_result_t result = pfnAppendMemBufferCopyExp(
@@ -8143,7 +8143,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnAppendMemBufferWriteExp(
@@ -8226,7 +8226,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnAppendMemBufferReadExp(
@@ -8319,12 +8319,12 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferCopyRectExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hSrcMem)) {
-    getContext()->refCountContext->logInvalidReference(hSrcMem);
+    URLOG_CTX_INVALID_REFERENCE(hSrcMem);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDstMem)) {
-    getContext()->refCountContext->logInvalidReference(hDstMem);
+    URLOG_CTX_INVALID_REFERENCE(hDstMem);
   }
 
   ur_result_t result = pfnAppendMemBufferCopyRectExp(
@@ -8421,7 +8421,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferWriteRectExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnAppendMemBufferWriteRectExp(
@@ -8517,7 +8517,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferReadRectExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnAppendMemBufferReadRectExp(
@@ -8603,7 +8603,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferAppendMemBufferFillExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hBuffer)) {
-    getContext()->refCountContext->logInvalidReference(hBuffer);
+    URLOG_CTX_INVALID_REFERENCE(hBuffer);
   }
 
   ur_result_t result = pfnAppendMemBufferFillExp(
@@ -8821,7 +8821,7 @@ __urdlllocal ur_result_t UR_APICALL urCommandBufferEnqueueExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnEnqueueExp(
@@ -9045,12 +9045,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueCooperativeKernelLaunchExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnCooperativeKernelLaunchExp(
@@ -9102,12 +9102,12 @@ __urdlllocal ur_result_t UR_APICALL urKernelSuggestMaxCooperativeGroupCountExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hDevice)) {
-    getContext()->refCountContext->logInvalidReference(hDevice);
+    URLOG_CTX_INVALID_REFERENCE(hDevice);
   }
 
   ur_result_t result = pfnSuggestMaxCooperativeGroupCountExp(
@@ -9175,7 +9175,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueTimestampRecordingExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnTimestampRecordingExp(
@@ -9256,12 +9256,12 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunchCustomExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hKernel)) {
-    getContext()->refCountContext->logInvalidReference(hKernel);
+    URLOG_CTX_INVALID_REFERENCE(hKernel);
   }
 
   ur_result_t result = pfnKernelLaunchCustomExp(
@@ -9299,7 +9299,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramBuildExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnBuildExp(hProgram, numDevices, phDevices, pOptions);
@@ -9334,7 +9334,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramCompileExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hProgram)) {
-    getContext()->refCountContext->logInvalidReference(hProgram);
+    URLOG_CTX_INVALID_REFERENCE(hProgram);
   }
 
   ur_result_t result = pfnCompileExp(hProgram, numDevices, phDevices, pOptions);
@@ -9387,7 +9387,7 @@ __urdlllocal ur_result_t UR_APICALL urProgramLinkExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnLinkExp(hContext, numDevices, phDevices, count,
@@ -9421,7 +9421,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMImportExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnImportExp(hContext, pMem, size);
@@ -9452,7 +9452,7 @@ __urdlllocal ur_result_t UR_APICALL urUSMReleaseExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hContext)) {
-    getContext()->refCountContext->logInvalidReference(hContext);
+    URLOG_CTX_INVALID_REFERENCE(hContext);
   }
 
   ur_result_t result = pfnReleaseExp(hContext, pMem);
@@ -9484,12 +9484,12 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PEnablePeerAccessExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(commandDevice)) {
-    getContext()->refCountContext->logInvalidReference(commandDevice);
+    URLOG_CTX_INVALID_REFERENCE(commandDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(peerDevice)) {
-    getContext()->refCountContext->logInvalidReference(peerDevice);
+    URLOG_CTX_INVALID_REFERENCE(peerDevice);
   }
 
   ur_result_t result = pfnEnablePeerAccessExp(commandDevice, peerDevice);
@@ -9521,12 +9521,12 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PDisablePeerAccessExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(commandDevice)) {
-    getContext()->refCountContext->logInvalidReference(commandDevice);
+    URLOG_CTX_INVALID_REFERENCE(commandDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(peerDevice)) {
-    getContext()->refCountContext->logInvalidReference(peerDevice);
+    URLOG_CTX_INVALID_REFERENCE(peerDevice);
   }
 
   ur_result_t result = pfnDisablePeerAccessExp(commandDevice, peerDevice);
@@ -9584,12 +9584,12 @@ __urdlllocal ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(commandDevice)) {
-    getContext()->refCountContext->logInvalidReference(commandDevice);
+    URLOG_CTX_INVALID_REFERENCE(commandDevice);
   }
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(peerDevice)) {
-    getContext()->refCountContext->logInvalidReference(peerDevice);
+    URLOG_CTX_INVALID_REFERENCE(peerDevice);
   }
 
   ur_result_t result = pfnPeerAccessGetInfoExp(
@@ -9649,7 +9649,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrierExt(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnEventsWaitWithBarrierExt(
@@ -9718,7 +9718,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueNativeCommandExp(
 
   if (getContext()->enableLifetimeValidation &&
       !getContext()->refCountContext->isReferenceValid(hQueue)) {
-    getContext()->refCountContext->logInvalidReference(hQueue);
+    URLOG_CTX_INVALID_REFERENCE(hQueue);
   }
 
   ur_result_t result = pfnNativeCommandExp(
@@ -11132,7 +11132,7 @@ ur_result_t context_t::init(ur_dditable_t *dditable,
 
 ur_result_t context_t::tearDown() {
   if (enableLeakChecking) {
-    getContext()->refCountContext->logInvalidReferences();
+    URLOG_CTX_INVALID_REFERENCES();
   }
 
   return UR_RESULT_SUCCESS;

--- a/source/loader/layers/validation/ur_validation_layer.cpp
+++ b/source/loader/layers/validation/ur_validation_layer.cpp
@@ -33,8 +33,8 @@ context_t::~context_t() {}
       result == UR_RESULT_ERROR_UNSUPPORTED_FEATURE)                           \
     return UR_RESULT_SUCCESS;                                                  \
   if (result != UR_RESULT_SUCCESS) {                                           \
-    getContext()->logger.error("Unexpected non-success result code from {}",   \
-                               #result);                                       \
+    URLOG_CTX(ERR, SHORT_FILE, UR_STR(__LINE__),                               \
+              "Unexpected non-success result code from {}", #result);          \
     assert(0);                                                                 \
     return result;                                                             \
   }

--- a/source/loader/ur_lib.cpp
+++ b/source/loader/ur_lib.cpp
@@ -76,7 +76,7 @@ __urdlllocal ur_result_t context_t::Init(
   ur_result_t result;
   const char *logger_name = "loader";
   logger::init(logger_name);
-  logger::debug("Logger {} initialized successfully!", logger_name);
+  URLOG(DEBUG, "Logger {} initialized successfully!", logger_name);
 
   result = ur_loader::getContext()->init();
 
@@ -215,7 +215,7 @@ ur_result_t urLoaderTearDown() {
 
   ur_result_t result =
       ret == 0 ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_UNINITIALIZED;
-  logger::info("---> urLoaderTearDown() -> {}", result);
+  URLOG(INFO, "---> urLoaderTearDown() -> {}", result);
   return result;
 }
 
@@ -324,9 +324,8 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
   // `std::map` with `std::queue<std::pair<key_type_t, value_type_t>>` or
   // something similar.)
   auto maybeEnvVarMap = getenv_to_map("ONEAPI_DEVICE_SELECTOR", false);
-  logger::debug(
-      "getenv_to_map parsed env var and {} a map",
-      (maybeEnvVarMap.has_value() ? "produced" : "failed to produce"));
+  URLOG(DEBUG, "getenv_to_map parsed env var and {} a map",
+        (maybeEnvVarMap.has_value() ? "produced" : "failed to produce"));
 
   // if the ODS env var is not set at all, then pretend it was set to the
   // default
@@ -461,23 +460,22 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
     if (backend.empty()) {
       // FIXME: never true because getenv_to_map rejects this case
       // malformed term: missing backend -- output ERROR, then continue
-      logger::error("ERROR: missing backend, format of filter = "
-                    "'[!]backend:filterStrings'");
+      URLOG(ERR, "ERROR: missing backend, format of filter = "
+                 "'[!]backend:filterStrings'");
       continue;
     }
     enum FilterType {
       AcceptFilter,
       DiscardFilter,
     } termType = (backend.front() != '!') ? AcceptFilter : DiscardFilter;
-    logger::debug(
-        "termType is {}",
-        (termType != AcceptFilter ? "DiscardFilter" : "AcceptFilter"));
+    URLOG(DEBUG, "termType is {}",
+          (termType != AcceptFilter ? "DiscardFilter" : "AcceptFilter"));
     auto &deviceList =
         (termType != AcceptFilter) ? discardDeviceList : acceptDeviceList;
     if (termType != AcceptFilter) {
-      logger::debug("DEBUG: backend was '{}'", backend);
+      URLOG(DEBUG, "DEBUG: backend was '{}'", backend);
       backend.erase(backend.cbegin());
-      logger::debug("DEBUG: backend now '{}'", backend);
+      URLOG(DEBUG, "DEBUG: backend now '{}'", backend);
     }
     // Note the hPlatform -> platformBackend -> platformBackendName conversion
     // above guarantees minimal sanity for the comparison with backend from the
@@ -492,13 +490,13 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                     })) {
       // irrelevant term for current request: different backend -- silently
       // ignore
-      logger::error("unrecognised backend '{}'", backend);
+      URLOG(ERR, "unrecognised backend '{}'", backend);
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     if (termPair.second.size() == 0) {
       // malformed term: missing filterStrings -- output ERROR
-      logger::error("missing filterStrings, format of filter = "
-                    "'[!]backend:filterStrings'");
+      URLOG(ERR, "missing filterStrings, format of filter = "
+                 "'[!]backend:filterStrings'");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     if (std::find_if(termPair.second.cbegin(), termPair.second.cend(),
@@ -506,8 +504,8 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
         termPair.second.cend()) {
       // FIXME: never true because getenv_to_map rejects this case
       // malformed term: missing filterString -- output warning, then continue
-      logger::warning("WARNING: empty filterString, format of filterStrings "
-                      "= 'filterString[,filterString[,...]]'");
+      URLOG(WARN, "WARNING: empty filterString, format of filterStrings "
+                  "= 'filterString[,filterString[,...]]'");
       continue;
     }
     if (std::find_if(termPair.second.cbegin(), termPair.second.cend(),
@@ -515,8 +513,8 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                        return std::count(s.cbegin(), s.cend(), '.') > 2;
                      }) != termPair.second.cend()) {
       // malformed term: too many dots in filterString
-      logger::error("too many dots in filterString, format of "
-                    "filterString = 'root[.sub[.subsub]]'");
+      URLOG(ERR, "too many dots in filterString, format of "
+                 "filterString = 'root[.sub[.subsub]]'");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
     if (std::find_if(termPair.second.cbegin(), termPair.second.cend(),
@@ -537,7 +535,7 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                        return false; // no BAD things, so must be okay
                      }) != termPair.second.cend()) {
       // malformed term: star dot no-star in filterString
-      logger::error("invalid wildcard in filterString, '*.' => '*.*'");
+      URLOG(ERR, "invalid wildcard in filterString, '*.' => '*.*'");
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
 
@@ -596,10 +594,9 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                                           0, 0, nullptr});
   }
 
-  logger::debug("DEBUG: size of acceptDeviceList = {}",
-                acceptDeviceList.size());
-  logger::debug("DEBUG: size of discardDeviceList = {}",
-                discardDeviceList.size());
+  URLOG(DEBUG, "DEBUG: size of acceptDeviceList = {}", acceptDeviceList.size());
+  URLOG(DEBUG, "DEBUG: size of discardDeviceList = {}",
+        discardDeviceList.size());
 
   std::vector<DeviceSpec> rootDevices;
   std::vector<DeviceSpec> subDevices;
@@ -725,50 +722,50 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
       // is a subsubdevice filter, then it must be '*.*.*'
       matches = (filter.hwType == device.hwType) ||
                 (filter.hwType == DeviceHardwareType::UR_DEVICE_TYPE_ALL);
-      logger::debug("DEBUG: In ApplyFilter, if block case 1, matches = {}",
-                    matches);
+      URLOG(DEBUG, "DEBUG: In ApplyFilter, if block case 1, matches = {}",
+            matches);
     } else if (filter.rootId != device.rootId) {
       // root part in filter is a number but does not match the number in the
       // root part of device
       matches = false;
-      logger::debug("DEBUG: In ApplyFilter, if block case 2, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 2, matches = ", matches);
     } else if (filter.level == DevicePartLevel::ROOT) {
       // this is a root device filter with a number that matches
       matches = true;
-      logger::debug("DEBUG: In ApplyFilter, if block case 3, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 3, matches = ", matches);
     } else if (filter.subId == DeviceIdTypeALL) {
       // sub type of star always matches (when root part matches, which we
       // already know here) if this is a subdevice filter, then it must be
       // 'matches.*' if this is a subsubdevice filter, then it must be
       // 'matches.*.*'
       matches = true;
-      logger::debug("DEBUG: In ApplyFilter, if block case 4, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 4, matches = ", matches);
     } else if (filter.subId != device.subId) {
       // sub part in filter is a number but does not match the number in the sub
       // part of device
       matches = false;
-      logger::debug("DEBUG: In ApplyFilter, if block case 5, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 5, matches = ", matches);
     } else if (filter.level == DevicePartLevel::SUB) {
       // this is a sub device number filter, numbers match in both parts
       matches = true;
-      logger::debug("DEBUG: In ApplyFilter, if block case 6, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 6, matches = ", matches);
     } else if (filter.subsubId == DeviceIdTypeALL) {
       // subsub type of star always matches (when other parts match, which we
       // already know here) this is a subsub device filter, it must be
       // 'matches.matches.*'
       matches = true;
-      logger::debug("DEBUG: In ApplyFilter, if block case 7, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 7, matches = ", matches);
     } else {
       // this is a subsub device filter, numbers in all three parts match
       matches = (filter.subsubId == device.subsubId);
-      logger::debug("DEBUG: In ApplyFilter, if block case 8, matches = ",
-                    matches);
+      URLOG(DEBUG,
+            "DEBUG: In ApplyFilter, if block case 8, matches = ", matches);
     }
     return matches;
   };
@@ -832,10 +829,11 @@ ur_result_t urDeviceGetSelected(ur_platform_handle_t hPlatform,
                           subSubDevices.end());
     }
     if (numAlreadySelected == selectedDevices.size()) {
-      logger::warning("WARNING: an accept term was ignored because it "
-                      "does not select any additional devices"
-                      "selectedDevices.size() = {}",
-                      selectedDevices.size());
+      URLOG(WARN,
+            "WARNING: an accept term was ignored because it "
+            "does not select any additional devices"
+            "selectedDevices.size() = {}",
+            selectedDevices.size());
     }
   }
 

--- a/test/loader/platforms/platforms.cpp
+++ b/test/loader/platforms/platforms.cpp
@@ -27,23 +27,23 @@ int main(int, char *[]) {
   // Initialize the platform
   status = urLoaderInit(0, nullptr);
   if (status != UR_RESULT_SUCCESS) {
-    out.error("urLoaderInit failed with return code: {}", status);
+    URLOG_(out, ERR, "urLoaderInit failed with return code: {}", status);
     return 1;
   }
-  out.info("urLoaderInit succeeded.");
+  URLOG_(out, INFO, "urLoaderInit succeeded.");
 
   uint32_t adapterCount = 0;
   std::vector<ur_adapter_handle_t> adapters;
   status = urAdapterGet(0, nullptr, &adapterCount);
   if (status != UR_RESULT_SUCCESS) {
-    out.error("urAdapterGet failed with return code: {}", status);
+    URLOG_(out, ERR, "urAdapterGet failed with return code: {}", status);
     return 1;
   }
 
   adapters.resize(adapterCount);
   status = urAdapterGet(adapterCount, adapters.data(), nullptr);
   if (status != UR_RESULT_SUCCESS) {
-    out.error("urAdapterGet failed with return code: {}", status);
+    URLOG_(out, ERR, "urAdapterGet failed with return code: {}", status);
     return 1;
   }
 
@@ -53,16 +53,16 @@ int main(int, char *[]) {
   status =
       urPlatformGet(adapters.data(), adapterCount, 1, nullptr, &platformCount);
   if (status != UR_RESULT_SUCCESS) {
-    out.error("urPlatformGet failed with return code: {}", status);
+    URLOG_(out, ERR, "urPlatformGet failed with return code: {}", status);
     goto out;
   }
-  out.info("urPlatformGet found {} platforms", platformCount);
+  URLOG_(out, INFO, "urPlatformGet found {} platforms", platformCount);
 
   platforms.resize(platformCount);
   status = urPlatformGet(adapters.data(), adapterCount, platformCount,
                          platforms.data(), nullptr);
   if (status != UR_RESULT_SUCCESS) {
-    out.error("urPlatformGet failed with return code: {}", status);
+    URLOG_(out, ERR, "urPlatformGet failed with return code: {}", status);
     goto out;
   }
 
@@ -70,7 +70,7 @@ int main(int, char *[]) {
     size_t name_len;
     status = urPlatformGetInfo(p, UR_PLATFORM_INFO_NAME, 0, nullptr, &name_len);
     if (status != UR_RESULT_SUCCESS) {
-      out.error("urPlatformGetInfo failed with return code: {}", status);
+      URLOG_(out, ERR, "urPlatformGetInfo failed with return code: {}", status);
       goto out;
     }
 
@@ -80,11 +80,11 @@ int main(int, char *[]) {
     status =
         urPlatformGetInfo(p, UR_PLATFORM_INFO_NAME, name_len, name, nullptr);
     if (status != UR_RESULT_SUCCESS) {
-      out.error("urPlatformGetInfo failed with return code: {}", status);
+      URLOG_(out, ERR, "urPlatformGetInfo failed with return code: {}", status);
       free(name);
       goto out;
     }
-    out.info("Found {} ", name);
+    URLOG_(out, INFO, "Found {} ", name);
 
     free(name);
   }

--- a/test/unit/logger/env_var.cpp
+++ b/test/unit/logger/env_var.cpp
@@ -8,17 +8,17 @@
 
 //////////////////////////////////////////////////////////////////////////////
 TEST_F(LoggerFromEnvVar, DebugMessage) {
-  logger::debug("Test message: {}", "success");
+  URLOG(DEBUG, "Test message: {}", "success");
 }
 
 TEST_F(LoggerFromEnvVar, InfoMessage) {
-  logger::info("Test message: {}", "success");
+  URLOG(INFO, "Test message: {}", "success");
 }
 
 TEST_F(LoggerFromEnvVar, WarningMessage) {
-  logger::warning("Test message: {}", "success");
+  URLOG(WARN, "Test message: {}", "success");
 }
 
 TEST_F(LoggerFromEnvVar, ErrorMessage) {
-  logger::error("Test message: {}", "success");
+  URLOG(ERR, "Test message: {}", "success");
 }

--- a/test/unit/logger/logger.cpp
+++ b/test/unit/logger/logger.cpp
@@ -13,41 +13,41 @@
 
 //////////////////////////////////////////////////////////////////////////////
 TEST_F(DefaultLoggerWithFileSink, DefaultLevelNoOutput) {
-  logger->info("This should not be printed: {}", 42);
+  URLOG_(*logger, INFO, "This should not be printed: {}", 42);
   test_msg.clear();
 }
 
 TEST_F(DefaultLoggerWithFileSink, MultipleLines) {
-  logger->warning("Test message: {}", "success");
-  logger->debug("This should not be printed: {}", 42);
-  logger->error("Test message: {}", "success");
+  URLOG_(*logger, WARN, "Test message: {}", "success");
+  URLOG_(*logger, DEBUG, "This should not be printed: {}", 42);
+  URLOG_(*logger, ERR, "Test message: {}", "success");
 
   test_msg << test_msg_prefix << "[WARNING]: Test message: success\n"
            << test_msg_prefix << "[ERROR]: Test message: success\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, ThreeParams) {
-  logger->error("{} {}: {}", "Test", 42, 3.8);
+  URLOG_(*logger, ERR, "{} {}: {}", "Test", 42, 3.8);
   test_msg << test_msg_prefix << "[ERROR]: Test 42: 3.8\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, DoubleBraces) {
-  logger->error("{{}} {}: {}", "Test", 42);
+  URLOG_(*logger, ERR, "{{}} {}: {}", "Test", 42);
   test_msg << test_msg_prefix << "[ERROR]: {} Test: 42\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, DoubleBraces2) {
-  logger->error("200 {{ {}: {{{}}} 3.8", "Test", 42);
+  URLOG_(*logger, ERR, "200 {{ {}: {{{}}} 3.8", "Test", 42);
   test_msg << test_msg_prefix << "[ERROR]: 200 { Test: {42} 3.8\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, DoubleBraces3) {
-  logger->error("{{ {}:}} {}}}", "Test", 42);
+  URLOG_(*logger, ERR, "{{ {}:}} {}}}", "Test", 42);
   test_msg << test_msg_prefix << "[ERROR]: { Test:} 42}\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, NoBraces) {
-  logger->error(" Test: 42");
+  URLOG_(*logger, ERR, " Test: 42");
   test_msg << test_msg_prefix << "[ERROR]:  Test: 42\n";
 }
 
@@ -55,7 +55,7 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelDebug) {
   auto level = logger::Level::DEBUG;
   logger->setLevel(level);
   logger->setFlushLevel(level);
-  logger->debug("Test message: {}", "success");
+  URLOG_(*logger, DEBUG, "Test message: {}", "success");
 
   test_msg << test_msg_prefix << "[DEBUG]: Test message: success\n";
 }
@@ -64,8 +64,8 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
   auto level = logger::Level::INFO;
   logger->setLevel(level);
   logger->setFlushLevel(level);
-  logger->info("Test message: {}", "success");
-  logger->debug("This should not be printed: {}", 42);
+  URLOG_(*logger, INFO, "Test message: {}", "success");
+  URLOG_(*logger, DEBUG, "This should not be printed: {}", 42);
 
   test_msg << test_msg_prefix << "[INFO]: Test message: success\n";
 }
@@ -73,16 +73,16 @@ TEST_F(DefaultLoggerWithFileSink, SetLevelInfo) {
 TEST_F(DefaultLoggerWithFileSink, SetLevelWarning) {
   auto level = logger::Level::WARN;
   logger->setLevel(level);
-  logger->warning("Test message: {}", "success");
-  logger->info("This should not be printed: {}", 42);
+  URLOG_(*logger, WARN, "Test message: {}", "success");
+  URLOG_(*logger, INFO, "This should not be printed: {}", 42);
 
   test_msg << test_msg_prefix << "[WARNING]: Test message: success\n";
 }
 
 TEST_F(DefaultLoggerWithFileSink, SetLevelError) {
   logger->setLevel(logger::Level::ERR);
-  logger->error("Test message: {}", "success");
-  logger->warning("This should not be printed: {}", 42);
+  URLOG_(*logger, ERR, "Test message: {}", "success");
+  URLOG_(*logger, WARN, "This should not be printed: {}", 42);
 
   test_msg << test_msg_prefix << "[ERROR]: Test message: success\n";
 }
@@ -93,7 +93,7 @@ TEST_F(UniquePtrLoggerWithFilesink, SetLogLevelAndFlushLevelDebugWithCtor) {
   logger = std::make_unique<logger::Logger>(
       level, std::make_unique<logger::FileSink>(logger_name, file_path, level));
 
-  logger->debug("Test message: {}", "success");
+  URLOG_(*logger, DEBUG, "Test message: {}", "success");
   test_msg << test_msg_prefix << "[DEBUG]: Test message: success\n";
 }
 
@@ -109,13 +109,13 @@ TEST_F(UniquePtrLoggerWithFilesink, NestedFilePath) {
       logger::Level::WARN, std::make_unique<logger::FileSink>(
                                logger_name, file_path, logger::Level::WARN));
 
-  logger->warning("Test message: {}", "success");
+  URLOG_(*logger, WARN, "Test message: {}", "success");
   test_msg << test_msg_prefix << "[WARNING]: Test message: success\n";
 }
 
 TEST_F(UniquePtrLoggerWithFilesinkFail, NullSink) {
   logger = std::make_unique<logger::Logger>(logger::Level::INFO, nullptr);
-  logger->info("This should not be printed: {}", 42);
+  URLOG_(*logger, INFO, "This should not be printed: {}", 42);
   test_msg.clear();
 }
 
@@ -136,7 +136,7 @@ TEST_P(FileSinkLoggerMultipleThreads, Multithreaded) {
   for (int i = 0; i < thread_count; i++) {
     threads.emplace_back([&]() {
       for (int j = 0; j < message_count; ++j) {
-        local_logger.warn("Test message: {}", "it's a success");
+        URLOG_(local_logger, WARN, "Test message: {}", "it's a success");
       }
     });
   }
@@ -150,7 +150,7 @@ TEST_P(FileSinkLoggerMultipleThreads, Multithreaded) {
   for (int i = 0; i < thread_count; i++) {
     threads.emplace_back([&]() {
       for (int j = 0; j < message_count; ++j) {
-        local_logger.error("Flushed test message: {}", "it's a success");
+        URLOG_(local_logger, ERR, "Flushed test message: {}", "it's a success");
       }
     });
   }
@@ -181,7 +181,7 @@ TEST_P(CommonLoggerWithMultipleThreads, StdoutMultithreaded) {
   for (int i = 0; i < thread_count; i++) {
     threads.emplace_back([&]() {
       for (int j = 0; j < message_count; ++j) {
-        local_logger.warn("Test message: {}", "it's a success");
+        URLOG_(local_logger, WARN, "Test message: {}", "it's a success");
       }
     });
   }
@@ -195,7 +195,7 @@ TEST_P(CommonLoggerWithMultipleThreads, StdoutMultithreaded) {
   for (int i = 0; i < thread_count; i++) {
     threads.emplace_back([&]() {
       for (int j = 0; j < message_count; ++j) {
-        local_logger.error("Flushed test message: {}", "it's a success");
+        URLOG_(local_logger, ERR, "Flushed test message: {}", "it's a success");
       }
     });
   }

--- a/tools/urtrace/collector.cpp
+++ b/tools/urtrace/collector.cpp
@@ -86,7 +86,7 @@ std::string time_to_str(std::chrono::nanoseconds dur, enum time_unit unit) {
     ostr << d.count() << "s";
   } break;
   default: {
-    out.error("invalid time unit {}", unit);
+    URLOG_(out, ERR, "invalid time unit {}", unit);
     break;
   }
   }
@@ -123,7 +123,7 @@ static class cli_args {
       return std::nullopt;
     }
     if (arg_values.size() != 1) {
-      out.warn("{} requires a single argument, skipping...", name);
+      URLOG_(out, WARN, "{} requires a single argument, skipping...", name);
       return std::nullopt;
     }
     return arg_values.at(0);
@@ -161,18 +161,20 @@ public:
           try {
             filter = filter_str;
           } catch (const std::regex_error &err) {
-            out.warn("invalid filter regex {} {}", *filter_str, err.what());
+            URLOG_(out, WARN, "invalid filter regex {} {}", *filter_str,
+                   err.what());
           }
         } else {
-          out.warn("unknown {} argument {}.", ARGS_ENV, arg_name);
+          URLOG_(out, WARN, "unknown {} argument {}.", ARGS_ENV, arg_name);
         }
       }
     }
-    out.debug("collector args (.print_begin = {}, .profiling = {}, "
-              ".time_unit = {}, .filter = {}, .output_format = {})",
-              print_begin, profiling, time_unit_str[time_unit],
-              filter_str.has_value() ? *filter_str : "none",
-              output_format_str[output_format]);
+    URLOG_(out, DEBUG,
+           "collector args (.print_begin = {}, .profiling = {}, "
+           ".time_unit = {}, .filter = {}, .output_format = {})",
+           print_begin, profiling, time_unit_str[time_unit],
+           filter_str.has_value() ? *filter_str : "none",
+           output_format_str[output_format]);
   }
 
   enum time_unit time_unit;
@@ -202,7 +204,7 @@ public:
 class HumanReadable : public TraceWriter {
   void begin(uint64_t id, const char *fname, std::string args) override {
     if (cli_args.print_begin) {
-      out.info("begin({}) - {}({});", id, fname, args);
+      URLOG_(out, INFO, "begin({}) - {}({});", id, fname, args);
     }
   }
   void end(uint64_t id, const char *fname, std::string args, Timepoint tp,
@@ -218,8 +220,8 @@ class HumanReadable : public TraceWriter {
           std::chrono::duration_cast<std::chrono::nanoseconds>(tp - start_tp);
       profile_str << " (" << time_to_str(dur, cli_args.time_unit) << ")";
     }
-    out.info("{}{}({}) -> {};{}", prefix_str.str(), fname, args, *resultp,
-             profile_str.str());
+    URLOG_(out, INFO, "{}{}({}) -> {};{}", prefix_str.str(), fname, args,
+           *resultp, profile_str.str());
   }
 };
 
@@ -234,15 +236,16 @@ public:
       // not much we can do here...
     }
   }
-  void prologue() override { out.info("{{\n \"traceEvents\": ["); }
+  void prologue() override { URLOG_(out, INFO, "{{\n \"traceEvents\": ["); }
   void epilogue() override {
     // Empty trace to avoid ending in a comma
     // To prevent that last comma from being printed in the first place
     // we could synchronize the entire 'end' function, while reversing the
     // logic and printing commas at the front. Not worth it probably.
-    out.info("{{\"name\": \"\", \"cat\": \"\", \"ph\": \"\", \"pid\": \"\", "
-             "\"tid\": \"\", \"ts\": \"\"}}");
-    out.info("]\n}}");
+    URLOG_(out, INFO,
+           "{{\"name\": \"\", \"cat\": \"\", \"ph\": \"\", \"pid\": \"\", "
+           "\"tid\": \"\", \"ts\": \"\"}}");
+    URLOG_(out, INFO, "]\n}}");
   }
   void begin(uint64_t, const char *, std::string) override {}
 
@@ -254,7 +257,7 @@ public:
                      .count();
     auto dur_us =
         std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
-    out.info("{{\
+    URLOG_(out, INFO, "{{\
             \"cat\": \"UR\", \
             \"ph\": \"X\",\
             \"pid\": {},\
@@ -264,8 +267,7 @@ public:
             \"name\": \"{}\",\
             \"args\": \"({})\"\
         }},",
-             ur_getpid(), std::this_thread::get_id(), ts_us, dur_us, fname,
-             args);
+           ur_getpid(), std::this_thread::get_id(), ts_us, dur_us, fname, args);
   }
 };
 
@@ -320,8 +322,8 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
 
   if (auto regex = cli_args.filter) {
     if (!std::regex_match(args->function_name, *regex)) {
-      out.debug("function {} does not match regex filter, skipping...",
-                args->function_name);
+      URLOG_(out, DEBUG, "function {} does not match regex filter, skipping...",
+             args->function_name);
       return;
     }
   }
@@ -342,9 +344,10 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
   } else if (trace_type == TRACE_FN_END) {
     auto ctx = pop_instance_data(instance);
     if (!ctx) {
-      out.error("Received TRACE_FN_END without corresponding "
-                "TRACE_FN_BEGIN, instance {}. Skipping...",
-                instance);
+      URLOG_(out, ERR,
+             "Received TRACE_FN_END without corresponding "
+             "TRACE_FN_BEGIN, instance {}. Skipping...",
+             instance);
       return;
     }
     auto resultp = static_cast<const ur_result_t *>(args->ret_data);
@@ -352,7 +355,7 @@ XPTI_CALLBACK_API void trace_cb(uint16_t trace_type, xpti::trace_event_data_t *,
     writer()->end(instance, args->function_name, args_str.str(), time_for_end,
                   *ctx->start, resultp);
   } else {
-    out.warn("unsupported trace type");
+    URLOG_(out, WARN, "unsupported trace type");
   }
 }
 
@@ -365,27 +368,27 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
                                      unsigned int minor_version, const char *,
                                      const char *stream_name) {
   if (stream_name == nullptr) {
-    out.debug("Found stream with null name. Skipping...");
+    URLOG_(out, DEBUG, "Found stream with null name. Skipping...");
     return;
   }
   if (std::string_view(stream_name) != UR_STREAM_NAME) {
-    out.debug("Found stream: {}. Expected: {}. Skipping...", stream_name,
-              UR_STREAM_NAME);
+    URLOG_(out, DEBUG, "Found stream: {}. Expected: {}. Skipping...",
+           stream_name, UR_STREAM_NAME);
     return;
   }
 
   if (UR_MAKE_VERSION(major_version, minor_version) != UR_API_VERSION_CURRENT) {
-    out.error("Invalid stream version: {}.{}. Expected: {}.{}. Skipping...",
-              major_version, minor_version,
-              UR_MAJOR_VERSION(UR_API_VERSION_CURRENT),
-              UR_MINOR_VERSION(UR_API_VERSION_CURRENT));
+    URLOG_(
+        out, ERR, "Invalid stream version: {}.{}. Expected: {}.{}. Skipping...",
+        major_version, minor_version, UR_MAJOR_VERSION(UR_API_VERSION_CURRENT),
+        UR_MINOR_VERSION(UR_API_VERSION_CURRENT));
     return;
   }
 
   uint8_t stream_id = xptiRegisterStream(stream_name);
 
-  out.debug("Registered stream {} ({}.{}).", stream_name, major_version,
-            minor_version);
+  URLOG_(out, DEBUG, "Registered stream {} ({}.{}).", stream_name,
+         major_version, minor_version);
 
   writer()->prologue();
   xptiRegisterCallback(stream_id, TRACE_FN_BEGIN, trace_cb);
@@ -397,12 +400,12 @@ XPTI_CALLBACK_API void xptiTraceInit(unsigned int major_version,
  */
 XPTI_CALLBACK_API void xptiTraceFinish(const char *stream_name) {
   if (stream_name == nullptr) {
-    out.debug("Found stream with null name. Skipping...");
+    URLOG_(out, DEBUG, "Found stream with null name. Skipping...");
     return;
   }
   if (std::string_view(stream_name) != UR_STREAM_NAME) {
-    out.debug("Found stream: {}. Expected: {}. Skipping...", stream_name,
-              UR_STREAM_NAME);
+    URLOG_(out, DEBUG, "Found stream: {}. Expected: {}. Skipping...",
+           stream_name, UR_STREAM_NAME);
     return;
   }
 


### PR DESCRIPTION
Added an option to print line number and filename in log file. When `fileline:1` is specified in an environment variable describing log, e.g:
```
URLOG_CTX(ERROR,
```
then instead of seeing logs like this
```
<LEVEL_ZERO>[DEBUG]: create command list ..., inOrder: 1
```
one will see log like this:
```
<LEVEL_ZERO>[DEBUG]: create command list ..., inOrder: 1 <source/adapters/level_zero/v2/command_list_cache.cpp:73>
```
Review seems to be big but in fact is much shorter. The only essential change are some changes in
-  [ur_logger.hpp](https://github.com/oneapi-src/unified-runtime/pull/2637/files#diff-9b730342f84b1abd4ffa2d5eb9c30718da31f6cf4ead4870d76b20ef2f68f6de) (removed unused functions)
- [ur_logger_details.hpp](https://github.com/oneapi-src/unified-runtime/pull/2637/files#diff-19f637a28200609af98fbade2a66d00823a86b2c23b9b0e68a98ba224c711400) (added macro, removed unused functions)
- [ur_sinks.hpp](https://github.com/oneapi-src/unified-runtime/pull/2637/files#diff-3c95e74198c671876ef6da6b2ecb1b4432d9ecd8964d2d723855fb8284755f7a) parsing new env var parameter
- two lines in [CMakeLists.txt](https://github.com/oneapi-src/unified-runtime/pull/2637/files#diff-51a8fde1a99f5c115465f0b3f79c4afa7a15d1fb2fbb03d99344f9a034f59473)

The rest was automated change of log statements from `logger::xxx(...)` to `URLOG(XXX, ...)`