### PR TITLE
In mirror script, ensure it uses remote sycl

### DIFF
--- a/scripts/mirror-commits-from-intel-llvm.py
+++ b/scripts/mirror-commits-from-intel-llvm.py
@@ -87,6 +87,8 @@ def main():
             "log",
             "-1",
             "--format=%H",
+            f"{args.intel_llvm_remote}/sycl",
+            "--",
             "unified-runtime",
         ],
         stdout=PIPE,


### PR DESCRIPTION
Previously, it used the currently checked out commit, causing desyncs
if the intel llvm directory isn't updated.
