### PR TITLE
[DeviceASAN][bugfix] Not allow concurrent kernel launches across different queue

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_ddi.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_ddi.cpp
@@ -474,6 +474,13 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// [out][optional] return an event object that identifies this
     /// particular kernel execution instance.
     ur_event_handle_t *phEvent) {
+
+  // This mutex is to prevent concurrent kernel launches on the same queue or
+  // across different queues as the DeviceASAN local/private shadow memory
+  // does not support concurrent kernel launches now.
+  static ur_shared_mutex KernelLaunchMutex;
+  std::scoped_lock<ur_shared_mutex> Guard(KernelLaunchMutex);
+
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 
   if (nullptr == pfnKernelLaunch) {

--- a/source/loader/layers/sanitizer/asan/asan_ddi.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_ddi.cpp
@@ -475,9 +475,9 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
     /// particular kernel execution instance.
     ur_event_handle_t *phEvent) {
 
-  // This mutex is to prevent concurrent kernel launches on the same queue or
-  // across different queues as the DeviceASAN local/private shadow memory
-  // does not support concurrent kernel launches now.
+  // This mutex is to prevent concurrent kernel launches across different queues
+  // as the DeviceASAN local/private shadow memory does not support concurrent
+  // kernel launches now.
   static ur_shared_mutex KernelLaunchMutex;
   std::scoped_lock<ur_shared_mutex> Guard(KernelLaunchMutex);
 

--- a/source/loader/layers/sanitizer/asan/asan_ddi.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_ddi.cpp
@@ -478,8 +478,8 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueKernelLaunch(
   // This mutex is to prevent concurrent kernel launches across different queues
   // as the DeviceASAN local/private shadow memory does not support concurrent
   // kernel launches now.
-  static ur_shared_mutex KernelLaunchMutex;
-  std::scoped_lock<ur_shared_mutex> Guard(KernelLaunchMutex);
+  std::scoped_lock<ur_shared_mutex> Guard(
+      getAsanInterceptor()->KernelLaunchMutex);
 
   auto pfnKernelLaunch = getContext()->urDdiTable.Enqueue.pfnKernelLaunch;
 

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.hpp
@@ -354,6 +354,8 @@ public:
   std::shared_ptr<ShadowMemory>
   getOrCreateShadowMemory(ur_device_handle_t Device, DeviceType Type);
 
+  ur_shared_mutex KernelLaunchMutex;
+
 private:
   ur_result_t updateShadowMemory(std::shared_ptr<ContextInfo> &ContextInfo,
                                  std::shared_ptr<DeviceInfo> &DeviceInfo,


### PR DESCRIPTION
Not allow concurrent kernel launches across different queues as the local/private shadow memory implementation does not support it.

intel/llvm PR: https://github.com/intel/llvm/pull/16935