### PR TITLE
[L0]: fix missing destroy of event given enqueue wait out event cherry-pick to 0.11.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
-project(unified-runtime VERSION 0.11.6)
+project(unified-runtime VERSION 0.11.7)
 
 # Check if unified runtime is built as a standalone project.
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR OR UR_STANDALONE_BUILD)

--- a/source/adapters/level_zero/event.cpp
+++ b/source/adapters/level_zero/event.cpp
@@ -881,7 +881,14 @@ ur_result_t
 urEventRelease(ur_event_handle_t Event ///< [in] handle of the event object
 ) {
   Event->RefCountExternal--;
+  bool isEventsWaitCompleted =
+      Event->CommandType == UR_COMMAND_EVENTS_WAIT && Event->Completed;
   UR_CALL(urEventReleaseInternal(Event));
+  // If this is a Completed Event Wait Out Event, then we need to cleanup the
+  // event at user release and not at the time of completion.
+  if (isEventsWaitCompleted) {
+    UR_CALL(CleanupCompletedEvent((Event), false, false));
+  }
 
   return UR_RESULT_SUCCESS;
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/oneapi-src/unified-runtime/pull/2612 to 0.11.x for release.