### PR TITLE
fix regenerating htmls using dry run in nightly

### DIFF
--- a/.github/workflows/benchmarks-reusable.yml
+++ b/.github/workflows/benchmarks-reusable.yml
@@ -254,6 +254,8 @@ jobs:
           fi
 
           echo "Regenerating data.json"
-          (cd ${{ github.workspace }} && ${{ github.workspace }}/sc/devops/scripts/benchmarks/main.py ~/ur_bench_workdir --dry-run --results-dir ${{ github.workspace }}/results-repo --output-html remote)
+          # --sycl and --ur params must be set to some values for the dry-run to properly output metadata for sycl and ur based benchmarks.
+          # TODO: remove this once it's addressed in the benchmark scripts.
+          (cd ${{ github.workspace }} && ${{ github.workspace }}/sc/devops/scripts/benchmarks/main.py ~/ur_bench_workdir --dry-run --sycl invalid --ur invalid --results-dir ${{ github.workspace }}/results-repo --output-html remote)
 
         done


### PR DESCRIPTION
The BMG nightly job is regularly failing on the first push to the benchmarks-results branch, requiring the benchmark data to be regenerated using a dry-run. However, currently there's an issue with dry-runs where it won't include all the metadata for benchmarks if ur and sycl aren't specified.

This workaround just sets ur/sycl to some values so that the metadata fields are populated. It's a dry-run so these values aren't really being used.

I've been regenerating the metadata manually:
https://github.com/oneapi-src/unified-runtime/actions/runs/14060532242
