### PR TITLE
Automate PR containing intel/llvm mirror commits

### DIFF
--- a/.github/workflows/mirror-intel-llvm-commits.yml
+++ b/.github/workflows/mirror-intel-llvm-commits.yml
@@ -3,9 +3,8 @@ name: Mirror intel/llvm commits
 
 on:
   workflow_dispatch:
-  # TODO: Renable schedule once push permission issue is resolved
-  # schedule:
-  #   - cron: "0 * * * *"
+  schedule:
+    - cron: "0 * * * *"
 
 permissions:
   contents: read
@@ -15,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -36,5 +36,10 @@ jobs:
       - run: |
           python3 unified-runtime/scripts/mirror-commits-from-intel-llvm.py ${{github.workspace}}/unified-runtime ${{github.workspace}}/intel-llvm
 
-      - run: |
-          git -C ${{github.workspace}}/unified-runtime push origin main
+      - id: date
+        run: echo "::set-output name=value::$(date +'%Y-%m-%d')"
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          title: Mirror intel/llvm commits ${{ steps.date.output.value }}
+          branch: mirror-commits-${{ steps.date.output.value }}


### PR DESCRIPTION
Since GitHub Actions bot is not allowed to push to main, instead periodically create a PR which can be merged by one of the team.
