### PR TITLE
Revert "[DeviceASAN] Fix throw "UR_RESULT_ERROR_INVALID_ARGUMENT" exception when catching free related error"

### DIFF
--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -175,10 +175,7 @@ ur_result_t AsanInterceptor::releaseMemory(ur_context_handle_t Context,
   if (!AllocInfoItOp) {
     // "Addr" might be a host pointer
     ReportBadFree(Addr, GetCurrentBacktrace(), nullptr);
-    if (getOptions().HaltOnError) {
-      exitWithErrors();
-    }
-    return UR_RESULT_SUCCESS;
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
   }
 
   auto AllocInfoIt = *AllocInfoItOp;
@@ -193,26 +190,17 @@ ur_result_t AsanInterceptor::releaseMemory(ur_context_handle_t Context,
       // "Addr" might be a host pointer
       ReportBadFree(Addr, GetCurrentBacktrace(), nullptr);
     }
-    if (getOptions().HaltOnError) {
-      exitWithErrors();
-    }
-    return UR_RESULT_SUCCESS;
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
   }
 
   if (Addr != AllocInfo->UserBegin) {
     ReportBadFree(Addr, GetCurrentBacktrace(), AllocInfo);
-    if (getOptions().HaltOnError) {
-      exitWithErrors();
-    }
-    return UR_RESULT_SUCCESS;
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
   }
 
   if (AllocInfo->IsReleased) {
     ReportDoubleFree(Addr, GetCurrentBacktrace(), AllocInfo);
-    if (getOptions().HaltOnError) {
-      exitWithErrors();
-    }
-    return UR_RESULT_SUCCESS;
+    return UR_RESULT_ERROR_INVALID_ARGUMENT;
   }
 
   AllocInfo->IsReleased = true;

--- a/source/loader/layers/sanitizer/asan/asan_options.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_options.cpp
@@ -90,7 +90,6 @@ AsanOptions::AsanOptions() {
   SetBoolOption("detect_privates", DetectPrivates);
   SetBoolOption("print_stats", PrintStats);
   SetBoolOption("detect_leaks", DetectLeaks);
-  SetBoolOption("halt_on_error", HaltOnError);
 
   auto KV = OptionsEnvMap->find("quarantine_size_mb");
   if (KV != OptionsEnvMap->end()) {

--- a/source/loader/layers/sanitizer/asan/asan_options.hpp
+++ b/source/loader/layers/sanitizer/asan/asan_options.hpp
@@ -28,7 +28,6 @@ struct AsanOptions {
   bool PrintStats = false;
   bool DetectKernelArguments = true;
   bool DetectLeaks = true;
-  bool HaltOnError = true;
 
   explicit AsanOptions();
 };


### PR DESCRIPTION
Reverts oneapi-src/unified-runtime#2592 due to test failures on https://github.com/intel/llvm/pull/16706