### PR TITLE
Enable tests for v2 command buffer

### DIFF
--- a/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/source/adapters/level_zero/v2/command_buffer.cpp
@@ -56,7 +56,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
                          ur_exp_command_buffer_handle_t *commandBuffer) try {
   checkImmediateAppendSupport(context);
 
-  if (commandBufferDesc != nullptr && commandBufferDesc->isUpdatable &&
+  if (commandBufferDesc->isUpdatable &&
       !context->getPlatform()->ZeMutableCmdListExt.Supported) {
     throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }

--- a/source/adapters/level_zero/v2/command_buffer.cpp
+++ b/source/adapters/level_zero/v2/command_buffer.cpp
@@ -56,7 +56,7 @@ urCommandBufferCreateExp(ur_context_handle_t context, ur_device_handle_t device,
                          ur_exp_command_buffer_handle_t *commandBuffer) try {
   checkImmediateAppendSupport(context);
 
-  if (commandBufferDesc->isUpdatable &&
+  if (commandBufferDesc != nullptr && commandBufferDesc->isUpdatable &&
       !context->getPlatform()->ZeMutableCmdListExt.Supported) {
     throw UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
   }

--- a/test/conformance/exp_command_buffer/commands.cpp
+++ b/test/conformance/exp_command_buffer/commands.cpp
@@ -56,12 +56,14 @@ struct urCommandBufferCommandsTest
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferCommandsTest);
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMMemcpyExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendUSMMemcpyExp(
       cmd_buf_handle, device_ptrs[0], device_ptrs[1], allocation_size, 0,
       nullptr, 0, nullptr, nullptr, nullptr, nullptr));
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMFillExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   uint32_t pattern = 42;
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptrs[0], &pattern, sizeof(pattern),
@@ -69,12 +71,14 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMFillExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferCopyExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferCopyExp(
       cmd_buf_handle, buffers[0], buffers[1], 0, 0, allocation_size, 0, nullptr,
       0, nullptr, nullptr, nullptr, nullptr));
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferCopyRectExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ur_rect_offset_t origin{0, 0, 0};
   ur_rect_region_t region{4, 4, 1};
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferCopyRectExp(
@@ -83,6 +87,7 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferCopyRectExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   std::array<uint32_t, elements> host_data{};
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferReadExp(
       cmd_buf_handle, buffers[0], 0, allocation_size, host_data.data(), 0,
@@ -90,6 +95,7 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadRectExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   std::array<uint32_t, elements> host_data{};
   ur_rect_offset_t origin{0, 0, 0};
   ur_rect_region_t region{4, 4, 1};
@@ -99,6 +105,7 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferReadRectExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferWriteExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   std::array<uint32_t, elements> host_data{};
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferWriteExp(
       cmd_buf_handle, buffers[0], 0, allocation_size, host_data.data(), 0,
@@ -107,6 +114,7 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferWriteExp) {
 
 TEST_P(urCommandBufferCommandsTest,
        urCommandBufferAppendMemBufferWriteRectExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   std::array<uint32_t, elements> host_data{};
   ur_rect_offset_t origin{0, 0, 0};
   ur_rect_region_t region{4, 4, 1};
@@ -116,6 +124,7 @@ TEST_P(urCommandBufferCommandsTest,
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferFillExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   uint32_t pattern = 42;
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffers[0], &pattern, sizeof(pattern), 0, allocation_size,
@@ -123,12 +132,14 @@ TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendMemBufferFillExp) {
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMPrefetchExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendUSMPrefetchExp(
       cmd_buf_handle, device_ptrs[0], allocation_size, 0, 0, nullptr, 0,
       nullptr, nullptr, nullptr, nullptr));
 }
 
 TEST_P(urCommandBufferCommandsTest, urCommandBufferAppendUSMAdviseExp) {
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendUSMAdviseExp(
       cmd_buf_handle, device_ptrs[0], allocation_size, 0, 0, nullptr, 0,
       nullptr, nullptr, nullptr, nullptr));

--- a/test/conformance/exp_command_buffer/fill.cpp
+++ b/test/conformance/exp_command_buffer/fill.cpp
@@ -14,6 +14,7 @@ struct testParametersFill {
 struct urCommandBufferFillCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<testParametersFill> {
   void SetUp() override {
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersFill>::SetUp());

--- a/test/conformance/exp_command_buffer/fill.cpp
+++ b/test/conformance/exp_command_buffer/fill.cpp
@@ -104,7 +104,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     printFillTestString<urCommandBufferFillCommandsTest>);
 
 TEST_P(urCommandBufferFillCommandsTest, Buffer) {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
       0, nullptr, &sync_point, nullptr, nullptr));
@@ -124,7 +124,7 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
 }
 
 TEST_P(urCommandBufferFillCommandsTest, USM) {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
+  UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptr, pattern.data(), pattern_size, size, 0,
       nullptr, 0, nullptr, &sync_point, nullptr, nullptr));

--- a/test/conformance/exp_command_buffer/fill.cpp
+++ b/test/conformance/exp_command_buffer/fill.cpp
@@ -14,7 +14,6 @@ struct testParametersFill {
 struct urCommandBufferFillCommandsTest
     : uur::command_buffer::urCommandBufferExpTestWithParam<testParametersFill> {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
     UUR_RETURN_ON_FATAL_FAILURE(
         uur::command_buffer::urCommandBufferExpTestWithParam<
             testParametersFill>::SetUp());
@@ -105,6 +104,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     printFillTestString<urCommandBufferFillCommandsTest>);
 
 TEST_P(urCommandBufferFillCommandsTest, Buffer) {
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendMemBufferFillExp(
       cmd_buf_handle, buffer, pattern.data(), pattern_size, 0, size, 0, nullptr,
       0, nullptr, &sync_point, nullptr, nullptr));
@@ -124,6 +124,7 @@ TEST_P(urCommandBufferFillCommandsTest, Buffer) {
 }
 
 TEST_P(urCommandBufferFillCommandsTest, USM) {
+    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
   ASSERT_SUCCESS(urCommandBufferAppendUSMFillExp(
       cmd_buf_handle, device_ptr, pattern.data(), pattern_size, size, 0,
       nullptr, 0, nullptr, &sync_point, nullptr, nullptr));

--- a/test/conformance/exp_command_buffer/fixtures.h
+++ b/test/conformance/exp_command_buffer/fixtures.h
@@ -55,8 +55,6 @@ static void checkCommandBufferUpdateSupport(
 
 struct urCommandBufferExpTest : uur::urContextTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
     UUR_RETURN_ON_FATAL_FAILURE(uur::urContextTest::SetUp());
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(device));
@@ -78,8 +76,6 @@ struct urCommandBufferExpTest : uur::urContextTest {
 template <class T>
 struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
     UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTestWithParam<T>::SetUp());
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(this->device));
@@ -100,8 +96,6 @@ struct urCommandBufferExpTestWithParam : urQueueTestWithParam<T> {
 
 struct urCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
     UUR_RETURN_ON_FATAL_FAILURE(uur::urKernelExecutionTest::SetUp());
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(device));
@@ -122,8 +116,6 @@ struct urCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
 
 struct urUpdatableCommandBufferExpTest : uur::urQueueTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
     UUR_RETURN_ON_FATAL_FAILURE(uur::urQueueTest::SetUp());
 
     UUR_RETURN_ON_FATAL_FAILURE(checkCommandBufferSupport(device));
@@ -158,8 +150,6 @@ struct urUpdatableCommandBufferExpTest : uur::urQueueTest {
 
 struct urUpdatableCommandBufferExpExecutionTest : uur::urKernelExecutionTest {
   void SetUp() override {
-    UUR_KNOWN_FAILURE_ON(uur::LevelZeroV2{});
-
     UUR_RETURN_ON_FATAL_FAILURE(uur::urKernelExecutionTest::SetUp());
 
     ASSERT_SUCCESS(urPlatformGetInfo(platform, UR_PLATFORM_INFO_BACKEND,

--- a/test/conformance/exp_command_buffer/release.cpp
+++ b/test/conformance/exp_command_buffer/release.cpp
@@ -13,7 +13,6 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urCommandBufferReleaseExpTest);
 
 TEST_P(urCommandBufferReleaseExpTest, Success) {
   EXPECT_SUCCESS(urCommandBufferRetainExp(cmd_buf_handle));
-
   uint32_t prev_ref_count = 0;
   EXPECT_SUCCESS(uur::GetObjectReferenceCount(cmd_buf_handle, prev_ref_count));
 


### PR DESCRIPTION
This PR enables conformance tests to work with v2 command buffer implementation. Unfortunately, some tests fail, due to the fact that respective functions are not implemented.