### PR TITLE
Mark OpenCL CPU known failing device more generally

### DIFF
--- a/test/conformance/kernel/urKernelGetGroupInfo.cpp
+++ b/test/conformance/kernel/urKernelGetGroupInfo.cpp
@@ -48,7 +48,7 @@ struct urKernelGetGroupInfoMaxWorkGroupSizeTest : uur::urKernelTest {
   void SetUp() override {
     UUR_KNOWN_FAILURE_ON(uur::CUDA{}, uur::HIP{});
     // see https://github.com/oneapi-src/unified-runtime/issues/2644
-    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"12th Gen", "13th Gen", "Intel(R) Xeon"});
+    UUR_KNOWN_FAILURE_ON(uur::OpenCL{"Intel(R) Core(TM)", "Intel(R) Xeon"});
     program_name = "max_wg_size";
     UUR_RETURN_ON_FATAL_FAILURE(urKernelTest::SetUp());
   }


### PR DESCRIPTION
Use "Intel(R) Core(TM)" to match all client CPUs instead of specific generations.
