### PR TITLE
[L0 v2] fix queue destruction

### DIFF
--- a/scripts/templates/queue_api.cpp.mako
+++ b/scripts/templates/queue_api.cpp.mako
@@ -31,6 +31,7 @@ ur_queue_t_::~ur_queue_t_() {}
 ## FUNCTION ###################################################################
 namespace ${x}::level_zero {
 %for obj in th.get_queue_related_functions(specs, n, tags):
+%if not 'Release' in obj['name'] and not 'Retain' in obj['name']:
 ${x}_result_t
 ${th.make_func_name(n, tags, obj)}(
     %for line in th.make_param_lines(n, tags, obj, format=["name", "type", "delim"]):
@@ -42,5 +43,18 @@ try {
 } catch(...) {
     return exceptionToResult(std::current_exception());
 }
+%else:
+${x}_result_t
+${th.make_func_name(n, tags, obj)}(
+    %for line in th.make_param_lines(n, tags, obj, format=["name", "type", "delim"]):
+    ${line}
+    %endfor
+    )
+try {
+    return ${obj['params'][0]['name']}->${th.transform_queue_related_function_name(n, tags, obj, format=["name"])};
+} catch(...) {
+    return exceptionToResult(std::current_exception());
+}
+%endif
 %endfor
 }

--- a/scripts/templates/queue_api.hpp.mako
+++ b/scripts/templates/queue_api.hpp.mako
@@ -33,7 +33,9 @@ struct ur_queue_t_ {
     virtual void deferEventFree(ur_event_handle_t hEvent) = 0;
 
     %for obj in th.get_queue_related_functions(specs, n, tags):
+    %if not 'Release' in obj['name'] and not 'Retain' in obj['name']:
     virtual ${x}_result_t ${th.transform_queue_related_function_name(n, tags, obj, format=["type"])} = 0;
+    %endif
     %endfor
 
     virtual ur_result_t

--- a/source/adapters/level_zero/v2/queue_api.cpp
+++ b/source/adapters/level_zero/v2/queue_api.cpp
@@ -30,12 +30,12 @@ ur_result_t urQueueGetInfo(ur_queue_handle_t hQueue, ur_queue_info_t propName,
   return exceptionToResult(std::current_exception());
 }
 ur_result_t urQueueRetain(ur_queue_handle_t hQueue) try {
-  return hQueue->get().queueRetain();
+  return hQueue->queueRetain();
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }
 ur_result_t urQueueRelease(ur_queue_handle_t hQueue) try {
-  return hQueue->get().queueRelease();
+  return hQueue->queueRelease();
 } catch (...) {
   return exceptionToResult(std::current_exception());
 }

--- a/source/adapters/level_zero/v2/queue_api.hpp
+++ b/source/adapters/level_zero/v2/queue_api.hpp
@@ -26,8 +26,6 @@ struct ur_queue_t_ {
 
   virtual ur_result_t queueGetInfo(ur_queue_info_t, size_t, void *,
                                    size_t *) = 0;
-  virtual ur_result_t queueRetain() = 0;
-  virtual ur_result_t queueRelease() = 0;
   virtual ur_result_t queueGetNativeHandle(ur_queue_native_desc_t *,
                                            ur_native_handle_t *) = 0;
   virtual ur_result_t queueFinish() = 0;

--- a/source/adapters/level_zero/v2/queue_handle.hpp
+++ b/source/adapters/level_zero/v2/queue_handle.hpp
@@ -29,4 +29,24 @@ struct ur_queue_handle_t_ {
   ur_queue_t_ &get() {
     return std::visit([&](auto &q) -> ur_queue_t_ & { return q; }, queue_data);
   }
+
+  ur_result_t queueRetain() {
+    return std::visit(
+        [](auto &q) {
+          q.RefCount.increment();
+          return UR_RESULT_SUCCESS;
+        },
+        queue_data);
+  }
+
+  ur_result_t queueRelease() {
+    return std::visit(
+        [queueHandle = this](auto &q) {
+          if (!q.RefCount.decrementAndTest())
+            return UR_RESULT_SUCCESS;
+          delete queueHandle;
+          return UR_RESULT_SUCCESS;
+        },
+        queue_data);
+  }
 };

--- a/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
+++ b/source/adapters/level_zero/v2/queue_immediate_in_order.hpp
@@ -83,12 +83,10 @@ public:
                                 ur_native_handle_t, ur_queue_flags_t,
                                 bool ownZeQueue);
 
-  ~ur_queue_immediate_in_order_t() {}
+  ~ur_queue_immediate_in_order_t();
 
   ur_result_t queueGetInfo(ur_queue_info_t propName, size_t propSize,
                            void *pPropValue, size_t *pPropSizeRet) override;
-  ur_result_t queueRetain() override;
-  ur_result_t queueRelease() override;
   ur_result_t queueGetNativeHandle(ur_queue_native_desc_t *pDesc,
                                    ur_native_handle_t *phNativeQueue) override;
   ur_result_t queueFinish() override;


### PR DESCRIPTION
after introducing variant to store the actual queue instance, urQueueRelease became incorrect. It called delete on 'this' and not on ur_queue_handle_t_ which is an UB.