### PR TITLE
add comparing to baseline in benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -219,6 +219,7 @@ jobs:
         --adapter ${{ matrix.adapter.str_name }}
         --compute-runtime ${{ inputs.compute_runtime_commit }}
         --build-igc
+        --compare baseline
         ${{ inputs.upload_report && '--output-html' || '' }}
         ${{ inputs.pr_no != 0 && '--output-markdown' || '' }}
         ${{ inputs.bench_script_params }}


### PR DESCRIPTION
The results from the benchmark run should be always compared against baseline. This is a temporary solution before more baselines could be available.