### PR TITLE
Improvements to align CTS and Spec for Event.

### DIFF
--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -63,10 +63,6 @@ TEST_P(urEventCreateWithNativeHandleTest, InvalidNullHandle) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urEventGetNativeHandle(event, &native_event));
 
-  // We cannot assume anything about a native_handle, not even if it's
-  // `nullptr` since this could be a valid representation within a backend.
-  // We can however convert the native_handle back into a unified-runtime handle
-  // and perform some query on it to verify that it works.
   uur::raii::Event evt = nullptr;
   ASSERT_EQ_RESULT(
       urEventCreateWithNativeHandle(native_event, nullptr, nullptr, evt.ptr()),
@@ -79,10 +75,6 @@ TEST_P(urEventCreateWithNativeHandleTest, InvalidNullPointer) {
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urEventGetNativeHandle(event, &native_event));
 
-  // We cannot assume anything about a native_handle, not even if it's
-  // `nullptr` since this could be a valid representation within a backend.
-  // We can however convert the native_handle back into a unified-runtime handle
-  // and perform some query on it to verify that it works.
   uur::raii::Event evt = nullptr;
   ASSERT_EQ_RESULT(
       urEventCreateWithNativeHandle(native_event, context, nullptr, nullptr),

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -56,3 +56,35 @@ TEST_P(urEventCreateWithNativeHandleTest, SuccessWithProperties) {
                                 sizeof(ur_execution_info_t), &exec_info,
                                 nullptr));
 }
+
+TEST_P(urEventCreateWithNativeHandleTest, InvalidNullHandle) {
+  ur_native_handle_t native_event = 0;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urEventGetNativeHandle(event, &native_event));
+
+  // We cannot assume anything about a native_handle, not even if it's
+  // `nullptr` since this could be a valid representation within a backend.
+  // We can however convert the native_handle back into a unified-runtime handle
+  // and perform some query on it to verify that it works.
+  uur::raii::Event evt = nullptr;
+  ASSERT_EQ_RESULT(
+      urEventCreateWithNativeHandle(native_event, nullptr, nullptr, evt.ptr()),
+      UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+}
+
+TEST_P(urEventCreateWithNativeHandleTest, InvalidNullPointer) {
+  ur_native_handle_t native_event = 0;
+
+  UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
+      urEventGetNativeHandle(event, &native_event));
+
+  // We cannot assume anything about a native_handle, not even if it's
+  // `nullptr` since this could be a valid representation within a backend.
+  // We can however convert the native_handle back into a unified-runtime handle
+  // and perform some query on it to verify that it works.
+  uur::raii::Event evt = nullptr;
+  ASSERT_EQ_RESULT(
+      urEventCreateWithNativeHandle(native_event, context, nullptr, nullptr),
+      UR_RESULT_ERROR_INVALID_NULL_POINTER);
+}

--- a/test/conformance/event/urEventSetCallback.cpp
+++ b/test/conformance/event/urEventSetCallback.cpp
@@ -189,4 +189,11 @@ TEST_P(urEventSetCallbackNegativeTest, InvalidEnumeration) {
       UR_RESULT_ERROR_INVALID_ENUMERATION);
 }
 
+TEST_P(urEventSetCallbackNegativeTest, UnsupportedEnumeration) {
+  ASSERT_EQ_RESULT(
+      urEventSetCallback(event, ur_execution_info_t::UR_EXECUTION_INFO_QUEUED,
+                         emptyCallback, nullptr),
+      UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION);
+}
+
 UUR_INSTANTIATE_DEVICE_TEST_SUITE(urEventSetCallbackNegativeTest);


### PR DESCRIPTION
* Added test case for urEventGetProfilingInfo return UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE
* Added test case for urEventCreateWithNativeHandle return UR_RESULT_ERROR_INVALID_NULL_HANDLE
* Added test case for urEventCreateWithNativeHandle return UR_RESULT_ERROR_INVALID_NULL_POINTER
* Added test case for urEventSetCallback return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION