### PR TITLE
[NFC] Small refactor for MsanInterceptor::allocateMemory

### DIFF
--- a/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/msan/msan_interceptor.cpp
@@ -51,8 +51,6 @@ ur_result_t MsanInterceptor::allocateMemory(ur_context_handle_t Context,
                                             void **ResultPtr) {
 
   auto ContextInfo = getContextInfo(Context);
-  std::shared_ptr<DeviceInfo> DeviceInfo =
-      Device ? getDeviceInfo(Device) : nullptr;
 
   void *Allocated = nullptr;
 
@@ -75,7 +73,9 @@ ur_result_t MsanInterceptor::allocateMemory(ur_context_handle_t Context,
   if (Type != AllocType::DEVICE_USM) {
     return UR_RESULT_SUCCESS;
   }
+
   assert(Device);
+  std::shared_ptr<DeviceInfo> DeviceInfo = getDeviceInfo(Device);
 
   auto AI = std::make_shared<MsanAllocInfo>(MsanAllocInfo{(uptr)Allocated,
                                                           Size,


### PR DESCRIPTION
This is a false positive flagged by coverity. However, since DeviceInfo
is never used if there is no device, may as well just de-footgun it.
