### PR TITLE
Improvements to align CTS and Spec for Enqueue

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -8295,8 +8295,6 @@ typedef enum ur_usm_migration_flag_t {
 ///        address space and return a pointer to the mapped region
 ///
 /// @details
-///     - Input parameter blockingMap indicates if the map is blocking or
-///       non-blocking.
 ///     - Currently, no direct support in Level Zero. Implemented as a shared
 ///       allocation followed by copying on discrete GPU
 ///     - TODO: add a driver function in Level Zero?
@@ -8569,7 +8567,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 /// @details
 ///     - Not all memory advice hints may be supported for all devices or
 ///       allocation types. If a memory advice hint is not supported, it will be
-///       ignored.
+///       ignored. Some adapters may return ::UR_RESULT_ERROR_ADAPTER_SPECIFIC,
+///       more information can be retrieved by using urAdapterGetLastError.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -863,7 +863,6 @@ class: $xEnqueue
 name: MemBufferMap
 ordinal: "0"
 details:
-    - "Input parameter blockingMap indicates if the map is blocking or non-blocking."
     - "Currently, no direct support in Level Zero. Implemented as a shared allocation followed by copying on discrete GPU"
     - "TODO: add a driver function in Level Zero?"
 analogue:
@@ -1180,7 +1179,7 @@ class: $xEnqueue
 name: USMAdvise
 ordinal: "0"
 details:
-    - "Not all memory advice hints may be supported for all devices or allocation types. If a memory advice hint is not supported, it will be ignored."
+    - "Not all memory advice hints may be supported for all devices or allocation types. If a memory advice hint is not supported, it will be ignored. Some adapters may return $X_RESULT_ERROR_ADAPTER_SPECIFIC, more information can be retrieved by using urAdapterGetLastError."
 params:
     - type: $x_queue_handle_t
       name: hQueue

--- a/source/loader/ur_libapi.cpp
+++ b/source/loader/ur_libapi.cpp
@@ -5951,8 +5951,6 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///        address space and return a pointer to the mapped region
 ///
 /// @details
-///     - Input parameter blockingMap indicates if the map is blocking or
-///       non-blocking.
 ///     - Currently, no direct support in Level Zero. Implemented as a shared
 ///       allocation followed by copying on discrete GPU
 ///     - TODO: add a driver function in Level Zero?
@@ -6272,7 +6270,8 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 /// @details
 ///     - Not all memory advice hints may be supported for all devices or
 ///       allocation types. If a memory advice hint is not supported, it will be
-///       ignored.
+///       ignored. Some adapters may return ::UR_RESULT_ERROR_ADAPTER_SPECIFIC,
+///       more information can be retrieved by using urAdapterGetLastError.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/source/ur_api.cpp
+++ b/source/ur_api.cpp
@@ -5218,8 +5218,6 @@ ur_result_t UR_APICALL urEnqueueMemImageCopy(
 ///        address space and return a pointer to the mapped region
 ///
 /// @details
-///     - Input parameter blockingMap indicates if the map is blocking or
-///       non-blocking.
 ///     - Currently, no direct support in Level Zero. Implemented as a shared
 ///       allocation followed by copying on discrete GPU
 ///     - TODO: add a driver function in Level Zero?
@@ -5507,7 +5505,8 @@ ur_result_t UR_APICALL urEnqueueUSMPrefetch(
 /// @details
 ///     - Not all memory advice hints may be supported for all devices or
 ///       allocation types. If a memory advice hint is not supported, it will be
-///       ignored.
+///       ignored. Some adapters may return ::UR_RESULT_ERROR_ADAPTER_SPECIFIC,
+///       more information can be retrieved by using urAdapterGetLastError.
 ///
 /// @returns
 ///     - ::UR_RESULT_SUCCESS

--- a/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
+++ b/test/conformance/enqueue/urEnqueueKernelLaunch.cpp
@@ -85,6 +85,18 @@ TEST_P(urEnqueueKernelLaunchTest, InvalidNullHandleQueue) {
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
+TEST_P(urEnqueueKernelLaunchTest, InvalidNullPointer) {
+  ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, kernel, n_dimensions, nullptr,
+                                         &global_size, nullptr, 0, nullptr,
+                                         nullptr),
+                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, kernel, n_dimensions,
+                                         &global_offset, nullptr, nullptr, 0,
+                                         nullptr, nullptr),
+                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}
+
 TEST_P(urEnqueueKernelLaunchTest, InvalidNullHandleKernel) {
   ASSERT_EQ_RESULT(urEnqueueKernelLaunch(queue, nullptr, n_dimensions,
                                          &global_offset, &global_size, nullptr,

--- a/test/conformance/enqueue/urEnqueueUSMFill.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMFill.cpp
@@ -155,10 +155,13 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullQueueHandle) {
                    UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 }
 
-TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullPtr) {
-
+TEST_P(urEnqueueUSMFillNegativeTest, InvalidNullPointer) {
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, nullptr, pattern_size,
                                     pattern.data(), size, 0, nullptr, nullptr),
+                   UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, nullptr, size, 0,
+                                    nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_NULL_POINTER);
 }
 
@@ -172,6 +175,11 @@ TEST_P(urEnqueueUSMFillNegativeTest, InvalidSize) {
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(), 7,
                                     0, nullptr, nullptr),
                    UR_RESULT_ERROR_INVALID_SIZE);
+
+  /* size does not exceed allocation size of ptr */
+  ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, pattern_size, pattern.data(),
+                                    size + 1, 0, nullptr, nullptr),
+                   UR_RESULT_ERROR_INVALID_SIZE);
 }
 
 TEST_P(urEnqueueUSMFillNegativeTest, OutOfBounds) {
@@ -181,7 +189,7 @@ TEST_P(urEnqueueUSMFillNegativeTest, OutOfBounds) {
                    UR_RESULT_ERROR_INVALID_SIZE);
 }
 
-TEST_P(urEnqueueUSMFillNegativeTest, invalidPatternSize) {
+TEST_P(urEnqueueUSMFillNegativeTest, InvalidPatternSize) {
   /* pattern_size is 0 */
   ASSERT_EQ_RESULT(urEnqueueUSMFill(queue, ptr, 0, pattern.data(), size, 0,
                                     nullptr, nullptr),

--- a/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
+++ b/test/conformance/enqueue/urEnqueueUSMMemcpy2D.cpp
@@ -21,9 +21,9 @@ struct urEnqueueUSMMemcpy2DTestWithParam
         uur::urQueueTestWithParam<TestParametersMemcpy2D>::SetUp());
 
     const auto [in2DParams, inSrcKind, inDstKind] = getParam();
-    std::tie(pitch, width, height, src_kind, dst_kind) =
-        std::make_tuple(in2DParams.pitch, in2DParams.width, in2DParams.height,
-                        inSrcKind, inDstKind);
+    std::tie(src_pitch, dst_pitch, width, height, src_kind, dst_kind) =
+        std::make_tuple(in2DParams.pitch, in2DParams.pitch, in2DParams.width,
+                        in2DParams.height, inSrcKind, inDstKind);
 
     ur_device_usm_access_capability_flags_t device_usm = 0;
     ASSERT_SUCCESS(uur::GetDeviceUSMDeviceSupport(device, device_usm));
@@ -42,7 +42,7 @@ struct urEnqueueUSMMemcpy2DTestWithParam
       GTEST_SKIP() << "2D USM memcpy is not supported";
     }
 
-    const size_t num_elements = pitch * height;
+    const size_t num_elements = src_pitch * height;
     ASSERT_SUCCESS(uur::MakeUSMAllocationByType(
         src_kind, context, device, nullptr, nullptr, num_elements, &pSrc));
 
@@ -52,8 +52,8 @@ struct urEnqueueUSMMemcpy2DTestWithParam
     ur_event_handle_t memset_event = nullptr;
 
     ASSERT_SUCCESS(urEnqueueUSMFill(queue, pSrc, sizeof(memset_value),
-                                    &memset_value, pitch * height, 0, nullptr,
-                                    &memset_event));
+                                    &memset_value, src_pitch * height, 0,
+                                    nullptr, &memset_event));
 
     ASSERT_SUCCESS(urQueueFlush(queue));
     ASSERT_SUCCESS(urEventWait(1, &memset_event));
@@ -71,19 +71,19 @@ struct urEnqueueUSMMemcpy2DTestWithParam
   }
 
   void verifyMemcpySucceeded() {
-    std::vector<uint8_t> host_mem(pitch * height);
+    std::vector<uint8_t> host_mem(src_pitch * height);
     const uint8_t *host_ptr = nullptr;
     if (dst_kind == ur_usm_type_t::UR_USM_TYPE_DEVICE) {
-      ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, true, host_mem.data(), pitch,
-                                          pDst, pitch, width, height, 0,
-                                          nullptr, nullptr));
+      ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, true, host_mem.data(),
+                                          src_pitch, pDst, dst_pitch, width,
+                                          height, 0, nullptr, nullptr));
       host_ptr = host_mem.data();
     } else {
       host_ptr = static_cast<const uint8_t *>(pDst);
     }
     for (size_t w = 0; w < width; ++w) {
       for (size_t h = 0; h < height; ++h) {
-        const size_t index = (pitch * h) + w;
+        const size_t index = (src_pitch * h) + w;
         ASSERT_TRUE(*(host_ptr + index) == memset_value);
       }
     }
@@ -92,7 +92,8 @@ struct urEnqueueUSMMemcpy2DTestWithParam
   void *pSrc = nullptr;
   void *pDst = nullptr;
   static constexpr uint8_t memset_value = 42;
-  size_t pitch = 0;
+  size_t src_pitch = 0;
+  size_t dst_pitch = 0;
   size_t width = 0;
   size_t height = 0;
   ur_usm_type_t src_kind;
@@ -125,15 +126,16 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     uur::print2DTestString<urEnqueueUSMMemcpy2DTestWithParam>);
 
 TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessBlocking) {
-  ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                      width, height, 0, nullptr, nullptr));
+  ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                      src_pitch, width, height, 0, nullptr,
+                                      nullptr));
   ASSERT_NO_FATAL_FAILURE(verifyMemcpySucceeded());
 }
 
 TEST_P(urEnqueueUSMMemcpy2DTestWithParam, SuccessNonBlocking) {
   ur_event_handle_t memcpy_event = nullptr;
-  ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, false, pDst, pitch, pSrc, pitch,
-                                      width, height, 0, nullptr,
+  ASSERT_SUCCESS(urEnqueueUSMMemcpy2D(queue, false, pDst, dst_pitch, pSrc,
+                                      src_pitch, width, height, 0, nullptr,
                                       &memcpy_event));
   ASSERT_SUCCESS(urQueueFlush(queue));
   ASSERT_SUCCESS(urEventWait(1, &memcpy_event));
@@ -157,54 +159,62 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
 
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidNullHandleQueue) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_HANDLE,
-                   urEnqueueUSMMemcpy2D(nullptr, true, pDst, pitch, pSrc, pitch,
-                                        width, height, 0, nullptr, nullptr));
+                   urEnqueueUSMMemcpy2D(nullptr, true, pDst, dst_pitch, pSrc,
+                                        src_pitch, width, height, 0, nullptr,
+                                        nullptr));
 }
 
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidNullPointer) {
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                   urEnqueueUSMMemcpy2D(queue, true, nullptr, pitch, pSrc,
-                                        pitch, width, height, 0, nullptr,
+                   urEnqueueUSMMemcpy2D(queue, true, nullptr, dst_pitch, pSrc,
+                                        src_pitch, width, height, 0, nullptr,
                                         nullptr));
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_NULL_POINTER,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, nullptr,
-                                        pitch, width, height, 0, nullptr,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, nullptr,
+                                        src_pitch, width, height, 0, nullptr,
                                         nullptr));
 }
 
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidSize) {
   // dstPitch == 0
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, 0, pSrc, pitch,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, 0, pSrc, src_pitch,
                                         width, height, 0, nullptr, nullptr));
 
   // srcPitch == 0
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, 0,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc, 0,
                                         width, height, 0, nullptr, nullptr));
 
   // height == 0
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                        width, 0, 0, nullptr, nullptr));
-
-  // dstPitch < width or srcPitch < width
-  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                        width + 1, height, 0, nullptr,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch, width, 0, 0, nullptr,
                                         nullptr));
+
+  // dstPitch < width
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch + 1, width + 1, height, 0,
+                                        nullptr, nullptr));
+
+  // srcPitch < width
+  ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch + 1, pSrc,
+                                        src_pitch, width + 1, height, 0,
+                                        nullptr, nullptr));
 
   // `dstPitch * height` is higher than the allocation size of `pDst`
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch + 1, pSrc,
-                                        pitch, width, height, 0, nullptr,
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch + 1, pSrc,
+                                        src_pitch, width, height, 0, nullptr,
                                         nullptr));
 
   // `srcPitch * height` is higher than the allocation size of `pSrc`
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_SIZE,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc,
-                                        pitch + 1, width, height, 0, nullptr,
-                                        nullptr));
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch + 1, width, height, 0,
+                                        nullptr, nullptr));
 }
 
 TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidEventWaitList) {
@@ -212,21 +222,24 @@ TEST_P(urEnqueueUSMMemcpy2DNegativeTest, InvalidEventWaitList) {
   ur_event_handle_t event = nullptr;
   uint8_t fill_pattern = 14;
   ASSERT_SUCCESS(urEnqueueUSMFill(queue, pDst, sizeof(fill_pattern),
-                                  &fill_pattern, pitch * height, 0, nullptr,
+                                  &fill_pattern, src_pitch * height, 0, nullptr,
                                   &event));
   ASSERT_NE(event, nullptr);
   ASSERT_SUCCESS(urQueueFinish(queue));
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                        width, height, 1, nullptr, nullptr));
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch, width, height, 1, nullptr,
+                                        nullptr));
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST,
-                   urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                        width, height, 0, &event, nullptr));
+                   urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch, width, height, 0, &event,
+                                        nullptr));
 
   ur_event_handle_t inv_evt = nullptr;
-  ASSERT_EQ_RESULT(urEnqueueUSMMemcpy2D(queue, true, pDst, pitch, pSrc, pitch,
-                                        width, height, 1, &inv_evt, nullptr),
+  ASSERT_EQ_RESULT(urEnqueueUSMMemcpy2D(queue, true, pDst, dst_pitch, pSrc,
+                                        src_pitch, width, height, 1, &inv_evt,
+                                        nullptr),
                    UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST);
 
   ASSERT_SUCCESS(urEventRelease(event));

--- a/test/conformance/usm/helpers.h
+++ b/test/conformance/usm/helpers.h
@@ -12,7 +12,7 @@
 namespace uur {
 
 using USMAllocTestParams =
-    std::tuple<uur::BoolTestParam, uint32_t, size_t, ur_usm_advice_flags_t>;
+    std::tuple<uur::BoolTestParam, uint32_t, size_t, ur_usm_advice_flag_t>;
 
 struct urUSMAllocTest : uur::urQueueTestWithParam<uur::USMAllocTestParams> {
   void SetUp() override {
@@ -42,7 +42,7 @@ struct urUSMAllocTest : uur::urQueueTestWithParam<uur::USMAllocTestParams> {
   ur_device_usm_access_capability_flags_t USMSupport = 0;
   const uint32_t alignment = std::get<1>(getParam());
   size_t allocation_size = std::get<2>(getParam());
-  const ur_usm_advice_flags_t advice_flags = std::get<3>(getParam());
+  const ur_usm_advice_flag_t advice_flags = std::get<3>(getParam());
   void *ptr = nullptr;
 };
 
@@ -68,7 +68,7 @@ inline std::string printUSMAllocTestString(
   return platform_device_name + "__" + ss.str();
 }
 
-static std::vector<ur_usm_advice_flags_t> usm_alloc_test_parameters{
+static std::vector<ur_usm_advice_flag_t> usm_advice_test_parameters{
     UR_USM_ADVICE_FLAG_DEFAULT,
     UR_USM_ADVICE_FLAG_SET_READ_MOSTLY,
     UR_USM_ADVICE_FLAG_CLEAR_READ_MOSTLY,

--- a/test/conformance/usm/urUSMDeviceAlloc.cpp
+++ b/test/conformance/usm/urUSMDeviceAlloc.cpp
@@ -27,7 +27,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(0), testing::Values(0),
-        ::testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        ::testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMDeviceAllocTest>);
 
 TEST_P(urUSMDeviceAllocTest, Success) {
@@ -138,7 +138,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(4, 8, 16, 32, 64), testing::Values(8, 512, 2048),
-        testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMDeviceAllocAlignmentTest>);
 
 TEST_P(urUSMDeviceAllocAlignmentTest, SuccessAlignedAllocations) {

--- a/test/conformance/usm/urUSMHostAlloc.cpp
+++ b/test/conformance/usm/urUSMHostAlloc.cpp
@@ -28,7 +28,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(0), testing::Values(0),
-        ::testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        ::testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMHostAllocTest>);
 
 TEST_P(urUSMHostAllocTest, Success) {
@@ -144,7 +144,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(4, 8, 16, 32, 64), testing::Values(8, 512, 2048),
-        ::testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        ::testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMHostAllocAlignmentTest>);
 
 TEST_P(urUSMHostAllocAlignmentTest, SuccessAlignedAllocations) {

--- a/test/conformance/usm/urUSMSharedAlloc.cpp
+++ b/test/conformance/usm/urUSMSharedAlloc.cpp
@@ -34,7 +34,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(0), testing::Values(0),
-        testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMSharedAllocTest>);
 
 TEST_P(urUSMSharedAllocTest, Success) {
@@ -171,7 +171,7 @@ UUR_DEVICE_TEST_SUITE_WITH_PARAM(
     testing::Combine(
         testing::ValuesIn(uur::BoolTestParam::makeBoolParam("UsePool")),
         testing::Values(4, 8, 16, 32, 64), testing::Values(8, 512, 2048),
-        testing::ValuesIn(uur::usm_alloc_test_parameters)),
+        testing::ValuesIn(uur::usm_advice_test_parameters)),
     uur::printUSMAllocTestString<urUSMSharedAllocAlignmentTest>);
 
 TEST_P(urUSMSharedAllocAlignmentTest, SuccessAlignedAllocations) {


### PR DESCRIPTION
- Add test for invalid null pointer for urEnqueueKernelLaunch and urEnqueueUSMFill
- Remove redundant sentence in urEnqueueMemBufferMap description
- Add advice flag parameters in test for urEnqueueUSMAdvise
- Added blocking/non-blocking success tests for urEnqueueDeviceGlobalVariableRead/Write
- Added all invalid size scenarios for urEnqueueMemBufferFill and urEnqueueMemBufferWrite/Read/CopyRect
- Added to description of urEnqueueMemAdvice to say some adapters will return UR_RESULT_ERROR_ADAPTER_SPECIFIC and allowing this return value in relevant tests

I've not attached an intel/llvm tag update as the spec change is very minor - just removing a sentence from an entry-point description.