### PR TITLE
Change MAX_MEMORY_BANDWIDTH device query to uint64

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -2121,7 +2121,7 @@ typedef enum ur_device_info_t {
   UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE = 94,
   /// [uint32_t][optional-query] return Intel GPU number of threads per EU
   UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU = 95,
-  /// [uint32_t][optional-query] return max memory bandwidth in Mb/s
+  /// [uint64_t][optional-query] return max memory bandwidth in B/s
   UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH = 96,
   /// [::ur_bool_t] device supports sRGB images
   UR_DEVICE_INFO_IMAGE_SRGB = 97,

--- a/include/ur_print.hpp
+++ b/include/ur_print.hpp
@@ -4186,9 +4186,9 @@ inline ur_result_t printTagged(std::ostream &os, const void *ptr,
     os << ")";
   } break;
   case UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH: {
-    const uint32_t *tptr = (const uint32_t *)ptr;
-    if (sizeof(uint32_t) > size) {
-      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint32_t)
+    const uint64_t *tptr = (const uint64_t *)ptr;
+    if (sizeof(uint64_t) > size) {
+      os << "invalid size (is: " << size << ", expected: >=" << sizeof(uint64_t)
          << ")";
       return UR_RESULT_ERROR_INVALID_SIZE;
     }

--- a/scripts/core/device.yml
+++ b/scripts/core/device.yml
@@ -393,7 +393,7 @@ etors:
     - name: GPU_HW_THREADS_PER_EU
       desc: "[uint32_t][optional-query] return Intel GPU number of threads per EU"
     - name: MAX_MEMORY_BANDWIDTH
-      desc: "[uint32_t][optional-query] return max memory bandwidth in Mb/s"
+      desc: "[uint64_t][optional-query] return max memory bandwidth in B/s"
     - name: IMAGE_SRGB
       desc: "[$x_bool_t] device supports sRGB images"
     - name: BUILD_ON_SUBDEVICE

--- a/source/adapters/cuda/device.cpp
+++ b/source/adapters/cuda/device.cpp
@@ -1008,8 +1008,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
           &MemoryBusWidth, CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH,
           hDevice->get()));
     }
+    // This is a collection of all constants mentioned in this computation:
+    // https://github.com/jeffhammond/HPCInfo/blob/aae05c733016cc8fbb91ee71fc8076f17fa7b912/cuda/gpu-detect.cu#L241
+    constexpr uint64_t MemoryBandwidthConstant = 250;
 
-    uint32_t MemoryBandwidth = MemoryClockKHz * MemoryBusWidth * 250;
+    uint64_t MemoryBandwidth =
+        MemoryBandwidthConstant * MemoryClockKHz * MemoryBusWidth;
 
     return ReturnValue(MemoryBandwidth);
   }

--- a/test/conformance/device/urDeviceGetInfo.cpp
+++ b/test/conformance/device/urDeviceGetInfo.cpp
@@ -99,7 +99,7 @@ static std::unordered_map<ur_device_info_t, size_t> device_info_size_map = {
     {UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE, sizeof(uint32_t)},
     {UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, sizeof(uint32_t)},
     {UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU, sizeof(uint32_t)},
-    {UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH, sizeof(uint32_t)},
+    {UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH, sizeof(uint64_t)},
     {UR_DEVICE_INFO_IMAGE_SRGB, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_BUILD_ON_SUBDEVICE, sizeof(ur_bool_t)},
     {UR_DEVICE_INFO_ATOMIC_64, sizeof(ur_bool_t)},

--- a/tools/urinfo/urinfo.hpp
+++ b/tools/urinfo/urinfo.hpp
@@ -271,7 +271,7 @@ inline void printDeviceInfos(ur_device_handle_t hDevice,
   std::cout << prefix;
   printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU);
   std::cout << prefix;
-  printDeviceInfo<uint32_t>(hDevice, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
+  printDeviceInfo<uint64_t>(hDevice, UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
   std::cout << prefix;
   printDeviceInfo<ur_bool_t>(hDevice, UR_DEVICE_INFO_IMAGE_SRGB);
   std::cout << prefix;


### PR DESCRIPTION
The max value that could be assigned to `MemoryBandwidth` variable is (250 * 3200000 * 256) which will overflow the uint32 max capacity. so we should change that to be uint64 to fit the maximum value from this computation.