### PR TITLE
Fix v1 adapter implementation of the spill memory size kernel propert…

### DIFF
--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -754,7 +754,7 @@ ur_result_t urKernelGetInfo(
   case UR_KERNEL_INFO_SPILL_MEM_SIZE: {
     std::vector<uint32_t> spills;
     spills.reserve(Kernel->ZeKernels.size());
-    for (const auto *K : Kernel->ZeKernels()) {
+    for (const auto *K : Kernel->ZeKernels) {
       spills.push_back(K->ZeKernelProperties->spillMemSize);
     }
     return ReturnValue(static_cast<const uint32_t *>(spills.data()),

--- a/source/adapters/level_zero/kernel.cpp
+++ b/source/adapters/level_zero/kernel.cpp
@@ -752,8 +752,11 @@ ur_result_t urKernelGetInfo(
   case UR_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(uint32_t{Kernel->ZeKernelProperties->numKernelArgs});
   case UR_KERNEL_INFO_SPILL_MEM_SIZE: {
-    std::vector<uint32_t> spills = {
-        uint32_t{Kernel->ZeKernelProperties->spillMemSize}};
+    std::vector<uint32_t> spills;
+    spills.reserve(Kernel->ZeKernels.size());
+    for (const auto *K : Kernel->ZeKernels()) {
+      spills.push_back(K->ZeKernelProperties->spillMemSize);
+    }
     return ReturnValue(static_cast<const uint32_t *>(spills.data()),
                        spills.size());
   }


### PR DESCRIPTION
…y query for multi-device systems

This fixes a problem in sycl that uses V1 implementation (see https://github.com/intel/llvm/pull/16834#discussion_r1954765022).