### PR TITLE
[UR][L0] Release parent of sub-buffer when sub-buffer dies

### DIFF
--- a/source/adapters/level_zero/memory.cpp
+++ b/source/adapters/level_zero/memory.cpp
@@ -2368,6 +2368,11 @@ _ur_buffer::_ur_buffer(ur_context_handle_t Context, size_t Size,
   LastDeviceWithValidAllocation = Device;
 }
 
+_ur_buffer::~_ur_buffer() {
+  if (isSubBuffer())
+    ur::level_zero::urMemRelease(SubBuffer->Parent);
+}
+
 ur_result_t _ur_buffer::getZeHandlePtr(char **&ZeHandlePtr,
                                        access_mode_t AccessMode,
                                        ur_device_handle_t Device,

--- a/source/adapters/level_zero/memory.hpp
+++ b/source/adapters/level_zero/memory.hpp
@@ -116,6 +116,8 @@ struct _ur_buffer final : ur_mem_handle_t_ {
     Parent->RefCount.increment();
   }
 
+  ~_ur_buffer();
+
   // Interop-buffer constructor
   _ur_buffer(ur_context_handle_t Context, size_t Size,
              ur_device_handle_t Device, char *ZeMemHandle, bool OwnZeMemHandle);


### PR DESCRIPTION
This commit fixes an issue where the sub-buffer object in the L0 V1 adapter would not release its retained parent, causing leaks.