### PR TITLE
[L0] Align L0 adapters DEPENDENTLOADFLAG with other adapters

### DIFF
--- a/source/adapters/level_zero/CMakeLists.txt
+++ b/source/adapters/level_zero/CMakeLists.txt
@@ -98,11 +98,6 @@ if(UR_BUILD_ADAPTER_L0)
         SOVERSION "${PROJECT_VERSION_MAJOR}"
     )
 
-    if (WIN32)
-    # 0x800: Search for the DLL only in the System32 folder
-    target_link_options(ur_adapter_level_zero PRIVATE LINKER:/DEPENDENTLOADFLAG:0x800)
-    endif()
-
     target_link_libraries(ur_adapter_level_zero PRIVATE
         ${PROJECT_NAME}::headers
         ${PROJECT_NAME}::common
@@ -199,11 +194,6 @@ if(UR_BUILD_ADAPTER_L0_V2)
         VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}"
         SOVERSION "${PROJECT_VERSION_MAJOR}"
     )
-
-    if (WIN32)
-    # 0x800: Search for the DLL only in the System32 folder
-    target_link_options(ur_adapter_level_zero_v2 PUBLIC LINKER:/DEPENDENTLOADFLAG:0x800)
-    endif()
 
     target_link_libraries(ur_adapter_level_zero_v2 PRIVATE
         ${PROJECT_NAME}::headers


### PR DESCRIPTION
Currently add_ur_library function which is called by each adapter automatically adds /DEPENDENTLOADFLAG:0x2000 linker flag. L0 adapter adds its own /DEPENDENTLOADFLAG:0x800 flag on top of that which is excessive. More over it looks like now L0 adapters depend on umf library as well (in addition to l0 loader) which is not necessarily in system directory, so /DEPENDENTLOADFLAG:0x2000 seems more suitable.