### PR TITLE
Don't dynamically allocate OpenCL adapter

### DIFF
--- a/source/adapters/opencl/adapter.cpp
+++ b/source/adapters/opencl/adapter.cpp
@@ -44,43 +44,19 @@ ur_adapter_handle_t_::ur_adapter_handle_t_() {
 #endif // _MSC_VER
 }
 
-static ur_adapter_handle_t adapter = nullptr;
-
-ur_adapter_handle_t ur::cl::getAdapter() {
-  if (!adapter) {
-    die("OpenCL adapter used before initalization or after destruction");
-  }
-  return adapter;
-}
-
-static void globalAdapterShutdown() {
-  if (cl_ext::ExtFuncPtrCache) {
-    delete cl_ext::ExtFuncPtrCache;
-    cl_ext::ExtFuncPtrCache = nullptr;
-  }
-  if (adapter) {
-    delete adapter;
-    adapter = nullptr;
-  }
-}
+static ur_adapter_handle_t_ adapter{};
+ur_adapter_handle_t ur::cl::getAdapter() { return &adapter; }
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
              uint32_t *pNumAdapters) {
   if (NumEntries > 0 && phAdapters) {
-    // Sometimes urAdaterGet may be called after the library already been torn
-    // down, we also need to create a temporary handle for it.
-    if (!adapter) {
-      adapter = new ur_adapter_handle_t_();
-      atexit(globalAdapterShutdown);
-    }
-
-    std::lock_guard<std::mutex> Lock{adapter->Mutex};
-    if (adapter->RefCount++ == 0) {
+    std::lock_guard<std::mutex> Lock{adapter.Mutex};
+    if (adapter.RefCount++ == 0) {
       cl_ext::ExtFuncPtrCache = new cl_ext::ExtFuncPtrCacheT();
     }
 
-    *phAdapters = adapter;
+    *phAdapters = &adapter;
   }
 
   if (pNumAdapters) {
@@ -91,19 +67,16 @@ urAdapterGet(uint32_t NumEntries, ur_adapter_handle_t *phAdapters,
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
-  ++adapter->RefCount;
+  ++adapter.RefCount;
   return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
-  // Check first if the adapter is valid pointer
-  if (adapter) {
-    std::lock_guard<std::mutex> Lock{adapter->Mutex};
-    if (--adapter->RefCount == 0) {
-      if (cl_ext::ExtFuncPtrCache) {
-        delete cl_ext::ExtFuncPtrCache;
-        cl_ext::ExtFuncPtrCache = nullptr;
-      }
+  std::lock_guard<std::mutex> Lock{adapter.Mutex};
+  if (--adapter.RefCount == 0) {
+    if (cl_ext::ExtFuncPtrCache) {
+      delete cl_ext::ExtFuncPtrCache;
+      cl_ext::ExtFuncPtrCache = nullptr;
     }
   }
   return UR_RESULT_SUCCESS;
@@ -128,7 +101,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,
   case UR_ADAPTER_INFO_BACKEND:
     return ReturnValue(UR_ADAPTER_BACKEND_OPENCL);
   case UR_ADAPTER_INFO_REFERENCE_COUNT:
-    return ReturnValue(adapter->RefCount.load());
+    return ReturnValue(adapter.RefCount.load());
   case UR_ADAPTER_INFO_VERSION:
     return ReturnValue(uint32_t{1});
   default:


### PR DESCRIPTION
There is always only one, so there's no point in allocating it via
`new`. This fixes an issue where calling `urReleaseAdapter` (or any
other UR function) in an `atexit` handler could be called after the
adapter is deleted.
