### PR TITLE
[NativeCPU] Handle null phEvent.

### DIFF
--- a/source/adapters/native_cpu/enqueue.cpp
+++ b/source/adapters/native_cpu/enqueue.cpp
@@ -244,7 +244,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
 #endif // NATIVECPU_USE_OCK
   event->set_futures(futures);
 
-  *phEvent = event;
+  if (phEvent) {
+    *phEvent = event;
+  }
   event->set_callback([hKernel, event]() {
     event->tick_end();
     // TODO: avoid calling clear() here.
@@ -252,7 +254,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   });
 
   if (hQueue->isInOrder()) {
-    urEventWait(1, phEvent);
+    urEventWait(1, &event);
   }
 
   return UR_RESULT_SUCCESS;


### PR DESCRIPTION
The documentation for urEnqueueKernelLaunch marks phEvent as optional, so make sure we only set it if provided.

Matching PR: https://github.com/intel/llvm/pull/16868