### PR TITLE
Remove use of deprecated GHA set var

### DIFF
--- a/.github/workflows/mirror-intel-llvm-commits.yml
+++ b/.github/workflows/mirror-intel-llvm-commits.yml
@@ -37,7 +37,7 @@ jobs:
           python3 unified-runtime/scripts/mirror-commits-from-intel-llvm.py unified-runtime intel-llvm
 
       - id: date
-        run: echo "::set-output name=value::$(date +'%Y-%m-%d')"
+        run: echo "value=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:


### PR DESCRIPTION
See [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
