### PR TITLE
[Benchmarks] redirect perf location to intel/llvm

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,17 +59,10 @@ jobs:
           sparse-checkout: |
             devops/scripts/benchmarks
 
-      - name: Move benchmark HTML files
+      - name: Redirect performance to intel/llvm
         run: |
           mkdir -p ${{ github.workspace }}/docs/html/performance
-          mv ${{ github.workspace }}/sc/devops/scripts/benchmarks/html/* ${{ github.workspace }}/docs/html/performance/
-
-      - name: Replace config.js
-        run: |
-          cat << 'EOF' > ${{ github.workspace }}/docs/html/performance/config.js
-          remoteDataUrl = 'https://raw.githubusercontent.com/oneapi-src/unified-runtime/refs/heads/benchmark-results/';
-          defaultCompareNames = ["Baseline_PVC_L0", "Baseline_PVC_L0v2"];
-          EOF
+          echo '<meta http-equiv="refresh" content="0; url=https://intel.github.io/llvm/benchmarks/">' > ${{ github.workspace }}/docs/html/performance/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0


### PR DESCRIPTION
We are moving perf CI to intel/llvm. Redirect the old URL.