### PR TITLE
Fixed bug with zero depth `ur_rect_region_t` which must be checked before calling funcs

### DIFF
--- a/scripts/core/enqueue.yml
+++ b/scripts/core/enqueue.yml
@@ -328,7 +328,7 @@ returns:
         - "An event in `phEventWaitList` has $X_EVENT_STATUS_ERROR."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_INVALID_SIZE:
-        - "`region.width == 0 || region.height == 0 || region.width == 0`"
+        - "`region.width == 0 || region.height == 0 || region.depth == 0`"
         - "`bufferRowPitch != 0 && bufferRowPitch < region.width`"
         - "`hostRowPitch != 0 && hostRowPitch < region.width`"
         - "`bufferSlicePitch != 0 && bufferSlicePitch < region.height * (bufferRowPitch != 0 ? bufferRowPitch : region.width)`"
@@ -406,7 +406,7 @@ returns:
         - "An event in `phEventWaitList` has $X_EVENT_STATUS_ERROR."
     - $X_RESULT_ERROR_INVALID_MEM_OBJECT
     - $X_RESULT_ERROR_INVALID_SIZE:
-        - "`region.width == 0 || region.height == 0 || region.width == 0`"
+        - "`region.width == 0 || region.height == 0 || region.depth == 0`"
         - "`bufferRowPitch != 0 && bufferRowPitch < region.width`"
         - "`hostRowPitch != 0 && hostRowPitch < region.width`"
         - "`bufferSlicePitch != 0 && bufferSlicePitch < region.height * (bufferRowPitch != 0 ? bufferRowPitch : region.width)`"

--- a/source/loader/layers/validation/ur_valddi.cpp
+++ b/source/loader/layers/validation/ur_valddi.cpp
@@ -4807,7 +4807,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     if (phEventWaitList != NULL && numEventsInWaitList == 0)
       return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
 
-    if (region.width == 0 || region.height == 0 || region.width == 0)
+    if (region.width == 0 || region.height == 0 || region.depth == 0)
       return UR_RESULT_ERROR_INVALID_SIZE;
 
     if (bufferRowPitch != 0 && bufferRowPitch < region.width)
@@ -4932,7 +4932,7 @@ __urdlllocal ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     if (phEventWaitList != NULL && numEventsInWaitList == 0)
       return UR_RESULT_ERROR_INVALID_EVENT_WAIT_LIST;
 
-    if (region.width == 0 || region.height == 0 || region.width == 0)
+    if (region.width == 0 || region.height == 0 || region.depth == 0)
       return UR_RESULT_ERROR_INVALID_SIZE;
 
     if (bufferRowPitch != 0 && bufferRowPitch < region.width)


### PR DESCRIPTION
@RossBrunton, it looks like a common typo when writing functions.

Fixed functions:
- urEnqueueMemBufferWriteRect()
- urEnqueueMemBufferReadRect()