### PR TITLE
Align UR_API fields (8 byte) for optimization create/move/copy structs on x64 cpus

### DIFF
--- a/include/ur_api.h
+++ b/include/ur_api.h
@@ -1631,11 +1631,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native platform creation properties
 typedef struct ur_platform_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -2754,11 +2754,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native device creation properties
 typedef struct ur_device_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -2943,11 +2943,11 @@ typedef enum ur_context_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Context creation properties
 typedef struct ur_context_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] context creation flags.
   ur_context_flags_t flags;
 
@@ -3150,11 +3150,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Properties for for ::urContextCreateWithNativeHandle.
 typedef struct ur_context_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -3429,10 +3429,10 @@ typedef struct ur_image_format_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Image descriptor type.
 typedef struct ur_image_desc_t {
-  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_IMAGE_DESC
-  ur_structure_type_t stype;
   /// [in][optional] pointer to extension-specific structure
   const void *pNext;
+  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_IMAGE_DESC
+  ur_structure_type_t stype;
   /// [in][nocheck] memory object type
   ur_mem_type_t type;
   /// [in] image width
@@ -3547,11 +3547,11 @@ typedef struct ur_buffer_properties_t {
 ///   _Analogues_
 ///     - cl_intel_mem_channel_property
 typedef struct ur_buffer_channel_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_BUFFER_CHANNEL_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Identifies the channel/region to which the buffer should be mapped.
   uint32_t channel;
 
@@ -3568,11 +3568,11 @@ typedef struct ur_buffer_channel_properties_t {
 ///   _Analogues_
 ///     - cl_intel_mem_alloc_buffer_location
 typedef struct ur_buffer_alloc_location_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_BUFFER_ALLOC_LOCATION_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Identifies the ID of global memory partition to which the memory
   /// should be allocated.
   uint32_t location;
@@ -3781,11 +3781,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native memory object creation properties
 typedef struct ur_mem_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -4017,10 +4017,10 @@ typedef enum ur_sampler_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Sampler description.
 typedef struct ur_sampler_desc_t {
-  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_SAMPLER_DESC
-  ur_structure_type_t stype;
   /// [in][optional] pointer to extension-specific structure
   const void *pNext;
+  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_SAMPLER_DESC
+  ur_structure_type_t stype;
   /// [in] Specify if image coordinates are normalized (true) or not (false)
   bool normalizedCoords;
   /// [in] Specify the address mode of the sampler
@@ -4187,11 +4187,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native sampler creation properties
 typedef struct ur_sampler_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -4400,10 +4400,10 @@ typedef struct ur_usm_desc_t {
 ///     - Specify these properties in ::urUSMHostAlloc and ::urUSMSharedAlloc
 ///       via ::ur_usm_desc_t as part of a `pNext` chain.
 typedef struct ur_usm_host_desc_t {
-  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_HOST_DESC
-  ur_structure_type_t stype;
   /// [in][optional] pointer to extension-specific structure
   const void *pNext;
+  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_HOST_DESC
+  ur_structure_type_t stype;
   /// [in] host memory allocation flags
   ur_usm_host_mem_flags_t flags;
 
@@ -4416,11 +4416,11 @@ typedef struct ur_usm_host_desc_t {
 ///     - Specify these properties in ::urUSMDeviceAlloc and ::urUSMSharedAlloc
 ///       via ::ur_usm_desc_t as part of a `pNext` chain.
 typedef struct ur_usm_device_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_USM_DEVICE_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] device memory allocation flags.
   ur_usm_device_mem_flags_t flags;
 
@@ -4437,11 +4437,11 @@ typedef struct ur_usm_device_desc_t {
 ///   _Analogues_
 ///     - cl_intel_mem_alloc_buffer_location
 typedef struct ur_usm_alloc_location_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_USM_ALLOC_LOCATION_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] Identifies the ID of global memory partition to which the memory
   /// should be allocated.
   uint32_t location;
@@ -4451,10 +4451,10 @@ typedef struct ur_usm_alloc_location_desc_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief USM pool descriptor type
 typedef struct ur_usm_pool_desc_t {
-  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_POOL_DESC
-  ur_structure_type_t stype;
   /// [in][optional] pointer to extension-specific structure
   const void *pNext;
+  /// [in] type of this structure, must be ::UR_STRUCTURE_TYPE_USM_POOL_DESC
+  ur_structure_type_t stype;
   /// [in] memory allocation flags
   ur_usm_pool_flags_t flags;
 
@@ -5113,11 +5113,11 @@ typedef enum ur_physical_mem_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Physical memory creation properties.
 typedef struct ur_physical_mem_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] physical memory creation flags
   ur_physical_mem_flags_t flags;
 
@@ -5296,11 +5296,11 @@ typedef struct ur_program_metadata_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Program creation properties.
 typedef struct ur_program_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] the number of entries in pMetadatas, if count is greater than
   /// zero then pMetadatas must not be null.
   uint32_t count;
@@ -5922,11 +5922,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native program creation properties
 typedef struct ur_program_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_PROGRAM_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -6480,11 +6480,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgSampler(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Properties for for ::urKernelSetArgMemObj.
 typedef struct ur_kernel_arg_mem_obj_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_KERNEL_ARG_MEM_OBJ_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Memory access flag. Allowed values are: ::UR_MEM_FLAG_READ_WRITE,
   /// ::UR_MEM_FLAG_WRITE_ONLY, ::UR_MEM_FLAG_READ_ONLY.
   ur_mem_flags_t memoryAccess;
@@ -6598,11 +6598,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Properties for for ::urKernelCreateWithNativeHandle.
 typedef struct ur_kernel_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_KERNEL_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -6814,11 +6814,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Queue creation properties
 typedef struct ur_queue_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_QUEUE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Bitfield of queue creation flags
   ur_queue_flags_t flags;
 
@@ -6831,11 +6831,11 @@ typedef struct ur_queue_properties_t {
 ///     - Specify these properties in ::urQueueCreate via
 ///       ::ur_queue_properties_t as part of a `pNext` chain.
 typedef struct ur_queue_index_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_QUEUE_INDEX_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Specifies the compute index as described in the
   /// sycl_ext_intel_queue_index extension.
   uint32_t computeIndex;
@@ -6993,11 +6993,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Properties for for ::urQueueCreateWithNativeHandle.
 typedef struct ur_queue_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -7429,11 +7429,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Properties for for ::urEventCreateWithNativeHandle.
 typedef struct ur_event_native_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] If true then ownership of the native handle is transferred to
   /// the resultant object. This means the object will be responsible for
   /// releasing the native resources at the end of its lifetime.
@@ -9096,11 +9096,11 @@ typedef enum ur_exp_async_usm_alloc_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Async alloc properties
 typedef struct ur_exp_async_usm_alloc_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_ASYNC_USM_ALLOC_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] async alloc flags
   ur_exp_async_usm_alloc_flags_t flags;
 
@@ -9589,11 +9589,11 @@ typedef enum ur_exp_external_semaphore_type_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief File descriptor
 typedef struct ur_exp_file_descriptor_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] A file descriptor used for Linux and & MacOS operating systems.
   int fd;
 
@@ -9645,11 +9645,11 @@ typedef struct ur_exp_sampler_mip_properties_t {
 ///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
 ///       as part of a `pNext` chain.
 typedef struct ur_exp_sampler_addr_modes_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_SAMPLER_ADDR_MODES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] Specify the address mode of the sampler per dimension
   ur_sampler_addressing_mode_t addrModes[3];
 
@@ -9662,11 +9662,11 @@ typedef struct ur_exp_sampler_addr_modes_t {
 ///     - Specify these properties in ::urSamplerCreate via ::ur_sampler_desc_t
 ///       as part of a `pNext` chain.
 typedef struct ur_exp_sampler_cubemap_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_SAMPLER_CUBEMAP_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] enables or disables seamless cubemap filtering between cubemap
   /// faces
   ur_exp_sampler_cubemap_filter_mode_t cubemapFilterMode;
@@ -10491,11 +10491,11 @@ typedef enum ur_exp_command_buffer_command_info_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Command-Buffer Descriptor Type
 typedef struct ur_exp_command_buffer_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] Commands in a finalized command-buffer can be updated.
   ur_bool_t isUpdatable;
   /// [in] Commands in a command-buffer may be executed in-order without
@@ -10524,11 +10524,11 @@ typedef struct ur_exp_command_buffer_command_handle_t_
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Descriptor type for updating a kernel command memobj argument.
 typedef struct ur_exp_command_buffer_update_memobj_arg_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_MEMOBJ_ARG_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] Argument index.
   uint32_t argIndex;
   /// [in][optional] Pointer to memory object properties.
@@ -10541,11 +10541,11 @@ typedef struct ur_exp_command_buffer_update_memobj_arg_desc_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Descriptor type for updating a kernel command pointer argument.
 typedef struct ur_exp_command_buffer_update_pointer_arg_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_POINTER_ARG_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] Argument index.
   uint32_t argIndex;
   /// [in][optional] Pointer to USM pointer properties.
@@ -10559,11 +10559,11 @@ typedef struct ur_exp_command_buffer_update_pointer_arg_desc_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Descriptor type for updating a kernel command value argument.
 typedef struct ur_exp_command_buffer_update_value_arg_desc_t {
+  /// [in][optional] pointer to extension-specific structure
+  const void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_VALUE_ARG_DESC
   ur_structure_type_t stype;
-  /// [in][optional] pointer to extension-specific structure
-  const void *pNext;
   /// [in] Argument index.
   uint32_t argIndex;
   /// [in] Argument size.
@@ -12514,11 +12514,11 @@ typedef enum ur_exp_enqueue_ext_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Extended enqueue properties
 typedef struct ur_exp_enqueue_ext_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_ENQUEUE_EXT_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] extended enqueue flags
   ur_exp_enqueue_ext_flags_t flags;
 
@@ -12603,11 +12603,11 @@ typedef enum ur_exp_enqueue_native_command_flag_t {
 ///////////////////////////////////////////////////////////////////////////////
 /// @brief Native enqueue properties
 typedef struct ur_exp_enqueue_native_command_properties_t {
+  /// [in,out][optional] pointer to extension-specific structure
+  void *pNext;
   /// [in] type of this structure, must be
   /// ::UR_STRUCTURE_TYPE_EXP_ENQUEUE_NATIVE_COMMAND_PROPERTIES
   ur_structure_type_t stype;
-  /// [in,out][optional] pointer to extension-specific structure
-  void *pNext;
   /// [in] native enqueue flags
   ur_exp_enqueue_native_command_flags_t flags;
 

--- a/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_interceptor.cpp
@@ -942,7 +942,7 @@ ContextInfo::~ContextInfo() {
 
 ur_usm_pool_handle_t ContextInfo::getUSMPool() {
   std::call_once(PoolInit, [this]() {
-    ur_usm_pool_desc_t Desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr, 0};
+    ur_usm_pool_desc_t Desc{nullptr, UR_STRUCTURE_TYPE_USM_POOL_DESC, 0};
     auto URes =
         getContext()->urDdiTable.USM.pfnPoolCreate(Handle, &Desc, &USMPool);
     if (URes != UR_RESULT_SUCCESS &&

--- a/source/loader/layers/sanitizer/asan/asan_shadow.cpp
+++ b/source/loader/layers/sanitizer/asan/asan_shadow.cpp
@@ -191,8 +191,8 @@ ur_result_t ShadowMemoryGPU::EnqueuePoisonShadow(ur_queue_handle_t Queue,
   {
     static const size_t PageSize = GetVirtualMemGranularity(Context, Device);
 
-    ur_physical_mem_properties_t Desc{UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
-                                      nullptr, 0};
+    ur_physical_mem_properties_t Desc{nullptr,
+                                      UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES, 0};
 
     // Make sure [Ptr, Ptr + Size] is mapped to physical memory
     for (auto MappedPtr = RoundDownTo(ShadowBegin, PageSize);

--- a/source/loader/layers/sanitizer/tsan/tsan_shadow.cpp
+++ b/source/loader/layers/sanitizer/tsan/tsan_shadow.cpp
@@ -134,8 +134,8 @@ ur_result_t ShadowMemoryGPU::CleanShadow(ur_queue_handle_t Queue, uptr Ptr,
   {
     static const size_t PageSize = GetVirtualMemGranularity(Context, Device);
 
-    ur_physical_mem_properties_t Desc{UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
-                                      nullptr, 0};
+    ur_physical_mem_properties_t Desc{nullptr,
+                                      UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES, 0};
 
     // Make sure [Ptr, Ptr + Size] is mapped to physical memory
     for (auto MappedPtr = RoundDownTo((uptr)Begin, PageSize); MappedPtr <= End;

--- a/test/conformance/context/urContextCreate.cpp
+++ b/test/conformance/context/urContextCreate.cpp
@@ -18,8 +18,8 @@ TEST_P(urContextCreateTest, Success) {
 }
 
 TEST_P(urContextCreateTest, SuccessWithProperties) {
-  ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES,
-                                     nullptr, 0};
+  ur_context_properties_t properties{nullptr,
+                                     UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES, 0};
   uur::raii::Context context = nullptr;
   ASSERT_SUCCESS(urContextCreate(1, &device, &properties, context.ptr()));
   ASSERT_NE(nullptr, context);
@@ -37,8 +37,8 @@ TEST_P(urContextCreateTest, InvalidNullPointerContext) {
 }
 
 TEST_P(urContextCreateTest, InvalidEnumeration) {
-  ur_context_properties_t properties{UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES,
-                                     nullptr, UR_CONTEXT_FLAGS_MASK};
+  ur_context_properties_t properties{nullptr,
+                                     UR_STRUCTURE_TYPE_CONTEXT_PROPERTIES, UR_CONTEXT_FLAGS_MASK};
   uur::raii::Context context = nullptr;
 
   ASSERT_EQ_RESULT(UR_RESULT_ERROR_INVALID_ENUMERATION,

--- a/test/conformance/context/urContextCreateWithNativeHandle.cpp
+++ b/test/conformance/context/urContextCreateWithNativeHandle.cpp
@@ -39,7 +39,7 @@ TEST_P(urContextCreateWithNativeHandleTest,
 
   ur_context_handle_t ctx = nullptr;
   ur_context_native_properties_t props{
-      UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_CONTEXT_NATIVE_PROPERTIES, false};
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urContextCreateWithNativeHandle(
       native_context, adapter, 1, &device, &props, &ctx));
   ASSERT_NE(ctx, nullptr);

--- a/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
+++ b/test/conformance/device/urDeviceCreateWithNativeHandle.cpp
@@ -37,7 +37,7 @@ TEST_P(urDeviceCreateWithNativeHandleTest,
 
   ur_device_handle_t dev = nullptr;
   ur_device_native_properties_t props{
-      UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_DEVICE_NATIVE_PROPERTIES, false};
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urDeviceCreateWithNativeHandle(native_handle, adapter, &props, &dev));
   ASSERT_NE(dev, nullptr);

--- a/test/conformance/event/urEventCreateWithNativeHandle.cpp
+++ b/test/conformance/event/urEventCreateWithNativeHandle.cpp
@@ -46,7 +46,7 @@ TEST_P(urEventCreateWithNativeHandleTest, SuccessWithProperties) {
   // we always get the native handle from a UR object, and transferring
   // ownership from one UR object to another isn't allowed.
   ur_event_native_properties_t props = {
-      UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_EVENT_NATIVE_PROPERTIES, false};
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urEventCreateWithNativeHandle(native_event, context, &props, evt.ptr()));
   ASSERT_NE(evt, nullptr);

--- a/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemBufferCreateWithNativeHandle.cpp
@@ -42,8 +42,8 @@ TEST_P(urMemBufferCreateWithNativeHandleTest, SuccessWithProperties) {
   // we always get the native handle from a UR object, and transferring
   // ownership from one UR object to another isn't allowed.
   ur_mem_native_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.isNativeHandleOwned =*/false,
   };
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
@@ -64,8 +64,8 @@ TEST_P(urMemBufferCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
 
   ur_mem_handle_t mem = nullptr;
   ur_mem_native_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.isNativeHandleOwned =*/false,
   };
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
@@ -86,8 +86,8 @@ TEST_P(urMemBufferCreateWithNativeHandleTest, InvalidNullHandle) {
 
   ur_mem_handle_t mem = nullptr;
   ur_mem_native_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.isNativeHandleOwned =*/false,
   };
   auto err =
@@ -102,8 +102,8 @@ TEST_P(urMemBufferCreateWithNativeHandleTest, InvalidNullPointer) {
       urMemGetNativeHandle(buffer, device, &hNativeMem));
 
   ur_mem_native_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.isNativeHandleOwned =*/false,
   };
   auto err =
@@ -122,8 +122,8 @@ TEST_P(urMemBufferMultiQueueMemBufferTest, WriteBack) {
   ASSERT_SUCCESS(urUSMHostAlloc(context, nullptr, nullptr, size, &ptr));
   ur_mem_handle_t mem = nullptr;
   ur_mem_native_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
       /*.isNativeHandleOwned =*/false,
   };
   {

--- a/test/conformance/memory/urMemImageCreate.cpp
+++ b/test/conformance/memory/urMemImageCreate.cpp
@@ -11,8 +11,8 @@ static ur_image_format_t image_format{UR_IMAGE_CHANNEL_ORDER_RGBA,
                                       UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32};
 
 static ur_image_desc_t image_desc{
-    UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
     nullptr, ///< [in][optional] pointer to extension-specific structure
+    UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
     UR_MEM_TYPE_IMAGE3D, ///< [in] memory object type
     1,                   ///< [in] image width
     1,                   ///< [in] image height
@@ -97,8 +97,8 @@ TEST_P(urMemImageCreateTestWith1DMemoryTypeParam, Success) {
   }
 
   ur_image_desc_t image_desc_with_param{
-      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       nullptr,    ///< [in][optional] pointer to extension-specific structure
+      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       getParam(), ///< [in] memory object type
       1,          ///< [in] image width
       0,          ///< [in] image height
@@ -133,8 +133,8 @@ TEST_P(urMemImageCreateTestWith2DMemoryTypeParam, Success) {
   }
 
   ur_image_desc_t image_desc_with_param{
-      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       nullptr,    ///< [in][optional] pointer to extension-specific structure
+      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       getParam(), ///< [in] memory object type
       1,          ///< [in] image width
       1,          ///< [in] image height
@@ -155,8 +155,8 @@ TEST_P(urMemImageCreateTestWith2DMemoryTypeParam, Success) {
 
 TEST_P(urMemImageCreateTest, SuccessWith3DImageType) {
   ur_image_desc_t image_desc_with_param{
-      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       nullptr, ///< [in][optional] pointer to extension-specific structure
+      UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
       UR_MEM_TYPE_IMAGE3D, ///< [in] memory object type
       1,                   ///< [in] image width
       1,                   ///< [in] image height

--- a/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
+++ b/test/conformance/memory/urMemImageCreateWithImageFormatParam.cpp
@@ -8,8 +8,8 @@
 #include <vector>
 
 static ur_image_desc_t image_desc{
-    UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
     nullptr, ///< [in][optional] pointer to extension-specific structure
+    UR_STRUCTURE_TYPE_IMAGE_DESC, ///< [in] type of this structure
     UR_MEM_TYPE_IMAGE3D, ///< [in] memory object type
     1,                   ///< [in] image width
     1,                   ///< [in] image height

--- a/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
+++ b/test/conformance/memory/urMemImageCreateWithNativeHandle.cpp
@@ -36,8 +36,8 @@ TEST_P(urMemImageCreateWithNativeHandleTest, SuccessWithProperties) {
       urMemGetNativeHandle(image, device, &native_handle));
 
   ur_mem_handle_t mem = nullptr;
-  ur_mem_native_properties_t props = {UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES,
-                                      nullptr, false};
+  ur_mem_native_properties_t props = {nullptr,
+                                      UR_STRUCTURE_TYPE_MEM_NATIVE_PROPERTIES, false};
   // We can't pass isNativeHandleOwned = true in the generic tests since
   // we always get the native handle from a UR object, and transferring
   // ownership from one UR object to another isn't allowed.

--- a/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
+++ b/test/conformance/platform/urPlatformCreateWithNativeHandle.cpp
@@ -49,7 +49,7 @@ TEST_P(urPlatformCreateWithNativeHandleTest,
   // We can however convert the native_handle back into a unified-runtime
   // handle and perform some query on it to verify that it works.
   ur_platform_native_properties_t props = {
-      UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_PLATFORM_NATIVE_PROPERTIES, false};
   ur_platform_handle_t plat = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(
       urPlatformCreateWithNativeHandle(native_handle, adapter, &props, &plat));

--- a/test/conformance/queue/urQueueCreate.cpp
+++ b/test/conformance/queue/urQueueCreate.cpp
@@ -55,8 +55,8 @@ TEST_P(urQueueCreateWithParamTest, SuccessWithProperties) {
 
   ur_queue_handle_t queue = nullptr;
   ur_queue_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.flags =*/queryFlag,
   };
   ASSERT_SUCCESS(urQueueCreate(context, device, &props, &queue));
@@ -89,8 +89,8 @@ TEST_P(urQueueCreateWithParamTest, MatchingDeviceHandles) {
   }
 
   ur_queue_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.flags =*/queryFlag,
   };
 
@@ -173,8 +173,8 @@ TEST_P(urQueueCreateTest, InvalidNullPointerQueue) {
 
 TEST_P(urQueueCreateTest, InvalidQueueProperties) {
   ur_queue_properties_t props = {
-      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       /*.flags =*/UR_QUEUE_FLAG_FORCE_UINT32,
   };
 

--- a/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
+++ b/test/conformance/queue/urQueueCreateWithNativeHandle.cpp
@@ -40,7 +40,7 @@ TEST_P(urQueueCreateWithNativeHandleTest, SuccessWithProperties) {
   // and perform some query on it to verify that it works.
   ur_queue_handle_t q = nullptr;
   ur_queue_native_properties_t properties = {
-      UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_QUEUE_NATIVE_PROPERTIES, false};
   ASSERT_SUCCESS(urQueueCreateWithNativeHandle(native_handle, context, device,
                                                &properties, &q));
   ASSERT_NE(q, nullptr);

--- a/test/conformance/queue/urQueueGetInfo.cpp
+++ b/test/conformance/queue/urQueueGetInfo.cpp
@@ -163,7 +163,7 @@ struct urQueueGetInfoDeviceQueueTestWithInfoParam : public uur::urQueueTest {
 
   ur_queue_handle_t queue = nullptr;
   const ur_queue_properties_t queueProperties = {
-      UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, nullptr,
+      nullptr, UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
       UR_QUEUE_FLAG_ON_DEVICE | UR_QUEUE_FLAG_ON_DEVICE_DEFAULT |
           UR_QUEUE_FLAG_OUT_OF_ORDER_EXEC_MODE_ENABLE};
 };

--- a/test/conformance/sampler/urSamplerCreate.cpp
+++ b/test/conformance/sampler/urSamplerCreate.cpp
@@ -21,8 +21,8 @@ struct urSamplerCreateTestWithParam
     }
 
     ur_sampler_desc_t sampler_desc{
-        UR_STRUCTURE_TYPE_SAMPLER_DESC, /* stype */
         nullptr,                        /* pNext */
+        UR_STRUCTURE_TYPE_SAMPLER_DESC, /* stype */
         {},                             /* normalizedCoords */
         {},                             /* addressing mode */
         {},                             /* filterMode */
@@ -64,8 +64,8 @@ TEST_P(urSamplerCreateTestWithParam, Success) {
   const auto filter_mode = std::get<2>(param);
 
   ur_sampler_desc_t sampler_desc{
-      UR_STRUCTURE_TYPE_SAMPLER_DESC, /* stype */
       nullptr,                        /* pNext */
+      UR_STRUCTURE_TYPE_SAMPLER_DESC, /* stype */
       normalized,                     /* normalizedCoords */
       addr_mode,                      /* addressing mode */
       filter_mode,                    /* filterMode */
@@ -81,8 +81,8 @@ UUR_INSTANTIATE_DEVICE_TEST_SUITE(urSamplerCreateTest);
 
 TEST_P(urSamplerCreateTest, InvalidNullHandleContext) {
   ur_sampler_desc_t sampler_desc{
-      UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
       nullptr,                          /* pNext */
+      UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
       true,                             /* normalizedCoords */
       UR_SAMPLER_ADDRESSING_MODE_CLAMP, /* addressing mode */
       UR_SAMPLER_FILTER_MODE_LINEAR,    /* filterMode */
@@ -94,8 +94,8 @@ TEST_P(urSamplerCreateTest, InvalidNullHandleContext) {
 
 TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
   ur_sampler_desc_t sampler_desc{
-      UR_STRUCTURE_TYPE_SAMPLER_DESC,          /* stype */
       nullptr,                                 /* pNext */
+      UR_STRUCTURE_TYPE_SAMPLER_DESC,          /* stype */
       true,                                    /* normalizedCoords */
       UR_SAMPLER_ADDRESSING_MODE_FORCE_UINT32, /* addressing mode */
       UR_SAMPLER_FILTER_MODE_LINEAR,           /* filterMode */
@@ -107,8 +107,8 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationAddrMode) {
 
 TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
   ur_sampler_desc_t sampler_desc{
-      UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
       nullptr,                             /* pNext */
+      UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
       true,                                /* normalizedCoords */
       UR_SAMPLER_ADDRESSING_MODE_CLAMP,    /* addressing mode */
       UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */
@@ -120,8 +120,8 @@ TEST_P(urSamplerCreateTest, InvalidEnumerationFilterMode) {
 
 TEST_P(urSamplerCreateTest, InvalidNullPointer) {
   ur_sampler_desc_t sampler_desc{
-      UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
       nullptr,                             /* pNext */
+      UR_STRUCTURE_TYPE_SAMPLER_DESC,      /* stype */
       true,                                /* normalizedCoords */
       UR_SAMPLER_ADDRESSING_MODE_CLAMP,    /* addressing mode */
       UR_SAMPLER_FILTER_MODE_FORCE_UINT32, /* filterMode */

--- a/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
+++ b/test/conformance/sampler/urSamplerCreateWithNativeHandle.cpp
@@ -46,7 +46,7 @@ TEST_P(urSamplerCreateWithNativeHandleTest,
   // and perform some query on it to verify that it works.
   ur_sampler_handle_t hSampler = nullptr;
   ur_sampler_native_properties_t props{
-      UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, false};
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
       native_sampler, context, &props, &hSampler));
   ASSERT_NE(hSampler, nullptr);
@@ -89,8 +89,8 @@ TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
   uur::raii::Sampler hSampler = nullptr;
   {
     ur_sampler_desc_t sampler_desc{
-        UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
         nullptr,                         /* pNext */
+        UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
         true,                            /* normalizedCoords */
         UR_SAMPLER_ADDRESSING_MODE_NONE, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_NEAREST,  /* filterMode */
@@ -103,7 +103,7 @@ TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithOwnedNativeHandle) {
   }
 
   ur_sampler_native_properties_t props = {
-      UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, nullptr, true};
+      nullptr, UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, true};
   ur_sampler_handle_t sampler = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
       native_handle, context, &props, &sampler));
@@ -116,8 +116,8 @@ TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
   uur::raii::Sampler hSampler = nullptr;
   {
     ur_sampler_desc_t sampler_desc{
-        UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
         nullptr,                         /* pNext */
+        UR_STRUCTURE_TYPE_SAMPLER_DESC,  /* stype */
         true,                            /* normalizedCoords */
         UR_SAMPLER_ADDRESSING_MODE_NONE, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_NEAREST,  /* filterMode */
@@ -130,7 +130,7 @@ TEST_P(urSamplerCreateWithNativeHandleTest, SuccessWithUnOwnedNativeHandle) {
   }
 
   ur_sampler_native_properties_t props = {
-      UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, nullptr, false};
+      nullptr, UR_STRUCTURE_TYPE_SAMPLER_NATIVE_PROPERTIES, false};
   ur_sampler_handle_t sampler = nullptr;
   UUR_ASSERT_SUCCESS_OR_UNSUPPORTED(urSamplerCreateWithNativeHandle(
       native_handle, context, &props, &sampler));

--- a/test/conformance/testing/include/uur/fixtures.h
+++ b/test/conformance/testing/include/uur/fixtures.h
@@ -190,8 +190,8 @@ struct urSamplerTest : urContextTest {
     }
 
     sampler_desc = {
-        UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         nullptr,                          /* pNext */
+        UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         true,                             /* normalizedCoords */
         UR_SAMPLER_ADDRESSING_MODE_CLAMP, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_LINEAR,    /* filterMode */
@@ -260,8 +260,8 @@ struct urMemImageTest : urContextTest {
       /*.channelType =*/UR_IMAGE_CHANNEL_TYPE_UNORM_INT8,
   };
   ur_image_desc_t image_desc = {
-      /*.stype =*/UR_STRUCTURE_TYPE_IMAGE_DESC,
       /*.pNext =*/nullptr,
+      /*.stype =*/UR_STRUCTURE_TYPE_IMAGE_DESC,
       /*.type =*/UR_MEM_TYPE_IMAGE2D,
       /*.width =*/16,
       /*.height =*/16,
@@ -321,8 +321,8 @@ template <class T> struct urSamplerTestWithParam : urContextTestWithParam<T> {
     }
 
     sampler_desc = {
-        UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         nullptr,                          /* pNext */
+        UR_STRUCTURE_TYPE_SAMPLER_DESC,   /* stype */
         true,                             /* normalizedCoords */
         UR_SAMPLER_ADDRESSING_MODE_CLAMP, /* addressing mode */
         UR_SAMPLER_FILTER_MODE_LINEAR,    /* filterMode */
@@ -360,8 +360,8 @@ struct urQueueTest : urContextTest {
     UUR_RETURN_ON_FATAL_FAILURE(urContextTest::TearDown());
   }
 
-  ur_queue_properties_t queue_properties = {UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
-                                            nullptr, 0};
+  ur_queue_properties_t queue_properties = {nullptr,
+                                            UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, 0};
   ur_queue_handle_t queue = nullptr;
 };
 
@@ -433,8 +433,8 @@ template <class T> struct urQueueTestWithParam : urContextTestWithParam<T> {
     }
     UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::TearDown());
   }
-  ur_queue_properties_t queue_properties = {UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
-                                            nullptr, 0};
+  ur_queue_properties_t queue_properties = {nullptr,
+                                            UR_STRUCTURE_TYPE_QUEUE_PROPERTIES, 0};
   ur_queue_handle_t queue = nullptr;
 };
 
@@ -463,8 +463,8 @@ struct urProfilingQueueTest : urContextTest {
   void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urContextTest::SetUp());
     ur_queue_properties_t props = {
-        /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
         /*.pNext =*/nullptr,
+        /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
         /*.flags =*/UR_QUEUE_FLAG_PROFILING_ENABLE,
     };
     ASSERT_SUCCESS(urQueueCreate(this->context, this->device, &props, &queue));
@@ -485,8 +485,8 @@ struct urProfilingQueueTestWithParam : urContextTestWithParam<T> {
   void SetUp() override {
     UUR_RETURN_ON_FATAL_FAILURE(urContextTestWithParam<T>::SetUp());
     ur_queue_properties_t props = {
-        /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
         /*.pNext =*/nullptr,
+        /*.stype =*/UR_STRUCTURE_TYPE_QUEUE_PROPERTIES,
         /*.flags =*/UR_QUEUE_FLAG_PROFILING_ENABLE,
     };
     ASSERT_SUCCESS(urQueueCreate(this->context, this->device, &props, &queue));
@@ -675,8 +675,8 @@ struct urMemImageQueueTest : urQueueTest {
   ur_rect_offset_t origin{0, 0, 0};
   ur_image_format_t format = {UR_IMAGE_CHANNEL_ORDER_RGBA,
                               UR_IMAGE_CHANNEL_TYPE_FLOAT};
-  ur_image_desc_t desc1D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc1D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE1D,          // mem object type
                             width,                        // image width
                             1,                            // image height
@@ -687,8 +687,8 @@ struct urMemImageQueueTest : urQueueTest {
                             0,                            // mip levels
                             0};                           // num samples
 
-  ur_image_desc_t desc2D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc2D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE2D,          // mem object type
                             width,                        // image width
                             height,                       // image height
@@ -699,8 +699,8 @@ struct urMemImageQueueTest : urQueueTest {
                             0,                            // mip levels
                             0};                           // num samples
 
-  ur_image_desc_t desc3D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc3D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE3D,          // mem object type
                             width,                        // image width
                             height,                       // image height
@@ -759,8 +759,8 @@ struct urMultiDeviceMemImageTest : urMultiDeviceContextTest {
   ur_rect_offset_t origin{0, 0, 0};
   ur_image_format_t format = {UR_IMAGE_CHANNEL_ORDER_RGBA,
                               UR_IMAGE_CHANNEL_TYPE_FLOAT};
-  ur_image_desc_t desc1D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc1D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE1D,          // mem object type
                             width,                        // image width
                             1,                            // image height
@@ -771,8 +771,8 @@ struct urMultiDeviceMemImageTest : urMultiDeviceContextTest {
                             0,                            // mip levels
                             0};                           // num samples
 
-  ur_image_desc_t desc2D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc2D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE2D,          // mem object type
                             width,                        // image width
                             height,                       // image height
@@ -783,8 +783,8 @@ struct urMultiDeviceMemImageTest : urMultiDeviceContextTest {
                             0,                            // mip levels
                             0};                           // num samples
 
-  ur_image_desc_t desc3D = {UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
-                            nullptr,                      // pNext
+  ur_image_desc_t desc3D = {nullptr,                      // pNext
+                            UR_STRUCTURE_TYPE_IMAGE_DESC, // stype
                             UR_MEM_TYPE_IMAGE3D,          // mem object type
                             width,                        // image width
                             height,                       // image height
@@ -886,7 +886,7 @@ struct urUSMPoolTest : urContextTest {
     if (!poolSupport) {
       GTEST_SKIP() << "USM pools are not supported.";
     }
-    ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr, 0};
+    ur_usm_pool_desc_t pool_desc{nullptr, UR_STRUCTURE_TYPE_USM_POOL_DESC, 0};
     ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
   }
 
@@ -908,7 +908,7 @@ template <class T> struct urUSMPoolTestWithParam : urContextTestWithParam<T> {
     if (!poolSupport) {
       GTEST_SKIP() << "USM pools are not supported.";
     }
-    ur_usm_pool_desc_t pool_desc{UR_STRUCTURE_TYPE_USM_POOL_DESC, nullptr, 0};
+    ur_usm_pool_desc_t pool_desc{nullptr, UR_STRUCTURE_TYPE_USM_POOL_DESC, 0};
     ASSERT_SUCCESS(urUSMPoolCreate(this->context, &pool_desc, &pool));
   }
 
@@ -983,8 +983,8 @@ struct urPhysicalMemTest : urVirtualMemGranularityTest {
   size_t size = 0;
   ur_physical_mem_handle_t physical_mem = nullptr;
   ur_physical_mem_properties_t properties{
-      UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
       nullptr,
+      UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
       0 /*flags*/,
   };
 };
@@ -996,8 +996,8 @@ struct urPhysicalMemTestWithParam : urVirtualMemGranularityTestWithParam<T> {
         urVirtualMemGranularityTestWithParam<T>::SetUp());
     size = this->granularity * 256;
     ur_physical_mem_properties_t props{
-        UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
         nullptr,
+        UR_STRUCTURE_TYPE_PHYSICAL_MEM_PROPERTIES,
         0 /*flags*/,
     };
     ASSERT_SUCCESS(urPhysicalMemCreate(this->context, this->device, size,
@@ -1230,7 +1230,7 @@ struct urProgramTest : urQueueTest {
         program_name, platform, il_binary));
 
     const ur_program_properties_t properties = {
-        UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES, nullptr,
+        nullptr, UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES,
         static_cast<uint32_t>(metadatas.size()),
         metadatas.empty() ? nullptr : metadatas.data()};
     ASSERT_SUCCESS(uur::KernelsEnvironment::instance->CreateProgram(
@@ -1269,7 +1269,7 @@ template <class T> struct urProgramTestWithParam : urQueueTestWithParam<T> {
         program_name, this->platform, il_binary));
 
     const ur_program_properties_t properties = {
-        UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES, nullptr,
+        nullptr, UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES,
         static_cast<uint32_t>(metadatas.size()),
         metadatas.empty() ? nullptr : metadatas.data()};
 
@@ -1681,7 +1681,7 @@ struct urMultiDeviceProgramTest : urMultiDeviceQueueTest {
         program_name, platform, il_binary));
 
     const ur_program_properties_t properties = {
-        UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES, nullptr,
+        nullptr, UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES,
         static_cast<uint32_t>(metadatas.size()),
         metadatas.empty() ? nullptr : metadatas.data()};
 


### PR DESCRIPTION
@RossBrunton, @aarongreig,

Would you like to organize migration to aligned structures your Unified Runtime API for modern x64 processors? This should be guaranteed to lead to more frequent structs entry into CPU cache, which can greatly affect performance if aligned structures are used frequently. I hope that you (as Intel employees) know advantage this optimization method at the architectural level codebase and its inconveniences as stylistic ABI breakdown.

Very briefly, your API is not badly broken, I have changed only first and second field in all aligned structures.
(pNext and sType)

More info about technique: 
https://stackoverflow.com/a/20882083
https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/
https://en.wikipedia.org/wiki/Data_structure_alignment

Affected API structures:
- ur_image_desc_t 80 -> 72 bytes
- ur_exp_command_buffer_update_value_arg_desc_t 48 -> 40 bytes
- ur_exp_command_buffer_update_memobj_arg_desc_t 40 -> 32 bytes
- ur_exp_command_buffer_update_pointer_arg_desc_t 40 -> 32 bytes
- ur_sampler_desc_t 32 -> 24 bytes
- ur_program_properties_t 32 -> 24 bytes
- ur_exp_sampler_addr_modes_t 32 -> 24 bytes
- ur_platform_native_properties_t 24 -> 16 bytes
- ur_device_native_properties_t 24 -> 16 bytes
- ur_context_properties_t 24 -> 16 bytes
- ur_context_native_properties_t 24 -> 16 bytes
- ur_buffer_channel_properties_t 24 -> 16 bytes
- ur_buffer_alloc_location_properties_t 24 -> 16 bytes
- ur_mem_native_properties_t 24 -> 16 bytes
- ur_sampler_native_properties_t 24 -> 16 bytes
- ur_usm_host_desc_t 24 -> 16 bytes
- ur_usm_device_desc_t 24 -> 16 bytes
- ur_usm_alloc_location_desc_t 24 -> 16 bytes
- ur_usm_pool_desc_t 24 -> 16 bytes
- ur_physical_mem_properties_t 24 -> 16 bytes
- ur_program_native_properties_t 24 -> 16 bytes
- ur_kernel_arg_mem_obj_properties_t 24 -> 16 bytes
- ur_kernel_native_properties_t 24 -> 16 bytes
- ur_queue_properties_t 24 -> 16 bytes
- ur_queue_index_properties_t 24 -> 16 bytes
- ur_queue_native_properties_t 24 -> 16 bytes
- ur_event_native_properties_t 24 -> 16 bytes
- ur_exp_async_usm_alloc_properties_t 24 -> 16 bytes
- ur_exp_file_descriptor_t 24 -> 16 bytes
- ur_exp_sampler_cubemap_properties_t 24 -> 16 bytes
- ur_exp_command_buffer_desc_t 24 -> 16 bytes
- ur_exp_enqueue_ext_properties_t 24 -> 16 bytes
- ur_exp_enqueue_native_command_properties_t 24 -> 16 bytes