### PR TITLE
Add two new workflows to warn PR authors about the intel/llvm migration

### DIFF
--- a/.github/workflows/pr-migration-auto-close.yml
+++ b/.github/workflows/pr-migration-auto-close.yml
@@ -1,0 +1,82 @@
+name: Auto-Close PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: read
+
+jobs:
+  close-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PRs labeled "auto-close"
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const label = "auto-close";
+            const now = new Date();
+            const millisecondsInADay = 24 * 60 * 60 * 1000;
+            const autoCloseDays = 30; // how many days before PRs should be closed automatically
+
+            // Fetch all open PRs
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: "open",
+              per_page: 100
+            });
+
+            for (const pr of prs) {
+              // Check if PR has the "auto-close" label
+              if (!pr.labels.some(l => l.name === label)) continue;
+
+              // Get the PR's label event timeline
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner,
+                repo,
+                issue_number: pr.number
+              });
+
+              // Find the label added event
+              const labelEvent = events.find(e => e.event === "labeled" && e.label.name === label);
+
+              const timeSinceLabeled = Math.floor((now - new Date(labelEvent.created_at)) / millisecondsInADay);
+
+              // If label added event found and is older than autoCloseDays days, close the PR
+              if (labelEvent && timeSinceLabeled >= autoCloseDays) {
+                console.log(`Closing PR #${pr.number}`);
+                
+                // Close the PR
+                await github.rest.pulls.update({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  state: "closed"
+                });
+
+                const commentBody = 
+                  "# Automatic PR Closure Notice\n" +
+                  "## Information\n" +
+                  "This PR has been closed automatically. It was marked with the `auto-close` [label](https://github.com/oneapi-src/unified-runtime/labels/auto-close) 30 days ago as part of the Unified Runtime source code migration to the intel/llvm repository - https://github.com/intel/llvm/pull/17043.\n\n" +
+                  "All Unified Runtime development should be done in [intel/llvm](https://github.com/intel/llvm/tree/sycl/unified-runtime), details can be found in the updated [contribution guide](https://oneapi-src.github.io/unified-runtime/core/CONTRIB.html).\n" +
+                  "This repository will continue to exist as a mirror and will host the [specification documentation](https://oneapi-src.github.io/unified-runtime/).\n\n" +
+                  "## Next Steps\n" +
+                  "Should you wish to re-open this PR it **must be moved** to [intel/llvm](https://github.com/intel/llvm/tree/sycl/unified-runtime). We have provided a [script to help automate this process](https://github.com/oneapi-src/unified-runtime/blob/main/scripts/move-pr-to-intel-llvm.py), otherwise no actions are required.\n\n" +
+                  "---\n" +
+                  "*This is an automated comment.*";
+
+                // Comment on the PR
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: commentBody
+                });
+              }
+            }

--- a/.github/workflows/pr-migration-warn.yml
+++ b/.github/workflows/pr-migration-warn.yml
@@ -1,0 +1,67 @@
+name: Warn about intel/llvm migration
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: read
+
+jobs:
+  label-and-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label and comment on PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const label = "auto-close";
+            
+            // Get current labels on the PR
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number: pr_number
+            });
+
+            // Check if label is already present
+            if (!labels.some(labelObj => labelObj.name === label)) {
+              // Add the label if not present
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr_number,
+                labels: [label]
+              });
+
+              const commentBody = 
+                  "# Unified Runtime -> intel/llvm Repo Move Notice\n" +
+                  "## Information\n" +
+                  "The source code of Unified Runtime has been moved to [intel/llvm](https://github.com/intel/llvm) under the [unified-runtime](https://github.com/intel/llvm/tree/sycl/unified-runtime) top-level directory,\n" +
+                  "all future development will now be carried out there. This was done in https://github.com/intel/llvm/pull/17043.\n\n" +
+                  "The code will be mirrored to [oneapi-src/unified-runtime](https://github.com/oneapi-src/unified-runtime) and the specification will continue to be hosted at [oneapi-src.github.io/unified-runtime](https://oneapi-src.github.io/unified-runtime/).\n\n" +
+                  "The [contribution guide](https://oneapi-src.github.io/unified-runtime/core/CONTRIB.html) will be updated with new instructions for contributing to Unified Runtime.\n\n" +
+                  "## PR Migration\n" +
+                  "All open PRs including this one will be marked with the `auto-close` [label](https://github.com/oneapi-src/unified-runtime/labels/auto-close) and shall be **automatically closed after 30 days**.\n\n" +
+                  "Should you wish to continue with your PR **you will need to migrate it** to [intel/llvm](https://github.com/intel/llvm/tree/sycl/unified-runtime).\n" +
+                  "We have provided a [script to help automate this process](https://github.com/oneapi-src/unified-runtime/blob/main/scripts/move-pr-to-intel-llvm.py).\n\n" +
+                  "If your PR should remain open and not be closed automatically, you can remove the `auto-close` label.\n\n" +
+                  "---\n" +
+                  "*This is an automated comment.*";
+
+              // Add a comment about the migration process and warn the PR will be automatically closed
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr_number,
+                body: commentBody
+              });
+
+              console.log(`Added label '${label}' and commented on PR #${pr_number}`);
+            } else {
+              console.log(`PR #${pr_number} already has the '${label}' label. Skipping.`);
+            }


### PR DESCRIPTION
Add two new workflows to warn PR authors about the intel/llvm migration, label PRs and automatically close them after 30 days.

- `pr-migration-warn.yml`
  - comments on new PRs (also reopened, edited, marked ready for review or synchronized) explaining the move to intel/llvm
  - label the PR with the new `auto-close` label
  - will only run when `auto-close` is not present

- `pr-migration-auto-close.yml`
  - runs once daily and checks for any `auto-close` labelled PRs older than 30 days, and closes them with an additional comment about the intel/llvm migration

Should there be a reason to keep a PR open, simply manually remove the `auto-close` label. The first workflow does not run when PR labels are modified, so it would not run and re-label the PR again.