### PR TITLE
Fix the easily dealt with CL adapter KNOWN_FAILURES.

### DIFF
--- a/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
+++ b/test/conformance/device/urDeviceGetGlobalTimestamps.cpp
@@ -31,6 +31,7 @@ using urDeviceGetGlobalTimestampTest = uur::urDeviceTest;
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urDeviceGetGlobalTimestampTest);
 
 TEST_P(urDeviceGetGlobalTimestampTest, Success) {
+  // See https://github.com/oneapi-src/unified-runtime/issues/2633
   UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
 
   uint64_t device_time = 0;

--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -46,8 +46,9 @@ TEST_P(urKernelGetGroupInfoFixedWorkGroupSizeTest,
 
 struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{},
-                         uur::OpenCL{"12th Gen", "13th Gen", "Intel(R) Xeon"});
+    UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
+    // see https://github.com/oneapi-src/unified-runtime/issues/2644
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"12th Gen", "13th Gen", "Intel(R) Xeon"});
     program_name = "max_wg_size";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
   }

--- a/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetSubGroupInfo.cpp
@@ -10,6 +10,7 @@
 
 struct urKernelGetSubGroupInfoFixedSubGroupSizeTest : uur::urKernelTest {
   void SetUp() override {
+    // See https://github.com/oneapi-src/unified-runtime/issues/2514
     UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{}, uur::OpenCL{},
                          uur::LevelZero{}, uur::LevelZeroV2{});
     program_name = "fixed_sg_size";

--- a/test/conformance/kernel/urKernelSetArgSampler.cpp
+++ b/test/conformance/kernel/urKernelSetArgSampler.cpp
@@ -10,8 +10,6 @@
 struct urKernelSetArgSamplerTestWithParam
     : uur::urBaseKernelTestWithParam<uur::SamplerCreateParamT> {
   void SetUp() {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
     const auto param = getParam();
     const auto normalized = std::get<0>(param);
     const auto addr_mode = std::get<1>(param);
@@ -28,6 +26,12 @@ struct urKernelSetArgSamplerTestWithParam
     program_name = "image_copy";
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urBaseKernelTestWithParam<uur::SamplerCreateParamT>::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
 
     auto ret = urSamplerCreate(context, &sampler_desc, &sampler);
     if (ret == UR_RESULT_ERROR_UNSUPPORTED_FEATURE ||
@@ -72,10 +76,14 @@ TEST_P(urKernelSetArgSamplerTestWithParam, Success) {
 
 struct urKernelSetArgSamplerTest : uur::urBaseKernelTest {
   void SetUp() {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
     program_name = "image_copy";
     UUR_RETURN_ON_FATAL_FAILURE(urBaseKernelTest::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
 
     ur_sampler_desc_t sampler_desc = {
         UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* sType */

--- a/test/conformance/memory/urMemGetInfo.cpp
+++ b/test/conformance/memory/urMemGetInfo.cpp
@@ -116,7 +116,7 @@ struct urMemGetInfoImageTest : uur::urMemImageTest {
 UUR_INSTANTIATE_DEVICE_TEST_SUITE_P(urMemGetInfoImageTest);
 
 TEST_P(urMemGetInfoImageTest, SuccessSize) {
-  UUR_KNOWN_FAILURE_ON(uur::LevelZero{}, uur::OpenCL{"UHD Graphics"});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZero{});
 
   ur_mem_info_t property_name = UR_MEM_INFO_SIZE;
   size_t property_size = 0;
@@ -135,7 +135,9 @@ TEST_P(urMemGetInfoImageTest, SuccessSize) {
                                      image_desc.arraySize * image_desc.width *
                                      image_desc.height * image_desc.depth;
 
-  ASSERT_EQ(image_size_bytes, expected_image_size);
+  // Make sure the driver has allocated enough space to hold the image (the
+  // actual size may be padded out to above the requested size)
+  ASSERT_GE(image_size_bytes, expected_image_size);
 }
 
 TEST_P(urMemGetInfoImageTest, SuccessContext) {

--- a/test/conformance/memory/urMemImageCreate.cpp
+++ b/test/conformance/memory/urMemImageCreate.cpp
@@ -26,8 +26,13 @@ static ur_image_desc_t image_desc{
 
 struct urMemImageCreateTest : public uur::urContextTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
     UUR_RETURN_ON_FATAL_FAILURE(uur::urContextTest::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
 
     uur::raii::Mem image_handle = nullptr;
     auto ret = urMemImageCreate(context, UR_MEM_FLAG_READ_WRITE, &image_format,
@@ -36,6 +41,8 @@ struct urMemImageCreateTest : public uur::urContextTest {
     if (ret == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       GTEST_SKIP() << "urMemImageCreate not supported";
     }
+
+    ASSERT_SUCCESS(ret);
   }
 
   void TearDown() override {
@@ -51,6 +58,12 @@ struct urMemImageCreateTestWithParam
   void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(uur::urContextTestWithParam<Param>::SetUp());
 
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(this->device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
+
     uur::raii::Mem image_handle = nullptr;
     auto ret =
         urMemImageCreate(this->context, UR_MEM_FLAG_READ_WRITE, &image_format,
@@ -59,6 +72,8 @@ struct urMemImageCreateTestWithParam
     if (ret == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       GTEST_SKIP() << "urMemImageCreate not supported";
     }
+
+    ASSERT_SUCCESS(ret);
   }
 
   void TearDown() override {

--- a/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
+++ b/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
@@ -97,8 +97,9 @@ UUR_DEVICE_TEST_SUITE_P(
     uur::deviceTestWithParamPrinter<ur_image_format_t>);
 
 TEST_P(urMemImageCreateTestWithImageFormatParam, Success) {
-  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{}, uur::NativeCPU{},
-                       uur::OpenCL{"Intel(R) UHD Graphics 770"});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{}, uur::NativeCPU{});
+  // See https://github.com/oneapi-src/unified-runtime/issues/2638
+  UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) UHD Graphics 770"});
 
   ur_image_channel_order_t channel_order = std::get<1>(GetParam()).channelOrder;
   ur_image_channel_type_t channel_type = std::get<1>(GetParam()).channelType;

--- a/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
+++ b/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
@@ -67,9 +67,13 @@ std::vector<ur_image_format_t> all_image_formats;
 struct urMemImageCreateTestWithImageFormatParam
     : uur::urContextTestWithParam<ur_image_format_t> {
   void SetUp() {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urContextTestWithParam<ur_image_format_t>::SetUp());
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
   }
   void TearDown() {
     UUR_RETURN_ON_FATAL_FAILURE(

--- a/test/conformance/sampler/urSamplerCreate.cpp
+++ b/test/conformance/sampler/urSamplerCreate.cpp
@@ -11,10 +11,14 @@
 struct urSamplerCreateTestWithParam
     : public uur::urContextTestWithParam<uur::SamplerCreateParamT> {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
-
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::urContextTestWithParam<uur::SamplerCreateParamT>::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
 
     ur_sampler_desc_t sampler_desc{
         UR_STRUCTURE_TYPE_SAMPLER_DESC, /* stype */
@@ -30,6 +34,7 @@ struct urSamplerCreateTestWithParam
         ret == UR_RESULT_ERROR_UNINITIALIZED) {
       GTEST_SKIP() << "urSamplerCreate not supported";
     }
+    ASSERT_SUCCESS(ret);
   }
 
   void TearDown() override {

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -205,8 +205,14 @@ struct urContextTest : urDeviceTest {
 
 struct urSamplerTest : urContextTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
     UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
+
     sampler_desc = {
         UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         nullptr,                          /* pNext */
@@ -330,8 +336,14 @@ template <class T> struct urContextTestWithParam : urDeviceTestWithParam<T> {
 
 template <class T> struct urSamplerTestWithParam : urContextTestWithParam<T> {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) FPGA"});
     UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
+
+    bool image_support = false;
+    ASSERT_SUCCESS(uur::GetDeviceImageSupport(this->device, image_support));
+    if (!image_support) {
+      GTEST_SKIP() << "Device doesn't support images";
+    }
+
     sampler_desc = {
         UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         nullptr,                          /* pNext */

--- a/test/conformance/usm/urUSMGetMemAllocInfo.cpp
+++ b/test/conformance/usm/urUSMGetMemAllocInfo.cpp
@@ -25,7 +25,7 @@ UUR_DEVICE_TEST_SUITE_P(urUSMGetMemAllocInfoPoolTest,
                         uur::deviceTestWithParamPrinter<ur_usm_alloc_info_t>);
 
 TEST_P(urUSMGetMemAllocInfoPoolTest, SuccessPool) {
-  UUR_KNOWN_FAILURE_ON(uur::OpenCL{}, uur::LevelZeroV2{});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
 
   size_t property_size = 0;
   ur_usm_alloc_info_t property_name = UR_USM_ALLOC_INFO_POOL;


### PR DESCRIPTION
Mostly this involved removing unneeded skips and checking for image support where appropriate. Also adds ticket links for the less simple fails.